### PR TITLE
fix: [Assets / Applications] Cannot edit Key values in Parameters tab — Save button becomes inactive (Issue #1434)

### DIFF
--- a/apps/ai-dial-admin/src/components/Applications/ParametersTab/utils.ts
+++ b/apps/ai-dial-admin/src/components/Applications/ParametersTab/utils.ts
@@ -237,6 +237,7 @@ export const getAppPropertiesColumns = (
             component: JsonEditorCellRenderer,
             params: {
               onChange: onChangeJSON,
+              disableValidation: true,
             },
           };
         } else if (params.data.type == 'boolean') {

--- a/apps/ai-dial-admin/src/components/Common/JsonEditorInput/JsonEditorInput.tsx
+++ b/apps/ai-dial-admin/src/components/Common/JsonEditorInput/JsonEditorInput.tsx
@@ -14,9 +14,18 @@ interface Props {
   disabled?: boolean;
   inputClassName?: string;
   onChangeValue: (json: object) => void;
+  disableValidation?: boolean;
 }
 
-const JsonEditorInput: FC<Props> = ({ value, disabled, fieldTitle, elementId, inputClassName, onChangeValue }) => {
+const JsonEditorInput: FC<Props> = ({
+  value,
+  disabled,
+  fieldTitle,
+  elementId,
+  inputClassName,
+  onChangeValue,
+  disableValidation,
+}) => {
   const t = useI18n();
   const [isValid, setIsValid] = useState(false);
   const [jsonValue, setJsonValue] = useState<string | undefined>(undefined);
@@ -81,7 +90,7 @@ const JsonEditorInput: FC<Props> = ({ value, disabled, fieldTitle, elementId, in
           onSubmit={onApply}
           cancelLabel={t(ButtonsI18nKey.Cancel)}
           onCancel={onCloseModal}
-          disableSubmitButton={!isValid}
+          disableSubmitButton={!isValid && !disableValidation}
         >
           <div className="px-6 py-4 h-[540px] max-h-[35vh]">
             <JsonEditorBase value={jsonValue} onChange={onChangeJsonValue} onValidateJSON={onValidateJSON} />

--- a/apps/ai-dial-admin/src/components/Grid/CellRenderers/JsonEditorCellRenderer.tsx
+++ b/apps/ai-dial-admin/src/components/Grid/CellRenderers/JsonEditorCellRenderer.tsx
@@ -6,15 +6,28 @@ import JsonEditorInput from '@/src/components/Common/JsonEditorInput/JsonEditorI
 
 interface JsonCellRendererParams extends ICellRendererParams {
   onChange?: (value: object, data: unknown, column: string, index?: number) => void;
+  disableValidation: boolean;
 }
 
-const JsonEditorCellRenderer: FC<JsonCellRendererParams> = ({ value, data, colDef, node, onChange }) => {
+const JsonEditorCellRenderer: FC<JsonCellRendererParams> = ({
+  value,
+  data,
+  colDef,
+  node,
+  onChange,
+  disableValidation,
+}) => {
   const onChangeValue = (json: object) => {
     onChange?.(json, data, colDef?.field as string, node.rowIndex as number);
   };
   return (
     <div className="h-8 w-full">
-      <JsonEditorInput value={value as object} onChangeValue={onChangeValue} inputClassName="h-8" />
+      <JsonEditorInput
+        value={value as object}
+        onChangeValue={onChangeValue}
+        inputClassName="h-8"
+        disableValidation={disableValidation}
+      />
     </div>
   );
 };


### PR DESCRIPTION
**Description:**

 removed validation for jsoneditor in object table param

Issues:

- Issue #1434

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:` or `hotfix:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:` or `hotfix!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information like private URLs or any other secrets.
