### PR TITLE
fix: [Assets-Prompts] Impossible to switch between different versions of a prompt. (Issue #2858)

### DIFF
--- a/apps/ai-dial-admin/src/components/Assets/Deployments/AssetVersionControl.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Deployments/AssetVersionControl.tsx
@@ -10,7 +10,9 @@ import { getToolset } from '@/src/app/[lang]/assets-toolsets/actions';
 import { getPrompt } from '@/src/app/[lang]/prompts/actions';
 import AddVersionModal from '@/src/components/Assets/Modals/AddVersionModal';
 import CompareVersions from '@/src/components/Assets/Modals/CompareVersions';
+import { getVersionsPerName } from '@/src/components/Assets/utils';
 import { ModalType } from '@/src/components/EntityListView/Components/Modals';
+import { DEFAULT_ETAG } from '@/src/constants/api-headers';
 import { ButtonsI18nKey, CompareI18nKey, EntityFieldsI18nKey, PromptsI18nKey } from '@/src/constants/i18n';
 import { BASE_BUTTON_ICON_PROPS } from '@/src/constants/main-layout';
 import { useProtectedRequest } from '@/src/hooks/use-protected-request';
@@ -20,11 +22,9 @@ import { DialPrompt } from '@/src/models/dial/prompt';
 import { ApplicationRoute } from '@/src/types/routes';
 import { isDeploymentAsset } from '@/src/utils/is-view';
 import { modifyNameVersionInPrompt } from '@/src/utils/prompts/versions';
-import { getVersionsPerName } from '../utils';
 
 interface Props {
   view: ApplicationRoute;
-  etag?: string;
   asset: AssetWithVersion;
   assets?: AssetWithVersion[] | null;
   onChangeAsset?: (asset: AssetWithVersion) => void;
@@ -34,7 +34,6 @@ interface Props {
 
 const AssetVersionControl: FC<Props> = ({
   view,
-  etag,
   asset,
   assets,
   onChangeAsset,
@@ -87,7 +86,7 @@ const AssetVersionControl: FC<Props> = ({
           : view === ApplicationRoute.AssetsToolsets
             ? getToolset
             : getPrompt;
-      getReqRef.current(getAsset, asset.folderId, asset.name as string, version, etag).then((res) => {
+      getReqRef.current(getAsset, asset.folderId, asset.name as string, version, DEFAULT_ETAG).then((res) => {
         if (res.success) {
           const newVersionAsset = res.response as DeploymentAsset;
           changeAssetForNewVersion(version, newVersionAsset);
@@ -96,7 +95,7 @@ const AssetVersionControl: FC<Props> = ({
         }
       });
     },
-    [asset, view, etag, changeAssetForNewVersion],
+    [asset, view, changeAssetForNewVersion],
   );
 
   const handleModalClose = useCallback(() => {

--- a/apps/ai-dial-admin/src/components/EntityHeaderControls/Wrappers/AssetButtonsWrapper.tsx
+++ b/apps/ai-dial-admin/src/components/EntityHeaderControls/Wrappers/AssetButtonsWrapper.tsx
@@ -131,7 +131,6 @@ const AssetButtonsWrapper: FC<AssetButtonsWrapperProps> = ({
                   onChangeAddedVersion={onChangeAddedVersion}
                   assets={assets}
                   onChangeAsset={onChangeAsset}
-                  etag={etag}
                 />
                 <DialNeutralButton
                   className={buttonsClassName}


### PR DESCRIPTION
**Description:**

added default etag for new version fetching

Issues:

- Issue #2858


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
