### PR TITLE
fix: [Export Config/Interceptor Templates] The list of Interceptor Templates is not displayed in the Export File Preview modal. (Issue #2814)

### DIFF
--- a/apps/ai-dial-admin/src/components/ExportConfig/Preview/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/ExportConfig/Preview/tests/utils.spec.ts
@@ -105,6 +105,21 @@ describe('Export Config Utils :: getPreviewTabs', () => {
     expect(convertedData.ADAPTER).toEqual([{ id: 'adapter1' }]);
   });
 
+  test('should handle interceptorRunners correctly', () => {
+    const data = {
+      interceptorRunners: [{ id: 'interceptorRunner1' }],
+    };
+
+    const mockEntities = [{ id: 'interceptorRunner1' }];
+    entitiesUtils.getInterceptorTemplatesForEntitiesGrid.mockReturnValue(mockEntities);
+
+    const { tabs, convertedData } = getPreviewTabs(data, false, ExportFormat.ADMIN, t);
+
+    expect(tabs).toEqual([{ id: 'INTERCEPTOR_RUNNER', label: 'translated(Menu.InterceptorTemplates): 1' }]);
+
+    expect(convertedData.INTERCEPTOR_RUNNER).toEqual([{ id: 'interceptorRunner1' }]);
+  });
+
   test('should merge entities from applications and routes as well', () => {
     const mockEntitiesFromApplications = [{ id: 'app1' }];
     const mockEntitiesFromRoutes = [{ id: 'route1' }];

--- a/apps/ai-dial-admin/src/components/ExportConfig/Preview/utils.ts
+++ b/apps/ai-dial-admin/src/components/ExportConfig/Preview/utils.ts
@@ -11,6 +11,7 @@ import {
   getKeysForEntitiesGrid,
   getToolsetsForEntitiesGrid,
   getRunnersForEntitiesGrid,
+  getInterceptorTemplatesForEntitiesGrid,
 } from '@/src/utils/entities/entities-list-view';
 import { DialModel } from '@/src/models/dial/model';
 import { EntityType } from '@/src/types/entity-type';
@@ -122,6 +123,14 @@ export const getPreviewTabs = (
         tabs.push({
           id: EntityType.TOOLSET,
           label: `${t(MenuI18nKey.Toolsets)}: ${data[key].length}`,
+        });
+      }
+
+      if (key === 'interceptorRunners') {
+        convertedData[EntityType.INTERCEPTOR_RUNNER] = getInterceptorTemplatesForEntitiesGrid(data[key]);
+        tabs.push({
+          id: EntityType.INTERCEPTOR_RUNNER,
+          label: `${t(MenuI18nKey.InterceptorTemplates)}: ${data[key].length}`,
         });
       }
     }

--- a/apps/ai-dial-admin/src/utils/entities/entities-list-view.ts
+++ b/apps/ai-dial-admin/src/utils/entities/entities-list-view.ts
@@ -136,3 +136,19 @@ export const getAdaptersForEntitiesGrid = (adapters?: DialAdapter[] | null): Ent
     route: ApplicationRoute.Adapters,
   }));
 };
+
+/** Get list of InterceptorRunner with type and route for entities view
+ *
+ * @param {?(InterceptorTemplate[] | null)} [interceptorRunners] - Interceptor runners array
+ * @returns {EntitiesGridData[]} - EntitiesGridData array
+ */
+
+export const getInterceptorTemplatesForEntitiesGrid = (
+  interceptorTemplates?: InterceptorTemplate[] | null,
+): EntitiesGridData[] => {
+  return [...(interceptorTemplates || [])].map((template) => ({
+    ...template,
+    type: MenuI18nKey.InterceptorTemplates,
+    route: ApplicationRoute.InterceptorTemplates,
+  }));
+};

--- a/apps/ai-dial-admin/src/utils/entities/tests/entities-list-view.spec.ts
+++ b/apps/ai-dial-admin/src/utils/entities/tests/entities-list-view.spec.ts
@@ -5,6 +5,7 @@ import {
   getAdaptersForEntitiesGrid,
   getApplicationsForEntitiesGrid,
   getInterceptorsForEntitiesGrid,
+  getInterceptorTemplatesForEntitiesGrid,
   getTemplatesForEntitiesGrid,
   getKeysForEntitiesGrid,
   getModelsForEntitiesGrid,
@@ -179,5 +180,27 @@ describe('Utils :: getAdaptersForEntitiesGrid', () => {
     const res1 = getAdaptersForEntitiesGrid([{ name: 'adapter' }]);
 
     expect(res1).toEqual([{ name: 'adapter', type: MenuI18nKey.Adapters, route: ApplicationRoute.Adapters }]);
+  });
+});
+
+describe('Utils :: getInterceptorTemplatesForEntitiesGrid', () => {
+  test('Should return empty array', () => {
+    const res1 = getInterceptorTemplatesForEntitiesGrid(null);
+    const res2 = getInterceptorTemplatesForEntitiesGrid();
+
+    expect(res1).toEqual([]);
+    expect(res2).toEqual([]);
+  });
+
+  test('Should return array with type and route', () => {
+    const res1 = getInterceptorTemplatesForEntitiesGrid([{ name: 'interceptorTemplate' }]);
+
+    expect(res1).toEqual([
+      {
+        name: 'interceptorTemplate',
+        type: MenuI18nKey.InterceptorTemplates,
+        route: ApplicationRoute.InterceptorTemplates,
+      },
+    ]);
   });
 });


### PR DESCRIPTION
**Description:**

added missed interceptor template preview

Issues:

- Issue #2814


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
