### PR TITLE
fix(attachments-input): [Applications][Models] Align Attachments field width with other fields in Properties tab (Issue #379)

### DIFF
--- a/apps/ai-dial-admin/src/components/Common/AttachmentInput/AttachmentInput.tsx
+++ b/apps/ai-dial-admin/src/components/Common/AttachmentInput/AttachmentInput.tsx
@@ -26,6 +26,7 @@ interface Props {
   elementId?: string;
   optional?: boolean;
   disable?: boolean;
+  inputClass?: string;
   onChange?: (values: string[]) => void;
 }
 
@@ -40,6 +41,7 @@ const AttachmentInput: FC<Props> = ({
   elementId,
   optional,
   disable,
+  inputClass,
   onChange,
 }) => {
   const t = useI18n();
@@ -170,8 +172,8 @@ const AttachmentInput: FC<Props> = ({
           <Tag key="all-values" tag={allValueLabel || ''} remove={() => removeAttachment(0)} />
         </div>
       ) : (
-        <div className={classNames('flex flex-row gap-2 items-center', disable && 'pointer-events-none')}>
-          <div className={classNames('input min-h-[38px] p-[6px] flex-1')}>
+        <div className={classNames('flex flex-row gap-2 items-center w-full', disable && 'pointer-events-none')}>
+          <div className={classNames('input min-h-[38px] p-[6px]', inputClass)}>
             <div
               ref={containerRef}
               className={classNames('flex flex-wrap items-start gap-2', wraps ? 'flex-col-reverse' : 'flex-row')}

--- a/apps/ai-dial-admin/src/components/EntityProperties/EntityProperties.tsx
+++ b/apps/ai-dial-admin/src/components/EntityProperties/EntityProperties.tsx
@@ -73,9 +73,7 @@ const EntityProperties: FC<Props> = ({ entity, runners, names, view, updateEntit
         {view === ApplicationRoute.Applications && (
           <ApplicationSource entity={entity} onChangeEntity={updateEntity} runners={runners} isEntityImmutable={true} />
         )}
-        <div className="flex flex-col gap-4 lg:w-[75%]">
-          <EntityAttachments entity={entity} onChangeEntity={updateEntity} />
-        </div>
+        <EntityAttachments entity={entity} onChangeEntity={updateEntity} />
       </div>
       <div className="flex flex-col gap-4 mt-4 pt-4 lg:w-[35%]">
         <ForwardAuthTokenField view={view} entity={entity} onChangeEntity={updateEntity} />

--- a/apps/ai-dial-admin/src/components/EntityView/Properties/EntityAttachments.tsx
+++ b/apps/ai-dial-admin/src/components/EntityView/Properties/EntityAttachments.tsx
@@ -50,13 +50,14 @@ const EntityAttachments: FC<Props> = ({ entity, onChangeEntity }) => {
   );
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-4 w-full">
       <AttachmentInput
         initialValues={entity.inputAttachmentTypes}
         fieldTitle={t(AttachmentsI18nKey.Attachments)}
         placeholder={t(AttachmentsI18nKey.EnterAttachmentsTypes)}
         allValueLabel={t(ButtonsI18nKey.UseAllAttachment)}
         availableItems={mimeMapping}
+        inputClass="lg:w-[35%]"
         onChange={(values) => onChangeAttachmentTypes(values)}
       />
       {entity.inputAttachmentTypes?.length && (

--- a/apps/ai-dial-admin/src/components/ModelView/ModelProperties/ModelTypeProperties.tsx
+++ b/apps/ai-dial-admin/src/components/ModelView/ModelProperties/ModelTypeProperties.tsx
@@ -134,11 +134,7 @@ const ModelTypeProperties: FC<Props> = ({ model, onChangeModel }) => {
           </>
         )}
       </div>
-      {model.type === DialModelType.Chat && (
-        <div className="w-full flex flex-col gap-5 lg:w-[75%]">
-          <EntityAttachments entity={model} onChangeEntity={onChangeModel} />
-        </div>
-      )}
+      {model.type === DialModelType.Chat && <EntityAttachments entity={model} onChangeEntity={onChangeModel} />}
     </div>
   );
 };


### PR DESCRIPTION
**Description:**

fixed component width

Issues:

- Issue #379

**UI changes**

<img width="666" height="401" alt="image" src="https://github.com/user-attachments/assets/f0325cca-278a-498a-8b41-17c3a8cae8d1" />

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [ ] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
