### PR TITLE
fix: [Eval > Test Suites] Metric can be deleted without confirmation dialog (Issue #3181)

### DIFF
--- a/apps/ai-dial-admin/src/components/TestSuites/Metrics/Metrics.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/Metrics/Metrics.tsx
@@ -3,7 +3,14 @@
 import { FC, useCallback, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 
-import { DialLoader, DialNeutralButton, DialNoDataContent, DialPrimaryButton, ElementSize } from '@epam/ai-dial-ui-kit';
+import {
+  DialConfirmationPopup,
+  DialLoader,
+  DialNeutralButton,
+  DialNoDataContent,
+  DialPrimaryButton,
+  ElementSize,
+} from '@epam/ai-dial-ui-kit';
 import { IconEdit, IconPlus, IconTrash } from '@tabler/icons-react';
 
 import {
@@ -12,7 +19,7 @@ import {
   getTestSuiteMetrics,
   updateTestSuiteMetric,
 } from '@/src/app/[lang]/test-suites/actions';
-import { ButtonsI18nKey, EntitiesI18nKey, TabsI18nKey, TestSuitesI18nKey } from '@/src/constants/i18n';
+import { ButtonsI18nKey, DeleteI18nKey, EntitiesI18nKey, TabsI18nKey, TestSuitesI18nKey } from '@/src/constants/i18n';
 import { BASE_BUTTON_ICON_PROPS } from '@/src/constants/main-layout';
 import { useNotification } from '@/src/context/NotificationContext';
 import { useI18n } from '@/src/locales/client';
@@ -34,11 +41,14 @@ const Metrics: FC<Props> = ({ selectedTestSuite }) => {
   const [metrics, setMetrics] = useState<Metric[] | undefined>();
 
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [metricToEdit, setMetricToEdit] = useState<Metric | undefined>();
 
   const onRemoveMetric = useCallback(
     (metricId: string) => {
       deleteTestSuiteMetric(selectedTestSuite.id as string, metricId).then((response) => {
+        setIsDeleteModalOpen(false);
+        setMetricToEdit(undefined);
         if (response?.success) {
           getTestSuiteMetrics(selectedTestSuite.id as string, 0, 1000).then((response) => {
             setMetrics(response?.content);
@@ -135,7 +145,10 @@ const Metrics: FC<Props> = ({ selectedTestSuite }) => {
                       <DialNeutralButton
                         size={ElementSize.Small}
                         label={t(ButtonsI18nKey.Delete)}
-                        onClick={() => onRemoveMetric(metric.id as string)}
+                        onClick={() => {
+                          setMetricToEdit(metric);
+                          setIsDeleteModalOpen(true);
+                        }}
                         iconBefore={<IconTrash stroke={2} size={16} />}
                       />
                       <DialNeutralButton
@@ -185,6 +198,24 @@ const Metrics: FC<Props> = ({ selectedTestSuite }) => {
             }}
             editingMetric={metricToEdit}
           />,
+          document.body,
+        )}
+      {isDeleteModalOpen &&
+        createPortal(
+          <DialConfirmationPopup
+            open={isDeleteModalOpen}
+            header={t(DeleteI18nKey.Title, { entity: t(TestSuitesI18nKey.Metric) })}
+            onConfirm={() => onRemoveMetric(metricToEdit?.id as string)}
+            onClose={() => {
+              setIsDeleteModalOpen(false);
+              setMetricToEdit(undefined);
+            }}
+            confirmLabel={t(ButtonsI18nKey.Delete)}
+            description={t(DeleteI18nKey.Confirming, {
+              entity: `${metricToEdit?.name} ${t(TestSuitesI18nKey.Metric)}`,
+            })}
+          />,
+
           document.body,
         )}
     </div>

--- a/apps/ai-dial-admin/src/components/TestSuites/Metrics/tests/Metrics.spec.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/Metrics/tests/Metrics.spec.tsx
@@ -74,6 +74,14 @@ vi.mock('@epam/ai-dial-ui-kit', () => ({
       {label}
     </button>
   ),
+  DialConfirmationPopup: ({ open, onConfirm, confirmLabel }: any) =>
+    open ? (
+      <div role="dialog" aria-label="delete-metric-confirmation">
+        <button type="button" onClick={onConfirm}>
+          {confirmLabel}
+        </button>
+      </div>
+    ) : null,
   ElementSize: { Small: 'small' },
 }));
 
@@ -174,6 +182,12 @@ describe('Metrics', () => {
     });
 
     await user.click(screen.getByRole('button', { name: ButtonsI18nKey.Delete }));
+
+    await user.click(
+      within(screen.getByRole('dialog', { name: 'delete-metric-confirmation' })).getByRole('button', {
+        name: ButtonsI18nKey.Delete,
+      }),
+    );
 
     await waitFor(() => {
       expect(mockDeleteTestSuiteMetric).toHaveBeenCalledWith('suite-1', 'metric-1');

--- a/apps/ai-dial-admin/src/constants/i18n.ts
+++ b/apps/ai-dial-admin/src/constants/i18n.ts
@@ -1569,6 +1569,7 @@ export enum TestSuitesI18nKey {
   NoInformationToPreview = 'TestSuites.NoInformationToPreview',
   AddMetric = 'TestSuites.AddMetric',
   EditMetric = 'TestSuites.EditMetric',
+  Metric = 'TestSuites.Metric',
   Configuration = 'TestSuites.Configuration',
   Parameters = 'TestSuites.Parameters',
   Inputs = 'TestSuites.Inputs',

--- a/apps/ai-dial-admin/src/locales/en.ts
+++ b/apps/ai-dial-admin/src/locales/en.ts
@@ -1606,6 +1606,7 @@ export default {
     NoInformationToPreview: 'No information to preview',
     AddMetric: 'Add metric',
     EditMetric: 'Edit metric',
+    Metric: 'Metric',
     ResponseColumn: 'Response column',
     Bindings: 'Bindings',
     Parameters: 'Parameters',


### PR DESCRIPTION
**Description:**

added metric delete confirmation

Issues:

- Issue #3181

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
