### PR TITLE
fix: [ Entities --> Routes] Paths validation rules should be the same on FE&BE side (Issue #1390)

### DIFF
--- a/apps/ai-dial-admin/src/locales/en.ts
+++ b/apps/ai-dial-admin/src/locales/en.ts
@@ -1004,7 +1004,8 @@ export default {
     SystemUnavailable: 'The system is temporarily unavailable due to a technical update.',
     TryAgainLater: 'Please try again later.',
     RequiredProperty: 'This property is required',
-    InvalidPath: 'Path must start with / and use only letters, digits, - , and _',
+    InvalidPath:
+      'Invalid route path. Path must be a valid plain path (starting with /) or a valid regular expression pattern (starting with / or ^/)',
     InvalidStatus: 'Status must be a number from 100 to 999',
     UrlField: 'This field must be a valid URL starting with  http:// or https://',
     WarningEndpoint: 'The endpoint uses HTTP instead of HTTPS. This may expose data to security risks.',

--- a/apps/ai-dial-admin/src/utils/validation/path-error.ts
+++ b/apps/ai-dial-admin/src/utils/validation/path-error.ts
@@ -1,39 +1,104 @@
 import { ErrorI18nKey } from '@/src/constants/i18n';
 import { ErrorType } from '@/src/types/error-type';
 
-const META_SYMBOLS_REGEX = /.*[[\]()^$|{}\\].*/;
-const PATH_REGEX = /^\/?(?!.*\/\/)[\w\-./]*$/;
+const META_SYMBOLS_REGEX = /.*[()[\]{}*+?.^$|\\].*/;
+const PLAIN_PATH_PATTERN = /^\/[a-zA-Z0-9_\-./]+$/;
+export const MAX_LENGTH = 4096;
 
 export const isContainRegexSymbols = (path: string): boolean => {
-  return META_SYMBOLS_REGEX.test(path) || path.includes('*') || path.includes('?') || path.includes('+');
+  return META_SYMBOLS_REGEX.test(path);
 };
 
-export const isValidUrlPath = (urlPath: string): boolean => {
-  if (urlPath === '') {
+export const areBracketsBalanced = (pattern: string): boolean => {
+  const stack = [];
+
+  for (let i = 0; i < pattern.length; i++) {
+    let c = pattern[i];
+
+    // Skip escaped characters
+    if (c === '\\' && i + 1 < pattern.length) {
+      i++; // Skip the next character as it's escaped
+      continue;
+    }
+
+    // Handle opening brackets
+    if (c === '(' || c === '[' || c === '{') {
+      stack.push(c);
+    } else if (c === ')') {
+      // Handle closing brackets
+      if (stack.length === 0 || stack.pop() !== '(') {
+        return false;
+      }
+    } else if (c === ']') {
+      if (stack.length === 0 || stack.pop() !== '[') {
+        return false;
+      }
+    } else if (c === '}') {
+      if (stack.length === 0 || stack.pop() !== '{') {
+        return false;
+      }
+    }
+  }
+
+  return stack.length === 0;
+};
+
+export const validateRegexPattern = (pattern: string): boolean => {
+  // Must start with / or ^/ or ^/+ for HTTP paths
+  // ^/+ means ^ followed by one or more /, so ^/ covers the minimum case
+  if (!pattern.startsWith('/') && !pattern.startsWith('^/')) {
     return false;
   }
 
-  let path = urlPath;
-  if (!path.startsWith('/')) {
-    path = '/' + path;
+  // Check balanced brackets: (), [], {}
+  if (!areBracketsBalanced(pattern)) {
+    return false;
   }
 
-  return PATH_REGEX.test(path);
+  // Must compile as valid JavaScript regex
+  try {
+    new RegExp(pattern); // Validate if the pattern is a valid regex
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const validatePlainPath = (path: string): boolean => {
+  // Must start with /
+  if (!path.startsWith('/')) {
+    return false;
+  }
+
+  // Root path / is valid
+  if (path === '/') {
+    return true;
+  }
+
+  // No consecutive slashes
+  if (path.includes('//')) {
+    return false;
+  }
+
+  // Check pattern: only letters, digits, hyphens, underscores, dots, and slashes
+  if (!PLAIN_PATH_PATTERN.test(path)) {
+    return false;
+  }
+
+  return true;
 };
 
 export const isValidRoutePath = (path: string): boolean => {
   if (path === '') {
     return true;
   }
-  if (isContainRegexSymbols(path)) {
-    try {
-      new RegExp(path);
-      return true;
-    } catch {
-      return false;
-    }
+  if (path.length > MAX_LENGTH) {
+    return false;
   }
-  return isValidUrlPath(path);
+  if (isContainRegexSymbols(path)) {
+    return validateRegexPattern(path);
+  }
+  return validatePlainPath(path);
 };
 
 export const isValidPaths = (paths: string[]): boolean => {

--- a/apps/ai-dial-admin/src/utils/validation/path-error.ts
+++ b/apps/ai-dial-admin/src/utils/validation/path-error.ts
@@ -101,11 +101,6 @@ export const isValidRoutePath = (path: string): boolean => {
   return validatePlainPath(path);
 };
 
-export const isValidPaths = (paths: string[]): boolean => {
-  const validPaths = paths.filter((path) => !!getErrorForPath(path));
-  return !(validPaths.length === 0);
-};
-
 export const getErrorForPath = (path?: string, t?: (str: string) => string) => {
   const isEmptyPath = !path || path === '';
   const isInvalid = path && !isValidRoutePath(path);

--- a/apps/ai-dial-admin/src/utils/validation/tests/path-error.spec.ts
+++ b/apps/ai-dial-admin/src/utils/validation/tests/path-error.spec.ts
@@ -1,6 +1,15 @@
 import { describe, expect, test, vi } from 'vitest';
 import { ErrorType } from '@/src/types/error-type';
-import { getErrorForPath, isValidPaths, isContainRegexSymbols, isValidUrlPath, isValidRoutePath } from '../path-error';
+import {
+  getErrorForPath,
+  isValidPaths,
+  isContainRegexSymbols,
+  isValidRoutePath,
+  areBracketsBalanced,
+  validateRegexPattern,
+  validatePlainPath,
+  MAX_LENGTH,
+} from '../path-error';
 
 describe('isContainRegexSymbols', () => {
   test('should return true for string with regex metacharacters', () => {
@@ -41,83 +50,158 @@ describe('isContainRegexSymbols', () => {
   });
 });
 
-describe('isValidUrlPath', () => {
-  test('should return false for an empty string', () => {
-    expect(isValidUrlPath('')).toBe(false);
+describe('areBracketsBalanced', () => {
+  test('should return true for an empty string', () => {
+    expect(areBracketsBalanced('')).toBe(true);
   });
 
-  test('should return true for valid URL paths', () => {
-    expect(isValidUrlPath('/valid/path')).toBe(true);
-    expect(isValidUrlPath('valid/path')).toBe(true);
-    expect(isValidUrlPath('/my-resource')).toBe(true);
-    expect(isValidUrlPath('/folder/1')).toBe(true);
+  test('should return true for balanced brackets', () => {
+    expect(areBracketsBalanced('()')).toBe(true);
+    expect(areBracketsBalanced('{}[]()')).toBe(true);
+    expect(areBracketsBalanced('({[]})')).toBe(true);
   });
 
-  test('should return false for invalid URL paths', () => {
-    expect(isValidUrlPath('invalid|path')).toBe(false);
-    expect(isValidUrlPath('/invalid$path')).toBe(false);
-    expect(isValidUrlPath('/path/with space')).toBe(false);
-    expect(isValidUrlPath('/path//double-slash')).toBe(false);
+  test('should return false for unbalanced brackets', () => {
+    expect(areBracketsBalanced('(')).toBe(false);
+    expect(areBracketsBalanced('([)]')).toBe(false);
+    expect(areBracketsBalanced('({[})')).toBe(false);
+    expect(areBracketsBalanced(')(')).toBe(false);
+    expect(areBracketsBalanced('[](')).toBe(false);
   });
 
-  test('should add a leading slash to paths without one', () => {
-    expect(isValidUrlPath('validPathWithoutSlash')).toBe(true);
-    expect(isValidUrlPath('my-resource')).toBe(true);
+  test('should ignore escaped characters and return true for balanced brackets', () => {
+    expect(areBracketsBalanced('\\(')).toBe(true);
+    expect(areBracketsBalanced('()\\(')).toBe(true);
+    expect(areBracketsBalanced('({\\[})')).toBe(true);
   });
 
-  test('should return false for paths with special characters that are invalid', () => {
-    expect(isValidUrlPath('/foo@bar')).toBe(false);
-    expect(isValidUrlPath('/foo&bar')).toBe(false);
+  test('should return false for unbalanced brackets with escaped characters', () => {
+    expect(areBracketsBalanced('([\\])')).toBe(false);
   });
 
-  test('should return true for valid paths with common characters', () => {
-    expect(isValidUrlPath('/user/profile')).toBe(true);
-    expect(isValidUrlPath('/file-name')).toBe(true);
-    expect(isValidUrlPath('/folder1/subfolder2')).toBe(true);
+  test('should return true for balanced brackets with mixed types', () => {
+    expect(areBracketsBalanced('{[()]}')).toBe(true);
+    expect(areBracketsBalanced('({[()()]})')).toBe(true);
+  });
+
+  test('should return false when there are extra closing brackets', () => {
+    expect(areBracketsBalanced('([{}))')).toBe(false);
+    expect(areBracketsBalanced('{[}')).toBe(false);
+  });
+
+  test('should return false when there are extra opening brackets', () => {
+    expect(areBracketsBalanced('(((')).toBe(false);
+    expect(areBracketsBalanced('[{')).toBe(false);
+  });
+});
+
+describe('validateRegexPattern', () => {
+  test('should return true for valid patterns starting with / or ^/', () => {
+    expect(validateRegexPattern('/abc/')).toBe(true);
+    expect(validateRegexPattern('^/path/to/resource')).toBe(true);
+    expect(validateRegexPattern('^/user/\\d+/profile')).toBe(true);
+  });
+
+  test('should return false for patterns that don’t start with / or ^/', () => {
+    expect(validateRegexPattern('abc/')).toBe(false);
+    expect(validateRegexPattern('user/profile')).toBe(false);
+    expect(validateRegexPattern('^user/profile')).toBe(false);
+  });
+
+  test('should return false for unbalanced brackets', () => {
+    expect(validateRegexPattern('/[abc/')).toBe(false);
+    expect(validateRegexPattern('/(abc')).toBe(false);
+    expect(validateRegexPattern('/{abc')).toBe(false);
+  });
+
+  test('should return false for invalid regex patterns', () => {
+    expect(validateRegexPattern('/abc[')).toBe(false);
+    expect(validateRegexPattern('/^+*/')).toBe(false);
+    expect(validateRegexPattern('/\\d+[')).toBe(false);
+  });
+
+  test('should return false for empty pattern', () => {
+    expect(validateRegexPattern('')).toBe(false);
+  });
+});
+
+describe('validatePlainPath', () => {
+  test('should return true for a root path', () => {
+    expect(validatePlainPath('/')).toBe(true);
+  });
+
+  test('should return true for valid paths with allowed characters', () => {
+    expect(validatePlainPath('/user/profile')).toBe(true);
+    expect(validatePlainPath('/user_profile/123')).toBe(true);
+    expect(validatePlainPath('/abc/def-ghi/xyz.123')).toBe(true);
+  });
+
+  test('should return false for paths that don’t start with /', () => {
+    expect(validatePlainPath('user/profile')).toBe(false);
+  });
+
+  test('should return false for paths with consecutive slashes', () => {
+    expect(validatePlainPath('/user//profile')).toBe(false);
+  });
+
+  test('should return false for paths with invalid characters', () => {
+    expect(validatePlainPath('/user|profile')).toBe(false);
+    expect(validatePlainPath('/user@profile')).toBe(false);
+    expect(validatePlainPath('/user#profile')).toBe(false);
+    expect(validatePlainPath('/user profile')).toBe(false);
+  });
+
+  test('should return false for empty path', () => {
+    expect(validatePlainPath('')).toBe(false);
+  });
+
+  test('should return false for paths with only slashes', () => {
+    expect(validatePlainPath('///')).toBe(false);
+  });
+
+  test('should return true for a path with a dot', () => {
+    expect(validatePlainPath('/file.txt')).toBe(true);
+  });
+
+  test('should return false for a path with spaces', () => {
+    expect(validatePlainPath('/user name/profile')).toBe(false);
   });
 });
 
 describe('isValidRoutePath', () => {
-  test('should return true for an empty string', () => {
+ test('should return true for an empty path', () => {
     expect(isValidRoutePath('')).toBe(true);
   });
 
-  test('should return true for a valid regex pattern', () => {
-    expect(isValidRoutePath('[a-z]+')).toBe(true);
-    expect(isValidRoutePath('foo*bar')).toBe(true);
+ test('should return false for paths exceeding the maximum length', () => {
+    const longPath = 'a'.repeat(MAX_LENGTH + 1);
+    expect(isValidRoutePath(longPath)).toBe(false); 
   });
 
-  test('should return false for an invalid regex pattern', () => {
-    expect(isValidRoutePath('(foo|bar')).toBe(false);
+ test('should return true for valid regex paths', () => {
+    expect(isValidRoutePath('/abc/*')).toBe(true);
+    expect(isValidRoutePath('/user/\\d+/profile')).toBe(true);
   });
 
-  test('should return false for a string with regex symbols that is not a valid regex', () => {
-    expect(isValidRoutePath('[a-z')).toBe(false);
+ test('should return false for invalid regex patterns', () => {
+    expect(isValidRoutePath('/abc[')).toBe(false);
+    expect(isValidRoutePath('/^+*/')).toBe(false);
   });
 
-  test('should return true for valid URL paths', () => {
-    expect(isValidRoutePath('/valid/path')).toBe(true);
-    expect(isValidRoutePath('valid/path')).toBe(true);
-    expect(isValidRoutePath('/my-resource')).toBe(true);
-    expect(isValidRoutePath('/folder/1')).toBe(true);
+ test('should return true for valid plain paths', () => {
+    expect(isValidRoutePath('/user/profile')).toBe(true);
+    expect(isValidRoutePath('/abc/def-ghi/xyz.123')).toBe(true); 
   });
 
-  test('should return true for valid non-regex, non-URL paths', () => {
-    expect(isValidRoutePath('/home')).toBe(true);
-    expect(isValidRoutePath('/about-us')).toBe(true);
-    expect(isValidRoutePath('my-resource')).toBe(true);
+ test('should return false for invalid plain paths', () => {
+    expect(isValidRoutePath('/user>profile')).toBe(false);
+    expect(isValidRoutePath('/user@profile')).toBe(false); 
+    expect(isValidRoutePath('/user profile')).toBe(false);
   });
 
-  test('should return true for an empty path', () => {
-    expect(isValidRoutePath('')).toBe(true);
-  });
-
-  test('should return true for a valid path with a leading slash', () => {
-    expect(isValidRoutePath('/path/to/resource')).toBe(true);
-  });
-
-  test('should return true for valid paths without a leading slash', () => {
-    expect(isValidRoutePath('path/to/resource')).toBe(true);
+ test('should return true for valid plain paths with letters, digits, hyphens, and slashes', () => {
+    expect(isValidRoutePath('/user/123-profile')).toBe(true);
+    expect(isValidRoutePath('/home/abc/xyz')).toBe(true);
   });
 });
 

--- a/apps/ai-dial-admin/src/utils/validation/tests/path-error.spec.ts
+++ b/apps/ai-dial-admin/src/utils/validation/tests/path-error.spec.ts
@@ -2,7 +2,6 @@ import { describe, expect, test, vi } from 'vitest';
 import { ErrorType } from '@/src/types/error-type';
 import {
   getErrorForPath,
-  isValidPaths,
   isContainRegexSymbols,
   isValidRoutePath,
   areBracketsBalanced,
@@ -169,37 +168,37 @@ describe('validatePlainPath', () => {
 });
 
 describe('isValidRoutePath', () => {
- test('should return true for an empty path', () => {
+  test('should return true for an empty path', () => {
     expect(isValidRoutePath('')).toBe(true);
   });
 
- test('should return false for paths exceeding the maximum length', () => {
+  test('should return false for paths exceeding the maximum length', () => {
     const longPath = 'a'.repeat(MAX_LENGTH + 1);
-    expect(isValidRoutePath(longPath)).toBe(false); 
+    expect(isValidRoutePath(longPath)).toBe(false);
   });
 
- test('should return true for valid regex paths', () => {
+  test('should return true for valid regex paths', () => {
     expect(isValidRoutePath('/abc/*')).toBe(true);
     expect(isValidRoutePath('/user/\\d+/profile')).toBe(true);
   });
 
- test('should return false for invalid regex patterns', () => {
+  test('should return false for invalid regex patterns', () => {
     expect(isValidRoutePath('/abc[')).toBe(false);
     expect(isValidRoutePath('/^+*/')).toBe(false);
   });
 
- test('should return true for valid plain paths', () => {
+  test('should return true for valid plain paths', () => {
     expect(isValidRoutePath('/user/profile')).toBe(true);
-    expect(isValidRoutePath('/abc/def-ghi/xyz.123')).toBe(true); 
+    expect(isValidRoutePath('/abc/def-ghi/xyz.123')).toBe(true);
   });
 
- test('should return false for invalid plain paths', () => {
+  test('should return false for invalid plain paths', () => {
     expect(isValidRoutePath('/user>profile')).toBe(false);
-    expect(isValidRoutePath('/user@profile')).toBe(false); 
+    expect(isValidRoutePath('/user@profile')).toBe(false);
     expect(isValidRoutePath('/user profile')).toBe(false);
   });
 
- test('should return true for valid plain paths with letters, digits, hyphens, and slashes', () => {
+  test('should return true for valid plain paths with letters, digits, hyphens, and slashes', () => {
     expect(isValidRoutePath('/user/123-profile')).toBe(true);
     expect(isValidRoutePath('/home/abc/xyz')).toBe(true);
   });
@@ -260,20 +259,5 @@ describe('getErrorForPath', () => {
     const validPath = '/valid-path_123';
     const res = getErrorForPath(validPath);
     expect(res).toBeNull();
-  });
-});
-
-describe('isValidPaths', () => {
-  test('should return false for empty array', () => {
-    expect(isValidPaths([])).toBe(false);
-  });
-
-  test('should return false if all paths are valid', () => {
-    expect(isValidPaths(['validPath'])).toBe(false);
-  });
-
-  test('should return true if any path is invalid', () => {
-    expect(isValidPaths([''])).toBe(true);
-    expect(isValidPaths(['validPath', ''])).toBe(true);
   });
 });


### PR DESCRIPTION
**Description:**

changed validation according to BE

Issues:

- Issue #1390

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:` or `hotfix:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:` or `hotfix!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like private URLs or any other secrets.
