### PR TITLE
feat: implement MCP dashboard charts and tables

### DIFF
--- a/apps/ai-dial-admin/src/components/Charts/LineChart/McpUsageChart.tsx
+++ b/apps/ai-dial-admin/src/components/Charts/LineChart/McpUsageChart.tsx
@@ -1,0 +1,75 @@
+'use client';
+import { FC, useEffect, useState } from 'react';
+
+import { DialLoader, DialNoDataContent } from '@epam/ai-dial-ui-kit';
+import ReactECharts, { EChartsOption } from 'echarts-for-react';
+
+import { BasicI18nKey, TelemetryI18nKey } from '@/src/constants/i18n';
+import { MCP_USAGE_QUERY, refreshOptionsConfig } from '@/src/constants/telemetry';
+import { useI18n } from '@/src/locales/client';
+import { ServerActionResponse } from '@/src/models/server-action';
+import { TelemetryData, TelemetryQuery } from '@/src/models/telemetry';
+import { getListingData, prepareMultiSeriesChartData } from '@/src/utils/telemetry';
+
+interface Props {
+  getData: (query: TelemetryQuery) => Promise<ServerActionResponse>;
+  refreshTime?: string;
+}
+
+const McpUsageChart: FC<Props> = ({ getData, refreshTime }) => {
+  const t = useI18n();
+  const [data, setData] = useState<Record<string, string>[] | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [options, setOptions] = useState<EChartsOption | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setLoading(true);
+      const response = await getData(MCP_USAGE_QUERY);
+
+      if (response.success) {
+        const data = getListingData(response.response as TelemetryData);
+        setData(data);
+        setOptions(prepareMultiSeriesChartData(data, t));
+      } else {
+        setData(null);
+      }
+      setLoading(false);
+    };
+
+    fetchData();
+
+    const timeout = refreshOptionsConfig.find((item) => item?.value === refreshTime)?.timeout;
+    if (!timeout) {
+      return;
+    }
+
+    const intervalId = setInterval(() => {
+      fetchData();
+    }, timeout);
+
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, [getData, t, refreshTime]);
+
+  return (
+    <div className="flex flex-col flex-1 rounded-lg border border-primary p-4 min-h-[280px] min-w-[200px]">
+      <h3 className="text-primary mb-4">{t(TelemetryI18nKey.RequestPerMcpUsage)}</h3>
+
+      {loading ? (
+        <DialLoader size={24} />
+      ) : (
+        <>
+          {!data?.length ? (
+            <DialNoDataContent title={t(BasicI18nKey.NoData)} />
+          ) : (
+            <div>{options && <ReactECharts option={options} className="flex size-full min-h-[280px] m-0 p-0" />}</div>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default McpUsageChart;

--- a/apps/ai-dial-admin/src/components/Charts/LineChart/constants.ts
+++ b/apps/ai-dial-admin/src/components/Charts/LineChart/constants.ts
@@ -2,6 +2,8 @@ import { EChartsOption } from 'echarts-for-react/src/types';
 import { TelemetryI18nKey } from '@/src/constants/i18n';
 import { formatDateTimeToLocalString } from '@/src/utils/formatting/date';
 
+export const MULTI_SERIES_COLORS = ['#5C8DEA', '#4ECDC4', '#FFB347', '#FF6B6B', '#A78BFA', '#34D399'];
+
 // TODO: color variables from tailwind config
 export const lineChartDefaultOptions = (t: (key: string) => string): EChartsOption => {
   return {
@@ -121,5 +123,105 @@ export const lineChartDefaultOptions = (t: (key: string) => string): EChartsOpti
       borderColor: '',
     },
     color: '#74A4FF',
+  };
+};
+
+export const multiSeriesLineChartOptions = (t: (key: string) => string): EChartsOption => {
+  return {
+    title: {
+      show: false,
+    },
+    tooltip: {
+      trigger: 'axis',
+      backgroundColor: '#000000',
+      borderColor: '#000000',
+      borderWidth: 1,
+      padding: [8, 12],
+      textStyle: {
+        color: '#F3F4F6',
+        fontSize: 12,
+      },
+      axisPointer: {
+        type: 'line',
+        lineStyle: {
+          color: '#3B82F6',
+          width: 1,
+        },
+      },
+      formatter: (params: { axisValue: string; seriesName: string; value: string; color: string }[]) => {
+        if (!params.length) return '';
+        const title = formatDateTimeToLocalString(params[0].axisValue);
+        const items = params
+          .map(
+            (p) => `
+            <div style="display:flex;align-items:center;gap:6px;color:#F3F4F6;font-size:10px;">
+              <span style="width:8px;height:8px;border-radius:50%;background:${p.color};"></span>
+              <span>${p.seriesName}: <b>${p.value}</b></span>
+            </div>`,
+          )
+          .join('');
+
+        return `<div>
+          <div style="font-size:12px;color:#9AA2AD;margin-bottom:12px;">${title}</div>
+          ${items}
+        </div>`;
+      },
+    },
+    legend: {
+      bottom: 0,
+      textStyle: {
+        color: '#7F8792',
+        fontSize: 12,
+      },
+    },
+    xAxis: {
+      type: 'category',
+      data: [],
+      splitLine: {
+        show: true,
+        lineStyle: {
+          color: '#222932',
+          width: 1,
+        },
+      },
+      axisLine: {
+        show: false,
+      },
+      axisTick: {
+        show: false,
+      },
+      axisLabel: {
+        color: '#7F8792',
+        formatter: (value: string | number) => formatDateTimeToLocalString(value),
+      },
+    },
+    yAxis: {
+      type: 'value',
+      nameTextStyle: {
+        color: '#7F8792',
+        fontSize: 12,
+        fontWeight: 500,
+      },
+      name: t(TelemetryI18nKey.RequestsNumber),
+      axisLabel: {
+        color: '#7F8792',
+      },
+      splitLine: {
+        show: true,
+        lineStyle: {
+          color: '#222932',
+          width: 1,
+        },
+      },
+    },
+    series: [],
+    grid: {
+      left: 30,
+      right: 0,
+      bottom: 40,
+      top: 10,
+      borderColor: '',
+    },
+    color: MULTI_SERIES_COLORS,
   };
 };

--- a/apps/ai-dial-admin/src/components/Telemetry/Dashboard.tsx
+++ b/apps/ai-dial-admin/src/components/Telemetry/Dashboard.tsx
@@ -6,7 +6,6 @@ import TelemetryGrid from '@/src/components/Telemetry/TelemetryGrid';
 import {
   DEFAULT_REFRESH_TIME,
   ENTITY_CONSUMPTION_QUERY,
-  MCP_CALLS_BY_DEPLOYMENT_EXTRA_CONDITIONS,
   MCP_TOOL_CALLS_EXTRA_CONDITIONS,
   PROJECT_CONSUMPTION_QUERY,
   TOOLSET_DEPLOYMENT_PREFIX,
@@ -114,11 +113,6 @@ const Dashboard: FC<Props> = ({
     [getMcpDataWithConditions],
   );
 
-  const getMcpCallsByDeploymentData = useMemo(
-    () => getMcpDataWithConditions(MCP_CALLS_BY_DEPLOYMENT_EXTRA_CONDITIONS),
-    [getMcpDataWithConditions],
-  );
-
   const onRefreshTimeChange = useCallback(
     (time: string) => {
       setRefreshTime(time);
@@ -178,7 +172,6 @@ const Dashboard: FC<Props> = ({
         <McpDashboard
           getData={getData}
           getToolCallsData={getMcpToolCallsData}
-          getCallsByDeploymentData={getMcpCallsByDeploymentData}
           refreshTime={refreshTime}
           isEntityView={!!entity}
         />

--- a/apps/ai-dial-admin/src/components/Telemetry/Dashboard.tsx
+++ b/apps/ai-dial-admin/src/components/Telemetry/Dashboard.tsx
@@ -7,6 +7,7 @@ import {
   DEFAULT_REFRESH_TIME,
   ENTITY_CONSUMPTION_QUERY,
   MCP_TOOL_CALLS_EXTRA_CONDITIONS,
+  MCP_TOOLS_CONSUMPTION_EXTRA_CONDITIONS,
   PROJECT_CONSUMPTION_QUERY,
   TOOLSET_DEPLOYMENT_PREFIX,
 } from '@/src/constants/telemetry';
@@ -113,6 +114,11 @@ const Dashboard: FC<Props> = ({
     [getMcpDataWithConditions],
   );
 
+  const getMcpToolsConsumptionData = useMemo(
+    () => getMcpDataWithConditions(MCP_TOOLS_CONSUMPTION_EXTRA_CONDITIONS),
+    [getMcpDataWithConditions],
+  );
+
   const onRefreshTimeChange = useCallback(
     (time: string) => {
       setRefreshTime(time);
@@ -172,6 +178,7 @@ const Dashboard: FC<Props> = ({
         <McpDashboard
           getData={getData}
           getToolCallsData={getMcpToolCallsData}
+          getToolsConsumptionData={getMcpToolsConsumptionData}
           refreshTime={refreshTime}
           isEntityView={!!entity}
         />

--- a/apps/ai-dial-admin/src/components/Telemetry/McpDashboard.tsx
+++ b/apps/ai-dial-admin/src/components/Telemetry/McpDashboard.tsx
@@ -13,6 +13,7 @@ import {
 import {
   MCP_CALLS_BY_DEPLOYMENT_QUERY,
   MCP_CONSUMPTION_QUERY,
+  MCP_PROJECTS_CONSUMPTION_QUERY,
   MCP_TOOLS_CONSUMPTION_QUERY,
 } from '@/src/constants/telemetry';
 import { useI18n } from '@/src/locales/client';
@@ -83,7 +84,7 @@ const McpDashboard: FC<Props> = ({
             <TelemetryGrid
               getData={getData}
               refreshTime={refreshTime}
-              query={null}
+              query={MCP_PROJECTS_CONSUMPTION_QUERY}
               columnDefs={MCP_PROJECTS_CONSUMPTION_COLUMNS}
               title={t(TelemetryI18nKey.ProjectsConsumptionMcp)}
             />

--- a/apps/ai-dial-admin/src/components/Telemetry/McpDashboard.tsx
+++ b/apps/ai-dial-admin/src/components/Telemetry/McpDashboard.tsx
@@ -1,10 +1,9 @@
 import { FC } from 'react';
 
-import { DialNoDataContent } from '@epam/ai-dial-ui-kit';
-
+import McpUsageChart from '@/src/components/Charts/LineChart/McpUsageChart';
 import McpSingleValueChartsDashboard from '@/src/components/Charts/SingleValueChart/McpSingleValueChartsDashboard';
 import TelemetryGrid from '@/src/components/Telemetry/TelemetryGrid';
-import { BasicI18nKey, TelemetryI18nKey } from '@/src/constants/i18n';
+import { TelemetryI18nKey } from '@/src/constants/i18n';
 import {
   MCP_CALLS_BY_DEPLOYMENT_COLUMNS,
   MCP_CONSUMPTION_COLUMNS,
@@ -36,10 +35,7 @@ const McpDashboard: FC<Props> = ({
   return (
     <div className="flex flex-col flex-1 min-h-0 min-w-0 overflow-auto">
       <div className="flex flex-col md:flex-row mb-6 md:flex-wrap gap-6">
-        <div className="flex flex-col flex-1 rounded-lg border border-primary p-4 min-h-[280px] min-w-[200px]">
-          <h3 className="text-primary mb-4">{t(TelemetryI18nKey.RequestPerMcpUsage)}</h3>
-          <DialNoDataContent title={t(BasicI18nKey.NoData)} />
-        </div>
+        <McpUsageChart getData={getData} refreshTime={refreshTime} />
         <McpSingleValueChartsDashboard
           getData={getData}
           getToolCallsData={getToolCallsData}

--- a/apps/ai-dial-admin/src/components/Telemetry/McpDashboard.tsx
+++ b/apps/ai-dial-admin/src/components/Telemetry/McpDashboard.tsx
@@ -10,7 +10,11 @@ import {
   MCP_PROJECTS_CONSUMPTION_COLUMNS,
   TOOLS_CONSUMPTION_COLUMNS,
 } from '@/src/constants/grid-columns/grid-columns';
-import { MCP_CALLS_BY_DEPLOYMENT_QUERY, MCP_CONSUMPTION_QUERY } from '@/src/constants/telemetry';
+import {
+  MCP_CALLS_BY_DEPLOYMENT_QUERY,
+  MCP_CONSUMPTION_QUERY,
+  MCP_TOOLS_CONSUMPTION_QUERY,
+} from '@/src/constants/telemetry';
 import { useI18n } from '@/src/locales/client';
 import { ServerActionResponse } from '@/src/models/server-action';
 import { TelemetryQuery } from '@/src/models/telemetry';
@@ -18,11 +22,18 @@ import { TelemetryQuery } from '@/src/models/telemetry';
 interface Props {
   getData: (query: TelemetryQuery) => Promise<ServerActionResponse>;
   getToolCallsData: (query: TelemetryQuery) => Promise<ServerActionResponse>;
+  getToolsConsumptionData: (query: TelemetryQuery) => Promise<ServerActionResponse>;
   refreshTime: string;
   isEntityView?: boolean;
 }
 
-const McpDashboard: FC<Props> = ({ getData, getToolCallsData, refreshTime, isEntityView = false }) => {
+const McpDashboard: FC<Props> = ({
+  getData,
+  getToolCallsData,
+  getToolsConsumptionData,
+  refreshTime,
+  isEntityView = false,
+}) => {
   const t = useI18n();
 
   return (
@@ -50,9 +61,9 @@ const McpDashboard: FC<Props> = ({ getData, getToolCallsData, refreshTime, isEnt
           )}
           <div className="flex flex-1 relative">
             <TelemetryGrid
-              getData={getData}
+              getData={getToolsConsumptionData}
               refreshTime={refreshTime}
-              query={null}
+              query={MCP_TOOLS_CONSUMPTION_QUERY}
               columnDefs={TOOLS_CONSUMPTION_COLUMNS}
               title={t(TelemetryI18nKey.ToolsConsumption)}
             />

--- a/apps/ai-dial-admin/src/components/Telemetry/McpDashboard.tsx
+++ b/apps/ai-dial-admin/src/components/Telemetry/McpDashboard.tsx
@@ -18,18 +18,11 @@ import { TelemetryQuery } from '@/src/models/telemetry';
 interface Props {
   getData: (query: TelemetryQuery) => Promise<ServerActionResponse>;
   getToolCallsData: (query: TelemetryQuery) => Promise<ServerActionResponse>;
-  getCallsByDeploymentData: (query: TelemetryQuery) => Promise<ServerActionResponse>;
   refreshTime: string;
   isEntityView?: boolean;
 }
 
-const McpDashboard: FC<Props> = ({
-  getData,
-  getToolCallsData,
-  getCallsByDeploymentData,
-  refreshTime,
-  isEntityView = false,
-}) => {
+const McpDashboard: FC<Props> = ({ getData, getToolCallsData, refreshTime, isEntityView = false }) => {
   const t = useI18n();
 
   return (
@@ -68,7 +61,7 @@ const McpDashboard: FC<Props> = ({
         <div className="flex flex-col md:flex-row gap-6">
           <div className="flex flex-1 relative">
             <TelemetryGrid
-              getData={getCallsByDeploymentData}
+              getData={getData}
               refreshTime={refreshTime}
               query={isEntityView ? null : MCP_CALLS_BY_DEPLOYMENT_QUERY}
               columnDefs={MCP_CALLS_BY_DEPLOYMENT_COLUMNS}

--- a/apps/ai-dial-admin/src/components/Telemetry/tests/McpDashboard.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Telemetry/tests/McpDashboard.spec.tsx
@@ -6,6 +6,7 @@ import { TelemetryI18nKey } from '@/src/constants/i18n';
 
 const getData = vi.fn().mockResolvedValue({ success: false });
 const getToolCallsData = vi.fn().mockResolvedValue({ success: false });
+const getToolsConsumptionData = vi.fn().mockResolvedValue({ success: false });
 
 describe('McpDashboard', () => {
   test('renders chart placeholder, stat cards, and all tables in global view', () => {
@@ -13,6 +14,7 @@ describe('McpDashboard', () => {
       <McpDashboard
         getData={getData}
         getToolCallsData={getToolCallsData}
+        getToolsConsumptionData={getToolsConsumptionData}
         refreshTime="1m"
       />,
     );
@@ -32,6 +34,7 @@ describe('McpDashboard', () => {
       <McpDashboard
         getData={getData}
         getToolCallsData={getToolCallsData}
+        getToolsConsumptionData={getToolsConsumptionData}
         refreshTime="1m"
         isEntityView
       />,

--- a/apps/ai-dial-admin/src/components/Telemetry/tests/McpDashboard.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Telemetry/tests/McpDashboard.spec.tsx
@@ -6,7 +6,6 @@ import { TelemetryI18nKey } from '@/src/constants/i18n';
 
 const getData = vi.fn().mockResolvedValue({ success: false });
 const getToolCallsData = vi.fn().mockResolvedValue({ success: false });
-const getCallsByDeploymentData = vi.fn().mockResolvedValue({ success: false });
 
 describe('McpDashboard', () => {
   test('renders chart placeholder, stat cards, and all tables in global view', () => {
@@ -14,7 +13,6 @@ describe('McpDashboard', () => {
       <McpDashboard
         getData={getData}
         getToolCallsData={getToolCallsData}
-        getCallsByDeploymentData={getCallsByDeploymentData}
         refreshTime="1m"
       />,
     );
@@ -34,7 +32,6 @@ describe('McpDashboard', () => {
       <McpDashboard
         getData={getData}
         getToolCallsData={getToolCallsData}
-        getCallsByDeploymentData={getCallsByDeploymentData}
         refreshTime="1m"
         isEntityView
       />,

--- a/apps/ai-dial-admin/src/constants/grid-columns/grid-columns.tsx
+++ b/apps/ai-dial-admin/src/constants/grid-columns/grid-columns.tsx
@@ -490,9 +490,9 @@ export const MCP_CONSUMPTION_COLUMNS: ColDef[] = [
 ];
 
 export const TOOLS_CONSUMPTION_COLUMNS: ColDef[] = [
-  { field: 'mcp_name', headerName: 'MCP Name', hide: false },
-  { field: 'tool', headerName: 'Tool', hide: false },
-  { field: 'calls', headerName: 'Calls', hide: false, ...numericColumn },
+  { field: 'name', headerName: 'MCP Name', hide: false },
+  { field: 'mcp_tool_call_name', headerName: 'Tool', hide: false },
+  { field: 'requests', headerName: 'Calls', hide: false, ...numericColumn },
 ];
 
 export const MCP_CALLS_BY_DEPLOYMENT_COLUMNS: ColDef[] = [

--- a/apps/ai-dial-admin/src/constants/grid-columns/grid-columns.tsx
+++ b/apps/ai-dial-admin/src/constants/grid-columns/grid-columns.tsx
@@ -496,8 +496,8 @@ export const TOOLS_CONSUMPTION_COLUMNS: ColDef[] = [
 ];
 
 export const MCP_CALLS_BY_DEPLOYMENT_COLUMNS: ColDef[] = [
-  { field: 'name', headerName: 'Deployment Name', hide: false },
-  { field: 'mcp_tool_call_name', headerName: 'MCP Name', hide: false },
+  { field: 'parent_deployment', headerName: 'Deployment Name', hide: false },
+  { field: 'name', headerName: 'MCP Name', hide: false },
   { field: 'requests', headerName: 'Calls', hide: false, ...numericColumn },
 ];
 

--- a/apps/ai-dial-admin/src/constants/grid-columns/grid-columns.tsx
+++ b/apps/ai-dial-admin/src/constants/grid-columns/grid-columns.tsx
@@ -502,7 +502,7 @@ export const MCP_CALLS_BY_DEPLOYMENT_COLUMNS: ColDef[] = [
 ];
 
 export const MCP_PROJECTS_CONSUMPTION_COLUMNS: ColDef[] = [
-  { field: 'project', headerName: 'Project', hide: false },
+  { field: 'name', headerName: 'Project', hide: false },
   { field: 'tool_calls', headerName: 'Tool Calls', hide: false, ...numericColumn },
   { field: 'mcp_calls', headerName: 'MCP Calls', hide: false, sort: 'desc', ...numericColumn },
 ];

--- a/apps/ai-dial-admin/src/constants/i18n.ts
+++ b/apps/ai-dial-admin/src/constants/i18n.ts
@@ -600,6 +600,7 @@ export enum TelemetryI18nKey {
   Custom = 'Telemetry.Custom',
   UniqueUsers = 'Telemetry.UniqueUsers',
   Requests = 'Telemetry.Requests',
+  RequestsNumber = 'Telemetry.RequestsNumber',
   RequestCount = 'Telemetry.RequestCount',
   TotalTokens = 'Telemetry.TotalTokens',
   Money = 'Telemetry.Money',

--- a/apps/ai-dial-admin/src/constants/telemetry.tsx
+++ b/apps/ai-dial-admin/src/constants/telemetry.tsx
@@ -263,14 +263,12 @@ export const MCP_CONSUMPTION_QUERY: TelemetryQuery = {
 export const MCP_CALLS_BY_DEPLOYMENT_QUERY: TelemetryQuery = {
   $type: 'json',
   query: {
-    expressions: ['deployment', 'count()'],
+    expressions: ['parent_deployment', 'deployment', 'count()'],
     from: MCP_TABLE_NAME,
-    groupBy: ['deployment', 'mcp_tool_call_name'],
+    groupBy: ['parent_deployment', 'deployment'],
     orderBy: [{ $desc: 'count()' }],
   },
 };
-
-export const MCP_CALLS_BY_DEPLOYMENT_EXTRA_CONDITIONS = [{ $ne: { left: 'mcp_tool_call_name', right: "'undefined'" } }];
 
 export const MCP_UNIQUE_USERS_QUERY: TelemetryQuery = {
   $type: 'json',
@@ -293,4 +291,5 @@ export const TELEMETRY_GRID_HEADERS_MAP: Record<string, string> = {
   tokens_p: 'prompts',
   tokens_c: 'completions',
   mcp_tool_call_name: 'mcp_tool_call_name',
+  parent_deployment: 'parent_deployment',
 };

--- a/apps/ai-dial-admin/src/constants/telemetry.tsx
+++ b/apps/ai-dial-admin/src/constants/telemetry.tsx
@@ -223,6 +223,15 @@ export const CONVERSATIONS_QUERY: TelemetryQuery = {
 export const MCP_TABLE_NAME = 'mcp_analytics';
 export const TOOLSET_DEPLOYMENT_PREFIX = 'toolsets/';
 
+export const MCP_USAGE_QUERY: TelemetryQuery = {
+  $type: 'json',
+  query: {
+    expressions: ["window(_time, 1, 'm')", 'mcp_method', 'count()'],
+    from: MCP_TABLE_NAME,
+    groupBy: ["window(_time, 1, 'm')", 'mcp_method'],
+  },
+};
+
 export const MCP_TOTAL_CALLS_QUERY: TelemetryQuery = {
   $type: 'json',
   query: {

--- a/apps/ai-dial-admin/src/constants/telemetry.tsx
+++ b/apps/ai-dial-admin/src/constants/telemetry.tsx
@@ -294,6 +294,20 @@ export const MCP_UNIQUE_USERS_QUERY: TelemetryQuery = {
   },
 };
 
+export const MCP_PROJECTS_CONSUMPTION_QUERY: TelemetryQuery = {
+  $type: 'json',
+  query: {
+    expressions: [
+      'project_id',
+      "sum(case when mcp_method = 'tools/call' then 1 else 0 end) as tool_calls",
+      'count() as mcp_calls',
+    ],
+    from: MCP_TABLE_NAME,
+    groupBy: ['project_id'],
+    orderBy: [{ $desc: 'count()' }],
+  },
+};
+
 export const TELEMETRY_GRID_HEADERS_MAP: Record<string, string> = {
   deployment: 'name',
   project_id: 'name',
@@ -304,4 +318,6 @@ export const TELEMETRY_GRID_HEADERS_MAP: Record<string, string> = {
   tokens_c: 'completions',
   mcp_tool_call_name: 'mcp_tool_call_name',
   parent_deployment: 'parent_deployment',
+  tool_calls: 'tool_calls',
+  mcp_calls: 'mcp_calls',
 };

--- a/apps/ai-dial-admin/src/constants/telemetry.tsx
+++ b/apps/ai-dial-admin/src/constants/telemetry.tsx
@@ -260,6 +260,18 @@ export const MCP_CONSUMPTION_QUERY: TelemetryQuery = {
   },
 };
 
+export const MCP_TOOLS_CONSUMPTION_QUERY: TelemetryQuery = {
+  $type: 'json',
+  query: {
+    expressions: ['deployment', 'mcp_tool_call_name', 'count()'],
+    from: MCP_TABLE_NAME,
+    groupBy: ['deployment', 'mcp_tool_call_name'],
+    orderBy: [{ $desc: 'count()' }],
+  },
+};
+
+export const MCP_TOOLS_CONSUMPTION_EXTRA_CONDITIONS = [{ $ne: { left: 'mcp_tool_call_name', right: "'undefined'" } }];
+
 export const MCP_CALLS_BY_DEPLOYMENT_QUERY: TelemetryQuery = {
   $type: 'json',
   query: {

--- a/apps/ai-dial-admin/src/locales/en.ts
+++ b/apps/ai-dial-admin/src/locales/en.ts
@@ -614,6 +614,7 @@ export default {
     Custom: 'Custom',
     UniqueUsers: 'Unique users',
     Requests: 'Requests',
+    RequestsNumber: 'Requests number',
     RequestCount: 'Request count',
     TotalTokens: 'Total tokens',
     Money: 'Money',

--- a/apps/ai-dial-admin/src/utils/telemetry.ts
+++ b/apps/ai-dial-admin/src/utils/telemetry.ts
@@ -2,7 +2,7 @@ import { SelectOption } from '@epam/ai-dial-ui-kit';
 import { Big } from 'big.js';
 import { EChartsOption } from 'echarts-for-react/src/types';
 
-import { lineChartDefaultOptions } from '@/src/components/Charts/LineChart/constants';
+import { lineChartDefaultOptions, multiSeriesLineChartOptions } from '@/src/components/Charts/LineChart/constants';
 import {
   filterConditionConfig,
   filterOperatorConfig,
@@ -121,6 +121,42 @@ export function prepareChartData(data: Record<string, string>[], t: (key: string
 
   (config.xAxis as unknown as { data: string[] }).data = xData;
   (config.series as unknown as { data: string[] }[])[0].data = yData;
+
+  return config;
+}
+
+export function prepareMultiSeriesChartData(data: Record<string, string>[], t: (key: string) => string): EChartsOption {
+  const config = { ...multiSeriesLineChartOptions(t) };
+
+  const timeSet = new Set<string>();
+  const methodSet = new Set<string>();
+
+  for (const row of data) {
+    timeSet.add(row.window);
+    methodSet.add(row.mcp_method);
+  }
+
+  const times = Array.from(timeSet).sort();
+  const methods = Array.from(methodSet).sort();
+
+  const dataByMethod = new Map<string, Map<string, number>>();
+  for (const method of methods) {
+    dataByMethod.set(method, new Map());
+  }
+  for (const row of data) {
+    dataByMethod.get(row.mcp_method)!.set(row.window, Number(row.count));
+  }
+
+  (config.xAxis as unknown as { data: string[] }).data = times;
+  (config as unknown as { series: unknown[] }).series = methods.map((method) => {
+    const methodData = dataByMethod.get(method)!;
+    return {
+      name: method,
+      type: 'line',
+      smooth: true,
+      data: times.map((time) => methodData.get(time) ?? 0),
+    };
+  });
 
   return config;
 }


### PR DESCRIPTION
## Summary
- Add **Request per MCP usage** multi-series line chart (grouped by `mcp_method` with legend)
- Fix **Calls by Deployment** table query to group by `parent_deployment` + `deployment`
- Implement **Tools Consumption** table with `mcp_tool_call_name != 'undefined'` filter
- Implement **Projects Consumption** table with conditional `tool_calls` sum and `mcp_calls` count

## Test plan
- [ ] Verify Request per MCP usage chart renders with multiple colored lines per `mcp_method`
- [ ] Verify chart legend, tooltip, and no-data state work correctly
- [ ] Verify Calls by Deployment table shows Deployment Name and MCP Name columns
- [ ] Verify Tools Consumption table shows MCP Name, Tool, and Calls columns
- [ ] Verify Projects Consumption table shows Project, Tool Calls, and MCP Calls columns
- [ ] Verify auto-refresh works on the chart
- [ ] Verify all tables load data with correct time range and filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)