### PR TITLE
fix(prompt-version): [Prompts] Literal values of prompts version are reset when a user saved one and opened prompts list #28

### DIFF
--- a/apps/ai-dial-admin/src/components/PromptsList/prompts-list.ts
+++ b/apps/ai-dial-admin/src/components/PromptsList/prompts-list.ts
@@ -87,7 +87,7 @@ export const filterLatestVersions = (data: DialPrompt[]) => {
 
   data?.forEach((item) => {
     const name = item.name as string;
-    if (!latestVersions[name] || compareVersions(item.version, latestVersions[name].version) > 0) {
+    if (!latestVersions[name] || item.updateTime > latestVersions[name].updateTime) {
       latestVersions[name] = item;
     }
   });


### PR DESCRIPTION
**Description:**

 changed latest version check by updateTime

Issues:

- Issue (https://github.com/epam/ai-dial-admin-frontend/issues/28)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [ ] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
