### PR TITLE
fix: [Read-only] Users with Read-Only permissions can access and interact with the "Application custom UI" view (Issue #3220)

### DIFF
--- a/apps/ai-dial-admin/src/components/Applications/ParametersTab/ParametersTab.tsx
+++ b/apps/ai-dial-admin/src/components/Applications/ParametersTab/ParametersTab.tsx
@@ -90,8 +90,8 @@ const ParametersTab: FC<Props> = ({
       const config = getCorrectConfig(scheme, application, currentTheme, session as UserSession);
       const targetUrl = getTargetUrl(view, application, config);
 
-      setViewItems(generateViewItems(t, view, !!targetUrl, !!config));
-      setParamsView(getInitialParamsView(view, !!targetUrl));
+      setViewItems(generateViewItems(t, view, !!targetUrl && !isReadOnlyAdmin, !!config));
+      setParamsView(getInitialParamsView(view, !!targetUrl && !isReadOnlyAdmin));
     });
 
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
**Description:**

remove custom ui when readonly mode

Issues:

- Issue #3220


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
