### PR TITLE
fix(deployments): prevent modification of core entity fields in JSON Editor (Issue #2716)

### DIFF
--- a/apps/ai-dial-admin/src/components/Containers/View/ContainerView.tsx
+++ b/apps/ai-dial-admin/src/components/Containers/View/ContainerView.tsx
@@ -11,6 +11,7 @@ import { ApiRoute } from '@/src/constants/api-routes';
 import { JsonConfiguration } from '@/src/components/EntityHeaderControls/models';
 import EntityJsonEditor from '@/src/components/EntityTabs/JsonEditor/JsonEditor';
 import { IMAGE_BUILD_POLL_INTERVAL } from '@/src/constants/deployments/images';
+import { CONTAINER_IGNORED_FIELDS } from '@/src/constants/editor';
 import { ErrorI18nKey, ContainersI18nKey, DeploymentsI18nKey } from '@/src/constants/i18n';
 import { useAppContext } from '@/src/context/AppContext';
 import { useNotification } from '@/src/context/NotificationContext';
@@ -304,6 +305,7 @@ const ContainerView: FC<Props> = ({
               entity={selectedContainer}
               setSelectedEntity={setSelectedContainer}
               setIsChanged={setIsChanged}
+              ignoredFields={CONTAINER_IGNORED_FIELDS}
             />
           ) : (
             <TabsContent

--- a/apps/ai-dial-admin/src/components/EntityTabs/JsonEditor/JsonEditor.tsx
+++ b/apps/ai-dial-admin/src/components/EntityTabs/JsonEditor/JsonEditor.tsx
@@ -5,7 +5,7 @@ import { Dispatch, SetStateAction, useCallback, useEffect, useRef, useState } fr
 import { editor } from 'monaco-editor';
 
 import JsonEditorBase from '@/src/components/Common/JsonEditorBase/JsonEditorBase';
-import { clearResolvedErrors } from '@/src/components/EntityTabs/JsonEditor/utils';
+import { clearResolvedErrors, mergeWithIgnoredFields } from '@/src/components/EntityTabs/JsonEditor/utils';
 import { useNotification } from '@/src/context/NotificationContext';
 import { useSaveValidationContext, ValidationActionType } from '@/src/context/SaveValidationContext';
 import { useIsReadOnlyAdmin } from '@/src/hooks/use-is-read-only-admin';
@@ -15,6 +15,7 @@ interface Props<T> {
   entity: T | null;
   setSelectedEntity?: Dispatch<SetStateAction<T>>;
   setIsChanged?: Dispatch<SetStateAction<boolean>>;
+  ignoredFields?: (keyof T)[];
   readonly?: boolean;
   options?: editor.IStandaloneEditorConstructionOptions;
 }
@@ -23,6 +24,7 @@ const EntityJsonEditor = <T extends object>({
   entity,
   setSelectedEntity,
   setIsChanged,
+  ignoredFields,
   readonly,
   options,
 }: Props<T>) => {
@@ -60,7 +62,7 @@ const EntityJsonEditor = <T extends object>({
         const parsed = JSON.parse(updatedConfig);
         if (setSelectedEntity) {
           skipEntityModelSyncRef.current = true;
-          setSelectedEntity(parsed);
+          setSelectedEntity((prev) => mergeWithIgnoredFields(prev, parsed, ignoredFields));
         }
       } catch (error) {
         if (error) {
@@ -68,7 +70,7 @@ const EntityJsonEditor = <T extends object>({
         }
       }
     },
-    [setSelectedEntity, setIsChanged],
+    [setSelectedEntity, setIsChanged, ignoredFields],
   );
 
   const onValidateJSON = useCallback(

--- a/apps/ai-dial-admin/src/components/EntityTabs/JsonEditor/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/EntityTabs/JsonEditor/tests/utils.spec.ts
@@ -1,6 +1,6 @@
 import { JSONEditorError, JSONEditorErrorNotification } from '@/src/types/editor';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { clearResolvedErrors } from '../utils';
+import { clearResolvedErrors, mergeWithIgnoredFields } from '../utils';
 
 describe('clearResolvedErrors', () => {
   let mockRemoveNotification: ReturnType<typeof vi.fn>;
@@ -47,5 +47,52 @@ describe('clearResolvedErrors', () => {
     clearResolvedErrors(errorNotifications, mockRemoveNotification, errors);
 
     expect(mockRemoveNotification).not.toHaveBeenCalled();
+  });
+});
+
+describe('mergeWithIgnoredFields', () => {
+  test('should merge parsed into prev when no ignored fields', () => {
+    const prev = { id: '1', name: 'original', version: '1.0' };
+    const parsed = { id: '1', name: 'updated', version: '2.0' };
+
+    const result = mergeWithIgnoredFields(prev, parsed);
+
+    expect(result).toEqual({ id: '1', name: 'updated', version: '2.0' });
+  });
+
+  test('should preserve ignored fields from prev', () => {
+    const prev = { id: 'abc', name: 'original', version: '1.0' };
+    const parsed = { id: 'xyz', name: 'updated', version: '2.0' };
+
+    const result = mergeWithIgnoredFields(prev, parsed, ['id']);
+
+    expect(result).toEqual({ id: 'abc', name: 'updated', version: '2.0' });
+  });
+
+  test('should preserve multiple ignored fields', () => {
+    const prev = { name: 'original', $type: 'mcp' as const, version: '1.0' };
+    const parsed = { name: 'changed', $type: 'adapter' as const, version: '2.0' };
+
+    const result = mergeWithIgnoredFields(prev, parsed, ['name', '$type']);
+
+    expect(result).toEqual({ name: 'original', $type: 'mcp', version: '2.0' });
+  });
+
+  test('should handle undefined ignoredFields', () => {
+    const prev = { id: '1', name: 'original' };
+    const parsed = { id: '2', name: 'updated' };
+
+    const result = mergeWithIgnoredFields(prev, parsed, undefined);
+
+    expect(result).toEqual({ id: '2', name: 'updated' });
+  });
+
+  test('should handle empty ignoredFields array', () => {
+    const prev = { id: '1', name: 'original' };
+    const parsed = { id: '2', name: 'updated' };
+
+    const result = mergeWithIgnoredFields(prev, parsed, []);
+
+    expect(result).toEqual({ id: '2', name: 'updated' });
   });
 });

--- a/apps/ai-dial-admin/src/components/EntityTabs/JsonEditor/utils.ts
+++ b/apps/ai-dial-admin/src/components/EntityTabs/JsonEditor/utils.ts
@@ -1,5 +1,17 @@
 import { JSONEditorError, JSONEditorErrorNotification } from '@/src/types/editor';
 
+export const mergeWithIgnoredFields = <T extends object>(
+  prev: T,
+  parsed: Partial<T>,
+  ignoredFields?: (keyof T)[],
+): T => {
+  const merged = { ...prev, ...parsed };
+  for (const field of ignoredFields ?? []) {
+    merged[field] = prev[field];
+  }
+  return merged;
+};
+
 export const clearResolvedErrors = (
   errorNotifications: JSONEditorErrorNotification[],
   removeNotification: (id: string) => void,

--- a/apps/ai-dial-admin/src/components/Images/View/ImageView.tsx
+++ b/apps/ai-dial-admin/src/components/Images/View/ImageView.tsx
@@ -6,6 +6,7 @@ import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { getImage, updateImage } from '@/src/app/actions/deployments';
 import { IMAGE_BUILD_POLL_INTERVAL } from '@/src/constants/deployments/images';
+import { IMAGE_IGNORED_FIELDS } from '@/src/constants/editor';
 import { ImagesI18nKey } from '@/src/constants/i18n';
 import { useAppContext } from '@/src/context/AppContext';
 import { useNotification } from '@/src/context/NotificationContext';
@@ -143,6 +144,7 @@ const ImageView: FC<Props> = ({ image, containerNames, versions }) => {
             entity={selectedImage}
             setSelectedEntity={setSelectedImage}
             setIsChanged={setIsChanged}
+            ignoredFields={IMAGE_IGNORED_FIELDS}
           />
         ) : (
           <>

--- a/apps/ai-dial-admin/src/constants/editor.ts
+++ b/apps/ai-dial-admin/src/constants/editor.ts
@@ -1,3 +1,5 @@
+import { Container } from '@/src/models/deployments/containers';
+import { Image } from '@/src/models/deployments/images';
 import { JSONEditorThemeConfig, EDITOR_THEMES, EditorOptions } from '@/src/types/editor';
 
 const DEFAULT_COLORS = {
@@ -103,3 +105,6 @@ export const editorOptions: EditorOptions = {
   formatOnType: true,
   formatOnPaste: true,
 };
+
+export const IMAGE_IGNORED_FIELDS: (keyof Image)[] = ['id'];
+export const CONTAINER_IGNORED_FIELDS: (keyof Container)[] = ['name', '$type'];

--- a/openspec/changes/archive/2026-04-01-fix-json-editor-id-spoofing/proposal.md
+++ b/openspec/changes/archive/2026-04-01-fix-json-editor-id-spoofing/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+When editing a deployment entity (Image or Container) via the JSON editor, users can modify the identity field (`id` for images, `name` for containers). On save, the system uses the modified identity from the JSON payload to construct the API URL, causing an unintended update to a different resource. The originally opened entity remains unchanged.
+
+Root cause: `EntityJsonEditor` parses the full JSON and sets it as the new entity state without preserving the original identity. The API methods (`updateImage`, `updateContainer`) then extract the identity from this modified state.
+
+Issue: [#2716](https://github.com/epam/ai-dial-admin-frontend/issues/2716)
+
+## What Changes
+
+- Add an `ignoredFields` prop to `EntityJsonEditor` — an optional list of field names that should be preserved from the previous state on every JSON change
+- Extract the merge logic into a tested utility function `mergeWithIgnoredFields`
+- Wire `ignoredFields` in `ImageView` (`['id']`) and `ContainerView` (`['name', '$type']`)
+- Backend will also validate identity mismatch (covered separately), so this is defense in depth on the UI side
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+None — this is a bug fix preventing unintended resource modification via the JSON editor.
+
+## Non-goals
+
+- Fixing this for non-deployment entity types (models, applications, adapters, etc.) — out of scope for this change
+- Making identity fields visually readonly in Monaco — not feasible without significant complexity
+- Changing API method signatures — the fix is encapsulated in the JSON editor component
+
+## Impact
+
+- **Components**: `EntityJsonEditor`, `ImageView`, `ContainerView`
+- **New util**: `mergeWithIgnoredFields` — pure function with unit tests
+- **Scope**: Deployment entities only (images, containers)
+- **Risk**: Low — `ignoredFields` is optional, so all other usages of `EntityJsonEditor` are unaffected

--- a/openspec/changes/archive/2026-04-01-fix-json-editor-id-spoofing/tasks.md
+++ b/openspec/changes/archive/2026-04-01-fix-json-editor-id-spoofing/tasks.md
@@ -1,0 +1,36 @@
+## Tasks
+
+### 1. Create `mergeWithIgnoredFields` utility
+
+- [ ] Create util function in `apps/ai-dial-admin/src/components/EntityTabs/JsonEditor/utils.ts`
+  ```ts
+  mergeWithIgnoredFields<T extends object>(prev: T, parsed: Partial<T>, ignoredFields?: (keyof T)[]): T
+  ```
+  - Spreads `prev` with `parsed`, then restores `ignoredFields` from `prev`
+  - Returns `prev` spread unchanged when `ignoredFields` is empty/undefined
+
+### 2. Add unit tests for `mergeWithIgnoredFields`
+
+- [ ] Add tests in `apps/ai-dial-admin/src/components/EntityTabs/JsonEditor/tests/mergeWithIgnoredFields.spec.ts`
+  - Merges correctly when no ignored fields
+  - Preserves ignored fields from `prev` when `parsed` modifies them
+  - Handles missing `ignoredFields` param (undefined)
+  - Handles empty `ignoredFields` array
+
+### 3. Add `ignoredFields` prop to `EntityJsonEditor`
+
+- [ ] Update `Props<T>` interface in `apps/ai-dial-admin/src/components/EntityTabs/JsonEditor/JsonEditor.tsx` — add optional `ignoredFields?: (keyof T)[]`
+- [ ] Update `onChangeJSON` to use `mergeWithIgnoredFields` with functional `setSelectedEntity` update:
+  ```ts
+  setSelectedEntity(prev => mergeWithIgnoredFields(prev, parsed, ignoredFields));
+  ```
+
+### 4. Wire `ignoredFields` in deployment entity views
+
+- [ ] `apps/ai-dial-admin/src/components/Images/View/ImageView.tsx` — pass `ignoredFields={['id']}`
+- [ ] `apps/ai-dial-admin/src/components/Containers/View/ContainerView.tsx` — pass `ignoredFields={['name', '$type']}`
+
+### 5. Run code quality checks
+
+- [ ] Run `npm run lint` and `npm run format` — fix any issues
+- [ ] Run `npm run test` — verify all tests pass


### PR DESCRIPTION
**Description:**

When editing id for images, and $type or name for container in JSON editor, ignore this fields.

Issues:

- Issue #2716


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
