### PR TITLE
fix: [Eval > Test Suites] "Add Sub-field" button appears for array type fields in Request/Response Schema, should only appear for object type (Issue #3191)

### DIFF
--- a/apps/ai-dial-admin/src/components/Common/SchemaGrid/SchemaGrid.tsx
+++ b/apps/ai-dial-admin/src/components/Common/SchemaGrid/SchemaGrid.tsx
@@ -105,13 +105,23 @@ const SchemaGrid: FC<SchemaGridProps> = ({ schema, onChange, isSkipRefresh, isDi
   const onChangeType = useCallback(
     (value: string, data: SchemaFieldRow) => {
       const updated = updateFieldInList(fieldsRef.current, data.id, (f) => {
+        if (value.startsWith('array:')) {
+          const itemsType = value.slice(6) as SchemaFieldRow['type'];
+          return {
+            ...f,
+            type: 'array' as SchemaFieldRow['type'],
+            itemsType,
+            children: itemsType === 'object' ? f.children : [],
+            expanded: itemsType === 'object' ? f.expanded : false,
+          };
+        }
         const newType = value as SchemaFieldRow['type'];
-        const shouldClearChildren = newType !== 'object' && newType !== 'array';
         return {
           ...f,
           type: newType,
-          children: shouldClearChildren ? [] : f.children,
-          expanded: shouldClearChildren ? false : f.expanded,
+          itemsType: undefined,
+          children: newType === 'object' ? f.children : [],
+          expanded: newType === 'object' ? f.expanded : false,
         };
       });
       updateFields(updated);

--- a/apps/ai-dial-admin/src/components/Common/SchemaGrid/TreeNameCellRenderer.tsx
+++ b/apps/ai-dial-admin/src/components/Common/SchemaGrid/TreeNameCellRenderer.tsx
@@ -25,8 +25,8 @@ const TreeNameCellRenderer = ({
 
   if (!data) return null;
 
-  const { type, expanded, depth } = data;
-  const hasChildren = type === 'object' || type === 'array';
+  const { type, expanded, depth, itemsType } = data;
+  const hasChildren = type === 'object' || (type === 'array' && (itemsType === 'object' || !itemsType));
 
   return (
     <div className="flex items-center h-full gap-1" style={{ paddingLeft: depth * 24 }}>

--- a/apps/ai-dial-admin/src/components/Common/SchemaGrid/columns.tsx
+++ b/apps/ai-dial-admin/src/components/Common/SchemaGrid/columns.tsx
@@ -6,13 +6,24 @@ import { getSchemaTypes, SchemaFieldRow } from '@/src/components/Common/SchemaGr
 import BooleanButtonCellRenderer from '@/src/components/Grid/CellRenderers/BooleanButtonCellRenderer';
 import EditableCellRenderer from '@/src/components/Grid/CellRenderers/EditableCellRenderer';
 import SelectCellRenderer from '@/src/components/Grid/CellRenderers/SelectCellRenderer';
-import TreeNameCellRenderer from '@/src/components/Grid/CellRenderers/TreeNameCellRenderer';
+import TreeNameCellRenderer from '@/src/components/Common/SchemaGrid/TreeNameCellRenderer';
 import { NO_BORDER_CLASS, ONE_ACTION_COLUMN } from '@/src/constants/ag-grid';
 import { getDeleteOperation } from '@/src/constants/grid-columns/actions';
 import { BasicI18nKey } from '@/src/constants/i18n';
 import { startCase } from 'lodash';
 
-const SCHEMA_TYPE_OPTIONS: SelectOption[] = getSchemaTypes().map((t) => ({ value: t, label: startCase(t) }));
+const SCHEMA_TYPE_OPTIONS: SelectOption[] = [
+  ...getSchemaTypes()
+    .filter((t) => t !== 'array')
+    .map((t) => ({ value: t, label: startCase(t) })),
+  {
+    value: 'array',
+    label: 'Array',
+    children: getSchemaTypes()
+      .filter((t) => t !== 'array' && t !== 'null')
+      .map((t) => ({ value: `array:${t}`, label: `${startCase(t)}[]` })),
+  },
+];
 
 const getPropertyKindOptions = (t: (key: BasicI18nKey) => string): SelectOption[] => [
   { value: 'server', label: t(BasicI18nKey.Server) },
@@ -56,7 +67,7 @@ export const getSchemaGridColumns = (
       filter: false,
       floatingFilter: false,
       valueGetter: (params: ValueGetterParams<SchemaFieldRow>) =>
-        `${params.data?.name}|${params.data?.expanded}|${params.data?.type}`,
+        `${params.data?.name}|${params.data?.expanded}|${params.data?.type}|${params.data?.itemsType}`,
       cellRenderer: TreeNameCellRenderer,
       cellRendererParams: {
         onToggleExpand,
@@ -100,13 +111,19 @@ export const getSchemaGridColumns = (
     },
     {
       headerName: 'Data type',
-      field: 'type',
+      colId: 'dataType',
       cellClass: NO_BORDER_CLASS,
       width: 140,
       maxWidth: 160,
       sortable: false,
       filter: false,
       floatingFilter: false,
+      valueGetter: (params: ValueGetterParams<SchemaFieldRow>) => {
+        if (params.data?.type === 'array') {
+          return `array:${params.data.itemsType ?? 'string'}`;
+        }
+        return params.data?.type;
+      },
       cellRenderer: SelectCellRenderer,
       cellRendererParams: {
         items: SCHEMA_TYPE_OPTIONS,

--- a/apps/ai-dial-admin/src/components/Common/SchemaGrid/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/Common/SchemaGrid/tests/utils.spec.ts
@@ -366,7 +366,7 @@ describe('jsonSchemaToFields', () => {
     expect(fields[0].children).toEqual([]);
   });
 
-  test('should create a primitive child for array without object items', () => {
+  test('should set itemsType and have no children for array with primitive items', () => {
     const schema: JSONSchema7 = {
       type: 'object',
       properties: {
@@ -376,14 +376,8 @@ describe('jsonSchemaToFields', () => {
 
     const fields = jsonSchemaToFields(schema);
     expect(fields[0].expanded).toBe(false);
-    expect(fields[0].children).toHaveLength(1);
-    expect(fields[0].children[0]).toMatchObject({
-      name: 'simpleArray',
-      type: 'string',
-      required: false,
-      depth: 1,
-      parentId: fields[0].id,
-    });
+    expect(fields[0].itemsType).toBe('string');
+    expect(fields[0].children).toHaveLength(0);
   });
 
   test('should resolve $ref from $defs when building fields', () => {
@@ -983,6 +977,24 @@ describe('fieldsToJsonSchema and jsonSchemaToFields round-trip', () => {
     expect(result).toEqual(original);
   });
 
+  test('should round-trip an array with primitive items', () => {
+    const original: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        tags: {
+          type: 'array',
+          items: { type: 'string' },
+        },
+      },
+    };
+
+    const fields = jsonSchemaToFields(original);
+    expect(fields[0].itemsType).toBe('string');
+    expect(fields[0].children).toHaveLength(0);
+    const result = fieldsToJsonSchema(fields);
+    expect(result).toEqual(original);
+  });
+
   test('should round-trip an array with object items', () => {
     const original: JSONSchema7 = {
       type: 'object',
@@ -1133,12 +1145,13 @@ describe('flattenFields', () => {
     expect(result[3]).toMatchObject({ id: 'add-root-field', isAddSubFieldRow: true });
   });
 
-  test('should flatten expanded array field the same as object', () => {
+  test('should flatten expanded array with object itemsType the same as object', () => {
     const fields: SchemaFieldRow[] = [
       {
         id: 'f1',
         name: 'items',
         type: 'array',
+        itemsType: 'object',
         required: false,
         description: '',
         expanded: true,
@@ -1167,6 +1180,31 @@ describe('flattenFields', () => {
     expect(result[1]).toMatchObject({ id: 'c1', depth: 1 });
     expect(result[2]).toMatchObject({ id: 'add-sub-f1', isAddSubFieldRow: true, depth: 1 });
     expect(result[3]).toMatchObject({ id: 'add-root-field' });
+  });
+
+  test('should not show add-sub-field row for array with primitive itemsType', () => {
+    const fields: SchemaFieldRow[] = [
+      {
+        id: 'f1',
+        name: 'tags',
+        type: 'array',
+        itemsType: 'string',
+        required: false,
+        description: '',
+        expanded: true,
+        children: [],
+        parentId: null,
+        depth: 0,
+      },
+    ];
+
+    const result = flattenFields(fields);
+
+    // f1, add-root-field only — no add-sub row since itemsType is primitive
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ id: 'f1' });
+    expect(result[1]).toMatchObject({ id: 'add-root-field' });
+    expect(result.some((r) => r.isAddSubFieldRow && r.parentId === 'f1')).toBe(false);
   });
 
   test('should not flatten children of collapsed object/array', () => {

--- a/apps/ai-dial-admin/src/components/Common/SchemaGrid/utils.ts
+++ b/apps/ai-dial-admin/src/components/Common/SchemaGrid/utils.ts
@@ -6,6 +6,8 @@ export interface SchemaFieldRow {
   id: string;
   name: string;
   type: JSONSchema7TypeName;
+  /** For array fields: the type of items in the array (e.g. 'string', 'object'). Only defined when type === 'array'. */
+  itemsType?: JSONSchema7TypeName;
   required: boolean;
   title: string;
   description: string;
@@ -228,10 +230,11 @@ const convertPropertyToField = (
     typeof effectiveDef.items === 'object' &&
     isJSONSchema7(effectiveDef.items as JSONSchema7Definition)
   ) {
-    if ((effectiveDef.items as JSONSchema7).properties) {
-      const items = effectiveDef.items as JSONSchema7;
-      const nestedRequired = items.required || [];
-      field.children = Object.entries(items.properties!).map(([childName, childDef]) =>
+    const rawItems = effectiveDef.items as JSONSchema7;
+    if (rawItems.properties) {
+      field.itemsType = 'object';
+      const nestedRequired = rawItems.required || [];
+      field.children = Object.entries(rawItems.properties).map(([childName, childDef]) =>
         convertPropertyToField(
           childName,
           childDef,
@@ -246,35 +249,23 @@ const convertPropertyToField = (
         field.expanded = true;
       }
     } else {
-      // evaluation metric
-      const items = effectiveDef.items as JSONSchema7;
-      const effectiveChild = getEffectiveSchema(items, rootSchema) ?? resolveDef(items, rootSchema);
+      const effectiveChild = getEffectiveSchema(rawItems, rootSchema) ?? resolveDef(rawItems, rootSchema);
       if (!isJSONSchema7(effectiveChild)) {
         return { ...createEmptyField(field.id, depth + 1), name: field.name };
       }
       const childSchema = effectiveChild as JSONSchema7;
       const childType = getPrimaryType(childSchema);
-      field.children =
-        childSchema.type === 'object'
-          ? jsonSchemaToFields(childSchema, rootSchema).map((child) => ({
-              ...child,
-              parentId: field.id,
-              depth: depth + 1,
-            }))
-          : [
-              {
-                id: generateFieldId(),
-                name: field.name,
-                type: childType,
-                required: field.required,
-                title: childSchema.title || '',
-                description: childSchema.description || '',
-                expanded: false,
-                children: [],
-                parentId: field.id,
-                depth: depth + 1,
-              },
-            ];
+      field.itemsType = childType;
+      if (childType === 'object') {
+        field.children = jsonSchemaToFields(childSchema, rootSchema).map((child) => ({
+          ...child,
+          parentId: field.id,
+          depth: depth + 1,
+        }));
+        if (field.children.length) {
+          field.expanded = true;
+        }
+      }
     }
   }
 
@@ -332,8 +323,14 @@ export const fieldsToJsonSchema = (fields: SchemaFieldRow[]): JSONSchema7 => {
         prop.properties = {};
       }
     } else if (field.type === 'array') {
-      // Always add items for array type: use children schema or { type: 'string' }
-      prop.items = field.children?.length > 0 ? fieldChildrenToObjectSchema(field.children) : { type: 'string' };
+      if (field.itemsType === 'object') {
+        prop.items =
+          field.children?.length > 0 ? fieldChildrenToObjectSchema(field.children) : { type: 'object', properties: {} };
+      } else if (field.itemsType) {
+        prop.items = { type: field.itemsType };
+      } else {
+        prop.items = field.children?.length > 0 ? fieldChildrenToObjectSchema(field.children) : { type: 'string' };
+      }
     }
 
     if (field.parentId === null && field.dialMeta) {
@@ -380,7 +377,14 @@ const fieldChildrenToObjectSchema = (children: SchemaFieldRow[]): JSONSchema7 =>
         childProp.properties = {};
       }
     } else if (child.type === 'array') {
-      childProp.items = child.children?.length > 0 ? fieldChildrenToObjectSchema(child.children) : { type: 'string' };
+      if (child.itemsType === 'object') {
+        childProp.items =
+          child.children?.length > 0 ? fieldChildrenToObjectSchema(child.children) : { type: 'object', properties: {} };
+      } else if (child.itemsType) {
+        childProp.items = { type: child.itemsType };
+      } else {
+        childProp.items = child.children?.length > 0 ? fieldChildrenToObjectSchema(child.children) : { type: 'string' };
+      }
     }
 
     schema.properties![childName] = childProp;
@@ -411,7 +415,9 @@ export const flattenFields = (fields: SchemaFieldRow[], depth = 0, isReadonly?: 
   fields.forEach((field) => {
     result.push({ ...field, depth });
 
-    if ((field.type === 'object' || field.type === 'array') && field.expanded) {
+    const canExpand =
+      field.type === 'object' || (field.type === 'array' && (field.itemsType === 'object' || !field.itemsType));
+    if (canExpand && field.expanded) {
       if (field.children?.length) {
         result.push(...flattenFields(field.children, depth + 1, isReadonly));
       }


### PR DESCRIPTION
**Description:**

added correct subfield for array type in schema grid

Issues:

- Issue #3191


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
