### PR TITLE
feat(deployments): pre-filter supported  MCP registry servers (Issue #2227)

### DIFF
--- a/apps/ai-dial-admin/src/app/actions/deployments.ts
+++ b/apps/ai-dial-admin/src/app/actions/deployments.ts
@@ -162,9 +162,40 @@ export async function updateGlobalWhitelist(domainList: string[]) {
   return whitelistApi.updateGlobalWhitelist(domainList, token);
 }
 
-export async function getMcpServers(params: Record<string, string>) {
+export async function getContainerMcpServers(params: {
+  search?: string;
+  cursor?: string;
+  limit?: number;
+  minResults?: number;
+}) {
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
-  return mcpRegistryApi.getMcpServers(params, token);
+  const { minResults, ...requestParams } = params;
+
+  if (!minResults) {
+    return mcpRegistryApi.getContainerMcpServers(requestParams, token);
+  }
+
+  const allServers: unknown[] = [];
+  let cursor = params.cursor;
+
+  while (allServers.length < minResults) {
+    const result = await mcpRegistryApi.getContainerMcpServers({ ...requestParams, cursor }, token);
+    if (!result.success) return result;
+
+    const servers = result.response?.servers ?? [];
+    allServers.push(...servers);
+
+    cursor = result.response?.metadata?.nextCursor;
+    if (!cursor) break;
+  }
+
+  return {
+    success: true,
+    response: {
+      servers: allServers,
+      metadata: { nextCursor: cursor },
+    },
+  };
 }
 
 export async function getHuggingFaceModels(params: Record<string, string>) {

--- a/apps/ai-dial-admin/src/components/Deployments/Fields/ContainerSource/McpServerNameField.tsx
+++ b/apps/ai-dial-admin/src/components/Deployments/Fields/ContainerSource/McpServerNameField.tsx
@@ -10,9 +10,9 @@ import { CONTAINER_STATUS } from '@/src/types/deployments/containers';
 import { useSaveValidationContext, ValidationActionType } from '@/src/context/SaveValidationContext';
 import { getErrorForMcpServerName } from '@/src/utils/deployments/validation';
 import { ErrorType } from '@/src/types/error-type';
-import { getPreferredOciPackage, isServerSelectable, mapTransportType } from '@/src/utils/deployments/mcp-registry';
+import { getPreferredOciPackage, mapTransportType } from '@/src/utils/deployments/mcp-registry';
 import { debounce } from 'lodash';
-import { getMcpServers } from '@/src/app/actions/deployments';
+import { getContainerMcpServers } from '@/src/app/actions/deployments';
 import { BASE_BUTTON_ICON_PROPS } from '@/src/constants/main-layout';
 import OpenPopup from '@/public/images/icons/open-pop-up.svg';
 import { createPortal } from 'react-dom';
@@ -75,7 +75,7 @@ const McpServerNameField: FC<Props> = ({ container, setContainer, isModal, disab
 
   const validateAndApplyServer = useCallback(
     (value: string) => {
-      getMcpServers({ search: value, limit: '10' }).then(({ success, response }) => {
+      getContainerMcpServers({ search: value, limit: 10 }).then(({ success, response }) => {
         if (!success) return;
 
         const servers = (response.servers || []).map((s: McpServerResponse) => s.server) as McpServer[];
@@ -83,13 +83,6 @@ const McpServerNameField: FC<Props> = ({ container, setContainer, isModal, disab
 
         if (!exactMatch) {
           const error = { type: ErrorType.INVALID, text: t(ErrorI18nKey.McpServerNotFound) };
-          setServerNameError(error);
-          dispatch({ type: ValidationActionType.SetField, field: 'mcpServerName', isValid: false });
-          return;
-        }
-
-        if (!isServerSelectable(exactMatch)) {
-          const error = { type: ErrorType.INVALID, text: t(ErrorI18nKey.McpServerNotSupported) };
           setServerNameError(error);
           dispatch({ type: ValidationActionType.SetField, field: 'mcpServerName', isValid: false });
           return;
@@ -142,23 +135,23 @@ const McpServerNameField: FC<Props> = ({ container, setContainer, isModal, disab
   const onServerNameType = useMemo(
     () =>
       debounce((value: string) => {
-        if (value.length > 2) {
-          getMcpServers({ search: value, limit: '5' }).then(({ success, response }) => {
-            if (success) {
-              const servers = ((response.servers || []).map((s: McpServerResponse) => s.server) as McpServer[]).filter(
-                isServerSelectable,
-              );
-              if (servers.length) {
-                setServerOptions(servers.map((s) => ({ value: s.name, label: s.name })));
-                setServerCache((prev) => {
-                  const next = new Map(prev);
-                  servers.forEach((s) => next.set(s.name, s));
-                  return next;
-                });
-              }
-            }
-          });
+        if (value.length <= 2) {
+          setServerOptions([]);
+          return;
         }
+        getContainerMcpServers({ search: value, limit: 5 }).then(({ success, response }) => {
+          if (success) {
+            const servers = (response.servers || []).map((s: McpServerResponse) => s.server) as McpServer[];
+            if (servers.length) {
+              setServerOptions(servers.map((s) => ({ value: s.name, label: s.name })));
+              setServerCache((prev) => {
+                const next = new Map(prev);
+                servers.forEach((s) => next.set(s.name, s));
+                return next;
+              });
+            }
+          }
+        });
       }, 100),
     [],
   );
@@ -215,6 +208,7 @@ const McpServerNameField: FC<Props> = ({ container, setContainer, isModal, disab
             isModalOpen={isModalOpen}
             onClose={handleModalClose}
             onApply={(server) => applyServer(server)}
+            fetchServers={getContainerMcpServers}
           />,
           document.body,
         )}

--- a/apps/ai-dial-admin/src/components/Deployments/McpRegistryGrid/McpRegistryGrid.tsx
+++ b/apps/ai-dial-admin/src/components/Deployments/McpRegistryGrid/McpRegistryGrid.tsx
@@ -2,50 +2,55 @@
 
 import { GridApi, GridOptions, GridReadyEvent, IDatasource, IGetRowsParams } from 'ag-grid-community';
 import { isEqual } from 'lodash';
-import { FC, useCallback, useEffect, useMemo, useState } from 'react';
+import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { getMcpServers } from '@/src/app/actions/deployments';
 import { infiniteGridOptions, SINGLE_ROW_SELECTION } from '@/src/constants/ag-grid';
 import { ContainersI18nKey } from '@/src/constants/i18n';
 import { MCP_REGISTRY_COLUMNS } from '@/src/constants/grid-columns/grid-columns';
 import { useI18n } from '@/src/locales/client';
 import { FilterDto } from '@/src/models/request';
+import { ServerActionResponse } from '@/src/models/server-action';
 import { getRequestFilters } from '@/src/utils/request/get-request-filters';
-import { isServerSelectable } from '@/src/utils/deployments/mcp-registry';
 import { McpServer, McpServerResponse } from '@/src/types/deployments/mcp-registry';
 
 import RadioButtonRenderer from '@/src/components/Grid/CellRenderers/RadioButtonRenderer';
 import ListEntities from '@/src/components/ListView/List';
 
+export type McpRegistryFetchFn = (params: {
+  search?: string;
+  cursor?: string;
+  limit?: number;
+  minResults?: number;
+}) => Promise<ServerActionResponse>;
+
 interface Props {
   selectedServer?: McpServer;
   onSelect: (server: McpServer) => void;
+  fetchServers: McpRegistryFetchFn;
 }
 
-const McpRegistryGrid: FC<Props> = ({ selectedServer, onSelect }) => {
+const REGISTRY_META_KEY = 'io.modelcontextprotocol.registry/official';
+
+const McpRegistryGrid: FC<Props> = ({ selectedServer, onSelect, fetchServers }) => {
   const t = useI18n();
   const [gridApi, setGridApi] = useState<GridApi | null>(null);
+  const fetchServersRef = useRef(fetchServers);
+  fetchServersRef.current = fetchServers;
 
   const gridOptions: GridOptions = {
     ...infiniteGridOptions,
     ...SINGLE_ROW_SELECTION,
     selectionColumnDef: {
       ...SINGLE_ROW_SELECTION.selectionColumnDef,
-      cellRenderer: (data: { data?: McpServer }) => (
-        <RadioButtonRenderer inputId={data.data?.name as string} isChecked={data.data?.name === selectedServer?.name} />
-      ),
+      cellRenderer: (data: { data?: McpServer }) => {
+        if (!data.data) return null;
+        return <RadioButtonRenderer inputId={data.data.name} isChecked={data.data.name === selectedServer?.name} />;
+      },
     },
-    isRowSelectable: (node) => isServerSelectable(node.data),
     onRowSelected: (event) => {
       if (event.node.isSelected() && event.data) {
         onSelect(event.data);
       }
-    },
-    getRowStyle: (params) => {
-      if (params.data && !isServerSelectable(params.data)) {
-        return { opacity: '0.5' };
-      }
-      return undefined;
     },
   };
 
@@ -61,28 +66,24 @@ const McpRegistryGrid: FC<Props> = ({ selectedServer, onSelect }) => {
         }
         filters = currentFilters;
 
-        const requestFilters = Object.fromEntries(
-          currentFilters.map(({ column, value }) => [column === 'name' ? 'search' : column, encodeURIComponent(value)]),
-        );
+        const searchFilter = currentFilters.find(({ column }) => column === 'name');
+        const search = searchFilter ? String(searchFilter.value) : undefined;
 
-        getMcpServers({
-          cursor: nextCursor,
-          limit: '100',
-          ...requestFilters,
-        })
+        fetchServersRef
+          .current({
+            cursor: nextCursor || undefined,
+            limit: 100,
+            minResults: 100,
+            search,
+          })
           .then(({ response, success }) => {
             if (success) {
-              const REGISTRY_META_KEY = 'io.modelcontextprotocol.registry/official';
               const servers = (response.servers || []).map((s: McpServerResponse) => ({
                 ...s.server,
                 updatedAt: (s._meta?.[REGISTRY_META_KEY] as Record<string, unknown>)?.updatedAt,
               }));
-              if (servers.length === 0) {
-                params.successCallback([], 0);
-              } else {
-                nextCursor = response.metadata?.nextCursor || '';
-                params.successCallback(servers, nextCursor ? undefined : params.startRow + servers.length);
-              }
+              nextCursor = String(response.metadata?.nextCursor || '');
+              params.successCallback(servers, nextCursor ? undefined : params.startRow + servers.length);
             } else {
               params.failCallback();
             }

--- a/apps/ai-dial-admin/src/components/Deployments/Modals/McpRegistryModal/McpRegistryModal.tsx
+++ b/apps/ai-dial-admin/src/components/Deployments/Modals/McpRegistryModal/McpRegistryModal.tsx
@@ -1,7 +1,7 @@
 import { DialFormPopup, PopupSize } from '@epam/ai-dial-ui-kit';
 import { FC, useCallback, useState } from 'react';
 
-import McpRegistryGrid from '@/src/components/Deployments/McpRegistryGrid/McpRegistryGrid';
+import McpRegistryGrid, { McpRegistryFetchFn } from '@/src/components/Deployments/McpRegistryGrid/McpRegistryGrid';
 import { ButtonsI18nKey, ContainersI18nKey } from '@/src/constants/i18n';
 import { useI18n } from '@/src/locales/client';
 import { McpServer } from '@/src/types/deployments/mcp-registry';
@@ -10,10 +10,11 @@ interface Props {
   isModalOpen: boolean;
   onClose: () => void;
   onApply: (server: McpServer) => void;
+  fetchServers: McpRegistryFetchFn;
   preselectedServer?: McpServer;
 }
 
-const McpRegistryModal: FC<Props> = ({ isModalOpen, onClose, onApply, preselectedServer }) => {
+const McpRegistryModal: FC<Props> = ({ isModalOpen, onClose, onApply, fetchServers, preselectedServer }) => {
   const t = useI18n();
   const [selectedServer, setSelectedServer] = useState<McpServer | undefined>(preselectedServer);
 
@@ -39,7 +40,7 @@ const McpRegistryModal: FC<Props> = ({ isModalOpen, onClose, onApply, preselecte
       size={PopupSize.Lg}
     >
       <div className="flex h-full bg-layer-2 py-4 px-6 gap-4">
-        <McpRegistryGrid selectedServer={selectedServer} onSelect={handleSelect} />
+        <McpRegistryGrid selectedServer={selectedServer} onSelect={handleSelect} fetchServers={fetchServers} />
       </div>
     </DialFormPopup>
   );

--- a/apps/ai-dial-admin/src/server/deployments/mcp-registry.ts
+++ b/apps/ai-dial-admin/src/server/deployments/mcp-registry.ts
@@ -2,16 +2,27 @@ import { Token } from '@/src/models/auth';
 import { ServerActionResponse } from '@/src/models/server-action';
 import { API } from '@/src/server/api';
 import { BaseApi } from '@/src/server/base-api';
+import { McpServersRequestDto } from '@/src/types/deployments/mcp-registry';
 
-export const MCP_REGISTRY_SERVERS_BASE = `${API}/mcp-registry/servers`;
-export const MCP_REGISTRY_SERVERS = (params: Record<string, string>) => {
-  const queryString = new URLSearchParams(params).toString();
+export const MCP_REGISTRY_SERVERS_LIST = `${API}/mcp-registry/servers/list`;
 
-  return `${MCP_REGISTRY_SERVERS_BASE}?${queryString}`;
+const CONTAINER_FILTER = {
+  packageRegistryTypes: ['oci'],
+  packageTransportTypes: ['streamable-http', 'sse'],
 };
 
 export class McpRegistryApi extends BaseApi {
-  getMcpServers(params: Record<string, string>, token: Token): Promise<ServerActionResponse> {
-    return this.getAction(MCP_REGISTRY_SERVERS(params), token);
+  getContainerMcpServers(
+    params: { search?: string; cursor?: string; limit?: number },
+    token: Token,
+  ): Promise<ServerActionResponse> {
+    const body: McpServersRequestDto = {
+      ...(params.search ? { search: params.search } : {}),
+      ...(params.cursor ? { cursor: params.cursor } : {}),
+      ...(params.limit != null ? { limit: params.limit } : {}),
+      filter: CONTAINER_FILTER,
+    };
+
+    return this.postAction(MCP_REGISTRY_SERVERS_LIST, body, token);
   }
 }

--- a/apps/ai-dial-admin/src/server/deployments/tests/mcp-registry.spec.ts
+++ b/apps/ai-dial-admin/src/server/deployments/tests/mcp-registry.spec.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, vi } from 'vitest';
 
 import createFetchMock from 'vitest-fetch-mock';
 import { TEST_URL, TOKEN_MOCK } from '@/src/utils/tests/mock/api.mock';
-import { MCP_REGISTRY_SERVERS, McpRegistryApi } from '@/src/server/deployments/mcp-registry';
+import { MCP_REGISTRY_SERVERS_LIST, McpRegistryApi } from '@/src/server/deployments/mcp-registry';
 
 const fetch = createFetchMock(vi);
 fetch.enableMocks();
@@ -10,21 +10,59 @@ fetch.enableMocks();
 describe('McpRegistryApi', () => {
   const instance = new McpRegistryApi({ host: TEST_URL });
 
-  test('getMcpServers calls servers url', async () => {
+  test('getContainerMcpServers sends POST with OCI and transport filters', async () => {
     fetch.mockResponseOnce(JSON.stringify({ servers: [], metadata: {} }));
-    await instance.getMcpServers({}, TOKEN_MOCK);
+    await instance.getContainerMcpServers({ limit: 100 }, TOKEN_MOCK);
     expect(fetch).toHaveBeenCalledWith(
-      expect.stringContaining(MCP_REGISTRY_SERVERS({})),
-      expect.objectContaining({ method: 'GET' }),
+      expect.stringContaining(MCP_REGISTRY_SERVERS_LIST),
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          limit: 100,
+          filter: {
+            packageRegistryTypes: ['oci'],
+            packageTransportTypes: ['streamable-http', 'sse'],
+          },
+        }),
+      }),
     );
   });
 
-  test('getMcpServers calls servers url with search param', async () => {
+  test('getContainerMcpServers includes search and cursor when provided', async () => {
     fetch.mockResponseOnce(JSON.stringify({ servers: [], metadata: {} }));
-    await instance.getMcpServers({ search: 'test', limit: '5' }, TOKEN_MOCK);
+    await instance.getContainerMcpServers({ search: 'test', cursor: 'abc', limit: 5 }, TOKEN_MOCK);
     expect(fetch).toHaveBeenCalledWith(
-      expect.stringContaining(MCP_REGISTRY_SERVERS({ search: 'test', limit: '5' })),
-      expect.objectContaining({ method: 'GET' }),
+      expect.stringContaining(MCP_REGISTRY_SERVERS_LIST),
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          search: 'test',
+          cursor: 'abc',
+          limit: 5,
+          filter: {
+            packageRegistryTypes: ['oci'],
+            packageTransportTypes: ['streamable-http', 'sse'],
+          },
+        }),
+      }),
+    );
+  });
+
+  test('getContainerMcpServers omits undefined search and empty cursor', async () => {
+    fetch.mockResponseOnce(JSON.stringify({ servers: [], metadata: {} }));
+    await instance.getContainerMcpServers({ search: undefined, cursor: '', limit: 100 }, TOKEN_MOCK);
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining(MCP_REGISTRY_SERVERS_LIST),
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          limit: 100,
+          filter: {
+            packageRegistryTypes: ['oci'],
+            packageTransportTypes: ['streamable-http', 'sse'],
+          },
+        }),
+      }),
     );
   });
 });

--- a/apps/ai-dial-admin/src/types/deployments/mcp-registry.ts
+++ b/apps/ai-dial-admin/src/types/deployments/mcp-registry.ts
@@ -52,3 +52,17 @@ export interface McpServersResponse {
     count?: number;
   };
 }
+
+export interface McpServerFilterDto {
+  packageRegistryTypes?: string[];
+  packageTransportTypes?: string[];
+  remoteTransportTypes?: string[];
+  repositoryExists?: boolean;
+}
+
+export interface McpServersRequestDto {
+  search?: string;
+  cursor?: string;
+  limit?: number;
+  filter?: McpServerFilterDto;
+}

--- a/apps/ai-dial-admin/src/utils/deployments/mcp-registry.ts
+++ b/apps/ai-dial-admin/src/utils/deployments/mcp-registry.ts
@@ -1,22 +1,6 @@
 import { McpPackage, McpServer } from '@/src/types/deployments/mcp-registry';
 import { CONTAINER_TRANSPORT } from '@/src/types/deployments/containers';
 
-const SUPPORTED_TRANSPORTS = ['streamable-http', 'sse'];
-
-export const hasOciPackage = (server: McpServer): boolean => {
-  return !!server.packages?.some((pkg) => pkg.registryType === 'oci');
-};
-
-export const hasSupportedTransport = (server: McpServer): boolean => {
-  return !!server.packages?.some(
-    (pkg) => pkg.registryType === 'oci' && pkg.transport?.type && SUPPORTED_TRANSPORTS.includes(pkg.transport.type),
-  );
-};
-
-export const isServerSelectable = (server: McpServer): boolean => {
-  return hasOciPackage(server) && hasSupportedTransport(server);
-};
-
 export const getPreferredOciPackage = (server: McpServer): McpPackage | undefined => {
   if (!server.packages?.length) {
     return undefined;

--- a/apps/ai-dial-admin/src/utils/deployments/tests/mcp-registry.spec.ts
+++ b/apps/ai-dial-admin/src/utils/deployments/tests/mcp-registry.spec.ts
@@ -1,11 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import {
-  hasOciPackage,
-  hasSupportedTransport,
-  isServerSelectable,
-  getPreferredOciPackage,
-  mapTransportType,
-} from '../mcp-registry';
+import { getPreferredOciPackage, mapTransportType } from '../mcp-registry';
 import { McpServer } from '@/src/types/deployments/mcp-registry';
 import { CONTAINER_TRANSPORT } from '@/src/types/deployments/containers';
 
@@ -14,97 +8,6 @@ const makeServer = (overrides: Partial<McpServer> = {}): McpServer => ({
   description: 'test',
   version: '1.0.0',
   ...overrides,
-});
-
-describe('hasOciPackage', () => {
-  test('returns true when server has OCI package', () => {
-    const server = makeServer({ packages: [{ registryType: 'oci', identifier: 'docker.io/img:1.0' }] });
-    expect(hasOciPackage(server)).toBe(true);
-  });
-
-  test('returns false when server has no OCI package', () => {
-    const server = makeServer({ packages: [{ registryType: 'npm', identifier: '@scope/pkg' }] });
-    expect(hasOciPackage(server)).toBe(false);
-  });
-
-  test('returns false when packages is undefined', () => {
-    expect(hasOciPackage(makeServer())).toBe(false);
-  });
-
-  test('returns false when packages is empty', () => {
-    expect(hasOciPackage(makeServer({ packages: [] }))).toBe(false);
-  });
-});
-
-describe('hasSupportedTransport', () => {
-  test('returns true for OCI package with streamable-http transport', () => {
-    const server = makeServer({
-      packages: [{ registryType: 'oci', identifier: 'img:1.0', transport: { type: 'streamable-http' } }],
-    });
-    expect(hasSupportedTransport(server)).toBe(true);
-  });
-
-  test('returns true for OCI package with sse transport', () => {
-    const server = makeServer({
-      packages: [{ registryType: 'oci', identifier: 'img:1.0', transport: { type: 'sse' } }],
-    });
-    expect(hasSupportedTransport(server)).toBe(true);
-  });
-
-  test('returns false for OCI package with stdio transport', () => {
-    const server = makeServer({
-      packages: [{ registryType: 'oci', identifier: 'img:1.0', transport: { type: 'stdio' } }],
-    });
-    expect(hasSupportedTransport(server)).toBe(false);
-  });
-
-  test('returns false for non-OCI package with supported transport', () => {
-    const server = makeServer({
-      packages: [{ registryType: 'npm', identifier: 'pkg', transport: { type: 'streamable-http' } }],
-    });
-    expect(hasSupportedTransport(server)).toBe(false);
-  });
-
-  test('returns false when packages is undefined', () => {
-    expect(hasSupportedTransport(makeServer())).toBe(false);
-  });
-
-  test('returns true when at least one OCI package has supported transport among mixed packages', () => {
-    const server = makeServer({
-      packages: [
-        { registryType: 'oci', identifier: 'img:1.0', transport: { type: 'stdio' } },
-        { registryType: 'oci', identifier: 'img:1.0', transport: { type: 'streamable-http' } },
-      ],
-    });
-    expect(hasSupportedTransport(server)).toBe(true);
-  });
-});
-
-describe('isServerSelectable', () => {
-  test('returns true when server has OCI package with supported transport', () => {
-    const server = makeServer({
-      packages: [{ registryType: 'oci', identifier: 'docker.io/img:1.0', transport: { type: 'streamable-http' } }],
-    });
-    expect(isServerSelectable(server)).toBe(true);
-  });
-
-  test('returns false when server has OCI but only stdio transport', () => {
-    const server = makeServer({
-      packages: [{ registryType: 'oci', identifier: 'docker.io/img:1.0', transport: { type: 'stdio' } }],
-    });
-    expect(isServerSelectable(server)).toBe(false);
-  });
-
-  test('returns false when server has no OCI package', () => {
-    const server = makeServer({
-      packages: [{ registryType: 'npm', identifier: 'pkg', transport: { type: 'streamable-http' } }],
-    });
-    expect(isServerSelectable(server)).toBe(false);
-  });
-
-  test('returns false when server has neither', () => {
-    expect(isServerSelectable(makeServer())).toBe(false);
-  });
 });
 
 describe('getPreferredOciPackage', () => {

--- a/openspec/changes/archive/2026-04-07-mcp-registry-server-side-filtering/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-07-mcp-registry-server-side-filtering/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-02

--- a/openspec/changes/archive/2026-04-07-mcp-registry-server-side-filtering/design.md
+++ b/openspec/changes/archive/2026-04-07-mcp-registry-server-side-filtering/design.md
@@ -1,0 +1,137 @@
+## Context
+
+The MCP Registry integration (see `openspec/specs/mcp-registry-source/spec.md`) currently uses `GET /api/v1/mcp-registry/servers` with query params (`search`, `cursor`, `limit`). All servers are returned regardless of package type or transport, and the FE applies `isServerSelectable()` client-side to grey out non-selectable servers.
+
+BE PRs [#232](https://github.com/epam/ai-dial-admin-deployment-manager-backend/pull/232) and [#268](https://github.com/epam/ai-dial-admin-deployment-manager-backend/pull/268) add a `POST /api/v1/mcp-registry/servers/list` endpoint with a `filter` object supporting: `packageRegistryTypes`, `packageTransportTypes` (new in #268), `remoteTransportTypes` (renamed from `remoteTypes` in #268), and `repositoryExists`.
+
+Current call sites:
+- `McpRegistryGrid` — fetches pages for the registry browser modal
+- `McpServerNameField` — autocomplete search (limit 5) and freeform validation (limit 10)
+- Both go through server action `getMcpServers()` → `McpRegistryApi.getMcpServers()`
+
+## Goals / Non-Goals
+
+**Goals:**
+- Switch API layer from GET to POST with structured request DTO
+- Pre-filter container requests with `packageRegistryTypes: ["oci"]` + `packageTransportTypes: ["streamable-http", "sse"]`
+- Create purpose-specific API method and server action for containers
+- Remove client-side selectability logic (`isServerSelectable`, greyed-out rows)
+- Type the request/filter DTOs to mirror BE contract
+
+**Non-Goals:**
+- User-facing filter UI
+- Using `remoteTransportTypes` or `repositoryExists` filters
+- Changing pagination behavior or ag-grid configuration
+
+## Decisions
+
+### 1. POST with structured body over GET with query params
+
+**Choice**: Use `POST /api/v1/mcp-registry/servers/list` with JSON body.
+
+**Why**: The filter is a nested object with multiple dimensions. POST maps naturally to the BE `ServersRequestDto` and makes the FE types mirror the API contract directly. Also cleaner than CSV query params as dimensions grow.
+
+**Alternative considered**: Stay with GET. Simpler for one param but awkward with multiple filter arrays.
+
+### 2. Purpose-specific API methods and server actions
+
+**Choice**: Create `getContainerMcpServers()` in both `McpRegistryApi` and the server action layer. The API method constructs the full `McpServersRequestDto` internally — accepting only `search`, `cursor`, `limit` from callers — and bakes in the container filter.
+
+```
+// McpRegistryApi
+getContainerMcpServers({ search?, cursor?, limit }, token)
+  → POST /api/v1/mcp-registry/servers/list
+    body: { search, cursor, limit, filter: {
+      packageRegistryTypes: ["oci"],
+      packageTransportTypes: ["streamable-http", "sse"]
+    }}
+
+// Server action
+getContainerMcpServers({ search?, cursor?, limit })
+  → authenticates, delegates to McpRegistryApi.getContainerMcpServers()
+```
+
+**Why**: Filters are an API-layer concern, not a component concern. Components just call the action that matches their use case. Future consumers add their own API method + action with different filters.
+
+**Alternative considered**: Utility builder function. Adds an unnecessary abstraction layer when the logic can live directly in the API method.
+
+### 3. Filter types mirroring BE contract (PR #268)
+
+**Choice**: Define `McpServerFilterDto` and `McpServersRequestDto` in `src/types/deployments/mcp-registry.ts`.
+
+```
+McpServerFilterDto {
+  packageRegistryTypes?: string[];
+  packageTransportTypes?: string[];      // new in BE #268
+  remoteTransportTypes?: string[];       // renamed from remoteTypes in BE #268
+  repositoryExists?: boolean;
+}
+
+McpServersRequestDto {
+  search?: string;
+  cursor?: string;
+  limit?: number;
+  filter?: McpServerFilterDto;
+}
+```
+
+**Why**: Mirrors the BE contract exactly. Including all fields means future features just pass values without type changes.
+
+### 4. Remove isServerSelectable and greyed-out rows
+
+**Choice**: Remove `isServerSelectable()`, `hasOciPackage()`, `hasSupportedTransport()` from utils. Remove `isRowSelectable` and `getRowStyle` (opacity 0.5) from `McpRegistryGrid`. Remove client-side `isServerSelectable` filtering from `McpServerNameField` autocomplete.
+
+**Why**: With BE filtering by both `packageRegistryTypes: ["oci"]` and `packageTransportTypes: ["streamable-http", "sse"]`, every returned server has at least one OCI package and at least one package with a supported transport. Client-side checks are redundant.
+
+**Note**: BE evaluates filter dimensions independently across all packages (not per-package). A server with Package A (OCI, stdio) + Package B (npm, streamable-http) matches both filters even though no single package satisfies both. This is an edge case we accept — can re-implement client-side checks if it becomes a real problem.
+
+**Alternative considered**: Keep as safety net. Rejected — adds complexity for a theoretical edge case. Simpler to re-add if needed.
+
+### 5. Server-side result accumulation with `minResults`
+
+**Choice**: The `getContainerMcpServers` server action accepts an optional `minResults` param. When provided, it fetches multiple BE pages in a loop until `minResults` results are accumulated or the upstream cursor is exhausted. When omitted, a single fetch is made.
+
+```
+// Grid: accumulate until 100 results
+getContainerMcpServers({ search, cursor, limit: 100, minResults: 100 })
+
+// Autocomplete: single fast fetch
+getContainerMcpServers({ search, limit: 5 })
+```
+
+**Why**: With server-side filtering, matching servers are sparse (~106 out of 15K in the upstream registry). A single BE request with `maxPagesToScan: 25` might return only 4 results. The grid needs ~100 rows to fill the view. Accumulation in the server action (not the grid) keeps the grid simple and avoids ag-grid lifecycle issues that occurred when looping in the component.
+
+**Key detail**: The loop breaks only when `!cursor` (upstream exhausted), NOT on empty responses — the BE can return 0 matches from a scan batch but still have more upstream pages.
+
+**Alternative considered**: Accumulation loop in the grid component. Caused ag-grid infinite row model issues — the datasource was being recreated, wiping previous results on scroll.
+
+### 6. Reusable grid with `fetchServers` prop
+
+**Choice**: `McpRegistryGrid` accepts a `fetchServers: McpRegistryFetchFn` prop. The grid is agnostic to which action fetches data. Uses `useRef` for the function to avoid datasource recreation.
+
+**Why**: The grid will be reused for different consumers (containers, future image browsing) with different server actions and filter presets.
+
+### 7. Placeholder row fix
+
+**Choice**: The radio button `cellRenderer` in `McpRegistryGrid` returns `null` when `data` is undefined.
+
+**Why**: Ag-grid's infinite scroll pre-creates placeholder rows when more data might exist (`nextCursor` present). Without the guard, empty radio buttons render for these placeholders.
+
+### 8. Autocomplete clears on short input
+
+**Choice**: The debounced `onServerNameType` clears `serverOptions` when input length is <= 2 characters.
+
+**Why**: Previously, stale suggestions remained visible when the input was cleared or shortened. Now the dropdown closes immediately.
+
+## Risks / Trade-offs
+
+**[Risk] BE endpoints not yet deployed** → PRs #232 and #268 must be merged and deployed.
+→ Mitigation: Feature is behind `mcpRegistryEnabled` flag (disabled by default). No impact until both BE and FE are deployed and flag is enabled.
+
+**[Risk] Cross-package filter matching edge case** → BE evaluates `packageRegistryTypes` and `packageTransportTypes` independently. A server could match both filters without having a single OCI package with supported transport.
+→ Mitigation: Accepted as unlikely in practice. If it surfaces, re-implement `isServerSelectable()`.
+
+**[Risk] Response may exceed `limit`** → BE returns up to one extra upstream page when filtering.
+→ Mitigation: Ag-grid infinite row model handles variable page sizes naturally via cursor-based pagination. No code changes needed.
+
+**[Trade-off] Unused filter fields in types** → `remoteTransportTypes` and `repositoryExists` aren't used yet. Intentional — prepares for future features.

--- a/openspec/changes/archive/2026-04-07-mcp-registry-server-side-filtering/proposal.md
+++ b/openspec/changes/archive/2026-04-07-mcp-registry-server-side-filtering/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+The MCP Registry grid and autocomplete currently fetch all servers and apply client-side filtering (`isServerSelectable`) to grey out non-OCI servers or those without supported transports. This wastes bandwidth, pagination slots, and degrades UX — users scroll through rows they can never select. Backend PRs [#232](https://github.com/epam/ai-dial-admin-deployment-manager-backend/pull/232) and [#268](https://github.com/epam/ai-dial-admin-deployment-manager-backend/pull/268) introduce server-side filtering (by package registry type, package transport type, remote transport type, and repository existence), enabling the FE to request only relevant servers and remove client-side selectability logic entirely.
+
+## What Changes
+
+- **Switch MCP Registry API from GET to POST**: Replace `GET /api/v1/mcp-registry/servers` with `POST /api/v1/mcp-registry/servers/list` using structured request body with nested `filter` object.
+- **Purpose-specific API methods and server actions**: Create `getContainerMcpServers()` in `McpRegistryApi` and as a server action, with container-specific filters baked in: `packageRegistryTypes: ["oci"]` and `packageTransportTypes: ["streamable-http", "sse"]`. Components just call the action with search/pagination params. Future consumers get their own API method + action with their own filter presets.
+- **Remove client-side selectability logic**: Since BE now filters by both package registry type and package transport type, `isServerSelectable()`, `hasOciPackage()`, `hasSupportedTransport()` are no longer needed. Remove them along with grid `isRowSelectable`, `getRowStyle` (opacity 0.5), and autocomplete client-side filtering.
+- **Update filter types to match BE contract**: `remoteTypes` renamed to `remoteTransportTypes`, new `packageTransportTypes` field added.
+- **Server-side result accumulation**: The server action supports a `minResults` param. When provided, it fetches multiple BE pages until the target count is reached or data is exhausted. The grid uses `minResults: 100` to fill initial view; autocomplete omits it for fast single-fetch responses.
+- **Reusable grid with `fetchServers` prop**: `McpRegistryGrid` accepts a `fetchServers` function prop instead of importing a specific action. This allows future consumers (e.g., image browsing) to pass their own data-fetching action.
+- **Grid placeholder row fix**: Radio button cell renderer returns `null` for rows without data, preventing empty radio buttons on ag-grid placeholder rows.
+- **Autocomplete clears suggestions on short input**: When input has 2 or fewer characters, dropdown options are cleared immediately.
+
+## Capabilities
+
+### New Capabilities
+
+_None — this change enhances an existing capability._
+
+### Modified Capabilities
+
+- `mcp-registry-source`: API contract changes from GET to POST with structured filter body; new purpose-specific API method and server action for containers with OCI + transport pre-filter; removal of client-side selectability checks and greyed-out row styling; updated filter DTO types.
+
+## Impact
+
+- **Modified server code**: `McpRegistryApi` — new `getContainerMcpServers()` POST method, removal of old `getMcpServers()` GET method
+- **Modified server action**: New `getContainerMcpServers()` replacing `getMcpServers()`
+- **New types**: `McpServersRequestDto`, `McpServerFilterDto` interfaces mirroring BE contract
+- **Removed utils**: `isServerSelectable()`, `hasOciPackage()`, `hasSupportedTransport()` from `src/utils/deployments/mcp-registry.ts`
+- **Modified components**: `McpRegistryGrid` — accepts `fetchServers` prop, accumulation via `minResults`, placeholder row fix; `McpServerNameField` — call new action, remove client-side filtering, clear suggestions on short input; `McpRegistryModal` — passes `fetchServers` through
+- **No UI changes**: No new controls; greyed-out rows simply disappear (all returned rows are selectable)
+- **No feature flag changes**: Stays behind existing `mcpRegistryEnabled` flag
+- **Backend dependency**: BE PRs [#232](https://github.com/epam/ai-dial-admin-deployment-manager-backend/pull/232) and [#268](https://github.com/epam/ai-dial-admin-deployment-manager-backend/pull/268) must be deployed
+
+## Non-goals
+
+- User-facing filter UI (dropdowns/checkboxes for filter dimensions)
+- Using `remoteTransportTypes` or `repositoryExists` filters (for future features)
+- Switching other entity APIs to POST (scoped to MCP registry only)

--- a/openspec/changes/archive/2026-04-07-mcp-registry-server-side-filtering/specs/mcp-registry-source/spec.md
+++ b/openspec/changes/archive/2026-04-07-mcp-registry-server-side-filtering/specs/mcp-registry-source/spec.md
@@ -1,0 +1,140 @@
+## MODIFIED Requirements
+
+### Requirement: Backend API Contract
+
+**List/search servers**: `POST /api/v1/mcp-registry/servers/list`
+- Request body: `McpServersRequestDto` with fields: `search` (string), `cursor` (string), `limit` (number, default 100, max 1000), `filter` (McpServerFilterDto, optional)
+- `McpServerFilterDto`: `{ packageRegistryTypes?: string[], packageTransportTypes?: string[], remoteTransportTypes?: string[], repositoryExists?: boolean }`
+- Response: `{ servers: ServerResponseDto[], metadata: { nextCursor?, count? } }` (unchanged)
+- Each `ServerResponseDto`: `{ server: ServerDetail, _meta: Map }` (unchanged)
+
+The system SHALL use `POST /api/v1/mcp-registry/servers/list` for all MCP registry server requests instead of `GET /api/v1/mcp-registry/servers`.
+
+#### Scenario: Grid fetches servers via POST
+- **WHEN** the MCP registry grid requests a page of servers
+- **THEN** the system SHALL send a POST request to `/api/v1/mcp-registry/servers/list` with a JSON body containing `cursor`, `limit`, `search` (if filtered), and `filter` fields
+
+#### Scenario: Autocomplete fetches servers via POST
+- **WHEN** the MCP server name field triggers an autocomplete search
+- **THEN** the system SHALL send a POST request to `/api/v1/mcp-registry/servers/list` with a JSON body containing `search`, `limit`, and `filter` fields
+
+### Requirement: Server Selectability
+
+With server-side filtering by `packageRegistryTypes` and `packageTransportTypes`, all returned servers are selectable. The client-side `isServerSelectable()` check, greyed-out row styling (`opacity: 0.5`), and `isRowSelectable` grid option SHALL be removed.
+
+All rows in the MCP registry grid SHALL be selectable.
+
+#### Scenario: All returned servers are selectable
+- **WHEN** the MCP registry grid displays servers returned from the backend
+- **THEN** all rows SHALL be selectable (no greyed-out rows)
+
+#### Scenario: Autocomplete shows all returned servers
+- **WHEN** the MCP server name autocomplete receives results from the backend
+- **THEN** all results SHALL be shown as options without client-side filtering
+
+## ADDED Requirements
+
+### Requirement: Server-side container pre-filter
+
+All container-related MCP registry server requests (grid pagination, autocomplete search, freeform validation) SHALL include a `filter` with `packageRegistryTypes: ["oci"]` and `packageTransportTypes: ["streamable-http", "sse"]` so that only servers with OCI packages and supported transports are returned.
+
+#### Scenario: Grid requests include container pre-filter
+- **WHEN** the MCP registry grid fetches a page of servers (with or without a search term)
+- **THEN** the request body SHALL contain `filter: { packageRegistryTypes: ["oci"], packageTransportTypes: ["streamable-http", "sse"] }`
+
+#### Scenario: Autocomplete requests include container pre-filter
+- **WHEN** the MCP server name field triggers an autocomplete search
+- **THEN** the request body SHALL contain `filter: { packageRegistryTypes: ["oci"], packageTransportTypes: ["streamable-http", "sse"] }`
+
+#### Scenario: Freeform validation requests include container pre-filter
+- **WHEN** the MCP server name field validates a manually typed server name
+- **THEN** the request body SHALL contain `filter: { packageRegistryTypes: ["oci"], packageTransportTypes: ["streamable-http", "sse"] }`
+
+### Requirement: Purpose-specific API method for containers
+
+`McpRegistryApi` SHALL expose a `getContainerMcpServers()` method that accepts `search`, `cursor`, and `limit` params, constructs a `McpServersRequestDto` with `filter: { packageRegistryTypes: ["oci"], packageTransportTypes: ["streamable-http", "sse"] }` internally, and sends a POST request to `/api/v1/mcp-registry/servers/list`.
+
+Callers SHALL NOT provide filter values — the filter is an implementation detail of the API method.
+
+#### Scenario: API method constructs request with container filter
+- **WHEN** `getContainerMcpServers({ search: "github", cursor: "abc", limit: 100 }, token)` is called
+- **THEN** it SHALL POST to `/api/v1/mcp-registry/servers/list` with body `{ search: "github", cursor: "abc", limit: 100, filter: { packageRegistryTypes: ["oci"], packageTransportTypes: ["streamable-http", "sse"] } }`
+
+#### Scenario: API method omits undefined fields
+- **WHEN** `getContainerMcpServers({ limit: 5 }, token)` is called
+- **THEN** the request body SHALL NOT contain `search` or `cursor` keys with empty/undefined values
+
+### Requirement: Purpose-specific server action for containers
+
+A `getContainerMcpServers()` server action SHALL be created that accepts `{ search?, cursor?, limit }`, authenticates, and delegates to `McpRegistryApi.getContainerMcpServers()`. This replaces the current generic `getMcpServers()` action for container use cases.
+
+#### Scenario: Server action delegates to API method
+- **WHEN** `getContainerMcpServers({ search: "test", limit: 5 })` is called
+- **THEN** it SHALL authenticate and pass params to `McpRegistryApi.getContainerMcpServers()`
+
+### Requirement: Typed request and filter DTOs
+
+The system SHALL define TypeScript interfaces mirroring the BE contract:
+
+- `McpServerFilterDto` with optional fields: `packageRegistryTypes` (`string[]`), `packageTransportTypes` (`string[]`), `remoteTransportTypes` (`string[]`), `repositoryExists` (`boolean`)
+- `McpServersRequestDto` with optional fields: `search` (`string`), `cursor` (`string`), `limit` (`number`), `filter` (`McpServerFilterDto`)
+
+These interfaces SHALL be located in `src/types/deployments/mcp-registry.ts`.
+
+#### Scenario: Filter DTO accepts all BE-supported dimensions
+- **WHEN** a `McpServerFilterDto` is constructed
+- **THEN** it SHALL accept `packageRegistryTypes`, `packageTransportTypes`, `remoteTransportTypes`, and `repositoryExists` as optional fields
+
+#### Scenario: Request DTO includes filter
+- **WHEN** a `McpServersRequestDto` is constructed with a filter
+- **THEN** it SHALL contain the `filter` field with the `McpServerFilterDto` value
+
+### Requirement: Server action accumulates results with minResults
+
+The `getContainerMcpServers` server action SHALL accept an optional `minResults` param. When provided, it SHALL fetch multiple BE pages until `minResults` results are accumulated or the upstream cursor is exhausted. When omitted, a single fetch SHALL be made.
+
+The accumulation loop SHALL NOT break on empty responses — only when the cursor is exhausted.
+
+#### Scenario: Grid uses minResults for full page
+- **WHEN** `getContainerMcpServers({ limit: 100, minResults: 100 })` is called
+- **THEN** the server action SHALL fetch multiple BE pages until at least 100 servers are accumulated or no more data exists
+
+#### Scenario: Autocomplete uses single fetch without minResults
+- **WHEN** `getContainerMcpServers({ search: "test", limit: 5 })` is called without `minResults`
+- **THEN** the server action SHALL make a single BE request and return the result directly
+
+#### Scenario: Accumulation continues through empty responses
+- **WHEN** a BE page returns 0 servers but `nextCursor` is present
+- **THEN** the server action SHALL continue fetching the next page
+
+### Requirement: Reusable grid with fetchServers prop
+
+`McpRegistryGrid` SHALL accept a `fetchServers: McpRegistryFetchFn` prop and use it for all data fetching. The grid SHALL NOT import any specific server action directly.
+
+`McpRegistryModal` SHALL accept and pass through the `fetchServers` prop to `McpRegistryGrid`.
+
+#### Scenario: Grid uses provided fetch function
+- **WHEN** `McpRegistryGrid` is rendered with `fetchServers={getContainerMcpServers}`
+- **THEN** all data fetching SHALL use the provided function
+
+### Requirement: Placeholder rows do not render radio buttons
+
+The radio button cell renderer in `McpRegistryGrid` SHALL return `null` when the row has no data, preventing empty radio buttons on ag-grid placeholder rows.
+
+#### Scenario: Placeholder row has no radio button
+- **WHEN** ag-grid renders a placeholder row (data is undefined)
+- **THEN** the selection column SHALL render nothing
+
+### Requirement: Autocomplete clears suggestions on short input
+
+The `McpServerNameField` autocomplete SHALL clear the dropdown options when the input has 2 or fewer characters.
+
+#### Scenario: User clears input
+- **WHEN** the user deletes text so the input has 2 or fewer characters
+- **THEN** the dropdown options SHALL be cleared immediately
+
+## REMOVED Requirements
+
+### Requirement: Client-side selectability utils
+**Reason**: Server-side filtering by `packageRegistryTypes` and `packageTransportTypes` makes client-side checks redundant.
+**Migration**: Remove `isServerSelectable()`, `hasOciPackage()`, `hasSupportedTransport()` from `src/utils/deployments/mcp-registry.ts` and all their usages in `McpRegistryGrid` and `McpServerNameField`. Remove corresponding tests.

--- a/openspec/changes/archive/2026-04-07-mcp-registry-server-side-filtering/tasks.md
+++ b/openspec/changes/archive/2026-04-07-mcp-registry-server-side-filtering/tasks.md
@@ -1,0 +1,35 @@
+## 1. Types
+
+- [x] 1.1 Add `McpServerFilterDto` and `McpServersRequestDto` interfaces to `src/types/deployments/mcp-registry.ts` — filter fields: `packageRegistryTypes`, `packageTransportTypes`, `remoteTransportTypes`, `repositoryExists` (all optional)
+
+## 2. API Layer
+
+- [x] 2.1 Add `getContainerMcpServers({ search?, cursor?, limit }, token)` method to `McpRegistryApi` in `src/server/deployments/mcp-registry.ts` — constructs `McpServersRequestDto` with `filter: { packageRegistryTypes: ["oci"], packageTransportTypes: ["streamable-http", "sse"] }` internally, sends POST to `/api/v1/mcp-registry/servers/list` via `postAction`
+- [x] 2.2 Add `getContainerMcpServers({ search?, cursor?, limit, minResults? })` server action in `src/app/actions/deployments.ts` — when `minResults` provided, accumulates multiple BE pages until target reached or cursor exhausted; without `minResults`, single fetch
+- [x] 2.3 Remove old `getMcpServers()` method from `McpRegistryApi` and old `getMcpServers()` server action
+- [x] 2.4 Update API tests in `src/server/deployments/tests/mcp-registry.spec.ts` — verify `getContainerMcpServers()` sends POST with JSON body containing both OCI and transport filters, omits undefined/empty fields
+
+## 3. Remove Client-Side Selectability
+
+- [x] 3.1 Remove `isServerSelectable()`, `hasOciPackage()`, `hasSupportedTransport()` from `src/utils/deployments/mcp-registry.ts`
+- [x] 3.2 Remove corresponding tests from `src/utils/deployments/tests/mcp-registry.spec.ts`
+- [x] 3.3 Update `McpRegistryGrid` — remove `isRowSelectable`, `getRowStyle` (opacity 0.5), and `isServerSelectable` import
+- [x] 3.4 Update `McpServerNameField` — remove `isServerSelectable` import and client-side filtering of autocomplete results
+
+## 4. Grid Improvements
+
+- [x] 4.1 Add `fetchServers: McpRegistryFetchFn` prop to `McpRegistryGrid` — grid uses provided function via `useRef` for data fetching, no direct action import
+- [x] 4.2 Add `fetchServers` prop to `McpRegistryModal` — passes through to `McpRegistryGrid`
+- [x] 4.3 Grid passes `minResults: 100` to `fetchServers` for full-page accumulation
+- [x] 4.4 Radio button cell renderer returns `null` for placeholder rows (no data)
+- [x] 4.5 Fix grid `successCallback` — always report `startRow + servers.length` as last row when no cursor, instead of special-casing empty responses with `successCallback([], 0)`
+- [x] 4.6 Fix TS error — coerce `response.metadata?.nextCursor` to string, coerce filter value to string
+
+## 5. Consumer Updates
+
+- [x] 5.1 Update `McpServerNameField` — call `getContainerMcpServers()` for autocomplete (`limit: 5`) and freeform validation (`limit: 10`), pass `getContainerMcpServers` as `fetchServers` to `McpRegistryModal`
+- [x] 5.2 Autocomplete clears dropdown options when input has <= 2 characters
+
+## 6. Quality Checks
+
+- [x] 6.1 Run lint, format, and full test suite — all passing

--- a/openspec/specs/mcp-registry-source/spec.md
+++ b/openspec/specs/mcp-registry-source/spec.md
@@ -4,13 +4,16 @@ UI flow for creating MCP containers from the MCP Registry, including registry br
 
 ### Backend API Contract
 
-**List/search servers**: `GET /api/v1/mcp-registry/servers`
-- Query params: `search` (string), `cursor` (string), `limit` (number, default 100, max 1000), `updatedSince` (RFC3339), `version` (string)
+**List/search servers**: `POST /api/v1/mcp-registry/servers/list`
+- Request body: `McpServersRequestDto` with fields: `search` (string), `cursor` (string), `limit` (number, default 100, max 1000), `filter` (McpServerFilterDto, optional)
+- `McpServerFilterDto`: `{ packageRegistryTypes?: string[], packageTransportTypes?: string[], remoteTransportTypes?: string[], repositoryExists?: boolean }`
 - Response: `{ servers: ServerResponseDto[], metadata: { nextCursor?, count? } }`
 - Each `ServerResponseDto`: `{ server: ServerDetail, _meta: Map }`
 - `ServerDetail`: `{ name, description, title?, version, repository?, websiteUrl?, packages?, remotes?, icons? }`
 - `Package`: `{ registryType: "npm"|"pypi"|"oci"|"nuget"|"mcpb", identifier, version?, transport: { type }, runtimeHint?, environmentVariables? }`
 - `Remote`: `{ type: "streamable-http"|"sse", url, headers?, variables? }`
+
+The system SHALL use `POST /api/v1/mcp-registry/servers/list` for all MCP registry server requests instead of `GET /api/v1/mcp-registry/servers`.
 
 ### Feature Flag
 
@@ -27,37 +30,57 @@ UI flow for creating MCP containers from the MCP Registry, including registry br
 
 ### Server Selectability
 
-A server is selectable (in both grid and autocomplete) when it has **both**:
-1. At least one package with `registryType === "oci"`
-2. At least one OCI package with `transport.type === "streamable-http"` or `transport.type === "sse"`
+With server-side filtering by `packageRegistryTypes` and `packageTransportTypes`, all returned servers are selectable. All rows in the MCP registry grid SHALL be selectable.
 
-Transport is read from `packages[].transport.type` (NOT from `remotes[]`).
+### Server-side Container Pre-filter
 
-A server is blocked when:
-- No packages at all
-- No OCI package
-- OCI packages only have unsupported transport (e.g., `stdio`)
+All container-related MCP registry server requests (grid pagination, autocomplete search, freeform validation) SHALL include a `filter` with `packageRegistryTypes: ["oci"]` and `packageTransportTypes: ["streamable-http", "sse"]` so that only servers with OCI packages and supported transports are returned.
+
+### Purpose-specific API Method for Containers
+
+`McpRegistryApi` SHALL expose a `getContainerMcpServers()` method that accepts `search`, `cursor`, and `limit` params, constructs a `McpServersRequestDto` with `filter: { packageRegistryTypes: ["oci"], packageTransportTypes: ["streamable-http", "sse"] }` internally, and sends a POST request to `/api/v1/mcp-registry/servers/list`.
+
+Callers SHALL NOT provide filter values — the filter is an implementation detail of the API method.
+
+### Purpose-specific Server Action for Containers
+
+A `getContainerMcpServers()` server action SHALL be created that accepts `{ search?, cursor?, limit }`, authenticates, and delegates to `McpRegistryApi.getContainerMcpServers()`. This replaces the current generic `getMcpServers()` action for container use cases.
+
+### Server Action Accumulates Results with minResults
+
+The `getContainerMcpServers` server action SHALL accept an optional `minResults` param. When provided, it SHALL fetch multiple BE pages until `minResults` results are accumulated or the upstream cursor is exhausted. When omitted, a single fetch SHALL be made.
+
+The accumulation loop SHALL NOT break on empty responses — only when the cursor is exhausted.
+
+### Typed Request and Filter DTOs
+
+The system SHALL define TypeScript interfaces mirroring the BE contract:
+
+- `McpServerFilterDto` with optional fields: `packageRegistryTypes` (`string[]`), `packageTransportTypes` (`string[]`), `remoteTransportTypes` (`string[]`), `repositoryExists` (`boolean`)
+- `McpServersRequestDto` with optional fields: `search` (`string`), `cursor` (`string`), `limit` (`number`), `filter` (`McpServerFilterDto`)
+
+These interfaces SHALL be located in `src/types/deployments/mcp-registry.ts`.
 
 ### MCP Server Name Field
 
 - SHALL render a `DialSelectField` with inline search (debounced, same pattern as `HFModelNameField`)
-- Autocomplete SHALL call `getMcpServers({ search: value, limit: "5" })` on input (debounce ~100ms, trigger after 2+ characters)
-- Autocomplete results SHALL be filtered to only selectable servers (`isServerSelectable`)
+- Autocomplete SHALL call `getContainerMcpServers({ search: value, limit: 5 })` on input (debounce ~100ms, trigger after 2+ characters)
+- All autocomplete results SHALL be shown as options without client-side filtering
 - SHALL maintain a server cache (`Map<string, McpServer>`) for instant pre-fill on autocomplete selection
 - SHALL render a "Select from registry" button that opens the registry browser modal
 - SHALL validate server name against pattern `^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$`
 - SHALL register validity with `SaveValidationContext` (field: `mcpServerName`)
 - SHALL be disabled when container is in edit-disabled state or running
+- SHALL clear dropdown options when input has 2 or fewer characters
 
 ### Freeform Validation
 
 When user types a server name that is not in the local cache:
 1. `imageReference` SHALL be cleared immediately
 2. `mcpServerName` field SHALL be marked invalid (Save blocked, no error message shown)
-3. A fetch SHALL be made to `getMcpServers({ search: value, limit: "10" })`
-4. If exact name match found and selectable → `applyServer()` called, field becomes valid
-5. If exact match found but not selectable → error: "MCP server does not have a supported OCI package and transport"
-6. If no exact match → error: "MCP server not found in registry"
+3. A fetch SHALL be made to `getContainerMcpServers({ search: value, limit: 10 })`
+4. If exact name match found → `applyServer()` called, field becomes valid
+5. If no exact match → error: "MCP server not found in registry"
 
 ### On Server Selection (autocomplete or modal)
 
@@ -83,9 +106,12 @@ Package preference: prefer OCI package with `streamable-http` transport over `ss
 
 - SHALL use ag-grid with infinite scroll and cursor-based pagination
 - SHALL support single-row radio selection
-- Rows not passing `isServerSelectable` SHALL be disabled (not selectable, visually greyed with opacity 0.5)
+- All rows SHALL be selectable (server-side filtering ensures only compatible servers are returned)
 - Search filter on server name column SHALL map to `search` query parameter
 - `updatedAt` SHALL be flattened from `_meta["io.modelcontextprotocol.registry/official"].updatedAt` during response mapping
+- SHALL accept a `fetchServers: McpRegistryFetchFn` prop and use it for all data fetching (no direct action import)
+- `McpRegistryModal` SHALL accept and pass through the `fetchServers` prop to `McpRegistryGrid`
+- Radio button cell renderer SHALL return `null` when the row has no data (placeholder rows)
 
 **Columns:**
 
@@ -103,7 +129,6 @@ Package preference: prefer OCI package with `streamable-http` transport over `ss
 
 - MCP server name: required, pattern `^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$`
 - Server existence: validated against registry on freeform input
-- Server selectability: must have OCI + supported transport
 - `source.imageReference`: populated automatically from OCI identifier
 
 ### Error Handling
@@ -115,6 +140,5 @@ Package preference: prefer OCI package with `streamable-http` transport over `ss
 ### Accessibility
 
 - Registry grid SHALL be keyboard navigable (ag-grid default)
-- Disabled rows SHALL have reduced opacity (0.5) visual indicator
 - Modal SHALL trap focus (handled by `DialFormPopup`)
 - "Select from registry" button SHALL have descriptive label for screen readers


### PR DESCRIPTION
**Description:**

Filter registry container list to only containers that are supported by Admin Panel (OCI package + http/sse transport)

Issues:

- Issue #2227


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
