### PR TITLE
fix: [Assets][Files] Folder Storage tree does not auto-scroll to the selected folder when opening Manage Permissions (Issue #2492)

### DIFF
--- a/apps/ai-dial-admin/src/components/Common/FolderList/FolderList.tsx
+++ b/apps/ai-dial-admin/src/components/Common/FolderList/FolderList.tsx
@@ -73,6 +73,21 @@ const FolderList: FC<Props> = ({
 
   const showFolderActions = isAssetView(view);
 
+  const scrollToFolder = useCallback(() => {
+    let attempts = 0;
+    const maxAttempts = 20;
+    const scrollInterval = setInterval(() => {
+      const selectedElement = document.querySelector('[aria-selected="true"]');
+      if (selectedElement) {
+        selectedElement.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+        clearInterval(scrollInterval);
+      } else if (attempts >= maxAttempts) {
+        clearInterval(scrollInterval);
+      }
+      attempts++;
+    }, 500);
+  }, []);
+
   const folderCreateItems = (node: DialFolder) => {
     if (disabled) return [];
     const items = [
@@ -149,6 +164,7 @@ const FolderList: FC<Props> = ({
     const context = folderContext as RuleFolderContextType;
     if (initialPath && context?.fetchFolderHierarchy && (context?.files == null || context?.files?.length === 0)) {
       context?.fetchFolderHierarchy(initialPath, true);
+      scrollToFolder();
     } else if (
       !disableAutoFetch &&
       !initialPath &&
@@ -157,7 +173,7 @@ const FolderList: FC<Props> = ({
     ) {
       folderContext?.fetchFiles(`${ROOT_FOLDER}/`);
     }
-  }, [folderContext, disableAutoFetch, initialPath, isBulkDelete]);
+  }, [folderContext, disableAutoFetch, initialPath, isBulkDelete, scrollToFolder]);
 
   const getFolderClassName = (node: DialFile, level: number) => {
     const isSelected = folderContext?.filePath === node.path;
@@ -210,6 +226,7 @@ const FolderList: FC<Props> = ({
           {isFolder(nodeType) && (
             <div className="flex flex-col">
               <div
+                aria-selected={path === folderContext?.filePath}
                 className={classNames(
                   'group py-2',
                   baseClassName,


### PR DESCRIPTION
**Description:**

added scroll for folder list

Issues:

- Issue #2492


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
