### PR TITLE
fix: [Entities][Properties: Sync with core] Long text is not wrapped on Admin side in Sync with Core comparison view (Issue #2564)

### DIFF
--- a/apps/ai-dial-admin/src/constants/editor.ts
+++ b/apps/ai-dial-admin/src/constants/editor.ts
@@ -77,6 +77,7 @@ const defaultOptions: EditorOptions = {
   automaticLayout: true,
   scrollBeyondLastLine: false,
   wordWrap: 'on',
+  diffWordWrap: 'on',
   smoothScrolling: true,
   overviewRulerLanes: 0,
   scrollbar: {
@@ -93,6 +94,8 @@ export const diffEditorOptions: EditorOptions = {
   renderIndicators: false,
   renderOverviewRuler: false,
   glyphMargin: false,
+  // Force side-by-side so both original and modified panes get word wrap (Monaco bug workaround)
+  useInlineViewWhenSpaceIsLimited: false,
 };
 
 export const editorOptions: EditorOptions = {


### PR DESCRIPTION
**Description:**

added workaround for diff view

Issues:

- Issue #2564


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
