### PR TITLE
feat(toolsets): incorrect configuration path on toolset creation (Issue #700)

### DIFF
--- a/apps/ai-dial-admin/src/components/SourceField/SourceField.tsx
+++ b/apps/ai-dial-admin/src/components/SourceField/SourceField.tsx
@@ -85,7 +85,7 @@ const SourceField = <T extends DialInterceptor | DialModel | Toolset>({
         ...entity,
         source: {
           $type: sourceItems[0].id,
-          completionEndpointPath: view === ApplicationRoute.Models ? getEndpointPostfix(DialModelType.Chat) : '',
+          completionEndpointPath: view === ApplicationRoute.Models ? getEndpointPostfix(DialModelType.Chat) : null,
         },
       });
     } else {

--- a/apps/ai-dial-admin/src/components/SourceField/types.ts
+++ b/apps/ai-dial-admin/src/components/SourceField/types.ts
@@ -10,6 +10,6 @@ export interface SOURCE_FIELD {
   runnerName?: string;
   adapterName?: string;
   containerId?: string;
-  completionEndpointPath?: string;
+  completionEndpointPath?: string | null;
   configurationEndpointPath?: string;
 }


### PR DESCRIPTION
**Description:**

Configuration path by default should be null in toolset

Issues:

- Issue #700

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:` or `hotfix:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:` or `hotfix!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like private URLs or any other secrets.
