### PR TITLE
fix: [Eval > Test Suites] Allow editing Test Suite Display Name after creation (Issue #3334)

### DIFF
--- a/apps/ai-dial-admin/src/components/TestSuites/Properties/Properties.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/Properties/Properties.tsx
@@ -66,15 +66,13 @@ const TestSuiteProperties: FC<Props> = ({ testSuite, onChange, isModal = false, 
 
   return (
     <div className="flex flex-col gap-y-8">
-      {isModal && (
-        <DisplayNameControl
-          displayName={testSuite.name}
-          required
-          isFullWidth={false}
-          onChange={(name) => onChange({ ...testSuite, name })}
-          externalError={nameExistsError}
-        />
-      )}
+      <DisplayNameControl
+        displayName={testSuite.name}
+        required
+        isFullWidth={false}
+        onChange={(name) => onChange({ ...testSuite, name })}
+        externalError={nameExistsError}
+      />
       <DescriptionControl isFullWidth={false} entity={testSuite} onChangeEntity={onChange} />
       {!isModal && (
         <>

--- a/apps/ai-dial-admin/src/components/TestSuites/View/TabsContent.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/View/TabsContent.tsx
@@ -2,17 +2,14 @@
 
 import { FC, RefObject, useMemo } from 'react';
 
-import LabelledText from '@/src/components/Common/LabelledText/LabelledText';
 import ValidityStatusLabel from '@/src/components/Common/ValidityStatus/ValidityStatusLabel';
 import PropertiesTabContent from '@/src/components/EntityTabs/PropertiesTabContent';
 import Metrics from '@/src/components/TestSuites/Metrics/Metrics';
 import TestSuiteProperties from '@/src/components/TestSuites/Properties/Properties';
-import MethodTabContent from '@/src/components/TestSuites/View/MethodTabContent';
 import Runs from '@/src/components/TestSuites/Runs/Runs';
 import TestCases from '@/src/components/TestSuites/TestCases/TestCases';
 import { TestCasesActions } from '@/src/components/TestSuites/TestCases/TestCasesList';
-import { EntityFieldsI18nKey } from '@/src/constants/i18n';
-import { useI18n } from '@/src/locales/client';
+import MethodTabContent from '@/src/components/TestSuites/View/MethodTabContent';
 import { TestSuite } from '@/src/models/evaluation/test-suite';
 import { ApplicationRoute } from '@/src/types/routes';
 import { EntityViewTab } from '@/src/utils/tabs/utils';
@@ -38,12 +35,6 @@ const TabsContent: FC<Props> = ({
   selectedTestSuite,
   isSkipRefresh,
 }) => {
-  const t = useI18n();
-
-  const headerPrefix = useMemo(() => {
-    return <LabelledText copyable={true} label={t(EntityFieldsI18nKey.name)} text={selectedTestSuite.name} />;
-  }, [selectedTestSuite.name, t]);
-
   const headerPostfix = useMemo(() => {
     return (
       <ValidityStatusLabel
@@ -59,7 +50,6 @@ const TabsContent: FC<Props> = ({
     <>
       {activeTab === EntityViewTab.Properties && (
         <PropertiesTabContent
-          headerPrefix={headerPrefix}
           headerPostfix={headerPostfix}
           entity={selectedTestSuite}
           view={ApplicationRoute.TestSuites}


### PR DESCRIPTION
**Description:**

added ability to edit display name of test suite

Issues:

- Issue #3334


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
