### PR TITLE
fix: [Assets][Files] Add Child reuses existing “New Folder” and shows incorrect success message instead of creating a new folder (Issue #2752)

### DIFF
--- a/apps/ai-dial-admin/src/components/Common/FileManager/FileManager.tsx
+++ b/apps/ai-dial-admin/src/components/Common/FileManager/FileManager.tsx
@@ -34,10 +34,10 @@ import {
   getGridOptions,
   getToolbarOptions,
   getTreeOptions,
+  getNewFolderPath,
   getValidationMessages,
   validateCreateFolder,
 } from './utils';
-import { NEW_FOLDER_NAME } from './constants';
 import { FileManagerGridRow } from '@epam/ai-dial-ui-kit/dist/src/components/FileManager/FileManagerContext';
 import { AssetWithVersion } from '@/src/models/dial/deployment-asset';
 
@@ -164,18 +164,20 @@ const FileManager: FC<Props> = ({
 
   const handleAddChild = useCallback(
     (files: DialFile[]) => {
-      const newPath = files[0].path + NEW_FOLDER_NAME;
+      const rootItems = (filteredFiles as DialFile[])?.[0]?.items ?? [];
+      const newPath = getNewFolderPath(files[0], rootItems, 'child');
       handleCreateFolder(void 0, newPath);
     },
-    [handleCreateFolder],
+    [handleCreateFolder, filteredFiles],
   );
 
   const handleAddSibling = useCallback(
     (files: DialFile[]) => {
-      const newPath = files[0].path.replace(/([^/]+)\/?$/, NEW_FOLDER_NAME);
+      const rootItems = (filteredFiles as DialFile[])?.[0]?.items ?? [];
+      const newPath = getNewFolderPath(files[0], rootItems, 'sibling');
       handleCreateFolder(void 0, newPath);
     },
-    [handleCreateFolder],
+    [handleCreateFolder, filteredFiles],
   );
 
   const handleOnPathChange = useCallback(

--- a/apps/ai-dial-admin/src/components/Common/FileManager/FileManager.tsx
+++ b/apps/ai-dial-admin/src/components/Common/FileManager/FileManager.tsx
@@ -164,8 +164,7 @@ const FileManager: FC<Props> = ({
 
   const handleAddChild = useCallback(
     (files: DialFile[]) => {
-      const rootItems = (filteredFiles as DialFile[])?.[0]?.items ?? [];
-      const newPath = getNewFolderPath(files[0], rootItems, 'child');
+      const newPath = getNewFolderPath(files[0], filteredFiles, 'child');
       handleCreateFolder(void 0, newPath);
     },
     [handleCreateFolder, filteredFiles],
@@ -173,8 +172,7 @@ const FileManager: FC<Props> = ({
 
   const handleAddSibling = useCallback(
     (files: DialFile[]) => {
-      const rootItems = (filteredFiles as DialFile[])?.[0]?.items ?? [];
-      const newPath = getNewFolderPath(files[0], rootItems, 'sibling');
+      const newPath = getNewFolderPath(files[0], filteredFiles, 'sibling');
       handleCreateFolder(void 0, newPath);
     },
     [handleCreateFolder, filteredFiles],

--- a/apps/ai-dial-admin/src/components/Common/FileManager/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/Common/FileManager/tests/utils.spec.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test, vi } from 'vitest';
-import { createEmptyFile, getEmptyFile, validateCreateFolder } from '../utils';
+import { createEmptyFile, getEmptyFile, validateCreateFolder, findFolderByPath, getUniqueFolderName, getNewFolderPath } from '../utils';
 import { CREATE_FOLDER_FORBIDDEN_CHARS, FILE_NAME_MAX_LENGTH } from '../constants';
 import { FileManagerI18nKey } from '@/src/constants/i18n';
+import { DialFile, DialFileNodeType } from '@epam/ai-dial-ui-kit';
 
 describe('FileManager', () => {
   describe('createEmptyFile', () => {
@@ -144,6 +145,130 @@ describe('FileManager', () => {
       const result = validateCreateFolder(longName, mockTranslate);
 
       expect(result).toBe(FileManagerI18nKey.CreateFolderValidateNameLength);
+    });
+  });
+});
+
+const createFolder = (path: string, name: string, items?: DialFile[]): DialFile =>
+  ({
+    path,
+    name,
+    folderId: '',
+    nodeType: DialFileNodeType.FOLDER,
+    ...(items ? { items } : {}),
+  }) as DialFile;
+
+const createItem = (path: string, name: string, parentPath: string): DialFile =>
+  ({
+    path,
+    name,
+    folderId: '',
+    nodeType: DialFileNodeType.ITEM,
+    parentPath,
+  }) as DialFile;
+
+describe('findFolderByPath', () => {
+  const tree: DialFile[] = [
+    createFolder('public/a/', 'a', [
+      createFolder('public/a/b/', 'b', [createFolder('public/a/b/c/', 'c')]),
+    ]),
+    createFolder('public/d/', 'd'),
+  ];
+
+  test('should find a top-level folder', () => {
+    expect(findFolderByPath(tree, 'public/d/')?.name).toBe('d');
+  });
+
+  test('should find a nested folder', () => {
+    expect(findFolderByPath(tree, 'public/a/b/')?.name).toBe('b');
+  });
+
+  test('should find a deeply nested folder', () => {
+    expect(findFolderByPath(tree, 'public/a/b/c/')?.name).toBe('c');
+  });
+
+  test('should return undefined for non-existent path', () => {
+    expect(findFolderByPath(tree, 'public/x/')).toBeUndefined();
+  });
+
+  test('should return undefined for empty items', () => {
+    expect(findFolderByPath([], 'public/a/')).toBeUndefined();
+  });
+});
+
+describe('getUniqueFolderName', () => {
+  test('should return "New Folder" when no conflicts', () => {
+    expect(getUniqueFolderName([])).toBe('New Folder');
+    expect(getUniqueFolderName(['other'])).toBe('New Folder');
+  });
+
+  test('should return "New Folder 1" when "New Folder" exists', () => {
+    expect(getUniqueFolderName(['New Folder'])).toBe('New Folder 1');
+  });
+
+  test('should return "New Folder 2" when "New Folder" and "New Folder 1" exist', () => {
+    expect(getUniqueFolderName(['New Folder', 'New Folder 1'])).toBe('New Folder 2');
+  });
+
+  test('should skip to the next available number', () => {
+    expect(getUniqueFolderName(['New Folder', 'New Folder 1', 'New Folder 2', 'New Folder 3'])).toBe('New Folder 4');
+  });
+
+  test('should return first available number when there are gaps', () => {
+    expect(getUniqueFolderName(['New Folder', 'New Folder 2'])).toBe('New Folder 1');
+  });
+});
+
+describe('getNewFolderPath', () => {
+  const rootItems: DialFile[] = [
+    createFolder('public/yo/', 'yo', [
+      createItem('public/yo/.dial_folder', '.dial_folder', 'public/yo/'),
+      createFolder('public/yo/New Folder/', 'New Folder'),
+    ]),
+    createFolder('public/other/', 'other', [
+      createFolder('public/other/sub/', 'sub', [
+        createFolder('public/other/sub/New Folder/', 'New Folder'),
+        createFolder('public/other/sub/New Folder 1/', 'New Folder 1'),
+      ]),
+    ]),
+    createFolder('public/empty/', 'empty'),
+  ];
+
+  describe('child mode', () => {
+    test('should create "New Folder" in empty folder', () => {
+      const file = createFolder('public/empty/', 'empty');
+      expect(getNewFolderPath(file, rootItems, 'child')).toBe('public/empty/New Folder');
+    });
+
+    test('should create "New Folder 1" when "New Folder" already exists', () => {
+      const file = createFolder('public/yo/', 'yo');
+      expect(getNewFolderPath(file, rootItems, 'child')).toBe('public/yo/New Folder 1');
+    });
+
+    test('should create "New Folder 2" when "New Folder" and "New Folder 1" exist', () => {
+      const file = createFolder('public/other/sub/', 'sub');
+      expect(getNewFolderPath(file, rootItems, 'child')).toBe('public/other/sub/New Folder 2');
+    });
+  });
+
+  describe('sibling mode', () => {
+    test('should create sibling using parentPath', () => {
+      const file = { ...createFolder('public/yo/New Folder/', 'New Folder'), parentPath: 'public/yo/' } as DialFile;
+      expect(getNewFolderPath(file, rootItems, 'sibling')).toBe('public/yo/New Folder 1');
+    });
+
+    test('should derive parent from path when parentPath is missing', () => {
+      const file = createFolder('public/empty/', 'empty');
+      // parent of "public/empty/" is not in rootItems, so no conflicts → "New Folder"
+      expect(getNewFolderPath(file, rootItems, 'sibling')).toContain('New Folder');
+    });
+
+    test('should create sibling with incremented name in deeply nested folder', () => {
+      const file = {
+        ...createFolder('public/other/sub/New Folder/', 'New Folder'),
+        parentPath: 'public/other/sub/',
+      } as DialFile;
+      expect(getNewFolderPath(file, rootItems, 'sibling')).toBe('public/other/sub/New Folder 2');
     });
   });
 });

--- a/apps/ai-dial-admin/src/components/Common/FileManager/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/Common/FileManager/tests/utils.spec.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test, vi } from 'vitest';
-import { createEmptyFile, getEmptyFile, validateCreateFolder, findFolderByPath, getUniqueFolderName, getNewFolderPath } from '../utils';
+import {
+  createEmptyFile,
+  getEmptyFile,
+  validateCreateFolder,
+  findFolderByPath,
+  getUniqueFolderName,
+  getNewFolderPath,
+} from '../utils';
 import { CREATE_FOLDER_FORBIDDEN_CHARS, FILE_NAME_MAX_LENGTH } from '../constants';
 import { FileManagerI18nKey } from '@/src/constants/i18n';
 import { DialFile, DialFileNodeType } from '@epam/ai-dial-ui-kit';
@@ -170,9 +177,7 @@ const createItem = (path: string, name: string, parentPath: string): DialFile =>
 
 describe('findFolderByPath', () => {
   const tree: DialFile[] = [
-    createFolder('public/a/', 'a', [
-      createFolder('public/a/b/', 'b', [createFolder('public/a/b/c/', 'c')]),
-    ]),
+    createFolder('public/a/', 'a', [createFolder('public/a/b/', 'b', [createFolder('public/a/b/c/', 'c')])]),
     createFolder('public/d/', 'd'),
   ];
 

--- a/apps/ai-dial-admin/src/components/Common/FileManager/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/Common/FileManager/tests/utils.spec.ts
@@ -3,6 +3,7 @@ import { createEmptyFile, getEmptyFile, validateCreateFolder, findFolderByPath, 
 import { CREATE_FOLDER_FORBIDDEN_CHARS, FILE_NAME_MAX_LENGTH } from '../constants';
 import { FileManagerI18nKey } from '@/src/constants/i18n';
 import { DialFile, DialFileNodeType } from '@epam/ai-dial-ui-kit';
+import { Asset } from '@/src/models/dial/deployment-asset';
 
 describe('FileManager', () => {
   describe('createEmptyFile', () => {
@@ -220,7 +221,7 @@ describe('getUniqueFolderName', () => {
 });
 
 describe('getNewFolderPath', () => {
-  const rootItems: DialFile[] = [
+  const rootChildren: DialFile[] = [
     createFolder('public/yo/', 'yo', [
       createItem('public/yo/.dial_folder', '.dial_folder', 'public/yo/'),
       createFolder('public/yo/New Folder/', 'New Folder'),
@@ -234,33 +235,40 @@ describe('getNewFolderPath', () => {
     createFolder('public/empty/', 'empty'),
   ];
 
+  const allFiles: Asset[] = [createFolder('public/', 'public', rootChildren)];
+
   describe('child mode', () => {
     test('should create "New Folder" in empty folder', () => {
       const file = createFolder('public/empty/', 'empty');
-      expect(getNewFolderPath(file, rootItems, 'child')).toBe('public/empty/New Folder');
+      expect(getNewFolderPath(file, allFiles, 'child')).toBe('public/empty/New Folder');
     });
 
     test('should create "New Folder 1" when "New Folder" already exists', () => {
       const file = createFolder('public/yo/', 'yo');
-      expect(getNewFolderPath(file, rootItems, 'child')).toBe('public/yo/New Folder 1');
+      expect(getNewFolderPath(file, allFiles, 'child')).toBe('public/yo/New Folder 1');
     });
 
     test('should create "New Folder 2" when "New Folder" and "New Folder 1" exist', () => {
       const file = createFolder('public/other/sub/', 'sub');
-      expect(getNewFolderPath(file, rootItems, 'child')).toBe('public/other/sub/New Folder 2');
+      expect(getNewFolderPath(file, allFiles, 'child')).toBe('public/other/sub/New Folder 2');
+    });
+
+    test('should fall back to root folder items when parent not found in tree', () => {
+      const file = createFolder('public/nonexistent/', 'nonexistent');
+      expect(getNewFolderPath(file, allFiles, 'child')).toBe('public/nonexistent/New Folder');
     });
   });
 
   describe('sibling mode', () => {
     test('should create sibling using parentPath', () => {
       const file = { ...createFolder('public/yo/New Folder/', 'New Folder'), parentPath: 'public/yo/' } as DialFile;
-      expect(getNewFolderPath(file, rootItems, 'sibling')).toBe('public/yo/New Folder 1');
+      expect(getNewFolderPath(file, allFiles, 'sibling')).toBe('public/yo/New Folder 1');
     });
 
     test('should derive parent from path when parentPath is missing', () => {
       const file = createFolder('public/empty/', 'empty');
-      // parent of "public/empty/" is not in rootItems, so no conflicts → "New Folder"
-      expect(getNewFolderPath(file, rootItems, 'sibling')).toContain('New Folder');
+      // parent is "public/" which is allFiles[0] (fallback) with rootChildren
+      expect(getNewFolderPath(file, allFiles, 'sibling')).toContain('New Folder');
     });
 
     test('should create sibling with incremented name in deeply nested folder', () => {
@@ -268,7 +276,7 @@ describe('getNewFolderPath', () => {
         ...createFolder('public/other/sub/New Folder/', 'New Folder'),
         parentPath: 'public/other/sub/',
       } as DialFile;
-      expect(getNewFolderPath(file, rootItems, 'sibling')).toBe('public/other/sub/New Folder 2');
+      expect(getNewFolderPath(file, allFiles, 'sibling')).toBe('public/other/sub/New Folder 2');
     });
   });
 });

--- a/apps/ai-dial-admin/src/components/Common/FileManager/utils.ts
+++ b/apps/ai-dial-admin/src/components/Common/FileManager/utils.ts
@@ -11,6 +11,7 @@ import { ROOT_FOLDER } from '@/src/constants/file';
 import { ButtonsI18nKey, FileManagerI18nKey } from '@/src/constants/i18n';
 import { ApplicationRoute } from '@/src/types/routes';
 import { CREATE_FOLDER_FORBIDDEN_CHARS, FILE_NAME_MAX_LENGTH, NEW_FOLDER_NAME } from './constants';
+import { Asset } from '@/src/models/dial/deployment-asset';
 
 export const findFolderByPath = (items: DialFile[], targetPath: string): DialFile | undefined => {
   for (const item of items) {
@@ -27,7 +28,7 @@ export const findFolderByPath = (items: DialFile[], targetPath: string): DialFil
   return undefined;
 };
 
-export const getUniqueFolderName = (siblingNames: string[]): string => {
+export const getUniqueFolderName = (siblingNames: (string | undefined)[]): string => {
   const namesSet = new Set(siblingNames);
 
   if (!namesSet.has(NEW_FOLDER_NAME)) {
@@ -42,9 +43,10 @@ export const getUniqueFolderName = (siblingNames: string[]): string => {
   return `${NEW_FOLDER_NAME} ${counter}`;
 };
 
-export const getNewFolderPath = (file: DialFile, rootItems: DialFile[], mode: 'child' | 'sibling'): string => {
+export const getNewFolderPath = (file: DialFile, allFiles: Asset[], mode: 'child' | 'sibling'): string => {
+  const rootItems = (allFiles as DialFile[])?.[0]?.items ?? [];
   const parentPath = mode === 'child' ? file.path : (file.parentPath ?? file.path.replace(/[^/]+\/?$/, ''));
-  const parentFolder = findFolderByPath(rootItems, parentPath);
+  const parentFolder = findFolderByPath(rootItems, parentPath) || allFiles?.[0];
   const existingNames = parentFolder?.items?.map((item) => item.name) ?? [];
   const folderName = getUniqueFolderName(existingNames);
   return parentPath + folderName;

--- a/apps/ai-dial-admin/src/components/Common/FileManager/utils.ts
+++ b/apps/ai-dial-admin/src/components/Common/FileManager/utils.ts
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 
-import { DialUploadFileItem, GridOptions, GridSelectionMode } from '@epam/ai-dial-ui-kit';
+import { DialFile, DialUploadFileItem, GridOptions, GridSelectionMode } from '@epam/ai-dial-ui-kit';
 import { ColDef, ITextFilterParams } from 'ag-grid-community';
 
 import { bulkActionLabels } from '@/src/components/Assets/constants';
@@ -10,7 +10,45 @@ import FloatingFilter from '@/src/components/Grid/FloatingFilter/FloatingFilter'
 import { ROOT_FOLDER } from '@/src/constants/file';
 import { ButtonsI18nKey, FileManagerI18nKey } from '@/src/constants/i18n';
 import { ApplicationRoute } from '@/src/types/routes';
-import { CREATE_FOLDER_FORBIDDEN_CHARS, FILE_NAME_MAX_LENGTH } from './constants';
+import { CREATE_FOLDER_FORBIDDEN_CHARS, FILE_NAME_MAX_LENGTH, NEW_FOLDER_NAME } from './constants';
+
+export const findFolderByPath = (items: DialFile[], targetPath: string): DialFile | undefined => {
+  for (const item of items) {
+    if (item.path === targetPath) {
+      return item;
+    }
+    if (item.items?.length) {
+      const found = findFolderByPath(item.items, targetPath);
+      if (found) {
+        return found;
+      }
+    }
+  }
+  return undefined;
+};
+
+export const getUniqueFolderName = (siblingNames: string[]): string => {
+  const namesSet = new Set(siblingNames);
+
+  if (!namesSet.has(NEW_FOLDER_NAME)) {
+    return NEW_FOLDER_NAME;
+  }
+
+  let counter = 1;
+  while (namesSet.has(`${NEW_FOLDER_NAME} ${counter}`)) {
+    counter++;
+  }
+
+  return `${NEW_FOLDER_NAME} ${counter}`;
+};
+
+export const getNewFolderPath = (file: DialFile, rootItems: DialFile[], mode: 'child' | 'sibling'): string => {
+  const parentPath = mode === 'child' ? file.path : (file.parentPath ?? file.path.replace(/[^/]+\/?$/, ''));
+  const parentFolder = findFolderByPath(rootItems, parentPath);
+  const existingNames = parentFolder?.items?.map((item) => item.name) ?? [];
+  const folderName = getUniqueFolderName(existingNames);
+  return parentPath + folderName;
+};
 
 const assetEntityMap: Record<string, FileManagerI18nKey> = {
   [ApplicationRoute.AssetsApplications]: FileManagerI18nKey.Applications,


### PR DESCRIPTION
**Description:**

added new folder name check

Issues:

- Issue #2752 
- Issue #2757


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
