### PR TITLE
fix: [Builder][Application Runners] Invalid Display Name in App Routes does not block Save after navigation between tabs (Issue #3001)

### DIFF
--- a/apps/ai-dial-admin/src/components/BaseControls/DisplayName.tsx
+++ b/apps/ai-dial-admin/src/components/BaseControls/DisplayName.tsx
@@ -17,6 +17,7 @@ interface Props {
   names?: string[];
   allowWhitespace?: boolean;
   alphanumericOnly?: boolean;
+  trackGlobalValidity?: boolean;
   onChange?: (displayName?: string) => void;
 }
 
@@ -28,6 +29,7 @@ const DisplayNameControl: FC<Props> = ({
   names,
   allowWhitespace = true,
   alphanumericOnly = false,
+  trackGlobalValidity = true,
   disabled,
   ...props
 }) => {
@@ -39,21 +41,23 @@ const DisplayNameControl: FC<Props> = ({
   const [displayNameError, setDisplayNameError] = useState<FieldError | null>(null);
 
   const validateDisplayName = useCallback(
-    (displayName?: string) => {
+    (value?: string) => {
       const error = alphanumericOnly
-        ? getErrorForAppRouteName(displayName, names, t)
-        : getErrorForName(displayName, names, t, false, !allowWhitespace, true);
+        ? getErrorForAppRouteName(value, names, t)
+        : getErrorForName(value, names, t, false, !allowWhitespace, true);
       setDisplayNameError(error);
-      dispatch({ type: ValidationActionType.SetField, field: 'displayName', isValid: !error });
+      if (trackGlobalValidity) {
+        dispatch({ type: ValidationActionType.SetField, field: 'displayName', isValid: !error });
+      }
     },
-    [dispatch, t, names, allowWhitespace, alphanumericOnly],
+    [dispatch, t, names, allowWhitespace, alphanumericOnly, trackGlobalValidity],
   );
 
   // initial validation
   useEffect(() => {
     if (displayName) {
       validateDisplayName(displayName);
-    } else {
+    } else if (trackGlobalValidity) {
       dispatch({ type: ValidationActionType.SetField, field: 'displayName', isValid: !!displayName });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/ai-dial-admin/src/components/EntityView/AppRoute/AppRoute.tsx
+++ b/apps/ai-dial-admin/src/components/EntityView/AppRoute/AppRoute.tsx
@@ -12,6 +12,8 @@ import { useI18n } from '@/src/locales/client';
 import { DialRole } from '@/src/models/dial/role';
 import { DialRoleLimitsMap } from '@/src/models/dial/role-limits';
 import { DialAppRoute } from '@/src/models/dial/route';
+import { isValidRoutePath } from '@/src/utils/validation/path-error';
+import { getErrorForAppRouteName } from '@/src/utils/validation/name-error';
 import AppRouteList from './AppRouteList';
 
 interface Props {
@@ -48,6 +50,22 @@ const EntityRoutes: FC<Props> = ({
       setActiveRouteIndex(0);
     }
   }, [routes, activeRouteIndex]);
+
+  // Aggregate validity for all app routes — covers name, paths, methods, endpoints
+  useEffect(() => {
+    if (!isAppRunnerView) return;
+
+    const allValid = (routes || []).every((route, index) => {
+      const otherNames = (routes || []).filter((_, i) => i !== index).map((r) => r.name || '');
+      const nameValid = !getErrorForAppRouteName(route.name, otherNames, t);
+      const pathsValid = !!route.paths?.length && route.paths.every((p) => !!p && isValidRoutePath(p));
+      const methodsValid = !!route.methods?.length;
+      const endpointsValid = !!route.response || !!route.upstreams?.length;
+      return nameValid && pathsValid && methodsValid && endpointsValid;
+    });
+
+    dispatch({ type: ValidationActionType.SetField, field: 'appRoutes', isValid: allValid });
+  }, [routes, isAppRunnerView, t, dispatch]);
 
   const handleModalClose = useCallback(() => {
     setIsModalOpen(false);
@@ -90,16 +108,9 @@ const EntityRoutes: FC<Props> = ({
   const onRemoveRoute = useCallback(
     (name?: string) => {
       const newRoutes = routes?.filter((route) => route.name !== name) || [];
-      const statusErrors = newRoutes.some(
-        (r) => r.response?.status && (+r.response?.status < 100 || +r.response?.status > 999),
-      );
-      const methodErrors = newRoutes.some((r) => !r.methods?.length);
-
-      dispatch({ type: ValidationActionType.SetField, field: 'status', isValid: !statusErrors });
-      dispatch({ type: ValidationActionType.SetField, field: 'methods', isValid: !methodErrors });
       onChangeRoutes(newRoutes);
     },
-    [dispatch, onChangeRoutes, routes],
+    [onChangeRoutes, routes],
   );
 
   return (

--- a/apps/ai-dial-admin/src/components/EntityView/AppRoute/AppRouteList.tsx
+++ b/apps/ai-dial-admin/src/components/EntityView/AppRoute/AppRouteList.tsx
@@ -7,7 +7,6 @@ import classNames from 'classnames';
 import ActionsDropdown from '@/src/components/Common/ActionsDropdown/ActionsDropdown';
 import { EntitiesI18nKey, ActionMenuOperationI18nKey } from '@/src/constants/i18n';
 import { BASE_BUTTON_ICON_PROPS } from '@/src/constants/main-layout';
-import { useSaveValidationContext } from '@/src/context/SaveValidationContext';
 import { useI18n } from '@/src/locales/client';
 import { ActionMenuOperationDeclaration } from '@/src/models/action-menu-operations';
 import { DialAppRoute } from '@/src/models/dial/route';
@@ -22,7 +21,6 @@ interface Props {
 
 const AppRouteList: FC<Props> = ({ disabled, routes, activeRouteIndex, onRemove, onClick }) => {
   const t = useI18n();
-  const { isValid } = useSaveValidationContext();
   const getOperation = (onClick: () => void): ActionMenuOperationDeclaration<DialAppRoute> => {
     return {
       icon: <IconTrash {...BASE_BUTTON_ICON_PROPS} />,
@@ -42,8 +40,7 @@ const AppRouteList: FC<Props> = ({ disabled, routes, activeRouteIndex, onRemove,
                 key={route.name}
                 role="tab"
                 className={classNames(
-                  'rounded group pl-3 py-2 flex flex-row gap-2 h-[32px] w-full small',
-                  !isValid ? 'pointer-events-none opacity-50' : 'cursor-pointer hover:text-accent-primary',
+                  'rounded group pl-3 py-2 flex flex-row gap-2 h-[32px] w-full small cursor-pointer hover:text-accent-primary',
                   activeRouteIndex === index
                     ? 'bg-accent-primary-alpha border-l-2 border-l-accent-primary'
                     : 'text-primary',

--- a/apps/ai-dial-admin/src/components/Routes/Paths/Path.tsx
+++ b/apps/ai-dial-admin/src/components/Routes/Paths/Path.tsx
@@ -16,6 +16,7 @@ interface Props {
   disabled?: boolean;
   allPaths?: string[];
   disableValidation?: boolean;
+  trackGlobalValidity?: boolean;
   onRemove: (index: number) => void;
   onChangePath: (index: number, value?: string) => void;
 }
@@ -28,6 +29,7 @@ const Path: FC<Props> = ({
   label,
   allPaths,
   disableValidation,
+  trackGlobalValidity = true,
   onRemove,
   onChangePath,
 }) => {
@@ -55,12 +57,9 @@ const Path: FC<Props> = ({
   }, [path]);
 
   useEffect(() => {
+    if (!trackGlobalValidity) return;
     dispatch({ type: ValidationActionType.SetField, field: 'path ' + index, isValid: !error });
-    return () => {
-      dispatch({ type: ValidationActionType.SetField, field: 'path ' + index, isValid: true });
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [error]);
+  }, [dispatch, error, index, trackGlobalValidity]);
 
   return (
     <div className={classNames('flex flex-row gap-x-2', alignmentClassName)}>

--- a/apps/ai-dial-admin/src/components/Routes/Paths/Paths.tsx
+++ b/apps/ai-dial-admin/src/components/Routes/Paths/Paths.tsx
@@ -16,18 +16,28 @@ interface Props {
   required?: boolean;
   paths?: string[];
   disableValidation?: boolean;
+  trackGlobalValidity?: boolean;
   onChangePaths: (path: string[]) => void;
 }
 
-const Paths: FC<Props> = ({ label, required, disabled, paths, disableValidation, onChangePaths }) => {
+const Paths: FC<Props> = ({
+  label,
+  required,
+  disabled,
+  paths,
+  disableValidation,
+  trackGlobalValidity = true,
+  onChangePaths,
+}) => {
   const t = useI18n();
   const { dispatch } = useSaveValidationContext();
 
   const [pathError, setPathError] = useState('');
 
   useEffect(() => {
+    if (!trackGlobalValidity) return;
     dispatch({ type: ValidationActionType.SetField, field: 'path', isValid: !pathError });
-  }, [dispatch, pathError]);
+  }, [dispatch, pathError, trackGlobalValidity]);
 
   useEffect(() => {
     setPathError(
@@ -85,6 +95,7 @@ const Paths: FC<Props> = ({ label, required, disabled, paths, disableValidation,
           onRemove={onRemove}
           onChangePath={onChangePath}
           disableValidation={disableValidation}
+          trackGlobalValidity={trackGlobalValidity}
         />
       ))}
       {!disabled && (

--- a/apps/ai-dial-admin/src/components/Routes/View/Properties/RouteProperties.tsx
+++ b/apps/ai-dial-admin/src/components/Routes/View/Properties/RouteProperties.tsx
@@ -50,6 +50,9 @@ const RouteProperties: FC<Props> = ({ route, disabled, isAppRoute, routeNames, o
   const { dispatch, resetCounter } = useSaveValidationContext();
   const isReadOnlyAdmin = useIsReadOnlyAdmin();
 
+  // When true, all field-level validation is delegated to EntityRoutes aggregate key
+  const skipGlobalValidation = !!(isAppRoute && isAppRunnerView);
+
   const outputRadio: RadioButtonWithContent[] = [
     { id: RouteOutput.UPSTREAMS, name: t(EntityFieldsI18nKey.upstreams) },
     { id: RouteOutput.RESPONSE, name: t(EntityFieldsI18nKey.response) },
@@ -72,16 +75,19 @@ const RouteProperties: FC<Props> = ({ route, disabled, isAppRoute, routeNames, o
   const [isUpstreamsRequired, setIsUpstreamsRequired] = useState(!route.response);
 
   useEffect(() => {
+    if (skipGlobalValidation) return;
     dispatch({ type: ValidationActionType.SetField, field: 'status', isValid: !statusError });
-  }, [dispatch, statusError]);
+  }, [dispatch, statusError, skipGlobalValidation]);
 
   useEffect(() => {
+    if (skipGlobalValidation) return;
     dispatch({ type: ValidationActionType.SetField, field: 'body', isValid: !bodyError });
-  }, [dispatch, bodyError]);
+  }, [dispatch, bodyError, skipGlobalValidation]);
 
   useEffect(() => {
+    if (skipGlobalValidation) return;
     dispatch({ type: ValidationActionType.SetField, field: 'methods', isValid: !!route.methods?.length });
-  }, [dispatch, route.methods]);
+  }, [dispatch, route.methods, skipGlobalValidation]);
 
   useEffect(() => {
     if (resetCounter) {
@@ -91,14 +97,14 @@ const RouteProperties: FC<Props> = ({ route, disabled, isAppRoute, routeNames, o
   }, [resetCounter]);
 
   useEffect(() => {
-    if (isAppRoute) {
+    if (isAppRoute && !skipGlobalValidation) {
       dispatch({
         type: ValidationActionType.SetField,
         field: 'endpoints',
         isValid: !!route.response || !!route.upstreams?.length,
       });
     }
-  }, [isAppRoute, dispatch, route.upstreams?.length, route.response]);
+  }, [isAppRoute, dispatch, route.upstreams?.length, route.response, skipGlobalValidation]);
 
   const selectedPermissions = useMemo(() => {
     return (route as DialAppRoute).permissions?.map(
@@ -186,10 +192,12 @@ const RouteProperties: FC<Props> = ({ route, disabled, isAppRoute, routeNames, o
   const onChangeOrder = useCallback(
     (order?: string | number) => {
       onChange({ ...route, order: order ? +order : undefined });
-      dispatch({ type: ValidationActionType.SetField, field: 'order', isValid: !!order });
+      if (!skipGlobalValidation) {
+        dispatch({ type: ValidationActionType.SetField, field: 'order', isValid: !!order });
+      }
       setOrderError(order ? '' : t(ErrorI18nKey.RequiredField));
     },
-    [route, onChange, dispatch, t],
+    [route, onChange, dispatch, t, skipGlobalValidation],
   );
 
   const onResetOrder = useCallback(() => {
@@ -197,9 +205,11 @@ const RouteProperties: FC<Props> = ({ route, disabled, isAppRoute, routeNames, o
       ...route,
       order: ORDER_DEFAULT_VALUE,
     });
-    dispatch({ type: ValidationActionType.SetField, field: 'order', isValid: true });
+    if (!skipGlobalValidation) {
+      dispatch({ type: ValidationActionType.SetField, field: 'order', isValid: true });
+    }
     setOrderError('');
-  }, [route, onChange, dispatch]);
+  }, [route, onChange, dispatch, skipGlobalValidation]);
 
   return (
     <div className="flex flex-col size-full gap-y-8">
@@ -212,6 +222,7 @@ const RouteProperties: FC<Props> = ({ route, disabled, isAppRoute, routeNames, o
         names={isAppRoute ? routeNames || [] : void 0}
         allowWhitespace={!isAppRoute}
         alphanumericOnly={isAppRoute && isAppRunnerView}
+        trackGlobalValidity={!skipGlobalValidation}
       />
       {!isAppRoute && <DescriptionControl entity={route} onChangeEntity={onChange} isFullWidth={false} />}
       <Paths
@@ -220,6 +231,7 @@ const RouteProperties: FC<Props> = ({ route, disabled, isAppRoute, routeNames, o
         onChangePaths={onChangePaths}
         required
         disabled={disabled || isReadOnlyAdmin}
+        trackGlobalValidity={!skipGlobalValidation}
       />
       <DialSwitch
         isOn={route.rewritePath}

--- a/apps/ai-dial-admin/src/context/SaveValidationContext.tsx
+++ b/apps/ai-dial-admin/src/context/SaveValidationContext.tsx
@@ -4,6 +4,7 @@ import { JSONEditorError, JSONEditorErrorNotification } from '@/src/types/editor
 
 export enum ValidationActionType {
   SetField = 'SET_FIELD_VALIDATION',
+  RemoveField = 'REMOVE_FIELD_VALIDATION',
   SetJsonEditor = 'SET_JSON_EDITOR_VALIDATION',
   SetJsonEditorNotifications = 'SET_JSON_EDITOR_NOTIFICATIONS',
   Reset = 'RESET',
@@ -11,6 +12,7 @@ export enum ValidationActionType {
 
 type ValidationAction =
   | { type: ValidationActionType.SetField; field: string; isValid: boolean }
+  | { type: ValidationActionType.RemoveField; field: string }
   | { type: ValidationActionType.SetJsonEditor; errors: JSONEditorError[] | null }
   | { type: ValidationActionType.SetJsonEditorNotifications; errors: JSONEditorErrorNotification[] }
   | { type: ValidationActionType.Reset };
@@ -39,6 +41,19 @@ const validationReducer = (state: ValidationState, action: ValidationAction): Va
       newFieldValidations.set(action.field, action.isValid);
 
       const isValid = Array.from(newFieldValidations.values()).every((valid) => valid);
+
+      return {
+        ...state,
+        fieldValidations: newFieldValidations,
+        isValid,
+      };
+    }
+    case ValidationActionType.RemoveField: {
+      const newFieldValidations = new Map(state.fieldValidations);
+      newFieldValidations.delete(action.field);
+
+      const isValid =
+        newFieldValidations.size === 0 || Array.from(newFieldValidations.values()).every((valid) => valid);
 
       return {
         ...state,

--- a/openspec/changes/fix-approute-validation/.openspec.yaml
+++ b/openspec/changes/fix-approute-validation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/fix-approute-validation/design.md
+++ b/openspec/changes/fix-approute-validation/design.md
@@ -1,0 +1,81 @@
+## Context
+
+`SaveValidationContext` manages a flat `Map<string, boolean>` where each field control registers its validity by a string key. `DisplayNameControl` defaults to key `"displayName"` when no `validationPrefix` is provided.
+
+In the ApplicationRunner config view, the **Properties tab** registers `"dial:applicationTypeDisplayName"` (explicit prefix). The **AppRoutes tab** renders one `DisplayNameControl` per route (only the active route is mounted at any time), all writing to the same `"displayName"` key with no cleanup on unmount.
+
+This creates three compounding bugs:
+1. Switching routes leaves the old route's validity entry in the map (no cleanup).
+2. All routes share the same key — only the active route's validity is visible to the context.
+3. Stale `"displayName"` entries persist when switching away from the AppRoutes tab.
+
+A previous workaround disabled route switching when `!isValid`, which deadlocked users with invalid routes and must be removed.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Aggregate `isValid` in context always reflects reality regardless of which tab or route is active
+- Switching tabs or routes never leaves stale validation entries
+- Users can freely switch routes and tabs without validation state corruption
+- All app routes' name validity is tracked even when unmounted
+
+**Non-Goals:**
+- Changing how other field controls (Id, Description, etc.) interact with validation context
+- Refactoring `SaveValidationContext` to a more general-purpose form library
+- Per-route validation for fields other than `displayName` (status, methods, endpoints already handle removal correctly via `onRemoveRoute`)
+
+## Decisions
+
+### Decision 1: Add `RemoveField` action to `SaveValidationContext`
+
+**Chosen:** Add `RemoveField` action that deletes the key from the map and recomputes `isValid`.
+
+**Why:** The context has no way to clean up entries. This is the minimal addition needed by cleanup effects without restructuring the reducer. All other actions are set-style — `RemoveField` is a natural complement.
+
+**Alternative considered:** Reset the whole context on tab switch. Rejected: triggers full re-validation flash and requires coordinating the reset with every tab change site.
+
+---
+
+### Decision 2: `DisplayNameControl` cleans up its key on unmount
+
+**Chosen:** Add a `useEffect` cleanup that dispatches `RemoveField` for this component's key when it unmounts. Only fires when `trackGlobalValidity` is true (see Decision 3).
+
+**Why:** Stale entries from unmounted controls are the direct cause of cross-tab corruption. Cleanup at the source is the most reliable fix — no coordination needed with parent components.
+
+**Alternative considered:** Parent components explicitly clear keys. Rejected: too fragile, requires every usage site to know about validation context lifecycle.
+
+---
+
+### Decision 3: `trackGlobalValidity` prop on `DisplayNameControl` (default `true`)
+
+**Chosen:** Add optional `trackGlobalValidity?: boolean` prop. When `false`, the component renders inline errors but never reads or writes the global validation context.
+
+**Why:** For app routes, `EntityRoutes` will own the aggregate key (Decision 4). If `DisplayNameControl` also dispatches to the context, the same problem recurs — multiple instances write to the same or different keys, and unmounted routes vanish from the map. Opting out of global tracking for the per-route case is cleaner than threading a unique prefix through four component layers.
+
+**Alternative considered:** Thread a unique stable ID (`uuid`) per route down as `validationPrefix`. Rejected: adds complexity (stable ID management in `EntityRoutes`, prop threading through `RouteContent` → `RouteProperties`), and still leaves the "unmounted routes not tracked" problem unless the parent also computes validity.
+
+---
+
+### Decision 4: `EntityRoutes` eagerly computes aggregate route-name validity
+
+**Chosen:** A `useEffect` in `EntityRoutes` watches `routes` and validates **all** route names (uniqueness + alphanumeric) using the existing `getErrorForAppRouteName` utility. It dispatches `SetField("appRouteNames", allValid)` and cleans up with `RemoveField("appRouteNames")` on unmount.
+
+**Why:** Only `EntityRoutes` has access to all routes simultaneously. Mounted components can only track the route currently on screen. Moving the aggregate check to the data owner (not the rendering layer) means validity is always correct regardless of which route is active.
+
+**Validation logic reuse:** `getErrorForAppRouteName(name, otherNames, t)` already exists in `src/utils/validation/name-error.ts`. For each route at index `i`, `otherNames` is `routes.filter((_, j) => j !== i).map(r => r.name || '')`.
+
+---
+
+### Decision 5: Remove route-switching lock
+
+**Chosen:** Remove `pointer-events-none` guard on `AppRouteList` items when `!isValid`, and remove the `disabled` check on the "Add" button that was tied to `isValid`.
+
+**Why:** With Decision 4, `isValid` in context reflects all routes (not just the mounted one). The lock was a workaround for stale state — it's no longer needed and was worse UX than the bug it tried to prevent. The "Add" button should remain disabled while there are validation errors (prevents adding a route on top of existing errors).
+
+## Risks / Trade-offs
+
+- **`getErrorForAppRouteName` called for every route on every routes change** → O(n²) for uniqueness checks. Routes arrays are small (typically < 20), so this is not a concern in practice.
+
+- **`trackGlobalValidity={false}` is a new prop pattern** → Adds conceptual surface to `DisplayNameControl`. Mitigated by making it optional with a safe default, and documenting via prop name only.
+
+- **`RemoveField` makes `isValid` flip to `true` transiently** → When a component unmounts and removes its (invalid) key, `isValid` briefly becomes `true` before the replacement mounts. In practice the two effects fire in the same React commit/flush, so there is no observable UI flicker.

--- a/openspec/changes/fix-approute-validation/proposal.md
+++ b/openspec/changes/fix-approute-validation/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The `SaveValidationContext` uses a flat `Map<string, boolean>` with no key namespacing and no cleanup on component unmount. When multiple app routes share the same validation key (`"displayName"`), switching between routes or tabs leaves stale entries that corrupt the aggregate `isValid` signal — blocking saves for the wrong reasons or allowing them when invalid routes exist.
+
+## What Changes
+
+- Add `RemoveField` action to `SaveValidationContext` so keys can be explicitly deleted from the map
+- Add unmount cleanup to `DisplayNameControl` to remove its key from the context when it unmounts, preventing stale validation entries across tab switches
+- Add `trackGlobalValidity` prop to `DisplayNameControl` (default `true`); when `false`, the component only maintains local inline error state and does not dispatch to the global context
+- `EntityRoutes` computes validity for **all** routes eagerly from route data (not from mounted components) and registers a single `"appRouteNames"` key in the global context
+- Remove the existing workaround that disabled app route switching when `isValid` is false — this is no longer needed and was harmful to UX
+
+## Capabilities
+
+### New Capabilities
+
+- `approute-validation`: Correct validation tracking for app routes — all routes' name validity is computed from data in `EntityRoutes` and registered as a single context key; field controls clean up their context entries on unmount
+
+### Modified Capabilities
+
+_(none — no spec-level requirement changes to existing capabilities)_
+
+## Impact
+
+- `SaveValidationContext` — new action type, no breaking change to existing consumers
+- `DisplayNameControl` — new optional prop, fully backward-compatible
+- `EntityRoutes` — adds eagerly-computed route validity, removes the `isValid` guard on route switching
+- `AppRouteList` — remove `pointer-events-none` guard tied to `!isValid`
+- `RouteProperties` — passes `trackGlobalValidity={false}` for app route context
+- No API or server-action changes

--- a/openspec/changes/fix-approute-validation/specs/approute-validation/spec.md
+++ b/openspec/changes/fix-approute-validation/specs/approute-validation/spec.md
@@ -1,0 +1,94 @@
+## ADDED Requirements
+
+### Requirement: Validation context supports field removal
+The `SaveValidationContext` SHALL support a `RemoveField` action that removes a named key from the validation map and recomputes the aggregate `isValid` signal. After removal, `isValid` SHALL reflect only the remaining registered fields.
+
+#### Scenario: Removing the only invalid field restores isValid
+- **WHEN** a field is registered as invalid in the context
+- **AND** `RemoveField` is dispatched for that field
+- **THEN** the field is absent from the map
+- **AND** `isValid` becomes `true`
+
+#### Scenario: Removing a valid field from a mix
+- **WHEN** multiple fields are registered (some valid, some invalid)
+- **AND** `RemoveField` is dispatched for a valid field
+- **THEN** that field is absent from the map
+- **AND** `isValid` remains `false` (invalid fields still present)
+
+---
+
+### Requirement: DisplayNameControl cleans up its validation entry on unmount
+When `trackGlobalValidity` is `true` (the default), `DisplayNameControl` SHALL dispatch `RemoveField` for its registered key when the component unmounts. No stale entry SHALL remain in the validation context after the component is no longer rendered.
+
+#### Scenario: Switching tabs removes stale displayName entry
+- **WHEN** a `DisplayNameControl` is rendered on Tab A and registers its key
+- **AND** the user navigates to Tab B causing Tab A to unmount
+- **THEN** the key registered by Tab A's `DisplayNameControl` is removed from the validation map
+
+#### Scenario: Switching active app route clears previous route's entry
+- **WHEN** Route A is the active route and its `DisplayNameControl` registers its key
+- **AND** the user switches to Route B
+- **THEN** Route A's `DisplayNameControl` unmounts and its key is removed from the map
+- **AND** Route B's `DisplayNameControl` mounts and registers its own key
+
+---
+
+### Requirement: DisplayNameControl can opt out of global validation context
+`DisplayNameControl` SHALL accept a `trackGlobalValidity` prop (boolean, default `true`). When `false`, the component SHALL only maintain local inline error state and SHALL NOT read from or write to the global `SaveValidationContext`. All other behavior (inline error display, onChange callback) SHALL be unaffected.
+
+#### Scenario: Opt-out component does not affect aggregate validity
+- **WHEN** a `DisplayNameControl` is rendered with `trackGlobalValidity={false}`
+- **AND** the input value is invalid
+- **THEN** an inline error is shown
+- **AND** no entry is written to the global validation map
+- **AND** `isValid` in the context is unchanged
+
+#### Scenario: Opt-out component unmount does not dispatch RemoveField
+- **WHEN** a `DisplayNameControl` with `trackGlobalValidity={false}` unmounts
+- **THEN** no `RemoveField` action is dispatched to the context
+
+---
+
+### Requirement: EntityRoutes tracks validity of all app routes eagerly
+`EntityRoutes` SHALL maintain a single `"appRouteNames"` key in the global validation context. This key SHALL reflect whether **all** app route names pass validation (non-empty, alphanumeric, unique within the route list). The key SHALL be recomputed whenever the routes array changes. The key SHALL be removed from the context when `EntityRoutes` unmounts.
+
+#### Scenario: All routes have valid names
+- **WHEN** all routes have non-empty, alphanumeric, unique names
+- **THEN** `"appRouteNames"` is registered as valid in the context
+
+#### Scenario: One route has an invalid name
+- **WHEN** any route has an empty or non-alphanumeric name
+- **THEN** `"appRouteNames"` is registered as invalid
+- **AND** the aggregate `isValid` is `false`
+
+#### Scenario: Route with invalid name is removed
+- **WHEN** a route with an invalid name is removed from the list
+- **AND** all remaining routes have valid names
+- **THEN** `"appRouteNames"` is recomputed and registered as valid
+
+#### Scenario: EntityRoutes unmounts
+- **WHEN** the AppRoutes tab is left and `EntityRoutes` unmounts
+- **THEN** the `"appRouteNames"` key is removed from the validation map
+
+---
+
+### Requirement: App route DisplayNameControl uses local validation only
+In the `RouteProperties` component, when rendered for an app route in the ApplicationRunner context (`isAppRoute && isAppRunnerView`), the `DisplayNameControl` SHALL be rendered with `trackGlobalValidity={false}`. Inline errors SHALL still display. The aggregate validity for route names SHALL come exclusively from the `EntityRoutes` `"appRouteNames"` key.
+
+#### Scenario: Invalid route name shows inline error but does not double-register
+- **WHEN** a user clears the name field of an active app route
+- **THEN** an inline error is shown in the `DisplayNameControl`
+- **AND** no `"displayName"` key is written to the validation context by `DisplayNameControl`
+- **AND** `"appRouteNames"` in the context is updated to invalid by `EntityRoutes`
+
+---
+
+### Requirement: Route switching is never blocked by validation state
+Users SHALL be able to switch between app routes in `AppRouteList` at any time, regardless of whether the current route has validation errors. The `pointer-events-none` guard on route list items SHALL be removed.
+
+#### Scenario: User switches route while current route has errors
+- **WHEN** the active route has a validation error in any field
+- **AND** the user clicks a different route in the sidebar
+- **THEN** the selected route becomes active
+- **AND** inline errors are cleared (new route's fields initialize)
+- **AND** the aggregate validity (`isValid`) reflects all routes via `"appRouteNames"`

--- a/openspec/changes/fix-approute-validation/tasks.md
+++ b/openspec/changes/fix-approute-validation/tasks.md
@@ -1,0 +1,38 @@
+## 1. SaveValidationContext — Add RemoveField
+
+- [x] 1.1 Add `RemoveField` action type to `ValidationActionType` enum in `apps/ai-dial-admin/src/context/SaveValidationContext.tsx`
+- [x] 1.2 Add `RemoveField` to the `ValidationAction` union type
+- [x] 1.3 Add `RemoveField` case to `validationReducer`: delete the key from `fieldValidations`, recompute `isValid`
+
+## 2. DisplayNameControl — Cleanup and opt-out prop
+
+- [x] 2.1 Add `trackGlobalValidity?: boolean` prop (default `true`) to the `Props` interface in `apps/ai-dial-admin/src/components/BaseControls/DisplayName.tsx`
+- [x] 2.2 Guard all `dispatch(SetField)` calls in `validateDisplayName` and the initial `useEffect` with `if (trackGlobalValidity !== false)`
+- [x] 2.3 ~~Add a `useEffect` cleanup on unmount~~ — Removed: errors must persist in the background when switching tabs
+
+## 3. Path and Paths — Opt-out prop
+
+- [x] 3.1 Add `trackGlobalValidity?: boolean` to Props in `apps/ai-dial-admin/src/components/Routes/Paths/Path.tsx`; guard all `dispatch` calls with `if (trackGlobalValidity !== false)`; pass it through to the `<Path>` render in `Paths.tsx`
+- [x] 3.2 Add `trackGlobalValidity?: boolean` to Props in `apps/ai-dial-admin/src/components/Routes/Paths/Paths.tsx`; guard the `dispatch('path')` call; forward prop to each `<Path>` — no unmount cleanup
+
+## 4. RouteProperties — Opt out of global tracking for app runner routes
+
+- [x] 4.1 In `apps/ai-dial-admin/src/components/Routes/View/Properties/RouteProperties.tsx`, compute `skipGlobalValidation = !!(isAppRoute && isAppRunnerView)` and pass `trackGlobalValidity={!skipGlobalValidation}` to `DisplayNameControl` and `Paths`
+- [x] 4.2 Wrap the `methods`, `endpoints`, `status`, `body`, and `order` dispatch calls with `if (!skipGlobalValidation)` so they are skipped for app runner routes
+
+## 5. EntityRoutes — Eager aggregate validity for all routes
+
+- [x] 5.1 In `apps/ai-dial-admin/src/components/EntityView/AppRoute/AppRoute.tsx`, import `getErrorForAppRouteName` from `@/src/utils/validation/name-error` and `isValidRoutePath` from `@/src/utils/validation/path-error`; add `useI18n`
+- [x] 5.2 Add a `useEffect` that validates all routes (name, paths, methods, endpoints) and dispatches `SetField('appRoutes', allValid)` whenever `routes` or `isAppRunnerView` changes
+- [x] 5.3 ~~Add cleanup `useEffect` for `RemoveField('appRoutes')` on unmount~~ — Removed: `appRoutes` error persists in the background when switching tabs
+- [x] 5.4 Remove the `status` and `methods` `dispatch` calls from `onRemoveRoute` (replaced by the aggregate effect)
+
+## 6. Remove route-switching lock
+
+- [x] 6.1 In `apps/ai-dial-admin/src/components/EntityView/AppRoute/AppRouteList.tsx`, remove the `pointer-events-none opacity-50` guard and the `useSaveValidationContext` import (no longer needed)
+
+## 7. Code quality
+
+- [x] 7.1 Run `npm run lint` from repo root and fix any issues
+- [x] 7.2 Run `npm run format:write` to apply formatting
+- [x] 7.3 Run `npm run test` from `apps/ai-dial-admin/` and confirm all tests pass


### PR DESCRIPTION
**Description:**

added correct validation for app routes

Issues:

- Issue #3001


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
