### PR TITLE
fix: [Entities --> Toolsets] Duplicate toolset can be created with an existing Display Name, but error appears in Properties tab after creation (Issue #3062)

### DIFF
--- a/apps/ai-dial-admin/src/components/Toolsets/Modals/DuplicateToolset.tsx
+++ b/apps/ai-dial-admin/src/components/Toolsets/Modals/DuplicateToolset.tsx
@@ -1,8 +1,11 @@
-import { DialFormPopup } from '@epam/ai-dial-ui-kit';
 import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 
+import { DialFormPopup } from '@epam/ai-dial-ui-kit';
+
+import { checkIsUniqueDeploymentName } from '@/src/app/actions';
 import DisplayNameControl from '@/src/components/BaseControls/DisplayName';
 import IdControl from '@/src/components/BaseControls/Id/Id';
+import ApiKeyHeaderControl from '@/src/components/Toolsets/Auth/Controls/ApiKeyHeaderControl';
 import OAuthAuthSectionControl from '@/src/components/Toolsets/Auth/Controls/OAuthAuthSectionControl';
 import { ButtonsI18nKey, ToolsetI18nKey } from '@/src/constants/i18n';
 import { useSaveValidationContext, ValidationActionType } from '@/src/context/SaveValidationContext';
@@ -10,7 +13,6 @@ import { useI18n } from '@/src/locales/client';
 import { Toolset, ToolsetAuthType } from '@/src/models/dial/toolset';
 import { ApplicationRoute } from '@/src/types/routes';
 import { getClonedEntityName, getCloneTitle } from '@/src/utils/entities/duplicate-entity';
-import ApiKeyHeaderControl from '../Auth/Controls/ApiKeyHeaderControl';
 
 interface Props {
   isModalOpen: boolean;
@@ -29,6 +31,7 @@ const DuplicateToolset: FC<Props> = ({ names, onDuplicate, isModalOpen, onClose,
     displayName: getClonedEntityName(entity.displayName, true),
   });
   const { isValid, dispatch } = useSaveValidationContext();
+  const [isUniqueNameError, setIsUniqueNameError] = useState<boolean | undefined>(void 0);
 
   const authType = useMemo(
     () => clonedEntity.authSettings?.authenticationType || ToolsetAuthType.NONE,
@@ -140,6 +143,21 @@ const DuplicateToolset: FC<Props> = ({ names, onDuplicate, isModalOpen, onClose,
     [clonedEntity],
   );
 
+  const onIdChange = useCallback(async (entity: Toolset) => {
+    setEntity(entity);
+    setIsUniqueNameError(false);
+  }, []);
+
+  const onDuplicateClick = useCallback(async () => {
+    const isUnique = await checkIsUniqueDeploymentName(clonedEntity.name as string);
+
+    setIsUniqueNameError(!isUnique);
+
+    if (!isUnique) return;
+
+    onDuplicate(clonedEntity);
+  }, [clonedEntity, onDuplicate]);
+
   return (
     <DialFormPopup
       onClose={onClose}
@@ -148,15 +166,20 @@ const DuplicateToolset: FC<Props> = ({ names, onDuplicate, isModalOpen, onClose,
       open={isModalOpen}
       cancelLabel={t(ButtonsI18nKey.Cancel)}
       submitLabel={t(ButtonsI18nKey.Duplicate)}
-      onSubmit={() => onDuplicate(clonedEntity)}
+      onSubmit={onDuplicateClick}
       onCancel={onClose}
       disableSubmitButton={!isValid}
     >
       <div className="flex flex-col px-6 py-4">
         <div className="flex flex-col gap-y-8">
-          <IdControl entity={clonedEntity} onChangeEntity={setEntity} names={names} />
+          <IdControl entity={clonedEntity} onChangeEntity={onIdChange} isUniqueNameError={isUniqueNameError} />
 
-          <DisplayNameControl displayName={clonedEntity.displayName} onChange={onChangeDisplayName} required />
+          <DisplayNameControl
+            displayName={clonedEntity.displayName}
+            onChange={onChangeDisplayName}
+            names={names}
+            required
+          />
 
           {authType !== ToolsetAuthType.NONE && (
             <h3>

--- a/apps/ai-dial-admin/src/components/Toolsets/Modals/tests/DuplicateToolset.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Toolsets/Modals/tests/DuplicateToolset.spec.tsx
@@ -1,8 +1,11 @@
 import { ButtonsI18nKey, EntityFieldsI18nKey, EntityPlaceholdersI18nKey, ToolsetI18nKey } from '@/src/constants/i18n';
 import { Toolset, ToolsetAuthType } from '@/src/models/dial/toolset';
-import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, test, vi } from 'vitest';
+import { checkIsUniqueDeploymentName } from '@/src/app/actions';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
 import DuplicateToolset from '../DuplicateToolset';
+
+vi.mock('@/src/app/actions');
 
 describe('DuplicateToolset', () => {
   const baseToolset: Toolset = {
@@ -10,6 +13,11 @@ describe('DuplicateToolset', () => {
     displayName: 'Toolset One',
     description: 'Test toolset',
   };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (checkIsUniqueDeploymentName as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+  });
 
   describe('Rendering', () => {
     test('renders basic fields without auth settings', () => {
@@ -155,7 +163,7 @@ describe('DuplicateToolset', () => {
       expect(onClose).toHaveBeenCalled();
     });
 
-    test('calls onDuplicate with correct entity when Duplicate is clicked', () => {
+    test('calls onDuplicate with correct entity when Duplicate is clicked', async () => {
       const onDuplicate = vi.fn();
       render(
         <DuplicateToolset
@@ -169,15 +177,17 @@ describe('DuplicateToolset', () => {
 
       fireEvent.click(screen.getByText(ButtonsI18nKey.Duplicate));
 
-      expect(onDuplicate).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: expect.stringContaining('toolset1'),
-          displayName: expect.stringContaining('Toolset One'),
-        }),
+      await waitFor(() =>
+        expect(onDuplicate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: expect.stringContaining('toolset1'),
+            displayName: expect.stringContaining('Toolset One'),
+          }),
+        ),
       );
     });
 
-    test('updates clientId when OAuth field changes', () => {
+    test('updates clientId when OAuth field changes', async () => {
       const toolsetWithOAuth: Toolset = {
         ...baseToolset,
         authSettings: {
@@ -204,16 +214,18 @@ describe('DuplicateToolset', () => {
 
       fireEvent.click(screen.getByText(ButtonsI18nKey.Duplicate));
 
-      expect(onDuplicate).toHaveBeenCalledWith(
-        expect.objectContaining({
-          authSettings: expect.objectContaining({
-            clientId: 'new-client-id',
+      await waitFor(() =>
+        expect(onDuplicate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            authSettings: expect.objectContaining({
+              clientId: 'new-client-id',
+            }),
           }),
-        }),
+        ),
       );
     });
 
-    test('updates clientSecret when OAuth field changes', () => {
+    test('updates clientSecret when OAuth field changes', async () => {
       const toolsetWithOAuth: Toolset = {
         ...baseToolset,
         authSettings: {
@@ -240,16 +252,18 @@ describe('DuplicateToolset', () => {
 
       fireEvent.click(screen.getByText(ButtonsI18nKey.Duplicate));
 
-      expect(onDuplicate).toHaveBeenCalledWith(
-        expect.objectContaining({
-          authSettings: expect.objectContaining({
-            clientSecret: 'new-secret',
+      await waitFor(() =>
+        expect(onDuplicate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            authSettings: expect.objectContaining({
+              clientSecret: 'new-secret',
+            }),
           }),
-        }),
+        ),
       );
     });
 
-    test('updates authorizationEndpoint when OAuth field changes', () => {
+    test('updates authorizationEndpoint when OAuth field changes', async () => {
       const toolsetWithOAuth: Toolset = {
         ...baseToolset,
         authSettings: {
@@ -276,16 +290,18 @@ describe('DuplicateToolset', () => {
 
       fireEvent.click(screen.getByText(ButtonsI18nKey.Duplicate));
 
-      expect(onDuplicate).toHaveBeenCalledWith(
-        expect.objectContaining({
-          authSettings: expect.objectContaining({
-            authorizationEndpoint: 'https://new-auth.example.com',
+      await waitFor(() =>
+        expect(onDuplicate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            authSettings: expect.objectContaining({
+              authorizationEndpoint: 'https://new-auth.example.com',
+            }),
           }),
-        }),
+        ),
       );
     });
 
-    test('updates apiKeyHeader when API Key field changes', () => {
+    test('updates apiKeyHeader when API Key field changes', async () => {
       const toolsetWithApiKey: Toolset = {
         ...baseToolset,
         authSettings: {
@@ -310,16 +326,18 @@ describe('DuplicateToolset', () => {
 
       fireEvent.click(screen.getByText(ButtonsI18nKey.Duplicate));
 
-      expect(onDuplicate).toHaveBeenCalledWith(
-        expect.objectContaining({
-          authSettings: expect.objectContaining({
-            apiKeyHeader: 'X-Custom-API-Key',
+      await waitFor(() =>
+        expect(onDuplicate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            authSettings: expect.objectContaining({
+              apiKeyHeader: 'X-Custom-API-Key',
+            }),
           }),
-        }),
+        ),
       );
     });
 
-    test('updates displayName when field changes', () => {
+    test('updates displayName when field changes', async () => {
       const onDuplicate = vi.fn();
       render(
         <DuplicateToolset
@@ -336,16 +354,18 @@ describe('DuplicateToolset', () => {
 
       fireEvent.click(screen.getByText(ButtonsI18nKey.Duplicate));
 
-      expect(onDuplicate).toHaveBeenCalledWith(
-        expect.objectContaining({
-          displayName: 'New Toolset Name',
-        }),
+      await waitFor(() =>
+        expect(onDuplicate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            displayName: 'New Toolset Name',
+          }),
+        ),
       );
     });
   });
 
   describe('Entity Name Cloning', () => {
-    test('initializes with cloned name and displayName', () => {
+    test('initializes with cloned name and displayName', async () => {
       const onDuplicate = vi.fn();
       render(
         <DuplicateToolset
@@ -359,11 +379,13 @@ describe('DuplicateToolset', () => {
 
       fireEvent.click(screen.getByText(ButtonsI18nKey.Duplicate));
 
-      expect(onDuplicate).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: expect.stringContaining('toolset1'),
-          displayName: expect.stringContaining('Toolset One'),
-        }),
+      await waitFor(() =>
+        expect(onDuplicate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: expect.stringContaining('toolset1'),
+            displayName: expect.stringContaining('Toolset One'),
+          }),
+        ),
       );
     });
   });


### PR DESCRIPTION
**Description:**

duplicate toolset validation change

Issues:

- Issue #3062


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
