### PR TITLE
fix: [Eval] Request and response body is wrapped in extra JSON in Try out (Issue #3130)

### DIFF
--- a/apps/ai-dial-admin/src/components/TestSuites/RequestTemplate/components/TryOut.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/RequestTemplate/components/TryOut.tsx
@@ -89,7 +89,10 @@ const TryOut: FC<Props> = ({ testSuite, testCaseId }) => {
   }, [testSuite, testCaseId, requestBody]);
 
   // todo: possible change this component to codeViewer
-  const responseBodyCopyText = useMemo(() => (response ? JSON.stringify(response, null, 2) : ''), [response]);
+  const responseBodyCopyText = useMemo(
+    () => (response?.body ? JSON.stringify(response?.body, null, 2) : ''),
+    [response],
+  );
   const responseBody = useMemo(() => {
     return (
       <CollapsibleSection
@@ -102,7 +105,7 @@ const TryOut: FC<Props> = ({ testSuite, testCaseId }) => {
           <DialLoader />
         ) : (
           <JsonEditor
-            entity={response}
+            entity={response?.body as object}
             options={{ stickyScroll: { enabled: false }, wordWrap: 'off' }}
             readonly={true}
           />

--- a/apps/ai-dial-admin/src/components/TestSuites/RequestTemplate/components/TryOutResponse.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/RequestTemplate/components/TryOutResponse.tsx
@@ -29,7 +29,8 @@ const TryOutResponsePreview: FC<Props> = ({
   isMcp,
 }) => {
   const t = useI18n();
-  const requestBodyCopyText = useMemo(() => (response ? JSON.stringify(response, null, 2) : ''), [response]);
+  const requestBody = resolvedRequest.body as object;
+  const requestBodyCopyText = useMemo(() => (requestBody ? JSON.stringify(requestBody, null, 2) : ''), [requestBody]);
   const isError = isMcp
     ? (response as Record<string, unknown>).isError
     : !(response.statusCode >= 200 && response.statusCode < 300);
@@ -57,15 +58,15 @@ const TryOutResponsePreview: FC<Props> = ({
       {/* todo: possible change this component to codeViewer */}
       <CollapsibleSection
         title={t(BasicI18nKey.Request)}
-        fullViewContent={JSON.stringify(resolvedRequest, null, 2)}
-        headerIcon={<CopyButton value={requestBodyCopyText} valueLabel={t(BasicI18nKey.Response)} />}
+        fullViewContent={JSON.stringify(requestBody, null, 2)}
+        headerIcon={<CopyButton value={requestBodyCopyText} valueLabel={t(BasicI18nKey.Request)} />}
         growOnOpen
       >
         {isRequestSend ? (
           <DialLoader />
         ) : (
           <JsonEditor
-            entity={resolvedRequest}
+            entity={requestBody}
             options={{ stickyScroll: { enabled: false }, wordWrap: 'bounded' }}
             readonly={true}
           />


### PR DESCRIPTION
**Description:**

changed request and response json view to show only body

Issues:

- Issue #3130


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
