### PR TITLE
fix: [Entities --> Toolsets] Duplicated toolset with API Key is not synced with core due to empty clientSecret sent from frontend (Issue #2940)

### DIFF
--- a/apps/ai-dial-admin/src/components/EntityListView/Components/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/EntityListView/Components/tests/utils.spec.ts
@@ -182,7 +182,7 @@ describe('Utils :: prepareEntityForDuplicate', () => {
       authSettings: {
         authenticationType: 'oauth',
         clientId: 'client-123',
-        clientSecret: '',
+        clientSecret: undefined,
         authorizationEndpoint: 'https://auth.example.com',
         globalAuthStatus: undefined,
         userLevelAuthStatus: undefined,
@@ -221,7 +221,7 @@ describe('Utils :: prepareEntityForDuplicate', () => {
         apiKeyHeader: 'X-API-Key',
         globalAuthStatus: undefined,
         userLevelAuthStatus: undefined,
-        clientSecret: '',
+        clientSecret: undefined,
       },
     });
   });
@@ -252,7 +252,7 @@ describe('Utils :: prepareEntityForDuplicate', () => {
       authSettings: {
         authenticationType: 'oauth',
         clientId: 'client-789',
-        clientSecret: '',
+        clientSecret: undefined,
         authorizationEndpoint: 'https://auth2.example.com',
         globalAuthStatus: undefined,
         userLevelAuthStatus: undefined,
@@ -363,7 +363,7 @@ describe('Utils :: prepareEntityForDuplicate', () => {
         apiKeyHeader: 'X-Custom-Key',
         globalAuthStatus: undefined,
         userLevelAuthStatus: undefined,
-        clientSecret: '',
+        clientSecret: undefined,
       },
     });
   });

--- a/apps/ai-dial-admin/src/components/EntityListView/Components/utils.ts
+++ b/apps/ai-dial-admin/src/components/EntityListView/Components/utils.ts
@@ -115,7 +115,7 @@ export const prepareEntityForDuplicate = async <T>(
             ...toolset.authSettings,
             globalAuthStatus: undefined,
             userLevelAuthStatus: undefined,
-            clientSecret: '',
+            clientSecret: undefined,
             // Keep apiKeyHeader name for API_KEY auth, clear for others
             apiKeyHeader:
               toolset.authSettings.authenticationType === ToolsetAuthType.API_KEY


### PR DESCRIPTION
**Description:**

remove clientSecret from duplicate toolset

Issues:

- Issue #2940


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
