### PR TITLE
fix: [Routes] Back 'OPTIONS' and 'TRACE' methods to routes and but leave them inaccessible for app routes (Issue #2558)

### DIFF
--- a/apps/ai-dial-admin/src/components/Routes/View/Properties/RouteProperties.tsx
+++ b/apps/ai-dial-admin/src/components/Routes/View/Properties/RouteProperties.tsx
@@ -60,7 +60,12 @@ const RouteProperties: FC<Props> = ({ route, readonly, isAppRoute, routeNames, o
     [t],
   );
 
-  const methods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD'];
+  const methods = useMemo(() => {
+    if (isAppRoute) {
+      return ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD'];
+    }
+    return ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS', 'TRACE'];
+  }, [isAppRoute]);
 
   const [statusError, setStatusError] = useState('');
   const [bodyError, setBodyError] = useState('');


### PR DESCRIPTION
**Description:**

added correct methods for app route

Issues:

- Issue #2558


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
