### PR TITLE
fix: [Deployments] The URL of containers and the Value button of Secre file with an incorrect name is out of frame (Issue #2198)

### DIFF
--- a/apps/ai-dial-admin/src/components/Common/CopyButton/CopyButton.tsx
+++ b/apps/ai-dial-admin/src/components/Common/CopyButton/CopyButton.tsx
@@ -36,7 +36,7 @@ const CopyButton: FC<Props> = ({ buttonLabel, value, valueLabel, className }) =>
     />
   ) : (
     <DialIconButton
-      className={classNames('cursor-pointer text-secondary hover:text-accent-primary', className)}
+      className={classNames('cursor-pointer h-[20px] w-[20px] text-secondary hover:text-accent-primary', className)}
       aria-label="copy"
       onClick={onClick}
       icon={<IconCopy {...BASE_BUTTON_ICON_PROPS} />}


### PR DESCRIPTION
…

**Description:**

<SHORT_DESCRIPTION>

Issues:

- Issue #2198


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
