### PR TITLE
feat(entities): show stopped container in source field (Issue #2708)

### DIFF
--- a/apps/ai-dial-admin/src/components/SourceField/Containers/Containers.spec.tsx
+++ b/apps/ai-dial-admin/src/components/SourceField/Containers/Containers.spec.tsx
@@ -1,0 +1,101 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, test, expect, vi } from 'vitest';
+
+import Containers from '@/src/components/SourceField/Containers/Containers';
+import { DialModel, DialModelType } from '@/src/models/dial/model';
+import { Container } from '@/src/models/deployments/containers';
+import { SOURCE_TYPE } from '@/src/components/SourceField/types';
+import { ApplicationRoute } from '@/src/types/routes';
+import { CONTAINER_STATUS, CONTAINER_SOURCE_TYPE, CONTAINER_TYPE } from '@/src/types/deployments/containers';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+  usePathname: vi.fn(),
+}));
+
+vi.mock('@/src/hooks/use-protected-request', () => ({
+  useProtectedRequest: () => vi.fn((fn) => fn()),
+}));
+
+const runningContainer: Container = {
+  name: 'container-running',
+  displayName: 'Running Container',
+  $type: CONTAINER_TYPE.NIM,
+  source: { $type: CONTAINER_SOURCE_TYPE.INTERNAL_IMAGE },
+  status: CONTAINER_STATUS.RUNNING,
+  url: 'http://running.local',
+  metadata: { envs: [] },
+};
+
+const stoppedContainer: Container = {
+  name: 'container-stopped',
+  displayName: 'Stopped Container',
+  $type: CONTAINER_TYPE.NIM,
+  source: { $type: CONTAINER_SOURCE_TYPE.INTERNAL_IMAGE },
+  status: CONTAINER_STATUS.STOPPED,
+  url: '',
+  metadata: { envs: [] },
+};
+
+const createEntity = (containerId: string): DialModel => ({
+  name: 'test-model',
+  displayName: 'Test Model',
+  type: DialModelType.Chat,
+  source: { $type: SOURCE_TYPE.CONTAINER, containerId },
+});
+
+const mockGetContainers = (containers: Container[]) =>
+  vi.fn(() => Promise.resolve({ success: true, response: containers }));
+
+describe('Containers component', () => {
+  test('displays stopped container display name in edit view', async () => {
+    const entity = createEntity('container-stopped');
+
+    render(
+      <Containers
+        entity={entity}
+        onChange={vi.fn()}
+        getContainers={mockGetContainers([runningContainer, stoppedContainer])}
+        view={ApplicationRoute.Models}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Stopped Container')).toBeInTheDocument();
+    });
+  });
+
+  test('displays running container name in edit view', async () => {
+    const entity = createEntity('container-running');
+
+    render(
+      <Containers
+        entity={entity}
+        onChange={vi.fn()}
+        getContainers={mockGetContainers([runningContainer, stoppedContainer])}
+        view={ApplicationRoute.Models}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Running Container')).toBeInTheDocument();
+    });
+  });
+
+  test('shows empty state when container is not returned by API', async () => {
+    const entity = createEntity('container-deleted');
+
+    render(
+      <Containers
+        entity={entity}
+        onChange={vi.fn()}
+        getContainers={mockGetContainers([runningContainer])}
+        view={ApplicationRoute.Models}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Entities.NoContainers')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/ai-dial-admin/src/components/SourceField/Containers/Containers.tsx
+++ b/apps/ai-dial-admin/src/components/SourceField/Containers/Containers.tsx
@@ -58,6 +58,7 @@ const Containers = <T extends DialInterceptor | DialModel>({
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [containers, setContainers] = useState<Container[]>([]);
   const [selectedContainer, setSelectedContainer] = useState<Container | null>(null);
+  const [currentContainerDisplayName, setCurrentContainerDisplayName] = useState<string>();
 
   const isMobile = useIsMobileScreen();
 
@@ -103,14 +104,18 @@ const Containers = <T extends DialInterceptor | DialModel>({
     const fetchContainers = async () => {
       const containers = (await getReqRef.current(getContainers)).response as Container[] | null;
       if (containers?.length) {
-        setContainers(containers.filter((container) => container.status === 'running') || []);
+        const current = containers.find((c) => c.name === entity.source?.containerId);
+        if (current) {
+          setCurrentContainerDisplayName(current.displayName);
+        }
+        setContainers(containers.filter((container) => container.status === 'running'));
       }
     };
 
     fetchContainers().catch((error) =>
       showNotificationRef.current(getErrorNotification(error.errorHeader, error.errorMessage, error.requestId)),
     );
-  }, [getContainers]);
+  }, [entity.source?.containerId, getContainers]);
 
   useEffect(() => {
     setSelectedContainer(containers?.find((container) => container.name === entity.source?.containerId) || null);
@@ -143,7 +148,7 @@ const Containers = <T extends DialInterceptor | DialModel>({
               <DialInputPopup
                 open={isModalOpen}
                 onOpen={onOpenModal}
-                selectedValue={selectedContainer?.displayName}
+                selectedValue={selectedContainer?.displayName || currentContainerDisplayName}
                 elementId="containers"
                 emptyValueText={t(EntitiesI18nKey.NoContainers)}
                 disabled={disabled || !featureFlags.deploymentsEnabled}

--- a/openspec/changes/archive/2026-04-09-show-stopped-container-in-source-field/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-09-show-stopped-container-in-source-field/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-09

--- a/openspec/changes/archive/2026-04-09-show-stopped-container-in-source-field/design.md
+++ b/openspec/changes/archive/2026-04-09-show-stopped-container-in-source-field/design.md
@@ -1,0 +1,38 @@
+## Context
+
+The `Containers` component (`src/components/SourceField/Containers/Containers.tsx`) fetches all containers and immediately filters to `status === 'running'`. This means `selectedContainer` resolves to null when the entity's linked container is stopped, and the `DialInputPopup` shows "No Containers" instead of the container's name.
+
+The component has two render paths:
+- **Modal mode** (creation): `DialSelectField` dropdown — no existing `containerId`, always picks from running containers. No change needed.
+- **Non-modal mode** (edit view): `DialInputPopup` for display + `SelectContainerModal` for selection. These are already decoupled — the input shows `selectedContainer?.displayName`, the modal receives the `containers` array as options.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Show the stopped container's display name in the `DialInputPopup` input in the edit view
+- Keep the `SelectContainerModal` offering only running containers for selection
+
+**Non-Goals:**
+- No status indicators, warnings, or error styling on the container field
+- No backend changes (save rejection for stopped containers is a separate concern)
+- No changes to the modal (creation) flow
+- No changes to business logic (container filtering, selectedContainer resolution, validation)
+
+## Decisions
+
+### Cache display name from the full API response before filtering
+
+**Decision**: Add a `currentContainerDisplayName` state. In the `fetchContainers` effect, before filtering to running-only, find the container matching `entity.source?.containerId` and save its `displayName`. Use this as a fallback in the `DialInputPopup`'s `selectedValue` prop.
+
+**Why over alternatives:**
+- *Alternative: Store full `allContainers` list and resolve `selectedContainer` from it* — Changes business logic unnecessarily. Affects `selectedContainerName` memo (used by modal mode) and `selectedContainer` resolution (used by Endpoints section and Open button). Too much coupling for a display-only fix.
+- *Alternative: Show `containerId` as fallback* — Works but shows a technical ID instead of a human-readable name. The display name is already available in the fetch response.
+
+### No changes to modal mode or business logic
+
+**Decision**: Only the `DialInputPopup`'s `selectedValue` prop gains a fallback. All state (`containers`, `selectedContainer`, `selectedContainerName`), filtering, validation, and the modal path remain identical.
+
+## Risks / Trade-offs
+
+- **[Container deleted from API]** → If the container is completely removed (not returned by API at all), `currentContainerDisplayName` stays undefined and the input falls back to `emptyValueText` ("No Containers") as before.
+- **[DialInputPopup is stateless]** → Verified: the component derives display directly from props with no internal state caching. When `currentContainerDisplayName` is set after the async fetch, the re-render correctly updates the displayed value.

--- a/openspec/changes/archive/2026-04-09-show-stopped-container-in-source-field/proposal.md
+++ b/openspec/changes/archive/2026-04-09-show-stopped-container-in-source-field/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+When an entity (Model, Toolset, Interceptor) is created from a container and that container later stops running, the Container field in the entity's edit view shows "No Containers" instead of the selected container's name. This happens because the `Containers` component filters fetched containers to running-only, so the referenced container disappears from the list and `selectedContainer` resolves to null. The user loses context about which container the entity is linked to.
+
+Issue: [#2708](https://github.com/epam/ai-dial-admin-frontend/issues/2708)
+
+## What Changes
+
+- **Show stopped container name in the input**: In the non-modal (edit view) `Containers` component, resolve `selectedContainer` from the full unfiltered container list so the `DialInputPopup` displays the container's display name regardless of status.
+- **Keep selection modal running-only**: The `SelectContainerModal` dropdown continues to show only running containers — users can only switch to a running container.
+- **No status indicators**: The container name is shown as-is, without error/warning styling.
+
+## Non-goals
+
+- No backend changes — the backend still rejects saves when the container URL is absent (container not running). That is a separate concern.
+- No changes to the modal (creation) flow — it already only shows running containers and has no pre-existing `containerId`.
+- No container status highlighting or warning indicators on the field.
+
+## Capabilities
+
+### New Capabilities
+- `stopped-container-display`: Show the selected container's display name in the source field input even when the container is not running.
+
+### Modified Capabilities
+
+_(none — no existing spec-level requirements change)_
+
+## Impact
+
+- **`src/components/SourceField/Containers/Containers.tsx`**: Main change — store full container list separately for lookup, keep filtered list for selection modal.
+- No API changes, no new dependencies, no impact on other components consuming the `Containers` component in modal mode.

--- a/openspec/changes/archive/2026-04-09-show-stopped-container-in-source-field/specs/stopped-container-display/spec.md
+++ b/openspec/changes/archive/2026-04-09-show-stopped-container-in-source-field/specs/stopped-container-display/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Display stopped container name in entity edit view
+The `Containers` component in non-modal (edit view) mode SHALL display the linked container's display name in the `DialInputPopup` input regardless of the container's status, as long as the entity has a valid `source.containerId` that matches a container returned by the API.
+
+#### Scenario: Entity linked to a stopped container
+- **WHEN** the entity has `source.containerId` set and the referenced container has status other than `running`
+- **THEN** the `DialInputPopup` input SHALL display the container's `displayName`
+
+#### Scenario: Entity linked to a running container
+- **WHEN** the entity has `source.containerId` set and the referenced container has status `running`
+- **THEN** behavior is unchanged — the input displays the container's `displayName`
+
+#### Scenario: Entity linked to a container not returned by API
+- **WHEN** the entity has `source.containerId` set but no container with that ID is returned by the API
+- **THEN** the input SHALL show the empty state ("No Containers") as before
+
+### Requirement: Selection modal shows only running containers
+The `SelectContainerModal` SHALL continue to list only containers with status `running` as selectable options.
+
+#### Scenario: User opens selection modal with stopped containers in the system
+- **WHEN** the user opens the container selection modal
+- **THEN** only containers with status `running` SHALL appear in the list
+
+### Requirement: Modal (creation) mode unchanged
+The `DialSelectField` in modal mode SHALL continue to show only running containers as options. No change to creation flow.
+
+#### Scenario: Creating entity from container in modal mode
+- **WHEN** the `Containers` component renders in modal mode (`isModal=true`)
+- **THEN** the `DialSelectField` options SHALL include only containers with status `running`

--- a/openspec/changes/archive/2026-04-09-show-stopped-container-in-source-field/tasks.md
+++ b/openspec/changes/archive/2026-04-09-show-stopped-container-in-source-field/tasks.md
@@ -1,0 +1,11 @@
+## 1. Core Implementation
+
+- [x] 1.1 In `src/components/SourceField/Containers/Containers.tsx`: add `currentContainerDisplayName` state. In `fetchContainers` effect, extract the display name from the full API response before filtering to running-only. Use as fallback in `DialInputPopup`'s `selectedValue` prop.
+
+## 2. Tests
+
+- [x] 2.1 Add tests in `src/components/SourceField/Containers/Containers.spec.tsx` covering: (a) stopped container's display name shown in input, (b) running container display name shown in input, (c) empty state when container not returned by API.
+
+## 3. Quality Checks
+
+- [x] 3.1 Run lint, format, and tests — all pass.

--- a/openspec/specs/stopped-container-display/spec.md
+++ b/openspec/specs/stopped-container-display/spec.md
@@ -1,0 +1,28 @@
+### Requirement: Display stopped container name in entity edit view
+The `Containers` component in non-modal (edit view) mode SHALL display the linked container's display name in the `DialInputPopup` input regardless of the container's status, as long as the entity has a valid `source.containerId` that matches a container returned by the API.
+
+#### Scenario: Entity linked to a stopped container
+- **WHEN** the entity has `source.containerId` set and the referenced container has status other than `running`
+- **THEN** the `DialInputPopup` input SHALL display the container's `displayName`
+
+#### Scenario: Entity linked to a running container
+- **WHEN** the entity has `source.containerId` set and the referenced container has status `running`
+- **THEN** behavior is unchanged — the input displays the container's `displayName`
+
+#### Scenario: Entity linked to a container not returned by API
+- **WHEN** the entity has `source.containerId` set but no container with that ID is returned by the API
+- **THEN** the input SHALL show the empty state ("No Containers") as before
+
+### Requirement: Selection modal shows only running containers
+The `SelectContainerModal` SHALL continue to list only containers with status `running` as selectable options.
+
+#### Scenario: User opens selection modal with stopped containers in the system
+- **WHEN** the user opens the container selection modal
+- **THEN** only containers with status `running` SHALL appear in the list
+
+### Requirement: Modal (creation) mode unchanged
+The `DialSelectField` in modal mode SHALL continue to show only running containers as options. No change to creation flow.
+
+#### Scenario: Creating entity from container in modal mode
+- **WHEN** the `Containers` component renders in modal mode (`isModal=true`)
+- **THEN** the `DialSelectField` options SHALL include only containers with status `running`


### PR DESCRIPTION
**Description:**

Show container name in entities when container is stopped

Issues:

- Issue #2708


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
