### PR TITLE
fix(prompt-content): [Prompts] There is no JSON validation on Prompt Content JSON field that leads to crash on client side (Issue #41)

### DIFF
--- a/apps/ai-dial-admin/src/components/Common/JsonEditorBase/JsonEditorBase.tsx
+++ b/apps/ai-dial-admin/src/components/Common/JsonEditorBase/JsonEditorBase.tsx
@@ -20,9 +20,22 @@ const JsonEditorBase: FC<Props> = ({ value, onChange, onValidateJSON, options })
   function handleBeforeMount(monaco: Monaco) {
     monaco?.editor?.defineTheme(currentTheme, EDITOR_THEMES_CONFIG[currentTheme as EDITOR_THEMES]);
     monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
+      validate: true,
       enableSchemaRequest: false,
+      schemas: [
+        {
+          uri: 'http://custom-schema/object-required.json',
+          fileMatch: ['*'],
+          schema: {
+            type: 'object',
+            description: 'Top-level value must be an object',
+            additionalProperties: true,
+          },
+        },
+      ],
     });
   }
+
   return (
     <Editor
       beforeMount={handleBeforeMount}

--- a/apps/ai-dial-admin/src/components/PromptsList/PromptProperties.tsx
+++ b/apps/ai-dial-admin/src/components/PromptsList/PromptProperties.tsx
@@ -157,6 +157,7 @@ const PromptProperties: FC<Props> = ({
       if (typeof parsed === 'object') {
         setJsonValue(JSON.stringify(parsed, null, 2));
       }
+      setJsonValue(prompt.content);
     } catch {
       setJsonValue(prompt.content);
     }


### PR DESCRIPTION
**Description:**

added custom json validation

Issues:

- Issue (https://github.com/epam/ai-dial-admin-frontend/issues/41)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
