### PR TITLE
fix: [Approvals][Application/Toolset/Prompt/File]Folder Storage and Version fields are wider then specified (Issue #2458)

### DIFF
--- a/apps/ai-dial-admin/src/components/Assets/Apps/Properties.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Apps/Properties.tsx
@@ -42,7 +42,7 @@ const ApplicationAssetProperties: FC<Props> = ({ asset, runners, onChange, isPub
       />
       {isPublication && (
         <VersionControl
-          className="w-[175px]"
+          containerClassName="w-[175px]"
           version={asset.version}
           onChange={(version?: string) =>
             onChange?.({ ...asset, version: version || '', displayVersion: version || '' })

--- a/apps/ai-dial-admin/src/components/Assets/Prompts/View/Properties.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Prompts/View/Properties.tsx
@@ -69,7 +69,7 @@ const PromptProperties: FC<Props> = ({ prompt, onChangePrompt, isPublication }) 
     <div className="flex flex-col gap-y-8">
       {isPublication && (
         <VersionControl
-          className="w-[175px]"
+          containerClassName="w-[175px]"
           version={prompt.version}
           onChange={(version?: string) => onChangePrompt?.({ ...prompt, version: version || '' })}
         />

--- a/apps/ai-dial-admin/src/components/Assets/Toolsets/View/Properties/Properties.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Toolsets/View/Properties/Properties.tsx
@@ -41,7 +41,7 @@ const Properties: FC<Props> = ({ selectedToolset, onChange, isPublication }) => 
       />
       {isPublication && (
         <VersionControl
-          className="w-[175px]"
+          containerClassName="w-[175px]"
           version={selectedToolset.version}
           onChange={(version?: string) =>
             onChange?.({ ...selectedToolset, version: version || '', displayVersion: version || '' })

--- a/apps/ai-dial-admin/src/components/BaseControls/Version.tsx
+++ b/apps/ai-dial-admin/src/components/BaseControls/Version.tsx
@@ -33,11 +33,15 @@ const VersionControl: FC<Props> = ({
   onChange,
   title,
   view,
+  containerClassName,
   ...props
 }) => {
   const t = useI18n();
   const { dispatch } = useSaveValidationContext();
-  const containerClassName = useMemo(() => getControlClassName(isFullWidth), [isFullWidth]);
+  const containerClass = useMemo(
+    () => containerClassName || getControlClassName(isFullWidth),
+    [containerClassName, isFullWidth],
+  );
 
   const [versionError, setVersionError] = useState<FieldError | null>(null);
 
@@ -68,7 +72,7 @@ const VersionControl: FC<Props> = ({
       error={error || versionError?.text}
       invalid={!!error || !!versionError}
       onChange={onChangeVersion}
-      containerClassName={containerClassName}
+      containerClassName={containerClass}
       {...props}
     />
   );

--- a/apps/ai-dial-admin/src/components/Common/FilePath/FilePath.tsx
+++ b/apps/ai-dial-admin/src/components/Common/FilePath/FilePath.tsx
@@ -1,7 +1,7 @@
-import { ChangeEvent, FC, useCallback, useState } from 'react';
+import { FC, useCallback, useState } from 'react';
 import { createPortal } from 'react-dom';
 
-import { DialLabel, DialNeutralButton } from '@epam/ai-dial-ui-kit';
+import { DialInput, DialNeutralButton } from '@epam/ai-dial-ui-kit';
 import { IconFolderShare } from '@tabler/icons-react';
 
 import { FileManagerI18nKey } from '@/src/constants/i18n';
@@ -24,12 +24,8 @@ const FilePath: FC<Props> = ({ label, placeholder, disabled, value, modalTitle, 
   const t = useI18n();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const onInputChange = (event: ChangeEvent<HTMLInputElement>): void => {
-    onPathChange(event.target.value);
-  };
-
-  const onPathChange = (value: string) => {
-    onChange(value);
+  const onInputChange = (value?: string) => {
+    onChange(value || '');
   };
 
   const onOpenFilePathModal = useCallback(() => {
@@ -41,33 +37,30 @@ const FilePath: FC<Props> = ({ label, placeholder, disabled, value, modalTitle, 
   }, [setIsModalOpen]);
 
   return (
-    <div className="flex flex-col gap-y-2">
-      <DialLabel label={label} htmlFor="pathSelectButton" />
-      <div className="flex gap-2">
-        <div className={CONTROL_WITH_BUTTON_WIDTH}>
-          <input
-            disabled={disabled}
-            type="text"
-            value={value}
-            onChange={onInputChange}
-            placeholder={placeholder}
-            className="dial-input dial-input-field py-2 px-3"
-          />
-        </div>
-        <DialNeutralButton
-          disabled={disabled}
-          onClick={onOpenFilePathModal}
-          label={t(FileManagerI18nKey.Move)}
-          iconBefore={<IconFolderShare {...BASE_BUTTON_ICON_PROPS} />}
-        />
-      </div>
+    <div className="flex gap-2 items-end">
+      <DialInput
+        id="filePath"
+        disabled={disabled}
+        value={value}
+        onChange={onInputChange}
+        placeholder={placeholder}
+        labelProps={{ label }}
+        containerClassName={`${CONTROL_WITH_BUTTON_WIDTH} flex-none`}
+      />
+      <DialNeutralButton
+        disabled={disabled}
+        onClick={onOpenFilePathModal}
+        label={t(FileManagerI18nKey.Move)}
+        iconBefore={<IconFolderShare {...BASE_BUTTON_ICON_PROPS} />}
+      />
+
       {isModalOpen &&
         createPortal(
           <FilePathModal
             modalTitle={modalTitle}
             isModalOpen={isModalOpen}
             onClose={onCloseFilePathModal}
-            onApply={onPathChange}
+            onApply={onChange}
             initialPath={value}
             context={context}
           />,

--- a/apps/ai-dial-admin/src/components/Publications/View/View.tsx
+++ b/apps/ai-dial-admin/src/components/Publications/View/View.tsx
@@ -100,7 +100,10 @@ const PublicationView = <T extends Publication>({ view, publication, application
   useEffect(() => {
     if (selectedPublication.folderId === addTrailingSlash(ROOT_FOLDER)) {
       setIsPermissionsChanged(false);
-    } else {
+      return;
+    }
+
+    const timeout = setTimeout(() => {
       getReqRef.current(getRules, selectedPublication.folderId).then((res) => {
         if (res.success) {
           const rule = res.response?.[selectedPublication.folderId] || [];
@@ -110,7 +113,9 @@ const PublicationView = <T extends Publication>({ view, publication, application
           showNotificationRef.current(getErrorNotification(res.errorHeader, res.errorMessage, res.requestId));
         }
       });
-    }
+    }, 1000);
+
+    return () => clearTimeout(timeout);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedPublication.folderId]);
 


### PR DESCRIPTION
**Description:**

- corrected fields styles (version, folderId)
- added debounce for path change

Issues:

- Issue #2458

<img width="1136" height="582" alt="image" src="https://github.com/user-attachments/assets/9d25526f-f836-462f-95d1-2948c76e3fe5" />
<img width="876" height="726" alt="Screenshot 2026-03-09 161739" src="https://github.com/user-attachments/assets/1e5d04fc-48fb-4422-b35f-5dee656c5081" />



**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
