### PR TITLE
fix: Default section fields show values after removing data (Issue #536)

### DIFF
--- a/apps/ai-dial-admin/src/app/[lang]/interceptors/actions.ts
+++ b/apps/ai-dial-admin/src/app/[lang]/interceptors/actions.ts
@@ -23,7 +23,7 @@ export async function updateInterceptor(interceptor: DialInterceptor) {
     ...interceptor,
     defaults: convertDefaultsToRecord(interceptor.defaultsTemp || []),
   };
-  delete interceptor.defaultsTemp;
+  delete newInterceptor.defaultsTemp;
   return interceptorsApi.updateInterceptor(newInterceptor, token);
 }
 

--- a/apps/ai-dial-admin/src/app/[lang]/models/actions.ts
+++ b/apps/ai-dial-admin/src/app/[lang]/models/actions.ts
@@ -41,7 +41,7 @@ export async function updateModel(model: DialModel, etag?: string) {
     ...model,
     defaults: convertDefaultsToRecord(model.defaultsTemp || []),
   };
-  delete model.defaultsTemp;
+  delete newModel.defaultsTemp;
   return modelsApi.updateModel(newModel, token, etag);
 }
 

--- a/apps/ai-dial-admin/src/components/Defaults/Defaults.tsx
+++ b/apps/ai-dial-admin/src/components/Defaults/Defaults.tsx
@@ -22,6 +22,7 @@ const Defaults: FC<Props> = ({ entity, onChangeEntity }) => {
 
   const [defaultItems, setDefaultItems] = useState<DefaultTemp[]>([]);
   const [isCollapsed, setIsCollapsed] = useState(true);
+  const [count, setCount] = useState(0);
 
   const toggleCollapse = useCallback(() => {
     setIsCollapsed((prev) => !prev);
@@ -58,6 +59,14 @@ const Defaults: FC<Props> = ({ entity, onChangeEntity }) => {
     }
   }, [entity.defaults, entity.defaultsTemp]);
 
+  useEffect(() => {
+    if (defaultItems.length === 1 && !defaultItems[0].key && !defaultItems[0].value) {
+      setCount(0);
+    } else {
+      setCount(defaultItems.length);
+    }
+  }, [defaultItems]);
+
   return (
     <div className="flex flex-col p-4 rounded border border-primary">
       <button className="flex items-center justify-between" onClick={toggleCollapse}>
@@ -66,7 +75,7 @@ const Defaults: FC<Props> = ({ entity, onChangeEntity }) => {
             {isCollapsed ? <IconChevronRight {...BASE_ICON_PROPS} /> : <IconChevronDown {...BASE_ICON_PROPS} />}
           </i>
           <h3 className="mx-2">
-            {t(EntityFieldsI18nKey.defaults)}: {defaultItems.length}
+            {t(EntityFieldsI18nKey.defaults)}: {count}
           </h3>
         </div>
       </button>

--- a/apps/ai-dial-admin/src/components/Defaults/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/Defaults/tests/utils.spec.ts
@@ -13,7 +13,7 @@ import { BooleanType } from '@/src/types/boolean';
 describe('Defaults :: utils :: convertDefaultsToArray', () => {
   test('should convert an empty object to an array with one empty item', () => {
     const result = convertDefaultsToArray({});
-    expect(result).toEqual([]);
+    expect(result).toEqual([{ key: '', value: '' }]);
   });
 
   test('should convert a record with string values to an array', () => {

--- a/apps/ai-dial-admin/src/components/Defaults/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/Defaults/tests/utils.spec.ts
@@ -194,7 +194,7 @@ describe('Defaults :: utils :: getDefaultValueByType', () => {
 
   test('should return 0 when type is number', () => {
     const result = getDefaultValueByType(DefaultItemType.number);
-    expect(result).toBe(0);
+    expect(result).toBe(undefined);
   });
 
   test('should return an empty string when type is string', () => {
@@ -216,7 +216,7 @@ describe('Defaults :: utils :: getValueByType', () => {
 
   test('should return true for any truthy value when type is boolean', () => {
     const result = getValueByType(1, DefaultItemType.boolean);
-    expect(result).toBe(true);
+    expect(result).toBe(false);
   });
 
   test('should return 0 when value is falsy and type is number', () => {
@@ -236,7 +236,7 @@ describe('Defaults :: utils :: getValueByType', () => {
 
   test('should return empty string for value undefined when type is string', () => {
     const result = getValueByType(undefined, DefaultItemType.string);
-    expect(result).toBe('undefined');
+    expect(result).toBe('');
   });
 
   test('should return string value when type is string', () => {
@@ -246,7 +246,7 @@ describe('Defaults :: utils :: getValueByType', () => {
 
   test('should return string value for null or undefined if no type is passed', () => {
     const result = getValueByType(undefined);
-    expect(result).toBe('undefined');
+    expect(result).toBe('');
   });
 
   test('should return string value for any non-matching type', () => {

--- a/apps/ai-dial-admin/src/components/Defaults/utils.ts
+++ b/apps/ai-dial-admin/src/components/Defaults/utils.ts
@@ -13,6 +13,9 @@ export const convertDefaultsToArray = (defaults: Record<string, DefaultsValue>) 
     key,
     value,
   }));
+  if (array.length === 0) {
+    array.push({ key: '', value: '' });
+  }
   return array;
 };
 
@@ -28,11 +31,10 @@ export const convertDefaultsToRecord = (
   const record: Record<string, string | number | boolean> = {};
 
   for (const { key, value } of defaults) {
-    if (key) {
+    if (key && typeof value === 'number' ? !isNaN(value) : true) {
       record[key] = value;
     }
   }
-
   return record;
 };
 
@@ -57,12 +59,12 @@ export const getDefaultValueType = (value?: DefaultsValue): keyof typeof Default
  * @param {DefaultItemType} type - type (string | number | boolean )
  * @returns {DefaultsValue} - correct type value
  */
-export const getDefaultValueByType = (type: DefaultItemType): DefaultsValue => {
+export const getDefaultValueByType = (type: DefaultItemType): DefaultsValue | undefined => {
   switch (type) {
     case DefaultItemType.boolean:
       return false;
     case DefaultItemType.number:
-      return 0;
+      return undefined;
     default:
       return '';
   }
@@ -78,10 +80,10 @@ export const getDefaultValueByType = (type: DefaultItemType): DefaultsValue => {
 export const getValueByType = (value?: DefaultsValue, type?: DefaultItemType): DefaultsValue => {
   switch (type) {
     case DefaultItemType.boolean:
-      return value !== BooleanType.false;
+      return value === BooleanType.true;
     case DefaultItemType.number:
       return Number(value);
     default:
-      return String(value);
+      return value || '';
   }
 };

--- a/apps/ai-dial-admin/src/components/Defaults/utils.ts
+++ b/apps/ai-dial-admin/src/components/Defaults/utils.ts
@@ -84,6 +84,6 @@ export const getValueByType = (value?: DefaultsValue, type?: DefaultItemType): D
     case DefaultItemType.number:
       return Number(value);
     default:
-      return value || '';
+      return value ? String(value) : '';
   }
 };

--- a/apps/ai-dial-admin/src/components/InterceptorsList/InterceptorProperties.tsx
+++ b/apps/ai-dial-admin/src/components/InterceptorsList/InterceptorProperties.tsx
@@ -4,7 +4,7 @@ import { FC } from 'react';
 
 import { getInterceptorTemplatesList } from '@/src/app/[lang]/interceptor-templates/actions';
 import { getInterceptorContainers } from '@/src/app/[lang]/interceptors/actions';
-import Defaults from '@/src/components/Defaults/Defaults';
+// import Defaults from '@/src/components/Defaults/Defaults';
 import MaintainerControl from '@/src/components/EntityMainProperties/BaseProperties/Maintainer';
 import SimpleEntityProperties from '@/src/components/EntityMainProperties/SimpleEntityProperties';
 import ForwardAuthTokenField from '@/src/components/EntityView/Properties/ForwardAuthToken/ForwardAuthTokenField';
@@ -50,7 +50,7 @@ const InterceptorProperties: FC<Props> = ({ selectedInterceptor, names, onChange
           elementId={'sourceType'}
           fieldTitle={t(EntitiesI18nKey.SourceType)}
         />
-        <Defaults entity={selectedInterceptor} onChangeEntity={onChangeInterceptor} />
+        {/* <Defaults entity={selectedInterceptor} onChangeEntity={onChangeInterceptor} /> */}
       </div>
     </div>
   );


### PR DESCRIPTION
**Description:**

- temporary hide Defaults section for interceptor
- fixed initial view when defaults is empty
- changed type change values

Issues:

- Issue #536

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
