### PR TITLE
fix(prompt-version): [Prompts] Literal values of prompts version are reset when a user saved one and opened prompts list (Issue #28)

### DIFF
--- a/apps/ai-dial-admin/src/components/PromptView/PromptView.tsx
+++ b/apps/ai-dial-admin/src/components/PromptView/PromptView.tsx
@@ -32,7 +32,7 @@ const PromptView: FC<Props> = ({ originalPrompt, prompts }) => {
   const t = useI18n() as (stringToTranslate: string) => string;
   const tabs = [propertiesTabs(t)];
   const router = useRouter();
-  const { fetchFiles } = usePromptFolder();
+  const { fetchFiles, filePath } = usePromptFolder();
   const { showNotification } = useNotification();
 
   const [activeTab, setActiveTab] = useState(EntityViewTab.Properties);
@@ -100,6 +100,7 @@ const PromptView: FC<Props> = ({ originalPrompt, prompts }) => {
             });
           });
         } else {
+          fetchFiles(filePath);
           router.push(`${ApplicationRoute.Prompts}/${getEntityPath(ApplicationRoute.Prompts, res.response)}`);
         }
         router.refresh();
@@ -107,7 +108,7 @@ const PromptView: FC<Props> = ({ originalPrompt, prompts }) => {
         showNotification(getErrorNotification(res.errorHeader, res.errorMessage));
       }
     });
-  }, [showNotification, originalPrompt, selectedPrompt, router, fetchFiles]);
+  }, [selectedPrompt, originalPrompt, router, fetchFiles, filePath, showNotification]);
 
   const onChangeEntity = useCallback(
     (entity: DialPrompt) => {


### PR DESCRIPTION
**Description:**

added prompt folder re-fetch after adding new version of prompt

Issues:

- Issue (https://github.com/epam/ai-dial-admin-frontend/issues/28)

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [ ] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
