### PR TITLE
fix(deployements): disable image change modal in intermediate state (Issue #2534)

### DIFF
--- a/apps/ai-dial-admin/src/components/Containers/View/TabsContent.tsx
+++ b/apps/ai-dial-admin/src/components/Containers/View/TabsContent.tsx
@@ -1,4 +1,4 @@
-import { DialLabelledText } from '@epam/ai-dial-ui-kit';
+import { DialIconButton, DialLabelledText } from '@epam/ai-dial-ui-kit';
 import { useRouter } from 'next/navigation';
 import { FC, useCallback, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
@@ -25,6 +25,7 @@ import { Container, KubEvent, Pod } from '@/src/models/deployments/containers';
 import { Image } from '@/src/models/deployments/images';
 import { CONTAINER_STATUS } from '@/src/types/deployments/containers';
 import { ApplicationRoute } from '@/src/types/routes';
+import { isEditDisabled } from '@/src/utils/deployments/containers';
 import { getTranslatedType } from '@/src/utils/deployments/entity';
 import { getErrorNotification } from '@/src/utils/notification';
 import { EntityViewTab } from '@/src/utils/tabs/utils';
@@ -58,6 +59,7 @@ const TabsContent: FC<Props> = ({
   const { showNotification } = useNotification();
 
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const editDisabled = useMemo(() => isEditDisabled(selectedContainer), [selectedContainer]);
 
   const handleModalClose = useCallback(() => {
     setIsModalOpen(false);
@@ -88,12 +90,19 @@ const TabsContent: FC<Props> = ({
           <DialLabelledText
             label={t(ContainersI18nKey.ContainerImage, { type: getTranslatedType(route, t) })}
             text={`${image.name} (${image.version})`}
-            postfix={<OpenPopup {...BASE_BUTTON_ICON_PROPS} className="inline ml-2" onClick={handleModalOpen} />}
+            postfix={
+              <DialIconButton
+                className="size-auto ml-2 cursor-pointer text-secondary hover:text-accent-primary"
+                icon={<OpenPopup {...BASE_BUTTON_ICON_PROPS} />}
+                onClick={handleModalOpen}
+                disabled={editDisabled}
+              />
+            }
           />
         )}
       </>
     );
-  }, [handleModalOpen, image, route, t]);
+  }, [editDisabled, handleModalOpen, image, route, t]);
 
   const onApply = useCallback(
     (id: string) => {

--- a/apps/ai-dial-admin/src/utils/deployments/tests/containers.spec.ts
+++ b/apps/ai-dial-admin/src/utils/deployments/tests/containers.spec.ts
@@ -268,6 +268,8 @@ describe('containers utils', () => {
     test('should be false', () => {
       expect(isEditDisabled({ status: CONTAINER_STATUS.FAILED } as Container)).toBeFalsy();
       expect(isEditDisabled({ status: CONTAINER_STATUS.STOPPED } as Container)).toBeFalsy();
+      expect(isEditDisabled({ status: CONTAINER_STATUS.RUNNING } as Container)).toBeFalsy();
+      expect(isEditDisabled({ status: CONTAINER_STATUS.NOT_DEPLOYED } as Container)).toBeFalsy();
     });
   });
 

--- a/openspec/changes/archive/2026-03-13-disable-change-image-intermediate-status/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-13-disable-change-image-intermediate-status/.openspec.yaml
@@ -1,2 +1,2 @@
 schema: spec-driven
-created: 2026-03-04
+created: 2026-03-13

--- a/openspec/changes/archive/2026-03-13-disable-change-image-intermediate-status/design.md
+++ b/openspec/changes/archive/2026-03-13-disable-change-image-intermediate-status/design.md
@@ -1,0 +1,42 @@
+## Context
+
+The container detail view (`TabsContent.tsx`) renders an OpenPopup icon next to the container image label that opens a modal to change the image. Unlike all other editable fields in the container view, this icon is not disabled during intermediate statuses (PENDING, STOPPING).
+
+The codebase already has `isEditDisabled(container)` in `containers.ts` that returns `true` for PENDING and STOPPING. All form fields in `Properties.tsx` and `FirewallSettings.tsx` use this utility.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Disable the change image action during intermediate statuses, consistent with other controls
+- Use proper button semantics for the change image action
+
+**Non-Goals:**
+- Changing the ContainerChangeImage modal itself
+- Adding new status types or modifying existing status logic
+
+## Decisions
+
+**Replace raw OpenPopup SVG with `DialGhostButton`**
+
+The current implementation uses an OpenPopup SVG as `postfix` on `DialLabelledText` with a direct `onClick`. Since SVGs don't support `disabled`, this required workarounds (callback guards, CSS hacks). Instead, restructure to use `DialGhostButton` which:
+- Renders a native `<button>` with proper `disabled` support
+- Accepts `label` (image name + version text) and `iconAfter` (OpenPopup icon)
+- Ghost appearance keeps it visually lightweight inline with the label
+
+Layout change:
+- `DialLabelledText` keeps only the `label` prop (no `text` or `postfix`)
+- `DialGhostButton` becomes a child, containing the image text and popup icon
+
+Alternatives considered:
+1. CSS `opacity-50 pointer-events-none` on SVG — no button semantics, poor accessibility
+2. Guard in `handleModalOpen` callback — icon still looks clickable, poor UX
+3. Conditionally hide the icon — causes layout jumping
+
+**Use `isEditDisabled()` for disabled state**
+
+Same utility that guards all other fields. Computed via `useMemo` from `selectedContainer`.
+
+## Risks / Trade-offs
+
+- **Low risk**: Small change in one component, reusing existing utility and ui-kit components
+- **Visual change**: `DialGhostButton` may render slightly differently than raw text + SVG — needs visual verification

--- a/openspec/changes/archive/2026-03-13-disable-change-image-intermediate-status/proposal.md
+++ b/openspec/changes/archive/2026-03-13-disable-change-image-intermediate-status/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The "change image" button (OpenPopup icon) on the container detail view remains clickable when a container is in an intermediate status (PENDING or STOPPING). All other form fields are already disabled during these transitional states via `isEditDisabled()`, but this button was missed. Changing the image while a container is transitioning could cause conflicts or confusing behavior.
+
+## What Changes
+
+- Disable the "change image" OpenPopup icon in `TabsContent.tsx` when the container status is PENDING or STOPPING
+- Reuse the existing `isEditDisabled()` utility from `containers.ts`
+
+## Non-goals
+
+- Changing the behavior of the ContainerChangeImage modal itself
+- Adding new status types or modifying existing status logic
+- Changing backend validation
+
+## Capabilities
+
+### New Capabilities
+
+_None_
+
+### Modified Capabilities
+
+_None — this is a small UX fix using existing patterns, no spec-level behavior changes._
+
+## Impact
+
+- **Code**: `TabsContent.tsx` — the `headerPrefix` section where the OpenPopup icon is rendered
+- **UX**: Users will no longer be able to open the change image modal during transitional states, consistent with other disabled controls

--- a/openspec/changes/archive/2026-03-13-disable-change-image-intermediate-status/specs/change-image-button/spec.md
+++ b/openspec/changes/archive/2026-03-13-disable-change-image-intermediate-status/specs/change-image-button/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Change image button uses proper button semantics
+The change image action SHALL be rendered as a `DialGhostButton` with the image name and version as `label` and the OpenPopup icon as `iconAfter`. The `DialLabelledText` SHALL provide only the label, with the button as its child.
+
+#### Scenario: Button renders image name and version
+- **WHEN** a container has an associated image
+- **THEN** the change image button displays the image name and version as its label with the OpenPopup icon after it
+
+### Requirement: Change image button disabled during intermediate statuses
+The change image button SHALL be disabled via native button `disabled` prop when the container is in a PENDING or STOPPING status. The button SHALL be visually indicated as disabled and SHALL NOT open the change image modal when clicked.
+
+#### Scenario: Button disabled when container is PENDING
+- **WHEN** the container status is PENDING
+- **THEN** the change image button is natively disabled and clicking it does not open the modal
+
+#### Scenario: Button disabled when container is STOPPING
+- **WHEN** the container status is STOPPING
+- **THEN** the change image button is natively disabled and clicking it does not open the modal
+
+#### Scenario: Button enabled when container is RUNNING
+- **WHEN** the container status is RUNNING
+- **THEN** the change image button is enabled and opens the change image modal
+
+#### Scenario: Button enabled when container is STOPPED
+- **WHEN** the container status is STOPPED
+- **THEN** the change image button is enabled and opens the change image modal
+
+#### Scenario: Button enabled when container is FAILED
+- **WHEN** the container status is FAILED
+- **THEN** the change image button is enabled and opens the change image modal

--- a/openspec/changes/archive/2026-03-13-disable-change-image-intermediate-status/tasks.md
+++ b/openspec/changes/archive/2026-03-13-disable-change-image-intermediate-status/tasks.md
@@ -1,0 +1,14 @@
+## 1. Implementation
+
+- [x] 1.1 Import `isEditDisabled` from `@/src/utils/deployments/containers` in `TabsContent.tsx`
+- [x] 1.2 Compute `editDisabled` using `useMemo` with `isEditDisabled(selectedContainer)`
+- [x] 1.3 Replace `DialLabelledText` text+postfix pattern with `DialGhostButton` child: `label` for image name+version, `iconAfter` for OpenPopup, `disabled={editDisabled}`, `onClick={handleModalOpen}`
+- [x] 1.4 Remove callback guard from `handleModalOpen` (no longer needed with native button disabled)
+
+## 2. Testing
+
+- [x] 2.1 Add RUNNING and NOT_DEPLOYED cases to `isEditDisabled` tests in `containers.spec.ts`
+
+## 3. Quality Checks
+
+- [x] 3.1 Run lint, format, and test suite to verify no regressions

--- a/openspec/specs/change-image-button/spec.md
+++ b/openspec/specs/change-image-button/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Change image button uses proper button semantics
+The change image action SHALL be rendered as a `DialGhostButton` with the image name and version as `label` and the OpenPopup icon as `iconAfter`. The `DialLabelledText` SHALL provide only the label, with the button as its child.
+
+#### Scenario: Button renders image name and version
+- **WHEN** a container has an associated image
+- **THEN** the change image button displays the image name and version as its label with the OpenPopup icon after it
+
+### Requirement: Change image button disabled during intermediate statuses
+The change image button SHALL be disabled via native button `disabled` prop when the container is in a PENDING or STOPPING status. The button SHALL be visually indicated as disabled and SHALL NOT open the change image modal when clicked.
+
+#### Scenario: Button disabled when container is PENDING
+- **WHEN** the container status is PENDING
+- **THEN** the change image button is natively disabled and clicking it does not open the modal
+
+#### Scenario: Button disabled when container is STOPPING
+- **WHEN** the container status is STOPPING
+- **THEN** the change image button is natively disabled and clicking it does not open the modal
+
+#### Scenario: Button enabled when container is RUNNING
+- **WHEN** the container status is RUNNING
+- **THEN** the change image button is enabled and opens the change image modal
+
+#### Scenario: Button enabled when container is STOPPED
+- **WHEN** the container status is STOPPED
+- **THEN** the change image button is enabled and opens the change image modal
+
+#### Scenario: Button enabled when container is FAILED
+- **WHEN** the container status is FAILED
+- **THEN** the change image button is enabled and opens the change image modal


### PR DESCRIPTION
**Description:**

Block modal when container is in intermediate state

Issues:

- Issue #2534 


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
