### PR TITLE
fix(telemetry): remove orderBy from system usage query

### DIFF
--- a/apps/ai-dial-admin/src/constants/telemetry.tsx
+++ b/apps/ai-dial-admin/src/constants/telemetry.tsx
@@ -143,7 +143,6 @@ export const SYSTEM_USAGE_QUERY: TelemetryQuery = {
   query: {
     expressions: ["window(_time, 1, 'm') as time", 'count() as requests'],
     from: 'analytics',
-    orderBy: [{ $desc: '_time' }],
     groupBy: ["window(_time, 1, 'm')"],
   },
 };


### PR DESCRIPTION
## Summary
- Removed `orderBy: [{ $desc: '_time' }]` from `SYSTEM_USAGE_QUERY` as it breaks the system usage dashboard query

## Test plan
- [ ] Verify the System Usage dashboard loads data correctly without the orderBy clause

🤖 Generated with [Claude Code](https://claude.com/claude-code)