### PR TITLE
fix: [Access Management][Kyes] “Reset to default limits” option remains disabled after updating sharing limits (Issue #2472)

### DIFF
--- a/apps/ai-dial-admin/src/components/EntityView/Roles/RolesGrid.tsx
+++ b/apps/ai-dial-admin/src/components/EntityView/Roles/RolesGrid.tsx
@@ -1,10 +1,11 @@
-import { FC, useCallback, useEffect, useState } from 'react';
+import { FC, useCallback, useEffect, useRef } from 'react';
 
 import { DialGhostButton, DialPrimaryButton, DialSwitch } from '@epam/ai-dial-ui-kit';
 import { IconPlus, IconReload } from '@tabler/icons-react';
 import { GridApi, GridOptions, GridReadyEvent, IRowNode } from 'ag-grid-community';
 
 import GridView from '@/src/components/Grid/GridView/GridView';
+import { ACTIONS_COLUMN_CEL_ID } from '@/src/constants/ag-grid';
 import { ButtonsI18nKey, EntitiesI18nKey, RolesI18nKey, TabsI18nKey } from '@/src/constants/i18n';
 import { BASE_BUTTON_ICON_PROPS } from '@/src/constants/main-layout';
 import { useI18n } from '@/src/locales/client';
@@ -47,7 +48,7 @@ const RolesGrid: FC<Props> = ({
   isSkipRefresh,
 }) => {
   const t = useI18n();
-  const [gridApi, setGridApi] = useState<GridApi>();
+  const gridApiRef = useRef<GridApi | null>(null);
   const data = getRolesGridData(entity, roles);
 
   const columns = getRolesColumnDefs(
@@ -63,7 +64,7 @@ const RolesGrid: FC<Props> = ({
   );
 
   const onGridReady = (event: GridReadyEvent) => {
-    setGridApi(event.api);
+    gridApiRef.current = event.api ?? null;
     event.api?.updateGridOptions({
       columnDefs: columns,
       rowData: data,
@@ -71,13 +72,17 @@ const RolesGrid: FC<Props> = ({
   };
 
   useEffect(() => {
-    if (!isSkipRefresh && !gridApi?.isDestroyed()) {
-      gridApi?.updateGridOptions({
+    if (!isSkipRefresh && !gridApiRef.current?.isDestroyed()) {
+      gridApiRef.current?.updateGridOptions({
         columnDefs: columns,
         rowData: data,
       });
     }
-  }, [isSkipRefresh, columns, data, gridApi]);
+  }, [isSkipRefresh, columns, data]);
+
+  useEffect(() => {
+    gridApiRef.current?.refreshCells({ columns: [ACTIONS_COLUMN_CEL_ID], force: true });
+  }, [data]);
 
   const onSwitchSpecificRoles = useCallback(
     (isPublic: boolean) => {

--- a/apps/ai-dial-admin/src/components/Roles/View/Properties/Sharing.tsx
+++ b/apps/ai-dial-admin/src/components/Roles/View/Properties/Sharing.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { FC, useCallback, useEffect, useMemo, useRef } from 'react';
 
+import { DialGhostButton } from '@epam/ai-dial-ui-kit';
 import { IconReload } from '@tabler/icons-react';
 import { ColDef, GridApi, GridReadyEvent } from 'ag-grid-community';
 
@@ -14,13 +15,12 @@ import {
   getSharingData,
   isResetToDefaultHidden,
 } from '@/src/components/Roles/utils';
-import { ACTION_COLUMN } from '@/src/constants/ag-grid';
+import { ACTION_COLUMN, ACTIONS_COLUMN_CEL_ID } from '@/src/constants/ag-grid';
 import { getResetOperation } from '@/src/constants/grid-columns/actions';
 import { RolesI18nKey } from '@/src/constants/i18n';
 import { BASE_BUTTON_ICON_PROPS } from '@/src/constants/main-layout';
 import { useI18n } from '@/src/locales/client';
 import { DialRole } from '@/src/models/dial/role';
-import { DialGhostButton } from '@epam/ai-dial-ui-kit';
 
 interface Props {
   isSkipRefresh: boolean;
@@ -30,7 +30,8 @@ interface Props {
 
 const RoleSharing: FC<Props> = ({ isSkipRefresh, selectedRole, onChangeRole }) => {
   const t = useI18n();
-  const [gridApi, setGridApi] = useState<GridApi>();
+  const gridApiRef = useRef<GridApi | null>(null);
+  const entityRef = useRef(selectedRole);
 
   const onChangeTypeSharing = useCallback(
     (value: number, data: DialRole, token: string) => {
@@ -86,22 +87,18 @@ const RoleSharing: FC<Props> = ({ isSkipRefresh, selectedRole, onChangeRole }) =
       )
     );
   }, [selectedRole.share]);
-  const entityRef = useRef(selectedRole);
 
   const columns: ColDef[] = useMemo(() => {
     return [
-      ...SHARING_COLUMNS(t, onChangeTypeSharing, (node, colDef) => getDefaultPlaceholder(node, colDef)),
-      ACTION_COLUMN(
-        [getResetOperation(onResetSharingToDefault, (api, node) => isResetToDefaultHidden(api, node))],
-        true,
-      ),
+      ...SHARING_COLUMNS(t, onChangeTypeSharing, getDefaultPlaceholder),
+      ACTION_COLUMN([getResetOperation(onResetSharingToDefault, isResetToDefaultHidden)], true),
     ];
   }, [onChangeTypeSharing, onResetSharingToDefault, t]);
 
   const data = getSharingData(selectedRole);
 
   const onGridReady = (event: GridReadyEvent) => {
-    setGridApi(event.api);
+    gridApiRef.current = event.api ?? null;
     event.api?.updateGridOptions({
       columnDefs: columns,
       rowData: data,
@@ -113,13 +110,17 @@ const RoleSharing: FC<Props> = ({ isSkipRefresh, selectedRole, onChangeRole }) =
   }, [selectedRole]);
 
   useEffect(() => {
-    if (!isSkipRefresh && !gridApi?.isDestroyed()) {
-      gridApi?.updateGridOptions({
+    if (!isSkipRefresh && !gridApiRef.current?.isDestroyed()) {
+      gridApiRef.current?.updateGridOptions({
         columnDefs: columns,
         rowData: data,
       });
     }
-  }, [isSkipRefresh, columns, data, gridApi]);
+  }, [isSkipRefresh, columns, data]);
+
+  useEffect(() => {
+    gridApiRef.current?.refreshCells({ columns: [ACTIONS_COLUMN_CEL_ID], force: true });
+  }, [data]);
 
   return (
     <div className="max-w-[750px] w-full flex flex-col">


### PR DESCRIPTION
**Description:**

added action column refresh on data change

Issues:

- Issue #2472


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
