### PR TITLE
fix: [JSON editor] A user can click save after adding the same ID for Toolsets without error, and a user gets not valid error after saving the same ID Assets Toolsets and Applications, and a user can save the same Display name for Prompts (Issue #1079)

### DIFF
--- a/apps/ai-dial-admin/src/components/Toolsets/View/View.tsx
+++ b/apps/ai-dial-admin/src/components/Toolsets/View/View.tsx
@@ -136,12 +136,16 @@ const ToolsetView: FC<Props> = ({ names, etag, roles, originalToolset }) => {
   }, [selectedFormat, selectedToolset, originalToolset.name, etag, showNotification, t, router]);
 
   const onTryToSave = useCallback(() => {
-    if (selectedFormat !== ExportFormat.CORE && isDisableRole(selectedToolset as EntityRoleLimits)) {
+    if (
+      selectedFormat !== ExportFormat.CORE &&
+      isDisableRole(selectedToolset as EntityRoleLimits) &&
+      !jsonEditorEnabled
+    ) {
       setIsModalOpen(true);
     } else {
       onSave();
     }
-  }, [onSave, selectedFormat, selectedToolset]);
+  }, [jsonEditorEnabled, onSave, selectedFormat, selectedToolset]);
 
   return (
     <div className="flex flex-col flex-1 min-h-0 w-full bg-layer-2 rounded p-4 pb-14 lg:pb-4 relative">


### PR DESCRIPTION
**Description:**

changed toolset save from json editor

Issues:

- Issue #1079

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:` or `hotfix:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:` or `hotfix!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like private URLs or any other secrets.
