### PR TITLE
feat(prompt): [Assets][Prompts] Save as New Version Pop-up After Editing Prompt Content (Issue #71)

### DIFF
--- a/apps/ai-dial-admin/src/components/Common/AddVersionModal/AddVersionModal.tsx
+++ b/apps/ai-dial-admin/src/components/Common/AddVersionModal/AddVersionModal.tsx
@@ -3,7 +3,7 @@ import { FC, useState } from 'react';
 import Button from '@/src/components/Common/Button/Button';
 import { TextInputField } from '@/src/components/Common/InputField/InputField';
 import Popup from '@/src/components/Common/Popup/Popup';
-import { ButtonsI18nKey, CreateI18nKey } from '@/src/constants/i18n';
+import { ButtonsI18nKey, CreateI18nKey, PromptsI18nKey } from '@/src/constants/i18n';
 import { useI18n } from '@/src/locales/client';
 import { PopUpState } from '@/src/types/pop-up';
 
@@ -30,7 +30,7 @@ const AddVersionModal: FC<Props> = ({
   return (
     <Popup onClose={onClose} heading={heading} portalId="newVersionModal" state={modalState}>
       <div className=" flex flex-col gap-4 text-primary small px-6 py-4">
-        {prefilledVersion && <div className="text-secondary">Create a new version to save changes. </div>}
+        {prefilledVersion && <div className="text-secondary">{t(PromptsI18nKey.NewVersionSaveDescription)}</div>}
         <TextInputField
           elementId="name"
           fieldTitle={t(CreateI18nKey.VersionTitle)}

--- a/apps/ai-dial-admin/src/components/Common/AddVersionModal/AddVersionModal.tsx
+++ b/apps/ai-dial-admin/src/components/Common/AddVersionModal/AddVersionModal.tsx
@@ -1,26 +1,36 @@
 import { FC, useState } from 'react';
 
 import Button from '@/src/components/Common/Button/Button';
+import { TextInputField } from '@/src/components/Common/InputField/InputField';
 import Popup from '@/src/components/Common/Popup/Popup';
 import { ButtonsI18nKey, CreateI18nKey } from '@/src/constants/i18n';
 import { useI18n } from '@/src/locales/client';
 import { PopUpState } from '@/src/types/pop-up';
-import { TextInputField } from '@/src/components/Common/InputField/InputField';
 
 interface Props {
+  heading: string;
   modalState: PopUpState;
   existingVersions: string[];
+  prefilledVersion?: string;
   onClose: () => void;
   onConfirm: (version: string) => void;
 }
 
-const AddVersionModal: FC<Props> = ({ modalState, existingVersions, onConfirm, onClose }) => {
+const AddVersionModal: FC<Props> = ({
+  heading,
+  modalState,
+  existingVersions,
+  prefilledVersion,
+  onConfirm,
+  onClose,
+}) => {
   const t = useI18n();
-  const [version, setVersion] = useState<string>('');
+  const [version, setVersion] = useState<string>(prefilledVersion || '');
 
   return (
-    <Popup onClose={onClose} heading={'Create new version'} portalId="ConfirmationModal" state={modalState}>
-      <div className="text-primary small px-6 py-4">
+    <Popup onClose={onClose} heading={heading} portalId="newVersionModal" state={modalState}>
+      <div className=" flex flex-col gap-4 text-primary small px-6 py-4">
+        {prefilledVersion && <div className="text-secondary">Create a new version to save changes. </div>}
         <TextInputField
           elementId="name"
           fieldTitle={t(CreateI18nKey.VersionTitle)}

--- a/apps/ai-dial-admin/src/components/EntityView/EntityViewHeaderButtons.tsx
+++ b/apps/ai-dial-admin/src/components/EntityView/EntityViewHeaderButtons.tsx
@@ -9,13 +9,14 @@ import { useRouter } from 'next/navigation';
 
 import DeleteAdapter from '@/src/components/AdaptersList/Delete/DeleteAdapter';
 import DeleteScheme from '@/src/components/ApplicationRunners/ListView/Delete/DeleteAppRunner';
+import AddVersionModal from '@/src/components/Common/AddVersionModal/AddVersionModal';
 import Button from '@/src/components/Common/Button/Button';
 import ConfirmationModal from '@/src/components/Common/ConfirmationModal/ConfirmationModal';
 import Switch from '@/src/components/Common/Switch/Switch';
 import { isValidEntity } from '@/src/components/EntityListView/CreateEntity/validation';
 import { deleteModalTitleMap, getEntityPath } from '@/src/components/EntityListView/entity-list-view';
 import { showEditorErrorNotifications } from '@/src/components/JSONEditor/JSONEditor.utils';
-import { ButtonsI18nKey, DeleteI18nKey } from '@/src/constants/i18n';
+import { ButtonsI18nKey, DeleteI18nKey, PromptsI18nKey } from '@/src/constants/i18n';
 import { BASE_ICON_PROPS } from '@/src/constants/main-layout';
 import { useNotification } from '@/src/context/NotificationContext';
 import { usePromptFolder } from '@/src/context/PromptFolderContext';
@@ -32,6 +33,7 @@ import { PopUpState } from '@/src/types/pop-up';
 import { ApplicationRoute } from '@/src/types/routes';
 import { isSimpleEntity } from '@/src/utils/entities/is-simple-entity';
 import { getErrorNotification } from '@/src/utils/notification';
+import { generateNewInitialVersion } from '@/src/utils/prompts/versions';
 
 interface Props<T> {
   view: ApplicationRoute;
@@ -42,11 +44,12 @@ interface Props<T> {
   hideJsonEditor?: boolean;
   children?: ReactNode;
   onDiscard: () => void;
-  onSave: () => void;
+  onSave: (newVersion?: string) => void;
   removeEntity: (entity?: string) => Promise<ServerActionResponse>;
   toggleJsonEditor?: () => void;
   setErrorNotifications?: (notification: JSONEditorErrorNotification[]) => void;
   contentJsonErrors?: JSONEditorError[] | null;
+  promptVersions?: string[];
 }
 
 const EntityViewHeaderButtons = <T extends DialBaseEntity | DialKey>({
@@ -63,6 +66,7 @@ const EntityViewHeaderButtons = <T extends DialBaseEntity | DialKey>({
   hideJsonEditor,
   children,
   contentJsonErrors,
+  promptVersions,
 }: Props<T>) => {
   const t = useI18n() as (key: string, options?: Record<string, string | number>) => string;
   const router = useRouter();
@@ -71,6 +75,7 @@ const EntityViewHeaderButtons = <T extends DialBaseEntity | DialKey>({
   const { fetchFiles, filePath } = usePromptFolder();
 
   const [modalState, setIsOpenModal] = useState(PopUpState.Closed);
+  const [versionModalState, setVersionModalState] = useState(PopUpState.Closed);
   const [isValidJSON, setIsValidJSON] = useState<boolean>(true);
 
   const staticContainerClassnames = 'flex flex-row gap-3 divide-x divide-primary lg:h-[35px]';
@@ -112,20 +117,26 @@ const EntityViewHeaderButtons = <T extends DialBaseEntity | DialKey>({
     setIsValidJSON(!jsonErrors?.length);
   }, [jsonErrors]);
 
-  const onTryToSave = useCallback(() => {
-    if (jsonErrors?.length || contentJsonErrors?.length) {
-      setIsValidJSON(false);
-      const errors = (jsonErrors?.length ? jsonErrors : contentJsonErrors) as JSONEditorError[];
-      const errorNotifications = showEditorErrorNotifications({
-        errors,
-        showNotification,
-        t,
-      });
-      setErrorNotifications?.(errorNotifications);
-    } else {
-      onSave();
-    }
-  }, [jsonErrors, contentJsonErrors, showNotification, t, setErrorNotifications, onSave]);
+  const onTryToSave = useCallback(
+    (newVersion?: string) => {
+      if (newVersion) {
+        setVersionModalState(PopUpState.Closed);
+      }
+      if (jsonErrors?.length || contentJsonErrors?.length) {
+        setIsValidJSON(false);
+        const errors = (jsonErrors?.length ? jsonErrors : contentJsonErrors) as JSONEditorError[];
+        const errorNotifications = showEditorErrorNotifications({
+          errors,
+          showNotification,
+          t,
+        });
+        setErrorNotifications?.(errorNotifications);
+      } else {
+        onSave(newVersion);
+      }
+    },
+    [jsonErrors, contentJsonErrors, showNotification, t, setErrorNotifications, onSave],
+  );
 
   useEffect(() => {
     setContainerClassNames(
@@ -153,10 +164,18 @@ const EntityViewHeaderButtons = <T extends DialBaseEntity | DialKey>({
               title={t(ButtonsI18nKey.Discard)}
               onClick={onDiscard}
             />
+            {view === ApplicationRoute.Prompts && (
+              <Button
+                cssClass={`secondary ${buttonsClassNames}`}
+                title={t(ButtonsI18nKey.SaveAsNewVersion)}
+                onClick={() => setVersionModalState(PopUpState.Opened)}
+                disable={(jsonEditorEnabled && !isValidJSON) || !isValidEntity(view, entity)}
+              />
+            )}
             <Button
               cssClass={`primary ${buttonsClassNames}`}
               title={t(ButtonsI18nKey.Save)}
-              onClick={onTryToSave}
+              onClick={() => onTryToSave()}
               disable={(jsonEditorEnabled && !isValidJSON) || !isValidEntity(view, entity)}
             />
           </div>
@@ -202,6 +221,18 @@ const EntityViewHeaderButtons = <T extends DialBaseEntity | DialKey>({
               <DeleteAdapter entity={entity as DialAdapter} isEntityView={true} />
             ) : null}
           </ConfirmationModal>,
+          document.body,
+        )}
+      {versionModalState === PopUpState.Opened &&
+        createPortal(
+          <AddVersionModal
+            heading={t(PromptsI18nKey.NewVersionSave)}
+            modalState={versionModalState}
+            prefilledVersion={generateNewInitialVersion(entity.version)}
+            existingVersions={promptVersions || []}
+            onClose={() => setVersionModalState(PopUpState.Closed)}
+            onConfirm={onTryToSave}
+          />,
           document.body,
         )}
     </>

--- a/apps/ai-dial-admin/src/components/PromptView/PromptProperties.tsx
+++ b/apps/ai-dial-admin/src/components/PromptView/PromptProperties.tsx
@@ -11,9 +11,10 @@ import FilePath from '@/src/components/Common/FilePath/FilePath';
 import { TextInputField } from '@/src/components/Common/InputField/InputField';
 import JsonEditorBase from '@/src/components/Common/JsonEditorBase/JsonEditorBase';
 import LabeledText from '@/src/components/Common/LabeledText/LabeledText';
+import MdEditor from '@/src/components/Common/MdEditor/MdEditor';
 import Switch from '@/src/components/Common/Switch/Switch';
 import TextAreaField from '@/src/components/Common/TextAreaField/TextAreaField';
-import { BasicI18nKey, ButtonsI18nKey, CreateI18nKey } from '@/src/constants/i18n';
+import { BasicI18nKey, ButtonsI18nKey, CreateI18nKey, PromptsI18nKey } from '@/src/constants/i18n';
 import { BASE_ICON_PROPS } from '@/src/constants/main-layout';
 import { usePromptFolder } from '@/src/context/PromptFolderContext';
 import { useI18n } from '@/src/locales/client';
@@ -23,8 +24,8 @@ import { FieldError } from '@/src/models/error';
 import { JSONEditorError } from '@/src/types/editor';
 import { PopUpState } from '@/src/types/pop-up';
 import { formatDateTimeToLocalString } from '@/src/utils/formatting/date';
+import { modifyNameVersionInPrompt } from '@/src/utils/prompts/versions';
 import { getErrorForDescription } from '@/src/utils/validation/description-error';
-import MdEditor from '@/src/components/Common/MdEditor/MdEditor';
 
 interface Props {
   prompt: DialPrompt;
@@ -83,17 +84,21 @@ const PromptProperties: FC<Props> = ({
     async (version: string) => {
       const found = await getPrompt?.(prompt.folderId as string, prompt.name as string, version);
       if (found) {
+        const path = modifyNameVersionInPrompt(found.path, void 0, version);
         onChangePrompt?.({
           ...prompt,
           description: found.description,
           content: found.content,
           folderId: found.folderId,
           version,
+          path,
         });
       } else {
+        const path = modifyNameVersionInPrompt(prompt.path, void 0, version);
         onChangePrompt?.({
           ...prompt,
           version,
+          path,
         });
       }
     },
@@ -264,6 +269,7 @@ const PromptProperties: FC<Props> = ({
       {modalState === PopUpState.Opened &&
         createPortal(
           <AddVersionModal
+            heading={t(PromptsI18nKey.NewVersionCreate)}
             modalState={modalState}
             existingVersions={[...versions, ...addedVersions]}
             onClose={onCloseModal}

--- a/apps/ai-dial-admin/src/components/PromptView/PromptView.tsx
+++ b/apps/ai-dial-admin/src/components/PromptView/PromptView.tsx
@@ -12,16 +12,16 @@ import { EntityViewTab, propertiesTabs } from '@/src/components/EntityView/entit
 import EntityViewHeaderButtons from '@/src/components/EntityView/EntityViewHeaderButtons';
 import JSONEditor from '@/src/components/JSONEditor/JSONEditor';
 import PromptProperties from '@/src/components/PromptView/PromptProperties';
-import { getEntityForUpdate, getIsNeedToMove } from '@/src/components/PromptView/utils';
+import { addNewVersion, getEntityForUpdate, getIsNeedToMove } from '@/src/components/PromptView/utils';
 import { ROOT_FOLDER } from '@/src/constants/file';
-import { usePromptFolder } from '@/src/context/PromptFolderContext';
 import { useNotification } from '@/src/context/NotificationContext';
+import { usePromptFolder } from '@/src/context/PromptFolderContext';
 import { useI18n } from '@/src/locales/client';
 import { DialPrompt } from '@/src/models/dial/prompt';
 import { JSONEditorError, JSONEditorErrorNotification } from '@/src/types/editor';
 import { ApplicationRoute } from '@/src/types/routes';
+import { addTrailingSlash, changePath, getListOfPathsToMove, removeTrailingSlash } from '@/src/utils/files/path';
 import { getErrorNotification } from '@/src/utils/notification';
-import { addTrailingSlash, getListOfPathsToMove, changePath, removeTrailingSlash } from '@/src/utils/files/path';
 
 interface Props {
   originalPrompt: DialPrompt;
@@ -32,7 +32,7 @@ const PromptView: FC<Props> = ({ originalPrompt, prompts }) => {
   const t = useI18n() as (stringToTranslate: string) => string;
   const tabs = [propertiesTabs(t)];
   const router = useRouter();
-  const { fetchFiles, filePath } = usePromptFolder();
+  const { fetchFiles } = usePromptFolder();
   const { showNotification } = useNotification();
 
   const [activeTab, setActiveTab] = useState(EntityViewTab.Properties);
@@ -79,36 +79,42 @@ const PromptView: FC<Props> = ({ originalPrompt, prompts }) => {
     setAddedVersions([]);
   }, [setSelectedPrompt, originalPrompt, jsonEditorEnabled]);
 
-  const onSave = useCallback(() => {
-    const isNeedToMove = getIsNeedToMove(selectedPrompt, originalPrompt);
-    const updatedEntity = getEntityForUpdate(selectedPrompt, originalPrompt);
+  const onSave = useCallback(
+    (newVersion?: string) => {
+      const isNeedToMove = getIsNeedToMove(selectedPrompt, originalPrompt);
+      let updatedEntity = getEntityForUpdate(selectedPrompt, originalPrompt);
 
-    createPrompt(updatedEntity).then((res) => {
-      if (res.success) {
-        if (isNeedToMove) {
-          const responsePrompt = res.response as DialPrompt;
-          getPrompts(addTrailingSlash(responsePrompt.folderId)).then((prompts) => {
-            const pathsToMove = getListOfPathsToMove(responsePrompt, null, prompts || []);
-            const newPath = removeTrailingSlash(selectedPrompt.folderId);
-            movePrompts(pathsToMove, newPath).then((r) => {
-              if (r.every((response) => response.success)) {
-                router.push(
-                  `${ApplicationRoute.Prompts}/${getEntityPath(ApplicationRoute.Prompts, { name: (res.response as DialPrompt).name, path: changePath((res.response as DialPrompt).path, newPath) })}`,
-                );
-                fetchFiles(addTrailingSlash(ROOT_FOLDER), true);
-              }
-            });
-          });
-        } else {
-          fetchFiles(filePath);
-          router.push(`${ApplicationRoute.Prompts}/${getEntityPath(ApplicationRoute.Prompts, res.response)}`);
-        }
-        router.refresh();
-      } else {
-        showNotification(getErrorNotification(res.errorHeader, res.errorMessage));
+      if (newVersion) {
+        updatedEntity = addNewVersion(updatedEntity, newVersion);
       }
-    });
-  }, [selectedPrompt, originalPrompt, router, fetchFiles, filePath, showNotification]);
+      createPrompt(updatedEntity).then((res) => {
+        if (res.success) {
+          if (isNeedToMove) {
+            const responsePrompt = res.response as DialPrompt;
+            getPrompts(addTrailingSlash(responsePrompt.folderId)).then((prompts) => {
+              const pathsToMove = getListOfPathsToMove(responsePrompt, null, prompts || []);
+              const newPath = removeTrailingSlash(selectedPrompt.folderId);
+              movePrompts(pathsToMove, newPath).then((r) => {
+                if (r.every((response) => response.success)) {
+                  router.push(
+                    `${ApplicationRoute.Prompts}/${getEntityPath(ApplicationRoute.Prompts, { name: (res.response as DialPrompt).name, path: changePath((res.response as DialPrompt).path, newPath) })}`,
+                  );
+                  fetchFiles(addTrailingSlash(ROOT_FOLDER), true);
+                }
+              });
+            });
+          } else {
+            fetchFiles(updatedEntity.folderId);
+            router.push(`${ApplicationRoute.Prompts}/${getEntityPath(ApplicationRoute.Prompts, res.response)}`);
+          }
+          router.refresh();
+        } else {
+          showNotification(getErrorNotification(res.errorHeader, res.errorMessage));
+        }
+      });
+    },
+    [selectedPrompt, originalPrompt, router, fetchFiles, showNotification],
+  );
 
   const onChangeEntity = useCallback(
     (entity: DialPrompt) => {
@@ -137,6 +143,7 @@ const PromptView: FC<Props> = ({ originalPrompt, prompts }) => {
           jsonErrors={jsonErrors}
           contentJsonErrors={contentJsonErrors}
           setErrorNotifications={setErrorNotifications}
+          promptVersions={prompts?.map((prompt) => prompt.version) || []}
         />
       </div>
       <div className="flex-1 overflow-auto mt-3 min-h-0">

--- a/apps/ai-dial-admin/src/components/PromptView/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/PromptView/tests/utils.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { getIsNeedToMove, getEntityForUpdate } from '../utils';
+import { addNewVersion, getIsNeedToMove, getEntityForUpdate } from '../utils';
 
 describe('PromptView :: utils :: getIsNeedToMove', () => {
   test('getIsNeedToMove returns true if folderId changed', () => {
@@ -34,5 +34,29 @@ describe('PromptView :: utils :: getEntityForUpdate', () => {
     const result = getEntityForUpdate(entity, undefined);
     expect(result.folderId).toBeUndefined();
     expect(result.name).toBe('Prompt');
+  });
+});
+
+describe('PromptView :: utils :: addNewVersion', () => {
+  test('should correctly change version and path if version is numeric', () => {
+    const entity = { folderId: '2', name: 'Prompt', path: 'somePath__0.0.1' } as any;
+    const result = addNewVersion(entity, '1.2.3');
+    expect(result).toEqual({
+      folderId: '2',
+      name: 'Prompt',
+      path: 'somePath__1.2.3',
+      version: '1.2.3',
+    });
+  });
+
+  test('should correctly change version and path if version is not numeric', () => {
+    const entity = { folderId: '2', name: 'Prompt', path: 'somePath__oldVersion' } as any;
+    const result = addNewVersion(entity, 'newVersion');
+    expect(result).toEqual({
+      folderId: '2',
+      name: 'Prompt',
+      path: 'somePath__newVersion',
+      version: 'newVersion',
+    });
   });
 });

--- a/apps/ai-dial-admin/src/components/PromptView/utils.ts
+++ b/apps/ai-dial-admin/src/components/PromptView/utils.ts
@@ -1,4 +1,5 @@
 import { DialPrompt } from '@/src/models/dial/prompt';
+import { modifyNameVersionInPrompt } from '@/src/utils/prompts/versions';
 
 export const getIsNeedToMove = (entity: DialPrompt, initialEntity?: DialPrompt) => {
   return entity.folderId !== initialEntity?.folderId;
@@ -8,5 +9,14 @@ export const getEntityForUpdate = (entity: DialPrompt, initialEntity?: DialPromp
   return {
     ...entity,
     folderId: (initialEntity as DialPrompt)?.folderId,
+  };
+};
+
+export const addNewVersion = (entity: DialPrompt, version: string) => {
+  const path = modifyNameVersionInPrompt(entity.path, void 0, version);
+  return {
+    ...entity,
+    path,
+    version,
   };
 };

--- a/apps/ai-dial-admin/src/constants/i18n.ts
+++ b/apps/ai-dial-admin/src/constants/i18n.ts
@@ -534,6 +534,7 @@ export enum PromptsI18nKey {
   Import = 'Prompts.Import',
   NewVersionCreate = 'Prompts.NewVersionCreate',
   NewVersionSave = 'Prompts.NewVersionSave',
+  NewVersionSaveDescription = 'Prompts.NewVersionSaveDescription',
 }
 
 export enum ImportI18nKey {

--- a/apps/ai-dial-admin/src/constants/i18n.ts
+++ b/apps/ai-dial-admin/src/constants/i18n.ts
@@ -192,6 +192,7 @@ export enum ButtonsI18nKey {
   DeleteAll = 'Buttons.DeleteAll',
   Duplicate = 'Buttons.Duplicate',
   Save = 'Buttons.Save',
+  SaveAsNewVersion = 'Buttons.SaveAsNewVersion',
   Apply = 'Buttons.Apply',
   Discard = 'Buttons.Discard',
   Add = 'Buttons.Add',
@@ -531,6 +532,8 @@ export enum PromptsI18nKey {
   DuplicationType = 'Prompts.DuplicationType',
   Export = 'Prompts.Export',
   Import = 'Prompts.Import',
+  NewVersionCreate = 'Prompts.NewVersionCreate',
+  NewVersionSave = 'Prompts.NewVersionSave',
 }
 
 export enum ImportI18nKey {

--- a/apps/ai-dial-admin/src/locales/en.ts
+++ b/apps/ai-dial-admin/src/locales/en.ts
@@ -353,6 +353,7 @@ export default {
     Create: 'Create',
     Update: 'Update',
     Save: 'Save',
+    SaveAsNewVersion: 'Save as new version',
     Discard: 'Discard',
     Apply: 'Apply',
     Import: 'Import',
@@ -597,6 +598,8 @@ export default {
     DuplicationType: 'Duplication type',
     Export: 'Export prompts',
     Import: 'Import prompts',
+    NewVersionCreate: 'Create new version',
+    NewVersionSave: 'Save as New Version',
   },
   Keys: {
     SaveWithoutRoles: 'Save without adding Roles',

--- a/apps/ai-dial-admin/src/locales/en.ts
+++ b/apps/ai-dial-admin/src/locales/en.ts
@@ -600,6 +600,7 @@ export default {
     Import: 'Import prompts',
     NewVersionCreate: 'Create new version',
     NewVersionSave: 'Save as New Version',
+    NewVersionSaveDescription: 'Create a new version to save changes.',
   },
   Keys: {
     SaveWithoutRoles: 'Save without adding Roles',

--- a/apps/ai-dial-admin/src/utils/prompts/tests/versions.spec.ts
+++ b/apps/ai-dial-admin/src/utils/prompts/tests/versions.spec.ts
@@ -1,6 +1,7 @@
 import {
   checkNameVersionCombination,
   getInitialVersion,
+  generateNewInitialVersion,
   generateNameVersionForPrompt,
   getNameVersionFromPrompt,
   modifyNameVersionInPrompt,
@@ -82,6 +83,17 @@ describe('Prompts utils :: getInitialVersion', () => {
   test('Should return latest version + 1', () => {
     const res = getInitialVersion({ versions: ['1.0.1', '1.0.2', '1.0.3'] }, 'versions');
     expect(res).toEqual('1.0.4');
+  });
+});
+
+describe('Prompts utils :: generateNewInitialVersion', () => {
+  test('Should return version + 1', () => {
+    const res = generateNewInitialVersion('1.0.1');
+    expect(res).toEqual('1.0.2');
+  });
+   test('Should return unchanged version', () => {
+    const res = generateNewInitialVersion('someVersion');
+    expect(res).toEqual('someVersion');
   });
 });
 

--- a/apps/ai-dial-admin/src/utils/prompts/versions.ts
+++ b/apps/ai-dial-admin/src/utils/prompts/versions.ts
@@ -54,6 +54,14 @@ export const getInitialVersion = (versionsPerName: Record<string, string[]>, nam
   return latest?.join('.') || '';
 };
 
+export const generateNewInitialVersion = (version?: string) => {
+  const parts = version?.split('.');
+  if (parts && parts[2]) {
+    parts[2] = `${+parts[2] + 1}`;
+  }
+  return parts?.join('.') || '';
+};
+
 export const checkNameVersionCombination = (
   versionsPerName: Record<string, string[]>,
   name: string,


### PR DESCRIPTION
**Description:**

added save as new version button

Issues:

- Issue (https://github.com/epam/ai-dial-admin-frontend/issues/71)

**UI changes**

<img width="1219" height="177" alt="image" src="https://github.com/user-attachments/assets/886cdf9f-1a11-4f33-8f69-556297cca943" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
