### PR TITLE
fix: [Entities > Models] Disabled "Responses endpoint" field is shown in "Create Model" popup when Adapter with Responses endpoint is selected (Issue #3324)

### DIFF
--- a/apps/ai-dial-admin/src/components/SourceField/Adapters/Adapters.tsx
+++ b/apps/ai-dial-admin/src/components/SourceField/Adapters/Adapters.tsx
@@ -165,7 +165,7 @@ const Adapters = <T extends DialModel | DialInterceptor>({
           hideResponsesEndpoint
         />
       )}
-      {entity.source?.adapterName && selectedAdapter && selectedAdapter.responsesEndpoint && (
+      {entity.source?.adapterName && selectedAdapter && selectedAdapter.responsesEndpoint && !isModal && (
         <ComplexInput
           copyable
           id="responsesEndpoint"


### PR DESCRIPTION
**Description:**

create modal responses field remove

Issues:

- Issue #3324 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
