### PR TITLE
fix: initialize time filter from props to prevent stale data on tab s…

### DIFF
--- a/apps/ai-dial-admin/src/components/ActivityAudit/List/List.tsx
+++ b/apps/ai-dial-admin/src/components/ActivityAudit/List/List.tsx
@@ -80,22 +80,16 @@ const ActivityAuditList: FC<Props> = ({
 
   const [isLoading, setIsLoading] = useState(false);
   const [gridApi, setGridApi] = useState<GridApi | null>(null);
-  const [timePeriod, setTimePeriod] = useState<string | undefined>();
-  const [timeRange, setTimeRange] = useState<TimeRange>(getTimeRangeById(DEFAULT_TIME_PERIOD));
+  const [timePeriod, setTimePeriod] = useState<string | undefined>(
+    !isCustomRange ? (initTimeFilter as string) || DEFAULT_TIME_PERIOD : DEFAULT_TIME_PERIOD,
+  );
+  const [timeRange, setTimeRange] = useState<TimeRange>(
+    isCustomRange
+      ? (initTimeFilter as TimeRange) || getTimeRangeById(DEFAULT_TIME_PERIOD)
+      : getTimeRangeById((initTimeFilter as string) || DEFAULT_TIME_PERIOD),
+  );
   const [selectedActivity, setSelectedActivity] = useState<DialActivity | undefined>(void 0);
   const [innerIsCustomRange, setInnerIsCustomRange] = useState(false);
-
-  useEffect(() => {
-    if (!timePeriod) {
-      if (!isCustomRange) {
-        setTimePeriod((initTimeFilter as string) || DEFAULT_TIME_PERIOD);
-        setTimeRange(getTimeRangeById((initTimeFilter as string) || DEFAULT_TIME_PERIOD));
-      } else {
-        setTimePeriod(DEFAULT_TIME_PERIOD);
-        setTimeRange((initTimeFilter as TimeRange) || getTimeRangeById(DEFAULT_TIME_PERIOD));
-      }
-    }
-  }, [initTimeFilter, timePeriod, isCustomRange]);
 
   const onCloseModal = useCallback(() => {
     setIsRollbackModalOpen(false);

--- a/apps/ai-dial-admin/src/components/Telemetry/Dashboard.tsx
+++ b/apps/ai-dial-admin/src/components/Telemetry/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, FC, SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { Dispatch, FC, SetStateAction, useCallback, useMemo, useRef, useState } from 'react';
 import LineChart from '@/src/components/Charts/LineChart/LineChart';
 import SingleValueChartsDashboard from '@/src/components/Charts/SingleValueChart/SingleValueChartsDashboard';
 import McpDashboard from '@/src/components/Telemetry/McpDashboard';
@@ -48,8 +48,14 @@ const Dashboard: FC<Props> = ({
   const t = useI18n();
   const [filters, setFilters] = useState<FilterData[]>([]);
   const [refreshTime, setRefreshTime] = useState(DEFAULT_REFRESH_TIME);
-  const [timePeriod, setTimePeriod] = useState<string | undefined>();
-  const [timeRange, setTimeRange] = useState<TimeRange>(getTimeRangeById(DEFAULT_TIME_PERIOD));
+  const [timePeriod, setTimePeriod] = useState<string | undefined>(
+    !isCustomRange ? (initTimeFilter as string) || DEFAULT_TIME_PERIOD : DEFAULT_TIME_PERIOD,
+  );
+  const [timeRange, setTimeRange] = useState<TimeRange>(
+    isCustomRange
+      ? (initTimeFilter as TimeRange) || getTimeRangeById(DEFAULT_TIME_PERIOD)
+      : getTimeRangeById((initTimeFilter as string) || DEFAULT_TIME_PERIOD),
+  );
   const [viewType, setViewType] = useState<DASHBOARD_VIEW_TYPE>(DASHBOARD_VIEW_TYPE.Chat);
   const timePeriodOptions = useTimePeriodOptions();
   const getReqRef = useRef(useProtectedRequest());
@@ -63,18 +69,6 @@ const Dashboard: FC<Props> = ({
     }
     return entity?.name || null;
   }, [route, entity]);
-
-  useEffect(() => {
-    if (!timePeriod) {
-      if (!isCustomRange) {
-        setTimePeriod((initTimeFilter as string) || DEFAULT_TIME_PERIOD);
-        setTimeRange(getTimeRangeById((initTimeFilter as string) || DEFAULT_TIME_PERIOD));
-      } else {
-        setTimePeriod(DEFAULT_TIME_PERIOD);
-        setTimeRange((initTimeFilter as TimeRange) || getTimeRangeById(DEFAULT_TIME_PERIOD));
-      }
-    }
-  }, [initTimeFilter, timePeriod, isCustomRange]);
 
   const getCurrentTimeRange = useCallback(
     () => (isCustomRange ? timeRange : getTimeRangeById(timePeriod || DEFAULT_TIME_PERIOD)),

--- a/apps/ai-dial-admin/src/components/UsageLog/UsageLog.tsx
+++ b/apps/ai-dial-admin/src/components/UsageLog/UsageLog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Dispatch, FC, SetStateAction, useCallback, useEffect, useRef, useState } from 'react';
+import { Dispatch, FC, SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { DialNeutralButton, DialTabs } from '@epam/ai-dial-ui-kit';
 import { IconRefresh } from '@tabler/icons-react';
@@ -19,7 +19,7 @@ import {
 } from '@/src/constants/grid-columns/grid-columns';
 import { ButtonsI18nKey, TabsI18nKey, TelemetryI18nKey } from '@/src/constants/i18n';
 import { BASE_BUTTON_ICON_PROPS } from '@/src/constants/main-layout';
-import { CONVERSATIONS_QUERY, MCP_QUERY, TRACES_QUERY } from '@/src/constants/telemetry';
+import { CONVERSATIONS_QUERY, MCP_QUERY, TOOLSET_DEPLOYMENT_PREFIX, TRACES_QUERY } from '@/src/constants/telemetry';
 import { useProtectedRequest } from '@/src/hooks/use-protected-request';
 import { useI18n } from '@/src/locales/client';
 import { BaseEntity } from '@/src/models/dial/base-entity';
@@ -30,7 +30,8 @@ import { EntityViewTab, getUsageLogTabs } from '@/src/utils/tabs/utils';
 import { getFormattedFilters } from '@/src/utils/telemetry';
 import { getTimeRangeById } from '@/src/utils/time-filter/get-time-range-id';
 
-const isToolsetRoute = (route: ApplicationRoute) => route === ApplicationRoute.Toolsets;
+const isToolsetRoute = (route: ApplicationRoute) =>
+  route === ApplicationRoute.Toolsets || route === ApplicationRoute.AssetsToolsets;
 
 interface Props {
   route: ApplicationRoute;
@@ -74,17 +75,25 @@ const UsageLog: FC<Props> = ({
     }
   }, [initTimeFilter, timePeriod, isCustomRange]);
 
+  const entityFilterName = useMemo(() => {
+    if (route === ApplicationRoute.AssetsToolsets) {
+      const path = (entity as unknown as { path?: string })?.path;
+      return path ? `${TOOLSET_DEPLOYMENT_PREFIX}${path}` : entity?.name || null;
+    }
+    return entity?.name || null;
+  }, [route, entity]);
+
   const getData = useCallback(
     (query: TelemetryQuery) => {
       if (typeof query.query.from === 'string') {
-        query.query.where = getFormattedFilters(timeRange, [], entity?.name || null);
+        query.query.where = getFormattedFilters(timeRange, [], entityFilterName);
       } else {
-        query.query.from.where = getFormattedFilters(timeRange, [], entity?.name || null);
+        query.query.from.where = getFormattedFilters(timeRange, [], entityFilterName);
       }
 
       return getReqRef.current(getDashboardData, query);
     },
-    [entity?.name, timeRange],
+    [entityFilterName, timeRange],
   );
 
   const onTimePeriodChange = useCallback(

--- a/apps/ai-dial-admin/src/components/UsageLog/UsageLog.tsx
+++ b/apps/ai-dial-admin/src/components/UsageLog/UsageLog.tsx
@@ -14,6 +14,7 @@ import { useTimePeriodOptions } from '@/src/hooks/use-time-period-options';
 import {
   USAGE_LOG_CONVERSATIONS_COLUMNS,
   USAGE_LOG_MCP_COLUMNS,
+  USAGE_LOG_TOOLSET_TRACES_COLUMNS,
   USAGE_LOG_TRACES_COLUMNS,
 } from '@/src/constants/grid-columns/grid-columns';
 import { ButtonsI18nKey, TabsI18nKey, TelemetryI18nKey } from '@/src/constants/i18n';
@@ -28,6 +29,8 @@ import { ApplicationRoute } from '@/src/types/routes';
 import { EntityViewTab, getUsageLogTabs } from '@/src/utils/tabs/utils';
 import { getFormattedFilters } from '@/src/utils/telemetry';
 import { getTimeRangeById } from '@/src/utils/time-filter/get-time-range-id';
+
+const isToolsetRoute = (route: ApplicationRoute) => route === ApplicationRoute.Toolsets;
 
 interface Props {
   route: ApplicationRoute;
@@ -148,8 +151,8 @@ const UsageLog: FC<Props> = ({
           <List
             route={route}
             getData={getData}
-            columnDefs={USAGE_LOG_TRACES_COLUMNS}
-            query={TRACES_QUERY}
+            columnDefs={isToolsetRoute(route) ? USAGE_LOG_TOOLSET_TRACES_COLUMNS : USAGE_LOG_TRACES_COLUMNS}
+            query={isToolsetRoute(route) ? MCP_QUERY : TRACES_QUERY}
             listLabel={t(TabsI18nKey.Traces)}
             emptyDataTitle={t(TelemetryI18nKey.NoTracesTitle)}
           />

--- a/apps/ai-dial-admin/src/components/UsageLog/UsageLog.tsx
+++ b/apps/ai-dial-admin/src/components/UsageLog/UsageLog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Dispatch, FC, SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Dispatch, FC, SetStateAction, useCallback, useMemo, useRef, useState } from 'react';
 
 import { DialNeutralButton, DialTabs } from '@epam/ai-dial-ui-kit';
 import { IconRefresh } from '@tabler/icons-react';
@@ -60,20 +60,14 @@ const UsageLog: FC<Props> = ({
   const timePeriodOptions = useTimePeriodOptions();
 
   const [activeTab, setActiveTab] = useState(entityView || EntityViewTab.Traces);
-  const [timePeriod, setTimePeriod] = useState<string | undefined>();
-  const [timeRange, setTimeRange] = useState<TimeRange>(getTimeRangeById(DEFAULT_TIME_PERIOD));
-
-  useEffect(() => {
-    if (!timePeriod) {
-      if (!isCustomRange) {
-        setTimePeriod((initTimeFilter as string) || DEFAULT_TIME_PERIOD);
-        setTimeRange(getTimeRangeById((initTimeFilter as string) || DEFAULT_TIME_PERIOD));
-      } else {
-        setTimePeriod(DEFAULT_TIME_PERIOD);
-        setTimeRange((initTimeFilter as TimeRange) || getTimeRangeById(DEFAULT_TIME_PERIOD));
-      }
-    }
-  }, [initTimeFilter, timePeriod, isCustomRange]);
+  const [timePeriod, setTimePeriod] = useState<string | undefined>(
+    !isCustomRange ? (initTimeFilter as string) || DEFAULT_TIME_PERIOD : DEFAULT_TIME_PERIOD,
+  );
+  const [timeRange, setTimeRange] = useState<TimeRange>(
+    isCustomRange
+      ? (initTimeFilter as TimeRange) || getTimeRangeById(DEFAULT_TIME_PERIOD)
+      : getTimeRangeById((initTimeFilter as string) || DEFAULT_TIME_PERIOD),
+  );
 
   const entityFilterName = useMemo(() => {
     if (route === ApplicationRoute.AssetsToolsets) {

--- a/apps/ai-dial-admin/src/constants/grid-columns/grid-columns.tsx
+++ b/apps/ai-dial-admin/src/constants/grid-columns/grid-columns.tsx
@@ -507,6 +507,26 @@ export const USAGE_LOG_MCP_COLUMNS: ColDef[] = [
     hide: false,
   },
 ];
+export const USAGE_LOG_TOOLSET_TRACES_COLUMNS: ColDef[] = [
+  { field: 'completion_time', headerName: 'Last activity', hide: false, ...dateTimeColumn },
+  { field: 'project_id', headerName: 'Project', hide: false },
+  {
+    field: 'mcp_method',
+    headerName: 'Method',
+    hide: true,
+  },
+  {
+    field: 'mcp_tool_call_name',
+    headerName: 'Tool Name',
+    hide: false,
+  },
+  {
+    field: 'trace_id',
+    headerName: 'Trace ID',
+    hide: false,
+  },
+];
+
 export const PROJECT_GRID_COLUMNS: ColDef[] = [{ field: 'name', headerName: 'Project' }, ...TELEMETRY_COLUMNS];
 
 export const MCP_CONSUMPTION_COLUMNS: ColDef[] = [

--- a/apps/ai-dial-admin/src/constants/telemetry.tsx
+++ b/apps/ai-dial-admin/src/constants/telemetry.tsx
@@ -184,7 +184,14 @@ export const TRACES_QUERY: TelemetryQuery = {
 export const MCP_QUERY: TelemetryQuery = {
   $type: 'json',
   query: {
-    expressions: ['_time as completion_time', 'deployment', 'project_id', 'mcp_method', 'mcp_tool_call_name'],
+    expressions: [
+      '_time as completion_time',
+      'deployment',
+      'project_id',
+      'mcp_method',
+      'mcp_tool_call_name',
+      'trace_id',
+    ],
     from: 'mcp_analytics',
     orderBy: [{ $desc: '_time' }],
   },

--- a/apps/ai-dial-admin/src/utils/tabs/utils.ts
+++ b/apps/ai-dial-admin/src/utils/tabs/utils.ts
@@ -417,7 +417,7 @@ export const getAuditTabs = (
   const tabs: TabModel[] = [];
 
   if (featureFlags.dashboardEnabled && view === ApplicationRoute.AssetsToolsets) {
-    return [dashboardTab(t)];
+    return [dashboardTab(t), tracesTab(t)];
   }
 
   if (

--- a/apps/ai-dial-admin/src/utils/tabs/utils.ts
+++ b/apps/ai-dial-admin/src/utils/tabs/utils.ts
@@ -420,11 +420,12 @@ export const getAuditTabs = (
     return [dashboardTab(t), tracesTab(t)];
   }
 
-  if (
-    featureFlags.dashboardEnabled &&
-    (view === ApplicationRoute.Models || view === ApplicationRoute.Applications || view === ApplicationRoute.Toolsets)
-  ) {
+  if (featureFlags.dashboardEnabled && (view === ApplicationRoute.Models || view === ApplicationRoute.Applications)) {
     tabs.push(dashboardTab(t), tracesTab(t), conversationsTab(t));
+  }
+
+  if (featureFlags.dashboardEnabled && view === ApplicationRoute.Toolsets) {
+    tabs.push(dashboardTab(t), tracesTab(t));
   }
 
   tabs.push(activitiesTab(t));


### PR DESCRIPTION
…witch

When switching between audit tabs (Dashboard/Traces/Activities), the time period state was initialized as undefined with a useEffect to set it from props. This caused a race condition: child components fetched data with the default time range on the first render, then refetched with the correct range after the effect. If the stale fetch resolved last, it overwrote the correct data.

Initialize timePeriod and timeRange directly from initTimeFilter in useState, eliminating the extra render cycle and race condition.

**Description:**

<SHORT_DESCRIPTION>

Issues:

- Issue #<TICKET_ID>


**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
