### PR TITLE
feat: [Eval] added tryout response store

### DIFF
--- a/apps/ai-dial-admin/src/components/EntityView/Modals/Delete/Delete.tsx
+++ b/apps/ai-dial-admin/src/components/EntityView/Modals/Delete/Delete.tsx
@@ -22,6 +22,7 @@ import { ServerActionResponse } from '@/src/models/server-action';
 import { ApplicationRoute } from '@/src/types/routes';
 import { isAssetView, isBuildersView } from '@/src/utils/is-asset-view';
 import { getErrorNotification, getSuccessNotification } from '@/src/utils/notification';
+import { removeTryoutResponseFromStorage } from '@/src/components/TestSuites/utils/tryout-storage';
 import { getEntityPath } from '@/src/utils/open-in-new-tab';
 import { AllVersionValue } from './constants';
 import RelatedArtefacts from './RelatedArtefact';
@@ -123,6 +124,9 @@ const DeleteConfirmationModal = <T extends Artefact>({
         resArr.forEach((res, index) => {
           if (res.success) {
             showSuccessNotification(entityKeys[index]);
+            if (view === ApplicationRoute.TestSuites && id) {
+              removeTryoutResponseFromStorage(id);
+            }
           } else {
             isAllSuccess = false;
             showNotification(getErrorNotification(res.errorHeader, res.errorMessage, res.requestId));
@@ -148,6 +152,7 @@ const DeleteConfirmationModal = <T extends Artefact>({
   }, [
     view,
     entity,
+    id,
     onRemoveEntity,
     onCloseModal,
     onResetEntity,

--- a/apps/ai-dial-admin/src/components/TestSuites/RequestTemplate/components/TryOut.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/RequestTemplate/components/TryOut.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/src/app/[lang]/test-suites/actions';
 import Grafana from '@/public/images/icons/grafana.svg';
 import JsonEditor from '@/src/components/EntityTabs/JsonEditor/JsonEditor';
+import { saveTryoutResponseToStorage } from '@/src/components/TestSuites/utils/tryout-storage';
 import { convertVariableIntoInitialRequest } from '@/src/components/TestSuites/utils/template-variables';
 import { BasicI18nKey, ButtonsI18nKey, RunsI18nKey, TestSuitesI18nKey } from '@/src/constants/i18n';
 import { useAppContext } from '@/src/context/AppContext';
@@ -67,13 +68,18 @@ const TryOut: FC<Props> = ({ testSuite, testCaseId }) => {
         ? await tryOutTestCase(testSuite.id || '', testCaseId)
         : await tryOutTestSuite(testSuite.id || '', requestBody);
 
+      const testSuiteId = testSuite.id || '';
       if (res?.success) {
+        const tryoutResponse = (res.response?.response as TryOutResponse) || null;
         setResolvedRequest(res.response?.resolvedRequest || {});
-        setResponse((res.response?.response as TryOutResponse) || null);
+        setResponse(tryoutResponse);
         setGrafanaTraceUrl(res.response?.grafanaTraceUrl);
+        saveTryoutResponseToStorage(testSuiteId, tryoutResponse);
       } else {
+        const errorResponse = { error: res?.errorMessage || 'Unknown error', statusCode: 500 } as TryOutResponse;
         setResolvedRequest(requestBody || {});
-        setResponse({ error: res?.errorMessage || 'Unknown error', statusCode: 500 } as TryOutResponse);
+        setResponse(errorResponse);
+        saveTryoutResponseToStorage(testSuiteId, errorResponse);
       }
     } finally {
       setIsRequestSend(false);

--- a/apps/ai-dial-admin/src/components/TestSuites/utils/tests/tryout-storage.spec.ts
+++ b/apps/ai-dial-admin/src/components/TestSuites/utils/tests/tryout-storage.spec.ts
@@ -1,0 +1,253 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+  TEST_SUITES_TRYOUT_STORAGE_KEY,
+  getTryoutResponseFromStorage,
+  removeTryoutResponseFromStorage,
+  saveTryoutResponseToStorage,
+} from '../tryout-storage';
+
+describe('saveTryoutResponseToStorage', () => {
+  let localStorageMock: Record<string, string>;
+
+  beforeEach(() => {
+    localStorageMock = {};
+    vi.stubGlobal('localStorage', {
+      getItem: vi.fn((key: string) => localStorageMock[key] ?? null),
+      setItem: vi.fn((key: string, value: string) => {
+        localStorageMock[key] = value;
+      }),
+      removeItem: vi.fn((key: string) => {
+        delete localStorageMock[key];
+      }),
+      clear: vi.fn(() => {
+        localStorageMock = {};
+      }),
+      length: 0,
+      key: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test('should store response under testSuiteId in new map', () => {
+    saveTryoutResponseToStorage('suite-1', { statusCode: 200, data: 'ok' });
+
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      TEST_SUITES_TRYOUT_STORAGE_KEY,
+      JSON.stringify({ 'suite-1': { statusCode: 200, data: 'ok' } }),
+    );
+    expect(localStorageMock[TEST_SUITES_TRYOUT_STORAGE_KEY]).toBe(
+      JSON.stringify({ 'suite-1': { statusCode: 200, data: 'ok' } }),
+    );
+  });
+
+  test('should store null response', () => {
+    saveTryoutResponseToStorage('suite-2', null);
+
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      TEST_SUITES_TRYOUT_STORAGE_KEY,
+      JSON.stringify({ 'suite-2': null }),
+    );
+  });
+
+  test('should merge with existing map when key already exists in storage', () => {
+    localStorageMock[TEST_SUITES_TRYOUT_STORAGE_KEY] = JSON.stringify({
+      'suite-a': { statusCode: 201 },
+    });
+
+    saveTryoutResponseToStorage('suite-b', { statusCode: 200 });
+
+    expect(localStorageMock[TEST_SUITES_TRYOUT_STORAGE_KEY]).toBe(
+      JSON.stringify({
+        'suite-a': { statusCode: 201 },
+        'suite-b': { statusCode: 200 },
+      }),
+    );
+  });
+
+  test('should overwrite existing entry for same testSuiteId', () => {
+    localStorageMock[TEST_SUITES_TRYOUT_STORAGE_KEY] = JSON.stringify({
+      'suite-1': { statusCode: 500, error: 'old' },
+    });
+
+    saveTryoutResponseToStorage('suite-1', { statusCode: 200, data: 'new' });
+
+    expect(localStorageMock[TEST_SUITES_TRYOUT_STORAGE_KEY]).toBe(
+      JSON.stringify({ 'suite-1': { statusCode: 200, data: 'new' } }),
+    );
+  });
+
+  test('should not throw when getItem returns invalid JSON', () => {
+    localStorageMock[TEST_SUITES_TRYOUT_STORAGE_KEY] = 'not valid json';
+
+    expect(() => {
+      saveTryoutResponseToStorage('suite-1', { statusCode: 200 });
+    }).not.toThrow();
+  });
+
+  test('should not throw when setItem throws', () => {
+    vi.mocked(localStorage.setItem).mockImplementationOnce(() => {
+      throw new Error('QuotaExceeded');
+    });
+
+    expect(() => {
+      saveTryoutResponseToStorage('suite-1', { statusCode: 200 });
+    }).not.toThrow();
+  });
+});
+
+describe('getTryoutResponseFromStorage', () => {
+  let localStorageMock: Record<string, string>;
+
+  beforeEach(() => {
+    localStorageMock = {};
+    vi.stubGlobal('localStorage', {
+      getItem: vi.fn((key: string) => localStorageMock[key] ?? null),
+      setItem: vi.fn((key: string, value: string) => {
+        localStorageMock[key] = value;
+      }),
+      removeItem: vi.fn((key: string) => {
+        delete localStorageMock[key];
+      }),
+      clear: vi.fn(() => {
+        localStorageMock = {};
+      }),
+      length: 0,
+      key: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test('should return stored response for existing testSuiteId', () => {
+    const response = { statusCode: 200, data: 'ok' };
+    localStorageMock[TEST_SUITES_TRYOUT_STORAGE_KEY] = JSON.stringify({
+      'suite-1': response,
+    });
+
+    const result = getTryoutResponseFromStorage('suite-1');
+
+    expect(result).toEqual(response);
+  });
+
+  test('should return null when testSuiteId is not in storage', () => {
+    localStorageMock[TEST_SUITES_TRYOUT_STORAGE_KEY] = JSON.stringify({
+      'other-suite': { statusCode: 201 },
+    });
+
+    const result = getTryoutResponseFromStorage('suite-1');
+
+    expect(result).toBeNull();
+  });
+
+  test('should return null when storage key is missing', () => {
+    const result = getTryoutResponseFromStorage('suite-1');
+
+    expect(result).toBeNull();
+  });
+
+  test('should return null when stored value for testSuiteId is null', () => {
+    localStorageMock[TEST_SUITES_TRYOUT_STORAGE_KEY] = JSON.stringify({
+      'suite-1': null,
+    });
+
+    const result = getTryoutResponseFromStorage('suite-1');
+
+    expect(result).toBeNull();
+  });
+
+  test('should return correct response when map has multiple entries', () => {
+    const responseB = { statusCode: 200, id: 'b' };
+    localStorageMock[TEST_SUITES_TRYOUT_STORAGE_KEY] = JSON.stringify({
+      'suite-a': { statusCode: 201, id: 'a' },
+      'suite-b': responseB,
+      'suite-c': { statusCode: 500 },
+    });
+
+    const result = getTryoutResponseFromStorage('suite-b');
+
+    expect(result).toEqual(responseB);
+  });
+
+  test('should return null when getItem returns invalid JSON', () => {
+    localStorageMock[TEST_SUITES_TRYOUT_STORAGE_KEY] = 'not valid json';
+
+    const result = getTryoutResponseFromStorage('suite-1');
+
+    expect(result).toBeNull();
+  });
+
+  test('should return null when getItem throws', () => {
+    vi.mocked(localStorage.getItem).mockImplementationOnce(() => {
+      throw new Error('Storage unavailable');
+    });
+
+    const result = getTryoutResponseFromStorage('suite-1');
+
+    expect(result).toBeNull();
+  });
+});
+
+describe('removeTryoutResponseFromStorage', () => {
+  let localStorageMock: Record<string, string>;
+
+  beforeEach(() => {
+    localStorageMock = {};
+    vi.stubGlobal('localStorage', {
+      getItem: vi.fn((key: string) => localStorageMock[key] ?? null),
+      setItem: vi.fn((key: string, value: string) => {
+        localStorageMock[key] = value;
+      }),
+      removeItem: vi.fn((key: string) => {
+        delete localStorageMock[key];
+      }),
+      clear: vi.fn(() => {
+        localStorageMock = {};
+      }),
+      length: 0,
+      key: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test('should remove entry for testSuiteId from storage', () => {
+    localStorageMock[TEST_SUITES_TRYOUT_STORAGE_KEY] = JSON.stringify({
+      'suite-1': { statusCode: 200 },
+      'suite-2': { statusCode: 201 },
+    });
+
+    removeTryoutResponseFromStorage('suite-1');
+
+    expect(localStorageMock[TEST_SUITES_TRYOUT_STORAGE_KEY]).toBe(JSON.stringify({ 'suite-2': { statusCode: 201 } }));
+  });
+
+  test('should leave other entries when removing one', () => {
+    localStorageMock[TEST_SUITES_TRYOUT_STORAGE_KEY] = JSON.stringify({
+      'suite-a': { statusCode: 200 },
+      'suite-b': { statusCode: 201 },
+    });
+
+    removeTryoutResponseFromStorage('suite-a');
+
+    expect(JSON.parse(localStorageMock[TEST_SUITES_TRYOUT_STORAGE_KEY])).toEqual({
+      'suite-b': { statusCode: 201 },
+    });
+  });
+
+  test('should not throw when storage is empty or key missing', () => {
+    expect(() => removeTryoutResponseFromStorage('suite-1')).not.toThrow();
+  });
+
+  test('should not throw when getItem returns invalid JSON', () => {
+    localStorageMock[TEST_SUITES_TRYOUT_STORAGE_KEY] = 'not valid json';
+
+    expect(() => removeTryoutResponseFromStorage('suite-1')).not.toThrow();
+  });
+});

--- a/apps/ai-dial-admin/src/components/TestSuites/utils/tryout-storage.ts
+++ b/apps/ai-dial-admin/src/components/TestSuites/utils/tryout-storage.ts
@@ -1,0 +1,39 @@
+export const TEST_SUITES_TRYOUT_STORAGE_KEY = 'testSuitesTryout';
+
+export interface TryOutResponseStorage {
+  statusCode: number;
+  [key: string]: unknown;
+}
+
+export function saveTryoutResponseToStorage(testSuiteId: string, response: TryOutResponseStorage | null): void {
+  try {
+    const raw = localStorage.getItem(TEST_SUITES_TRYOUT_STORAGE_KEY);
+    const map: Record<string, TryOutResponseStorage | null> = raw ? JSON.parse(raw) : {};
+    map[testSuiteId] = response;
+    localStorage.setItem(TEST_SUITES_TRYOUT_STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    console.error('Failed to save tryout response to storage');
+  }
+}
+
+export function getTryoutResponseFromStorage(testSuiteId: string): TryOutResponseStorage | null {
+  try {
+    const raw = localStorage.getItem(TEST_SUITES_TRYOUT_STORAGE_KEY);
+    const map: Record<string, TryOutResponseStorage | null> = raw ? JSON.parse(raw) : {};
+    return map[testSuiteId] || null;
+  } catch {
+    console.error('Failed to get tryout response from storage');
+    return null;
+  }
+}
+
+export function removeTryoutResponseFromStorage(testSuiteId: string): void {
+  try {
+    const raw = localStorage.getItem(TEST_SUITES_TRYOUT_STORAGE_KEY);
+    const map: Record<string, TryOutResponseStorage | null> = raw ? JSON.parse(raw) : {};
+    delete map[testSuiteId];
+    localStorage.setItem(TEST_SUITES_TRYOUT_STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    console.error('Failed to remove tryout response from storage');
+  }
+}


### PR DESCRIPTION
**Description:**

added tryout response save in local storage

Issues:

- Issue #<TICKET_ID>


**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
