### PR TITLE
fix(adapters): [Builders][Adapters] Remove “(Optional)” from Display Name field in Create Adapter form (Issue #338)

### DIFF
--- a/apps/ai-dial-admin/src/components/AdaptersView/AdapterProperties.tsx
+++ b/apps/ai-dial-admin/src/components/AdaptersView/AdapterProperties.tsx
@@ -7,7 +7,7 @@ import AutocompleteField from '@/src/components/Common/Dropdown/Autocomplete/Aut
 import { TextInputField } from '@/src/components/Common/InputField/InputField';
 import TextAreaField from '@/src/components/Common/TextAreaField/TextAreaField';
 import { CreateI18nKey, EntitiesI18nKey } from '@/src/constants/i18n';
-import { MAX_NAME_SYMBOLS } from '@/src/constants/validation';
+import { MAX_NAME_SYMBOLS, MIN_NAME_SYMBOLS } from '@/src/constants/validation';
 import { useI18n } from '@/src/locales/client';
 import { DialAdapter } from '@/src/models/dial/adapter';
 import { FieldError } from '@/src/models/error';
@@ -39,9 +39,13 @@ const AdapterProperties: FC<Props> = ({ entity, names, onChangeAdapter, isEntity
 
   const onChangeDisplayName = useCallback(
     (displayName: string) => {
-      const isValid = displayName ? displayName.length <= MAX_NAME_SYMBOLS : true;
+      const isValid = displayName
+        ? displayName.length <= MAX_NAME_SYMBOLS && displayName.length >= MIN_NAME_SYMBOLS
+        : true;
       setIsValidDisplayName(isValid);
-      setDisplayNameError(isValid ? void 0 : t(CreateI18nKey.ErrorLength, { number: MAX_NAME_SYMBOLS }));
+      setDisplayNameError(
+        isValid ? void 0 : t(CreateI18nKey.MinMaxLength, { min: MIN_NAME_SYMBOLS, max: MAX_NAME_SYMBOLS }),
+      );
       onChangeAdapter({ ...entity, displayName });
     },
     [t, onChangeAdapter, entity],
@@ -85,7 +89,6 @@ const AdapterProperties: FC<Props> = ({ entity, names, onChangeAdapter, isEntity
         onChange={onChangeDisplayName}
         invalid={!isValidDisplayName}
         items={uniq(names)}
-        optional={true}
       />
 
       <TextAreaField

--- a/apps/ai-dial-admin/src/components/AdaptersView/AdapterView.tsx
+++ b/apps/ai-dial-admin/src/components/AdaptersView/AdapterView.tsx
@@ -123,16 +123,18 @@ const AdapterView: FC<Props> = ({ originalAdapter }) => {
         ) : (
           <>
             {activeTab === EntityViewTab.Properties && (
-              <div className="lg:w-[35%] flex flex-col mt-3">
+              <>
                 <EntityHeader entity={selectedAdapter} />
-                <div className="flex-1 min-h-0">
-                  <AdapterProperties
-                    entity={selectedAdapter}
-                    onChangeAdapter={onChangeAdapter}
-                    isEntityImmutable={true}
-                  />
+                <div className="lg:w-[35%] flex flex-col pt-3">
+                  <div className="flex-1 min-h-0">
+                    <AdapterProperties
+                      entity={selectedAdapter}
+                      onChangeAdapter={onChangeAdapter}
+                      isEntityImmutable={true}
+                    />
+                  </div>
                 </div>
-              </div>
+              </>
             )}
             {activeTab === EntityViewTab.Models && (
               <div className="w-full h-full">


### PR DESCRIPTION
**Description:**

- remove optional label from adapter properties
- changed validation message
- header divider length changed

Issues:

- Issue #338

**UI changes**

<img width="685" height="477" alt="image" src="https://github.com/user-attachments/assets/3b6d430d-6533-4e1f-b98a-e02caadd6d23" />
<img width="510" height="549" alt="image" src="https://github.com/user-attachments/assets/e08a3d7e-6e72-4d91-98e2-0dcc804de852" />


**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [ ] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
