### PR TITLE
fix: [Builders] Save button becomes inactive after closing “Create related entity” modal (Issue #2773)

### DIFF
--- a/apps/ai-dial-admin/src/components/Adapter/View/View.tsx
+++ b/apps/ai-dial-admin/src/components/Adapter/View/View.tsx
@@ -18,6 +18,7 @@ import { SOURCE_TYPE } from '@/src/components/SourceField/types';
 import { ButtonsI18nKey, CreateI18nKey } from '@/src/constants/i18n';
 import { BASE_BUTTON_ICON_PROPS } from '@/src/constants/main-layout';
 import { useNotification } from '@/src/context/NotificationContext';
+import { useSaveValidationContext, ValidationActionType } from '@/src/context/SaveValidationContext';
 import { useProtectedRequest } from '@/src/hooks/use-protected-request';
 import { useI18n } from '@/src/locales/client';
 import { DialAdapter } from '@/src/models/dial/adapter';
@@ -40,6 +41,7 @@ const AdapterView: FC<Props> = ({ originalAdapter, modelsNames, etag }) => {
   const t = useI18n();
   const router = useRouter();
   const { showNotification } = useNotification();
+  const { dispatch } = useSaveValidationContext();
 
   const getReqRef = useRef(useProtectedRequest());
 
@@ -125,7 +127,10 @@ const AdapterView: FC<Props> = ({ originalAdapter, modelsNames, etag }) => {
                   route={ApplicationRoute.Models}
                   isModalOpen={isModalOpen}
                   createEntity={createModel}
-                  onClose={() => setIsModalOpen(false)}
+                  onClose={() => {
+                    setIsModalOpen(false);
+                    dispatch({ type: ValidationActionType.Reset });
+                  }}
                   names={modelsNames}
                   initialValues={{
                     source: {

--- a/apps/ai-dial-admin/src/components/ApplicationRunners/View/View.tsx
+++ b/apps/ai-dial-admin/src/components/ApplicationRunners/View/View.tsx
@@ -194,7 +194,10 @@ const ApplicationRunnersView: FC<Props> = ({ etag, originalScheme, names, ...pro
               route={ApplicationRoute.Applications}
               isModalOpen={isCreateAppModalOpen}
               createEntity={createApplication}
-              onClose={() => setIsCreateAppModalOpen(false)}
+              onClose={() => {
+                setIsCreateAppModalOpen(false);
+                dispatch({ type: ValidationActionType.Reset });
+              }}
               names={names}
               initialValues={{
                 customAppSchemaId: selectedRunner.$id,
@@ -211,7 +214,10 @@ const ApplicationRunnersView: FC<Props> = ({ etag, originalScheme, names, ...pro
             <CreateAsset
               view={ApplicationRoute.AssetsApplications}
               isModalOpen={isCreateAssetAppModalOpen}
-              onClose={() => setIsCreateAssetAppModalOpen(false)}
+              onClose={() => {
+                setIsCreateAssetAppModalOpen(false);
+                dispatch({ type: ValidationActionType.Reset });
+              }}
               onCreate={createApp}
               context={useAppsFolder}
               initialValues={{

--- a/apps/ai-dial-admin/src/components/InterceptorTemplates/View/View.tsx
+++ b/apps/ai-dial-admin/src/components/InterceptorTemplates/View/View.tsx
@@ -18,6 +18,7 @@ import { SOURCE_TYPE } from '@/src/components/SourceField/types';
 import { ButtonsI18nKey, CreateI18nKey } from '@/src/constants/i18n';
 import { BASE_BUTTON_ICON_PROPS } from '@/src/constants/main-layout';
 import { useNotification } from '@/src/context/NotificationContext';
+import { useSaveValidationContext, ValidationActionType } from '@/src/context/SaveValidationContext';
 import { useProtectedRequest } from '@/src/hooks/use-protected-request';
 import { useI18n } from '@/src/locales/client';
 import { InterceptorTemplate } from '@/src/models/interceptor-template';
@@ -38,6 +39,7 @@ const View: FC<Props> = ({ etag, template, names }) => {
   const t = useI18n();
   const router = useRouter();
   const { showNotification } = useNotification();
+  const { dispatch } = useSaveValidationContext();
   const getReqRef = useRef(useProtectedRequest());
 
   const [activeTab, setActiveTab] = useState(EntityViewTab.Properties);
@@ -129,7 +131,10 @@ const View: FC<Props> = ({ etag, template, names }) => {
                   route={ApplicationRoute.Interceptors}
                   isModalOpen={isModalOpen}
                   createEntity={createInterceptor}
-                  onClose={() => setIsModalOpen(false)}
+                  onClose={() => {
+                    setIsModalOpen(false);
+                    dispatch({ type: ValidationActionType.Reset });
+                  }}
                   names={names || []}
                   initialValues={source}
                 />,


### PR DESCRIPTION
**Description:**

reset validation for builders when create modal closed

Issues:

- Issue #2773


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
