### PR TITLE
fix: Folder list long names

### DIFF
--- a/apps/ai-dial-admin/src/components/Common/FolderList/FolderList.tsx
+++ b/apps/ai-dial-admin/src/components/Common/FolderList/FolderList.tsx
@@ -13,6 +13,7 @@ import {
   getRenameFolderOperation,
 } from '@/src/components/Common/FolderCreate/utils';
 import NoDataContent from '@/src/components/Common/NoData/NoData';
+import Tooltip from '@/src/components/Common/Tooltip/Tooltip';
 import { ROOT_FOLDER } from '@/src/constants/file';
 import { EntitiesI18nKey, FoldersI18nKey } from '@/src/constants/i18n';
 import { BASE_ICON_PROPS } from '@/src/constants/main-layout';
@@ -188,22 +189,25 @@ const FolderList: FC<Props> = ({
               <div
                 className={`group ${baseClass} ${selectedClass} ${isMovableFolder && 'pointer-events-none'} ${isMoveError ? 'bg-error border-l-error' : ''} py-2`}
               >
-                <div className="flex-1 flex flex-row" onClick={() => folderContext?.toggleFolder(node)}>
+                <div className="flex-1 flex flex-row truncate" onClick={() => folderContext?.toggleFolder(node)}>
                   <div className={classNames(iconClass, 'flex items-center justify-center')}>
                     {isExpanded ? (
-                      <IconCaretDownFilled {...BASE_ICON_PROPS} widths={10} height={10} />
+                      <IconCaretDownFilled {...BASE_ICON_PROPS} widths={10} height={10} className="flex-shrink-0" />
                     ) : (
-                      <IconCaretRightFilled {...BASE_ICON_PROPS} widths={10} height={10} />
+                      <IconCaretRightFilled {...BASE_ICON_PROPS} widths={10} height={10} className="flex-shrink-0" />
                     )}
                   </div>
                   <IconFolder
                     {...BASE_ICON_PROPS}
                     className={classNames(
+                      'flex-shrink-0',
                       isMoveError ? 'text-error' : '',
                       isMovableFolder || isFolderDelete ? 'text-accent-primary' : '',
                     )}
                   />
-                  <span className="pl-2 text-primary">{name}</span>
+                  <Tooltip tooltip={name}>
+                    <span className="pl-2 text-primary truncate">{name}</span>
+                  </Tooltip>
                 </div>
 
                 {showFolderActions && (


### PR DESCRIPTION
**Description:**

support long folder name

**UI changes**

<img width="295" height="115" alt="image" src="https://github.com/user-attachments/assets/e2ffddcf-4976-4d98-9b04-b5979333ebeb" />
<img width="335" height="249" alt="image" src="https://github.com/user-attachments/assets/8351bd46-3192-4e78-b4a5-56775205563c" />


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like API keys or any other secrets and private URLs
