### PR TITLE
fix: [Prompts] Literal values of prompts version are reset when a user saved one and opened prompts list (Issue #28)

### DIFF
--- a/apps/ai-dial-admin/src/components/Assets/utils.ts
+++ b/apps/ai-dial-admin/src/components/Assets/utils.ts
@@ -7,7 +7,7 @@ export const filterLatestVersions = (data: (DialPrompt | DialAssetApp)[]) => {
 
   data?.forEach((item) => {
     const name = item.name as string;
-    if (!latestVersions[name] || item.updateTime > latestVersions[name].updateTime) {
+    if (!latestVersions[name] || compareVersions(item.version, latestVersions[name].version) > 0) {
       latestVersions[name] = item as DialPrompt;
     }
   });


### PR DESCRIPTION
**Description:**

reverted latest version showing

Issues:

- Issue #28

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:` or `hotfix:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:` or `hotfix!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like private URLs or any other secrets.
