### PR TITLE
feat(audit): show entity consumption in an tree view (Issue #2559, #2710)

### DIFF
--- a/apps/ai-dial-admin/src/components/Common/SchemaGrid/SchemaGrid.tsx
+++ b/apps/ai-dial-admin/src/components/Common/SchemaGrid/SchemaGrid.tsx
@@ -8,6 +8,7 @@ import { JSONSchema7 } from 'json-schema';
 import isEqual from 'lodash/isEqual';
 
 import GridView from '@/src/components/Grid/GridView/GridView';
+import { findRowInTree, updateRowInTree } from '@/src/components/Common/TreeGrid/utils';
 import { getRowIdById } from '@/src/components/Grid/utils';
 import { BasicI18nKey } from '@/src/constants/i18n';
 import { useIsReadOnlyAdmin } from '@/src/hooks/use-is-read-only-admin';
@@ -66,22 +67,9 @@ const SchemaGrid: FC<SchemaGridProps> = ({ schema, onChange, isSkipRefresh, isDi
     onChangeRef.current(newSchema, isSkipRefresh);
   }, []);
 
-  const updateFieldInList = useCallback(
-    (fieldList: SchemaFieldRow[], id: string, updater: (field: SchemaFieldRow) => SchemaFieldRow): SchemaFieldRow[] => {
-      return fieldList.map((field) => {
-        if (field.id === id) return updater(field);
-        if (field.children.length) {
-          return { ...field, children: updateFieldInList(field.children, id, updater) };
-        }
-        return field;
-      });
-    },
-    [],
-  );
-
   const onToggleExpand = useCallback(
     (data: SchemaFieldRow) => {
-      const updated = updateFieldInList(fieldsRef.current, data.id, (f) => ({
+      const updated = updateRowInTree(fieldsRef.current, data.id, (f) => ({
         ...f,
         expanded: !f.expanded,
       }));
@@ -92,20 +80,20 @@ const SchemaGrid: FC<SchemaGridProps> = ({ schema, onChange, isSkipRefresh, isDi
         gridApiRef.current?.updateGridOptions({ rowData: flattenFields(updated, 0, isReadonlyGrid) });
       }
     },
-    [updateFieldInList, isReadonlyGrid],
+    [isReadonlyGrid],
   );
 
   const onChangeName = useCallback(
     (value: string, data: SchemaFieldRow) => {
-      const updated = updateFieldInList(fieldsRef.current, data.id, (f) => ({ ...f, name: value }));
+      const updated = updateRowInTree(fieldsRef.current, data.id, (f) => ({ ...f, name: value }));
       updateFields(updated, true);
     },
-    [updateFieldInList, updateFields],
+    [updateFields],
   );
 
   const onChangeType = useCallback(
     (value: string, data: SchemaFieldRow) => {
-      const updated = updateFieldInList(fieldsRef.current, data.id, (f) => {
+      const updated = updateRowInTree(fieldsRef.current, data.id, (f) => {
         if (value.startsWith('array:')) {
           const itemsType = value.slice(6) as SchemaFieldRow['type'];
           return {
@@ -127,56 +115,56 @@ const SchemaGrid: FC<SchemaGridProps> = ({ schema, onChange, isSkipRefresh, isDi
       });
       updateFields(updated);
     },
-    [updateFieldInList, updateFields],
+    [updateFields],
   );
 
   const onChangeRequired = useCallback(
     (value: boolean, data: SchemaFieldRow) => {
-      const updated = updateFieldInList(fieldsRef.current, data.id, (f) => ({ ...f, required: value }));
+      const updated = updateRowInTree(fieldsRef.current, data.id, (f) => ({ ...f, required: value }));
       updateFields(updated);
     },
-    [updateFieldInList, updateFields],
+    [updateFields],
   );
 
   const onChangeTitle = useCallback(
     (value: string, data: SchemaFieldRow) => {
-      const updated = updateFieldInList(fieldsRef.current, data.id, (f) => ({ ...f, title: value }));
+      const updated = updateRowInTree(fieldsRef.current, data.id, (f) => ({ ...f, title: value }));
       updateFields(updated, true);
     },
-    [updateFieldInList, updateFields],
+    [updateFields],
   );
 
   const onChangeDescription = useCallback(
     (value: string, data: SchemaFieldRow) => {
-      const updated = updateFieldInList(fieldsRef.current, data.id, (f) => ({ ...f, description: value }));
+      const updated = updateRowInTree(fieldsRef.current, data.id, (f) => ({ ...f, description: value }));
       updateFields(updated, true);
     },
-    [updateFieldInList, updateFields],
+    [updateFields],
   );
 
   const onChangeOrder = useCallback(
     (value: number | string, data: SchemaFieldRow) => {
       if (data.parentId !== null) return;
       const num = typeof value === 'string' ? (value === '' ? undefined : Number(value)) : value;
-      const updated = updateFieldInList(fieldsRef.current, data.id, (f) => ({
+      const updated = updateRowInTree(fieldsRef.current, data.id, (f) => ({
         ...f,
         dialMeta: { ...f.dialMeta, 'dial:propertyOrder': num },
       }));
       updateFields(updated, true);
     },
-    [updateFieldInList, updateFields],
+    [updateFields],
   );
 
   const onChangePropertyKind = useCallback(
     (value: string, data: SchemaFieldRow) => {
       if (data.parentId !== null) return;
-      const updated = updateFieldInList(fieldsRef.current, data.id, (f) => ({
+      const updated = updateRowInTree(fieldsRef.current, data.id, (f) => ({
         ...f,
         dialMeta: { ...f.dialMeta, 'dial:propertyKind': value },
       }));
       updateFields(updated);
     },
-    [updateFieldInList, updateFields],
+    [updateFields],
   );
 
   const onRemoveField = useCallback(
@@ -185,7 +173,7 @@ const SchemaGrid: FC<SchemaGridProps> = ({ schema, onChange, isSkipRefresh, isDi
       let updated: SchemaFieldRow[];
 
       if (data.parentId) {
-        updated = updateFieldInList(fieldsRef.current, data.parentId, (parent) => ({
+        updated = updateRowInTree(fieldsRef.current, data.parentId, (parent) => ({
           ...parent,
           children: parent.children.filter((c) => c.id !== data.id),
         }));
@@ -194,7 +182,7 @@ const SchemaGrid: FC<SchemaGridProps> = ({ schema, onChange, isSkipRefresh, isDi
       }
       updateFields(updated);
     },
-    [updateFieldInList, updateFields],
+    [updateFields],
   );
 
   const onAddField = useCallback(() => {
@@ -203,27 +191,18 @@ const SchemaGrid: FC<SchemaGridProps> = ({ schema, onChange, isSkipRefresh, isDi
     updateFields(updated);
   }, [updateFields]);
 
-  const findFieldById = useCallback((id: string, fieldList: SchemaFieldRow[]): SchemaFieldRow | undefined => {
-    for (const field of fieldList) {
-      if (field.id === id) return field;
-      const found = findFieldById(id, field.children);
-      if (found) return found;
-    }
-    return undefined;
-  }, []);
-
   const onAddSubField = useCallback(
     (parentId: string) => {
-      const parent = findFieldById(parentId, fieldsRef.current);
+      const parent = findRowInTree(fieldsRef.current, parentId);
       const childDepth = (parent?.depth ?? 0) + 1;
-      const updated = updateFieldInList(fieldsRef.current, parentId, (p) => ({
+      const updated = updateRowInTree(fieldsRef.current, parentId, (p) => ({
         ...p,
         expanded: true,
         children: [...p.children, createEmptyField(parentId, childDepth)],
       }));
       updateFields(updated);
     },
-    [updateFieldInList, updateFields, findFieldById],
+    [updateFields],
   );
 
   const rowData = useMemo(() => flattenFields(fields, 0, isReadonlyGrid), [fields, isReadonlyGrid]);

--- a/apps/ai-dial-admin/src/components/Common/TreeGrid/ExpanderCell.tsx
+++ b/apps/ai-dial-admin/src/components/Common/TreeGrid/ExpanderCell.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
+import { ICellRendererParams } from 'ag-grid-community';
+import classNames from 'classnames';
+
+import { TreeRow } from './types';
+
+interface ExpanderCellParams extends ICellRendererParams<TreeRow<Record<string, unknown>>> {
+  onToggleExpand?: (row: TreeRow<Record<string, unknown>>) => void;
+}
+
+const ExpanderCell = ({ data, value, onToggleExpand }: ExpanderCellParams) => {
+  if (!data) return null;
+
+  const { depth, children, expanded, synthetic } = data;
+  const hasChildren = children.length > 0;
+
+  return (
+    <div className="flex items-center h-full gap-1" style={{ paddingLeft: depth * 24 }}>
+      <div
+        className={classNames(
+          'flex items-center justify-center w-[18px] h-[18px] shrink-0 rounded',
+          hasChildren && 'cursor-pointer hover:bg-layer-3',
+        )}
+        onClick={() => {
+          if (!hasChildren) return;
+          onToggleExpand?.(data);
+        }}
+      >
+        {hasChildren ? (
+          expanded ? (
+            <IconChevronDown size={14} className={classNames('text-secondary', synthetic && 'opacity-40')} />
+          ) : (
+            <IconChevronRight size={14} className={classNames('text-secondary', synthetic && 'opacity-40')} />
+          )
+        ) : (
+          <span className="size-1.5 rounded-full bg-tertiary" />
+        )}
+      </div>
+      <span className={classNames(synthetic && 'italic')}>{value}</span>
+    </div>
+  );
+};
+
+export default ExpanderCell;

--- a/apps/ai-dial-admin/src/components/Common/TreeGrid/TreeGrid.tsx
+++ b/apps/ai-dial-admin/src/components/Common/TreeGrid/TreeGrid.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { ColDef, GetRowIdParams, GridOptions } from 'ag-grid-community';
+import { useMemo } from 'react';
+
+import GridView from '@/src/components/Grid/GridView/GridView';
+import ExpanderCell from './ExpanderCell';
+import { TreeRow } from './types';
+import { useTreeRows } from './use-tree-rows';
+
+interface TreeGridProps<T extends object> {
+  rows: TreeRow<T>[];
+  columnDefs: ColDef[];
+  expanderColumnField: string;
+  emptyDataTitle?: string;
+}
+
+const TreeGrid = <T extends object>({ rows, columnDefs, expanderColumnField, emptyDataTitle }: TreeGridProps<T>) => {
+  const { flatRows, onToggleExpand, onGridReady } = useTreeRows<T>(rows);
+
+  const augmentedColumnDefs = useMemo(
+    () =>
+      columnDefs.map((col) => {
+        const sanitized: ColDef = { ...col, sort: null, sortable: false, filter: false };
+        return col.field === expanderColumnField
+          ? { ...sanitized, cellRenderer: ExpanderCell, cellRendererParams: { onToggleExpand } }
+          : sanitized;
+      }),
+    [columnDefs, expanderColumnField, onToggleExpand],
+  );
+
+  const additionalGridOptions = useMemo<GridOptions<TreeRow<T>>>(
+    () => ({ getRowId: (params: GetRowIdParams<TreeRow<T>>) => params.data.id }),
+    [],
+  );
+
+  return (
+    <GridView<TreeRow<T>>
+      rowData={flatRows}
+      columnDefs={augmentedColumnDefs}
+      additionalGridOptions={additionalGridOptions}
+      onGridReady={onGridReady}
+      getIsEmptyData={() => rows.length === 0}
+      emptyDataProps={emptyDataTitle ? { title: emptyDataTitle } : undefined}
+    />
+  );
+};
+
+export default TreeGrid;

--- a/apps/ai-dial-admin/src/components/Common/TreeGrid/tests/TreeGrid.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Common/TreeGrid/tests/TreeGrid.spec.tsx
@@ -1,0 +1,137 @@
+import { render, screen } from '@testing-library/react';
+import { ColDef } from 'ag-grid-community';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import TreeGrid from '../TreeGrid';
+import { TreeRow } from '../types';
+
+type Row = { name: string; parent: string | null };
+
+// Captured between renders so tests can assert on column definitions handed
+// to GridView. Reset in beforeEach.
+let lastColumnDefs: ColDef[] | undefined;
+
+vi.mock('@/src/components/Grid/GridView/GridView', () => ({
+  default: ({
+    rowData,
+    columnDefs,
+    getIsEmptyData,
+    emptyDataProps,
+  }: {
+    rowData: unknown[];
+    getIsEmptyData?: () => boolean;
+    emptyDataProps?: { title: string };
+    columnDefs?: ColDef[];
+  }) => {
+    lastColumnDefs = columnDefs;
+    const empty = getIsEmptyData ? getIsEmptyData() : !rowData?.length;
+    if (empty && emptyDataProps) {
+      return <div data-testid="empty">{emptyDataProps.title}</div>;
+    }
+    return (
+      <div data-testid="grid">
+        {(rowData as TreeRow<Row>[])?.map((row) => (
+          <div key={row.id} data-testid={`row-${row.name}`} data-depth={row.depth}>
+            {row.name}
+          </div>
+        ))}
+      </div>
+    );
+  },
+}));
+
+beforeEach(() => {
+  lastColumnDefs = undefined;
+});
+
+const makeTree = (rows: TreeRow<Row>[]): TreeRow<Row>[] => rows;
+
+const root: TreeRow<Row> = {
+  name: 'a',
+  parent: null,
+  id: 'a:',
+  parentId: null,
+  depth: 0,
+  expanded: false,
+  children: [
+    {
+      name: 'b',
+      parent: 'a',
+      id: 'b:a',
+      parentId: 'a',
+      depth: 1,
+      expanded: false,
+      children: [],
+    },
+  ],
+};
+
+const columnDefs = [{ field: 'name', headerName: 'Name' }];
+
+describe('TreeGrid', () => {
+  test('renders roots only when collapsed', () => {
+    render(<TreeGrid rows={makeTree([root])} columnDefs={columnDefs} expanderColumnField="name" />);
+    expect(screen.getByTestId('row-a')).toBeInTheDocument();
+    expect(screen.queryByTestId('row-b')).not.toBeInTheDocument();
+  });
+
+  test('shows empty state when rows is empty', () => {
+    render(<TreeGrid rows={[]} columnDefs={columnDefs} expanderColumnField="name" emptyDataTitle="No data" />);
+    expect(screen.getByTestId('empty')).toHaveTextContent('No data');
+  });
+
+  test('leaf rows have correct depth attribute', () => {
+    const expandedRoot: TreeRow<Row> = { ...root, expanded: true };
+    render(<TreeGrid rows={makeTree([expandedRoot])} columnDefs={columnDefs} expanderColumnField="name" />);
+    expect(screen.getByTestId('row-a')).toHaveAttribute('data-depth', '0');
+    expect(screen.getByTestId('row-b')).toHaveAttribute('data-depth', '1');
+  });
+
+  test('renders synthetic rows', () => {
+    const syntheticRoot: TreeRow<Row> = {
+      ...root,
+      synthetic: true,
+      children: [{ ...root.children[0] }],
+    };
+    render(<TreeGrid rows={makeTree([syntheticRoot])} columnDefs={columnDefs} expanderColumnField="name" />);
+    expect(screen.getByTestId('row-a')).toBeInTheDocument();
+  });
+
+  test('strips default column sort and disables sortable so tree order is preserved', () => {
+    // Regression: a column carrying `sort: 'desc'` (as `TELEMETRY_GRID_COLUMNS`
+    // does on `cost`) would otherwise let AG Grid scatter children away from
+    // their parents on every rowData update, breaking expand/collapse rendering.
+    const sortedCols: ColDef[] = [
+      { field: 'name', headerName: 'Name', sort: 'asc', sortable: true },
+      { field: 'cost', headerName: 'Cost', sort: 'desc', sortable: true },
+    ];
+    render(<TreeGrid rows={makeTree([root])} columnDefs={sortedCols} expanderColumnField="name" />);
+    expect(lastColumnDefs).toBeDefined();
+    for (const col of lastColumnDefs!) {
+      // `sort: null` is the AG Grid-canonical "no sort" value (same effect as
+      // omitting). Either null or undefined satisfies the regression intent.
+      expect(col.sort ?? null).toBeNull();
+      expect(col.sortable).toBe(false);
+      expect(col.filter).toBe(false);
+    }
+  });
+
+  test('new tree prop updates displayed rows', () => {
+    const { rerender } = render(
+      <TreeGrid rows={makeTree([root])} columnDefs={columnDefs} expanderColumnField="name" />,
+    );
+    expect(screen.queryByTestId('row-c')).not.toBeInTheDocument();
+
+    const newRoot: TreeRow<Row> = {
+      name: 'c',
+      parent: null,
+      id: 'c:',
+      parentId: null,
+      depth: 0,
+      expanded: false,
+      children: [],
+    };
+    rerender(<TreeGrid rows={makeTree([newRoot])} columnDefs={columnDefs} expanderColumnField="name" />);
+    expect(screen.getByTestId('row-c')).toBeInTheDocument();
+    expect(screen.queryByTestId('row-a')).not.toBeInTheDocument();
+  });
+});

--- a/apps/ai-dial-admin/src/components/Common/TreeGrid/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/Common/TreeGrid/tests/utils.spec.ts
@@ -1,0 +1,299 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import {
+  buildTreeFromParentPointer,
+  flattenTree,
+  findRowInTree,
+  overlayExpandedState,
+  updateRowInTree,
+} from '../utils';
+import { TreeRow } from '../types';
+
+type Row = { name: string; parent: string | null; value?: number };
+
+const opts = {
+  getId: (r: Row) => r.name,
+  getParentId: (r: Row) => r.parent,
+};
+
+beforeEach(() => {
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+describe('buildTreeFromParentPointer', () => {
+  test('empty input returns empty array', () => {
+    expect(buildTreeFromParentPointer([], opts)).toEqual([]);
+  });
+
+  test('single root row', () => {
+    const rows: Row[] = [{ name: 'a', parent: null }];
+    const tree = buildTreeFromParentPointer(rows, opts);
+    expect(tree).toHaveLength(1);
+    expect(tree[0].id).toBe('a:');
+    expect(tree[0].depth).toBe(0);
+    expect(tree[0].parentId).toBeNull();
+    expect(tree[0].children).toHaveLength(0);
+    expect(tree[0].expanded).toBe(false);
+  });
+
+  test('linear chain a → b → c produces nested tree', () => {
+    const rows: Row[] = [
+      { name: 'a', parent: null },
+      { name: 'b', parent: 'a' },
+      { name: 'c', parent: 'b' },
+    ];
+    const tree = buildTreeFromParentPointer(rows, opts);
+    expect(tree).toHaveLength(1);
+    expect(tree[0].id).toBe('a:');
+    expect(tree[0].children).toHaveLength(1);
+    expect(tree[0].children[0].id).toBe('b:a');
+    expect(tree[0].children[0].depth).toBe(1);
+    expect(tree[0].children[0].children[0].id).toBe('c:b');
+    expect(tree[0].children[0].children[0].depth).toBe(2);
+  });
+
+  test('branching: a → b and a → c', () => {
+    const rows: Row[] = [
+      { name: 'a', parent: null },
+      { name: 'b', parent: 'a' },
+      { name: 'c', parent: 'a' },
+    ];
+    const tree = buildTreeFromParentPointer(rows, opts);
+    expect(tree).toHaveLength(1);
+    expect(tree[0].children).toHaveLength(2);
+    const childIds = tree[0].children.map((c) => c.name);
+    expect(childIds).toContain('b');
+    expect(childIds).toContain('c');
+  });
+
+  test('multiple independent roots', () => {
+    const rows: Row[] = [
+      { name: 'a', parent: null },
+      { name: 'b', parent: null },
+    ];
+    const tree = buildTreeFromParentPointer(rows, opts);
+    expect(tree).toHaveLength(2);
+  });
+
+  test('cycle a → b, b → a: drops back-edge and warns', () => {
+    const rows: Row[] = [
+      { name: 'a', parent: 'b' },
+      { name: 'b', parent: 'a' },
+    ];
+    const tree = buildTreeFromParentPointer(rows, opts);
+    // One of them becomes root with the other as child — no infinite loop
+    expect(tree.length).toBeGreaterThanOrEqual(1);
+    // total nodes in tree = 2
+    const all = flattenTree(tree.map((r) => ({ ...r, expanded: true })));
+    expect(all).toHaveLength(2);
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  test('depth cap at maxDepth=2: nodes beyond cap not nested', () => {
+    // chain a→b→c→d (d would be depth 3)
+    const rows: Row[] = [
+      { name: 'a', parent: null },
+      { name: 'b', parent: 'a' },
+      { name: 'c', parent: 'b' },
+      { name: 'd', parent: 'c' },
+    ];
+    const tree = buildTreeFromParentPointer(rows, { ...opts, maxDepth: 2 });
+    // a(0) → b(1) → c(2) — d dropped
+    const all = flattenTree(tree.map((r) => ({ ...r, expanded: true })));
+    expect(all).toHaveLength(3); // a, b, c — d dropped
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  test('orphan with unknown parent becomes a root', () => {
+    const rows: Row[] = [{ name: 'b', parent: 'a' }];
+    const tree = buildTreeFromParentPointer(rows, opts);
+    expect(tree).toHaveLength(1);
+    expect(tree[0].name).toBe('b');
+    expect(tree[0].depth).toBe(0);
+  });
+
+  test('input rows with `synthetic: true` propagate to the built tree row', () => {
+    type R = { name: string; parent: string | null; synthetic?: boolean };
+    const rows: R[] = [
+      { name: 'a', parent: null, synthetic: true },
+      { name: 'b', parent: 'a' },
+    ];
+    const tree = buildTreeFromParentPointer(rows, {
+      getId: (r) => r.name,
+      getParentId: (r) => r.parent,
+    });
+    expect(tree[0].synthetic).toBe(true);
+    expect(tree[0].children[0].synthetic).toBeUndefined();
+  });
+
+  test('path-based tree: same deployment name in distinct execution paths stays distinct', () => {
+    // gpt-4o appears under two different routes — each is its own tree node, keyed by
+    // its full execution_path. Without execution_path the composite (name, parent_name)
+    // would collide for "gpt-4o:router" across both apps.
+    type R = { execution_path: string };
+    const rows: R[] = [
+      { execution_path: 'app-A' },
+      { execution_path: 'app-A/router' },
+      { execution_path: 'app-A/router/gpt-4o' },
+      { execution_path: 'app-B' },
+      { execution_path: 'app-B/router' },
+      { execution_path: 'app-B/router/gpt-4o' },
+    ];
+    const tree = buildTreeFromParentPointer(rows, {
+      getId: (r) => r.execution_path,
+      getParentId: (r) => {
+        const i = r.execution_path.lastIndexOf('/');
+        return i === -1 ? null : r.execution_path.slice(0, i);
+      },
+    });
+    expect(tree).toHaveLength(2);
+    expect(tree.map((r) => r.id).sort()).toEqual(['app-A:', 'app-B:']);
+    // Each app has its own router → gpt-4o chain
+    expect(tree[0].children[0].children[0].id).toBe('app-A/router/gpt-4o:app-A/router');
+    expect(tree[1].children[0].children[0].id).toBe('app-B/router/gpt-4o:app-B/router');
+  });
+
+  test('same deployment under multiple parents builds separate nodes with children intact', () => {
+    // gpt-4o appears as a direct call (parent=null) AND as a child of app-A
+    // child-model is always called by gpt-4o
+    // With the old rowById keyed only by name, gpt-4o(parent=app-A) would overwrite gpt-4o(parent=null)
+    // causing child-model to lose its parent link
+    const rows: Row[] = [
+      { name: 'gpt-4o', parent: null }, // gpt-4o direct
+      { name: 'gpt-4o', parent: 'app-A' }, // gpt-4o via app-A
+      { name: 'app-A', parent: null }, // app-A direct
+      { name: 'child-model', parent: 'gpt-4o' }, // called by gpt-4o (both instances)
+    ];
+    const tree = buildTreeFromParentPointer(rows, opts);
+
+    // Two roots: gpt-4o(direct) and app-A(direct)
+    expect(tree).toHaveLength(2);
+
+    const gpt4oRoot = tree.find((r) => r.name === 'gpt-4o' && r.parentId === null);
+    expect(gpt4oRoot).toBeDefined();
+    // gpt-4o (direct) should have child-model as a child
+    expect(gpt4oRoot!.children).toHaveLength(1);
+    expect(gpt4oRoot!.children[0].name).toBe('child-model');
+
+    const appA = tree.find((r) => r.name === 'app-A');
+    expect(appA).toBeDefined();
+    // app-A has gpt-4o(via app-A) as a child, which itself has child-model
+    expect(appA!.children).toHaveLength(1);
+    expect(appA!.children[0].name).toBe('gpt-4o');
+  });
+});
+
+describe('flattenTree', () => {
+  test('collapsed root hides children', () => {
+    const tree: TreeRow<Row>[] = [
+      {
+        name: 'a',
+        parent: null,
+        id: 'a:',
+        parentId: null,
+        depth: 0,
+        expanded: false,
+        children: [
+          {
+            name: 'b',
+            parent: 'a',
+            id: 'b:a',
+            parentId: 'a',
+            depth: 1,
+            expanded: false,
+            children: [],
+          },
+        ],
+      },
+    ];
+    expect(flattenTree(tree)).toHaveLength(1);
+  });
+
+  test('expanded root emits children before next sibling', () => {
+    const tree: TreeRow<Row>[] = [
+      {
+        name: 'a',
+        parent: null,
+        id: 'a:',
+        parentId: null,
+        depth: 0,
+        expanded: true,
+        children: [{ name: 'b', parent: 'a', id: 'b:a', parentId: 'a', depth: 1, expanded: false, children: [] }],
+      },
+      { name: 'c', parent: null, id: 'c:', parentId: null, depth: 0, expanded: false, children: [] },
+    ];
+    const flat = flattenTree(tree);
+    expect(flat.map((r) => r.name)).toEqual(['a', 'b', 'c']);
+  });
+});
+
+describe('updateRowInTree', () => {
+  test('updates the matching row by id', () => {
+    const tree: TreeRow<Row>[] = [
+      {
+        name: 'a',
+        parent: null,
+        id: 'a:',
+        parentId: null,
+        depth: 0,
+        expanded: false,
+        children: [{ name: 'b', parent: 'a', id: 'b:a', parentId: 'a', depth: 1, expanded: false, children: [] }],
+      },
+    ];
+    const updated = updateRowInTree(tree, 'b:a', (r) => ({ ...r, expanded: true }));
+    expect(updated[0].children[0].expanded).toBe(true);
+    expect(updated[0].expanded).toBe(false); // parent unchanged
+  });
+});
+
+describe('findRowInTree', () => {
+  test('finds nested row by id', () => {
+    const tree: TreeRow<Row>[] = [
+      {
+        name: 'a',
+        parent: null,
+        id: 'a:',
+        parentId: null,
+        depth: 0,
+        expanded: false,
+        children: [{ name: 'b', parent: 'a', id: 'b:a', parentId: 'a', depth: 1, expanded: false, children: [] }],
+      },
+    ];
+    expect(findRowInTree(tree, 'b:a')?.name).toBe('b');
+    expect(findRowInTree(tree, 'missing')).toBeUndefined();
+  });
+});
+
+describe('overlayExpandedState', () => {
+  test('applies prev expanded state to new tree', () => {
+    const tree: TreeRow<Row>[] = [
+      { name: 'a', parent: null, id: 'a:', parentId: null, depth: 0, expanded: false, children: [] },
+    ];
+    const prev = new Map([['a:', true]]);
+    const result = overlayExpandedState(tree, prev);
+    expect(result[0].expanded).toBe(true);
+  });
+
+  test('leaves untouched rows with no prev entry', () => {
+    const tree: TreeRow<Row>[] = [
+      { name: 'a', parent: null, id: 'a:', parentId: null, depth: 0, expanded: false, children: [] },
+    ];
+    expect(overlayExpandedState(tree, new Map())[0].expanded).toBe(false);
+  });
+
+  test('recurses into children', () => {
+    const tree: TreeRow<Row>[] = [
+      {
+        name: 'a',
+        parent: null,
+        id: 'a:',
+        parentId: null,
+        depth: 0,
+        expanded: true,
+        children: [{ name: 'b', parent: 'a', id: 'b:a', parentId: 'a', depth: 1, expanded: false, children: [] }],
+      },
+    ];
+    const prev = new Map([['b:a', true]]);
+    const result = overlayExpandedState(tree, prev);
+    expect(result[0].children[0].expanded).toBe(true);
+  });
+});

--- a/apps/ai-dial-admin/src/components/Common/TreeGrid/types.ts
+++ b/apps/ai-dial-admin/src/components/Common/TreeGrid/types.ts
@@ -1,0 +1,8 @@
+export type TreeRow<T> = T & {
+  id: string;
+  parentId: string | null;
+  depth: number;
+  expanded: boolean;
+  children: TreeRow<T>[];
+  synthetic?: boolean;
+};

--- a/apps/ai-dial-admin/src/components/Common/TreeGrid/use-tree-rows.ts
+++ b/apps/ai-dial-admin/src/components/Common/TreeGrid/use-tree-rows.ts
@@ -1,0 +1,59 @@
+import { GridApi, GridReadyEvent } from 'ag-grid-community';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { flattenTree, overlayExpandedState } from './utils';
+import { TreeRow } from './types';
+
+export function useTreeRows<T>(tree: TreeRow<T>[]) {
+  const [expandedState, setExpandedState] = useState<Map<string, boolean>>(() => new Map());
+  const gridApiRef = useRef<GridApi | null>(null);
+
+  useEffect(() => {
+    const currentIds = new Set<string>();
+    const collectIds = (rows: TreeRow<T>[]) => {
+      for (const row of rows) {
+        currentIds.add(row.id);
+        collectIds(row.children);
+      }
+    };
+    collectIds(tree);
+
+    setExpandedState((prev) => {
+      let changed = false;
+      const next = new Map(prev);
+      for (const id of prev.keys()) {
+        if (!currentIds.has(id)) {
+          next.delete(id);
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [tree]);
+
+  const currentTree = useMemo(() => overlayExpandedState(tree, expandedState), [tree, expandedState]);
+
+  const flatRows = useMemo(() => flattenTree(currentTree), [currentTree]);
+
+  // AG Grid only refreshes custom cell renderers when the displayed value changes;
+  // the expander chevron is driven by `data.expanded`, so we must force a refresh
+  // after every toggle or the icon stays stale even though flatRows is up to date.
+  useEffect(() => {
+    gridApiRef.current?.refreshCells({ force: true });
+  }, [flatRows]);
+
+  const onToggleExpand = useCallback((row: TreeRow<T>) => {
+    setExpandedState((prev) => {
+      const next = new Map(prev);
+      const isExpanded = prev.has(row.id) ? (prev.get(row.id) as boolean) : row.expanded;
+      next.set(row.id, !isExpanded);
+      return next;
+    });
+  }, []);
+
+  const onGridReady = useCallback((event: GridReadyEvent) => {
+    gridApiRef.current = event.api;
+  }, []);
+
+  return { flatRows, onToggleExpand, onGridReady };
+}

--- a/apps/ai-dial-admin/src/components/Common/TreeGrid/utils.ts
+++ b/apps/ai-dial-admin/src/components/Common/TreeGrid/utils.ts
@@ -1,0 +1,145 @@
+import { TreeRow } from './types';
+
+export interface BuildTreeOptions<T> {
+  getId: (r: T) => string;
+  getParentId: (r: T) => string | null;
+  maxDepth?: number;
+}
+
+export function buildTreeFromParentPointer<T>(rows: T[], opts: BuildTreeOptions<T>): TreeRow<T>[] {
+  const { getId, getParentId, maxDepth = 8 } = opts;
+
+  const compositeKey = (row: T) => `${getId(row)}:${getParentId(row) ?? ''}`;
+
+  const rowByKey = new Map<string, T>();
+  const keysByName = new Map<string, string[]>();
+
+  for (const row of rows) {
+    const key = compositeKey(row);
+    rowByKey.set(key, row);
+    const name = getId(row);
+    if (!keysByName.has(name)) keysByName.set(name, []);
+    keysByName.get(name)!.push(key);
+  }
+
+  const childrenByParentName = new Map<string, string[]>();
+  for (const [key, row] of rowByKey) {
+    const parentName = getParentId(row);
+    if (parentName !== null && keysByName.has(parentName)) {
+      if (!childrenByParentName.has(parentName)) childrenByParentName.set(parentName, []);
+      childrenByParentName.get(parentName)!.push(key);
+    }
+  }
+
+  const rootKeys: string[] = [];
+  for (const [key, row] of rowByKey) {
+    const parentName = getParentId(row);
+    if (parentName === null || !keysByName.has(parentName)) {
+      rootKeys.push(key);
+    }
+  }
+
+  const visitedKeys = new Set<string>();
+  const depthCapHits: string[] = [];
+  let cycleWarned = false;
+
+  const buildNode = (key: string, depth: number, ancestors: Set<string>): TreeRow<T> => {
+    visitedKeys.add(key);
+    const row = rowByKey.get(key)!;
+    const name = getId(row);
+    const rawChildKeys = childrenByParentName.get(name) || [];
+    const atCap = depth >= maxDepth;
+
+    if (atCap && rawChildKeys.length > 0) {
+      depthCapHits.push(key);
+    }
+    const childKeysToProcess = atCap ? [] : rawChildKeys;
+
+    const filteredChildKeys = childKeysToProcess.filter((childKey) => {
+      if (ancestors.has(childKey)) {
+        if (!cycleWarned) {
+          console.warn(`[TreeGrid] Cycle detected: "${childKey}" is an ancestor. Back-edge dropped.`);
+          cycleWarned = true;
+        }
+        return false;
+      }
+      return true;
+    });
+
+    const newAncestors = new Set([...ancestors, key]);
+    const children = filteredChildKeys.map((childKey) => buildNode(childKey, depth + 1, newAncestors));
+
+    return {
+      ...row,
+      id: key,
+      parentId: getParentId(row),
+      depth,
+      expanded: false,
+      children,
+    } as TreeRow<T>;
+  };
+
+  const result = rootKeys.map((key) => buildNode(key, 0, new Set()));
+
+  const cycleKeys = [...rowByKey.keys()].filter((key) => !visitedKeys.has(key));
+  if (cycleKeys.length > 0) {
+    console.warn(
+      `[TreeGrid] Cycle detected involving: ${cycleKeys.join(', ')}. Treating first unvisited node as root.`,
+    );
+    for (const key of cycleKeys) {
+      if (!visitedKeys.has(key)) {
+        result.push(buildNode(key, 0, new Set()));
+      }
+    }
+  }
+
+  if (depthCapHits.length > 0) {
+    console.warn(
+      `[TreeGrid] Depth cap (${maxDepth}) reached for ${depthCapHits.length} row(s). Further nesting removed.`,
+    );
+  }
+
+  return result;
+}
+
+export function flattenTree<T>(rows: TreeRow<T>[]): TreeRow<T>[] {
+  const out: TreeRow<T>[] = [];
+  for (const row of rows) {
+    out.push(row);
+    if (row.expanded && row.children.length > 0) {
+      out.push(...flattenTree(row.children));
+    }
+  }
+  return out;
+}
+
+export function updateRowInTree<R extends { id: string; children: R[] }>(
+  rows: R[],
+  id: string,
+  updater: (row: R) => R,
+): R[] {
+  return rows.map((row) => {
+    if (row.id === id) return updater(row);
+    if (row.children.length > 0) {
+      return { ...row, children: updateRowInTree(row.children, id, updater) } as R;
+    }
+    return row;
+  });
+}
+
+export function findRowInTree<R extends { id: string; children: R[] }>(rows: R[], id: string): R | undefined {
+  for (const row of rows) {
+    if (row.id === id) return row;
+    const found = findRowInTree(row.children, id);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+export function overlayExpandedState<T>(tree: TreeRow<T>[], prev: Map<string, boolean>): TreeRow<T>[] {
+  return tree.map((row) => ({
+    ...row,
+    expanded: prev.has(row.id) ? (prev.get(row.id) as boolean) : row.expanded,
+    children: overlayExpandedState(row.children, prev),
+  }));
+}

--- a/apps/ai-dial-admin/src/components/Telemetry/Dashboards/View/SimpleDashboard.tsx
+++ b/apps/ai-dial-admin/src/components/Telemetry/Dashboards/View/SimpleDashboard.tsx
@@ -1,8 +1,9 @@
 import LineChart from '@/src/components/Telemetry/Dashboards/LineChart/LineChart';
+import EntitiesConsumptionTree from '@/src/components/Telemetry/EntitiesConsumptionTree';
 import TelemetryGrid from '@/src/components/Telemetry/TelemetryGrid';
-import { PROJECT_GRID_COLUMNS, TELEMETRY_GRID_COLUMNS } from '@/src/constants/grid-columns/grid-columns';
+import { PROJECT_GRID_COLUMNS } from '@/src/constants/grid-columns/grid-columns';
 import { TelemetryI18nKey } from '@/src/constants/i18n';
-import { createSystemUsageQuery, ENTITY_CONSUMPTION_QUERY, PROJECT_CONSUMPTION_QUERY } from '@/src/constants/telemetry';
+import { createSystemUsageQuery, PROJECT_CONSUMPTION_QUERY } from '@/src/constants/telemetry';
 import { useI18n } from '@/src/locales/client';
 import { TelemetryQuery } from '@/src/models/telemetry';
 import { ApplicationRoute } from '@/src/types/routes';
@@ -36,11 +37,9 @@ const SimpleDashboard: FC<Props> = ({ route, effectiveRefreshTime, getData }) =>
       <div className="flex flex-col w-full">
         {route === ApplicationRoute.Dashboard && (
           <div className="flex mb-6 w-full relative">
-            <TelemetryGrid
+            <EntitiesConsumptionTree
               getData={getData}
               refreshTime={effectiveRefreshTime}
-              query={ENTITY_CONSUMPTION_QUERY}
-              columnDefs={TELEMETRY_GRID_COLUMNS}
               title={t(TelemetryI18nKey.EntitiesConsumption)}
             />
           </div>

--- a/apps/ai-dial-admin/src/components/Telemetry/EntitiesConsumptionTree.tsx
+++ b/apps/ai-dial-admin/src/components/Telemetry/EntitiesConsumptionTree.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { DialLoader } from '@epam/ai-dial-ui-kit';
+import { FC, useEffect, useState } from 'react';
+
+import TreeGrid from '@/src/components/Common/TreeGrid/TreeGrid';
+import { TreeRow } from '@/src/components/Common/TreeGrid/types';
+import { BasicI18nKey } from '@/src/constants/i18n';
+import { refreshOptionsConfig } from '@/src/constants/telemetry/filters';
+import { ENTITIES_CONSUMPTION_TREE_COLUMNS } from '@/src/constants/grid-columns/grid-columns';
+import { ENTITY_CONSUMPTION_TREE_QUERY } from '@/src/constants/telemetry';
+import { useI18n } from '@/src/locales/client';
+import { EntityRow, TelemetryData, TelemetryQuery } from '@/src/models/telemetry';
+import { ServerActionResponse } from '@/src/models/server-action';
+import { buildEntitiesConsumptionTree } from '@/src/utils/entities-consumption-tree';
+import { getGridData } from '@/src/utils/telemetry';
+
+interface Props {
+  title: string;
+  getData: (query: TelemetryQuery) => Promise<ServerActionResponse>;
+  refreshTime?: string;
+}
+
+const EntitiesConsumptionTree: FC<Props> = ({ title, getData, refreshTime }) => {
+  const t = useI18n();
+  const [loading, setLoading] = useState(true);
+  const [treeData, setTreeData] = useState<TreeRow<EntityRow>[] | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    const fetch = async () => {
+      const response = await getData(ENTITY_CONSUMPTION_TREE_QUERY);
+      if (response?.success) {
+        const rows = getGridData(response.response as TelemetryData) as EntityRow[];
+        setTreeData(buildEntitiesConsumptionTree(rows));
+      } else {
+        setTreeData(null);
+      }
+      setLoading(false);
+    };
+
+    fetch();
+
+    const timeout = refreshOptionsConfig.find((item) => item?.value === refreshTime)?.timeout;
+    if (!timeout) return;
+
+    const intervalId = setInterval(() => {
+      fetch();
+    }, timeout);
+
+    return () => clearInterval(intervalId);
+  }, [getData, refreshTime]);
+
+  return (
+    <div className="flex flex-col size-full rounded-lg border border-primary p-4 max-h-[580px]">
+      <div className="mb-4 flex flex-row items-center justify-between">
+        <h3>{title}</h3>
+      </div>
+      {loading ? (
+        <DialLoader size={24} />
+      ) : (
+        <div className="flex-1 min-h-0">
+          <TreeGrid<EntityRow>
+            rows={treeData ?? []}
+            columnDefs={ENTITIES_CONSUMPTION_TREE_COLUMNS}
+            expanderColumnField="name"
+            emptyDataTitle={t(BasicI18nKey.NoData)}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default EntitiesConsumptionTree;

--- a/apps/ai-dial-admin/src/components/Telemetry/tests/EntitiesConsumptionTree.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Telemetry/tests/EntitiesConsumptionTree.spec.tsx
@@ -1,0 +1,538 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import EntitiesConsumptionTree from '../EntitiesConsumptionTree';
+import { ServerActionResponse } from '@/src/models/server-action';
+import { TelemetryQuery } from '@/src/models/telemetry';
+
+type GetDataFn = (query: TelemetryQuery) => Promise<ServerActionResponse>;
+
+vi.mock('@epam/ai-dial-ui-kit', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@epam/ai-dial-ui-kit')>();
+  return {
+    ...actual,
+    DialLoader: () => <div data-testid="loader" />,
+  };
+});
+
+vi.mock('@/src/components/Common/TreeGrid/TreeGrid', () => ({
+  default: ({ rows, columnDefs }: { rows: { name: string; children?: unknown[] }[]; columnDefs: unknown[] }) => {
+    const summary = rows.map((r) => `${r.name}(${r.children?.length ?? 0})`).join(',');
+    return (
+      <div
+        data-testid="tree-grid"
+        data-row-count={rows.length}
+        data-col-count={columnDefs.length}
+        data-summary={summary}
+      />
+    );
+  },
+}));
+
+// TelemetryData shape: { headers: string[], data: string[][] }
+const makeTelemetryResponse = (backendRows: Record<string, string>[]) => {
+  if (backendRows.length === 0) {
+    return { success: true, response: { headers: [], data: [] } };
+  }
+  const headers = Object.keys(backendRows[0]);
+  const data = backendRows.map((r) => Object.values(r));
+  return { success: true, response: { headers, data } };
+};
+
+// Backend column names (before TELEMETRY_GRID_HEADERS_MAP remapping). Tree is built
+// from execution_path now, so each row carries its full slash-separated chain.
+const TREE_ROWS = [
+  {
+    deployment: 'gpt-4',
+    parent_deployment: '',
+    execution_path: 'gpt-4',
+    count: '10',
+    money: '5',
+    aggregated_money: '6',
+    tokens_p: '100',
+    tokens_c: '200',
+  },
+  {
+    deployment: 'child-model',
+    parent_deployment: 'gpt-4',
+    execution_path: 'gpt-4/child-model',
+    count: '3',
+    money: '1',
+    aggregated_money: '2',
+    tokens_p: '30',
+    tokens_c: '60',
+  },
+];
+
+describe('EntitiesConsumptionTree', () => {
+  let getData: ReturnType<typeof vi.fn<GetDataFn>>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getData = vi.fn<GetDataFn>().mockResolvedValue(makeTelemetryResponse(TREE_ROWS));
+  });
+
+  test('fetches tree data on mount with ENTITY_CONSUMPTION_TREE_QUERY shape', async () => {
+    render(<EntitiesConsumptionTree title="Entities" getData={getData} />);
+
+    await waitFor(() => {
+      expect(getData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({
+            groupBy: expect.arrayContaining(['deployment', 'parent_deployment', 'execution_path']),
+          }),
+        }),
+      );
+    });
+  });
+
+  test('renders title in header', () => {
+    render(<EntitiesConsumptionTree title="Entities Consumption" getData={getData} />);
+    expect(screen.getByText('Entities Consumption')).toBeInTheDocument();
+  });
+
+  test('shows loader while fetching, then renders TreeGrid', async () => {
+    let resolve: (v: ServerActionResponse) => void;
+    getData = vi.fn<GetDataFn>().mockImplementation(
+      () =>
+        new Promise<ServerActionResponse>((r) => {
+          resolve = r;
+        }),
+    );
+
+    render(<EntitiesConsumptionTree title="Entities" getData={getData} />);
+    expect(screen.getByTestId('loader')).toBeInTheDocument();
+
+    resolve!(makeTelemetryResponse(TREE_ROWS));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('tree-grid')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('loader')).not.toBeInTheDocument();
+  });
+
+  test('renders TreeGrid with rows from response', async () => {
+    render(<EntitiesConsumptionTree title="Entities" getData={getData} />);
+
+    await waitFor(() => {
+      const grid = screen.getByTestId('tree-grid');
+      expect(Number(grid.getAttribute('data-row-count'))).toBeGreaterThan(0);
+    });
+  });
+
+  test('empty response shows no-data message instead of TreeGrid', async () => {
+    getData = vi.fn<GetDataFn>().mockResolvedValue(makeTelemetryResponse([]));
+    render(<EntitiesConsumptionTree title="Entities" getData={getData} />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('tree-grid')).not.toBeInTheDocument();
+    });
+  });
+
+  test('failed response shows no-data message', async () => {
+    getData = vi.fn<GetDataFn>().mockResolvedValue({ success: false });
+    render(<EntitiesConsumptionTree title="Entities" getData={getData} />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('tree-grid')).not.toBeInTheDocument();
+    });
+  });
+
+  test('same deployment in different execution paths produces distinct tree nodes', async () => {
+    // gpt-4o appears in three execution chains: direct, under app-A, under app-B.
+    // Each chain produces its own tree node (keyed by execution_path) so clicking
+    // any one of them only toggles that single node — no cross-chain leakage.
+    const rows = [
+      {
+        deployment: 'gpt-4o',
+        parent_deployment: '',
+        execution_path: 'gpt-4o',
+        count: '10',
+        money: '5',
+        aggregated_money: '5',
+        tokens_p: '100',
+        tokens_c: '200',
+      },
+      {
+        deployment: 'gpt-4o',
+        parent_deployment: 'app-A',
+        execution_path: 'app-A/gpt-4o',
+        count: '3',
+        money: '1',
+        aggregated_money: '1',
+        tokens_p: '30',
+        tokens_c: '60',
+      },
+      {
+        deployment: 'gpt-4o',
+        parent_deployment: 'app-B',
+        execution_path: 'app-B/gpt-4o',
+        count: '2',
+        money: '1',
+        aggregated_money: '1',
+        tokens_p: '20',
+        tokens_c: '40',
+      },
+    ];
+    getData = vi.fn<GetDataFn>().mockResolvedValue(makeTelemetryResponse(rows));
+    render(<EntitiesConsumptionTree title="Entities" getData={getData} />);
+
+    await waitFor(() => {
+      const grid = screen.getByTestId('tree-grid');
+      // 3 root rows visible (children collapsed by default):
+      // - gpt-4o (direct, depth-1 path, root with no children)
+      // - app-A (synthetic root, has gpt-4o as child)
+      // - app-B (synthetic root, has gpt-4o as child)
+      expect(Number(grid.getAttribute('data-row-count'))).toBe(3);
+    });
+  });
+
+  test('REAL DATA: dial-rag with two instances each attaches its own children', async () => {
+    // Two dial-rag rows (one direct, one under an applications/... ancestor).
+    // gpt-4.1-2025-04-14 has TWO chains pointing to dial-rag — they must split:
+    // one under direct dial-rag, one under the applications chain.
+    const longApp = 'applications/9ynCk/Hope__0.0.3';
+    const rows = [
+      {
+        deployment: longApp,
+        parent_deployment: 'undefined',
+        execution_path: longApp,
+        count: '1',
+        money: '0',
+        aggregated_money: '0',
+        tokens_p: '0',
+        tokens_c: '0',
+      },
+      {
+        deployment: 'dial-rag',
+        parent_deployment: longApp,
+        execution_path: `${longApp}/dial-rag`,
+        count: '1',
+        money: '0',
+        aggregated_money: '0',
+        tokens_p: '0',
+        tokens_c: '0',
+      },
+      {
+        deployment: 'dial-rag',
+        parent_deployment: 'undefined',
+        execution_path: 'dial-rag',
+        count: '2',
+        money: '0',
+        aggregated_money: '0',
+        tokens_p: '0',
+        tokens_c: '0',
+      },
+      {
+        deployment: 'gpt-4.1-2025-04-14',
+        parent_deployment: 'dial-rag',
+        execution_path: `${longApp}/dial-rag/gpt-4.1-2025-04-14`,
+        count: '1',
+        money: '0',
+        aggregated_money: '0',
+        tokens_p: '0',
+        tokens_c: '0',
+      },
+      {
+        deployment: 'gpt-4.1-2025-04-14',
+        parent_deployment: 'dial-rag',
+        execution_path: 'dial-rag/gpt-4.1-2025-04-14',
+        count: '1',
+        money: '0',
+        aggregated_money: '0',
+        tokens_p: '0',
+        tokens_c: '0',
+      },
+    ];
+    getData = vi.fn<GetDataFn>().mockResolvedValue(makeTelemetryResponse(rows));
+    render(<EntitiesConsumptionTree title="Entities" getData={getData} />);
+
+    await waitFor(() => {
+      const grid = screen.getByTestId('tree-grid');
+      const summary = grid.getAttribute('data-summary');
+      // Two roots visible: the app (with dial-rag inside) and the direct dial-rag.
+      // Each root has 1 child — the gpt-4.1 attaches to the correct dial-rag instance.
+      expect(summary).toBe(`${longApp}(1),dial-rag(1)`);
+    });
+  });
+
+  test('REAL DATA: Ocr synthetic root with three siblings each having a dots-ocr child', async () => {
+    // No row exists for "Ocr" — it's referenced as a parent by layout-detector,
+    // markdown-extractor, tables-extractor. A synthetic "Ocr" root must be created.
+    const rows = [
+      {
+        deployment: 'layout-detector',
+        parent_deployment: 'Ocr',
+        execution_path: 'Ocr/layout-detector',
+        count: '34',
+        money: '0',
+        aggregated_money: '0',
+        tokens_p: '0',
+        tokens_c: '0',
+      },
+      {
+        deployment: 'markdown-extractor',
+        parent_deployment: 'Ocr',
+        execution_path: 'Ocr/markdown-extractor',
+        count: '11',
+        money: '0',
+        aggregated_money: '0',
+        tokens_p: '0',
+        tokens_c: '0',
+      },
+      {
+        deployment: 'tables-extractor',
+        parent_deployment: 'Ocr',
+        execution_path: 'Ocr/tables-extractor',
+        count: '8',
+        money: '0',
+        aggregated_money: '0',
+        tokens_p: '0',
+        tokens_c: '0',
+      },
+      {
+        deployment: 'dots-ocr',
+        parent_deployment: 'layout-detector',
+        execution_path: 'Ocr/layout-detector/dots-ocr',
+        count: '34',
+        money: '0',
+        aggregated_money: '0',
+        tokens_p: '0',
+        tokens_c: '0',
+      },
+      {
+        deployment: 'dots-ocr',
+        parent_deployment: 'markdown-extractor',
+        execution_path: 'Ocr/markdown-extractor/dots-ocr',
+        count: '11',
+        money: '0',
+        aggregated_money: '0',
+        tokens_p: '0',
+        tokens_c: '0',
+      },
+      {
+        deployment: 'dots-ocr',
+        parent_deployment: 'tables-extractor',
+        execution_path: 'Ocr/tables-extractor/dots-ocr',
+        count: '8',
+        money: '0',
+        aggregated_money: '0',
+        tokens_p: '0',
+        tokens_c: '0',
+      },
+    ];
+    getData = vi.fn<GetDataFn>().mockResolvedValue(makeTelemetryResponse(rows));
+    render(<EntitiesConsumptionTree title="Entities" getData={getData} />);
+
+    await waitFor(() => {
+      const grid = screen.getByTestId('tree-grid');
+      // Single synthetic root "Ocr" with 3 children (layout-detector, markdown-extractor, tables-extractor)
+      expect(grid.getAttribute('data-summary')).toBe('Ocr(3)');
+    });
+  });
+
+  test('REAL DATA: world-economy-v2-hybrid root must have 2 children attached', async () => {
+    // Mirror of actual BE rows the user pasted. The bug they reported: clicking
+    // `world-economy-v2-hybrid` shows no children even though `gpt-4.1-2025-04-14`
+    // and `text-embedding-3-large` reference it as their parent.
+    const rows = [
+      {
+        deployment: 'world-economy-v2-hybrid',
+        parent_deployment: 'undefined',
+        execution_path: 'world-economy-v2-hybrid',
+        count: '3',
+        money: '0',
+        aggregated_money: '0',
+        tokens_p: '0',
+        tokens_c: '0',
+      },
+      {
+        deployment: 'gpt-4.1-2025-04-14',
+        parent_deployment: 'world-economy-v2-hybrid',
+        execution_path: 'world-economy-v2-hybrid/gpt-4.1-2025-04-14',
+        count: '32',
+        money: '0',
+        aggregated_money: '0',
+        tokens_p: '0',
+        tokens_c: '0',
+      },
+      {
+        deployment: 'text-embedding-3-large',
+        parent_deployment: 'world-economy-v2-hybrid',
+        execution_path: 'world-economy-v2-hybrid/text-embedding-3-large',
+        count: '8',
+        money: '0',
+        aggregated_money: '0',
+        tokens_p: '0',
+        tokens_c: '0',
+      },
+    ];
+    getData = vi.fn<GetDataFn>().mockResolvedValue(makeTelemetryResponse(rows));
+    render(<EntitiesConsumptionTree title="Entities" getData={getData} />);
+
+    await waitFor(() => {
+      const grid = screen.getByTestId('tree-grid');
+      const summary = grid.getAttribute('data-summary');
+      // Only the root visible while collapsed
+      expect(Number(grid.getAttribute('data-row-count'))).toBe(1);
+      // ...and that root should have 2 children attached
+      expect(summary).toBe('world-economy-v2-hybrid(2)');
+    });
+  });
+
+  test('deployment names containing `/` are treated as single entities (not split into segments)', async () => {
+    // `applications/9ynCkZ.../v1` is one deployment, not three segments. The tree must
+    // recognize ep === deployment as a root, never strip the deployment apart.
+    const longName = 'applications/9ynCkZCVDkNMY1Rhww77oDUXJFJyr775NpIhasE92GWdaGRDr3k8t8criPxTMH3FLA/v1';
+    const rows = [
+      {
+        deployment: longName,
+        parent_deployment: '',
+        execution_path: longName,
+        count: '7',
+        money: '1',
+        aggregated_money: '1',
+        tokens_p: '50',
+        tokens_c: '100',
+      },
+      {
+        deployment: 'gpt-4o',
+        parent_deployment: longName,
+        execution_path: `${longName}/gpt-4o`,
+        count: '3',
+        money: '0.5',
+        aggregated_money: '0.5',
+        tokens_p: '20',
+        tokens_c: '40',
+      },
+    ];
+    getData = vi.fn<GetDataFn>().mockResolvedValue(makeTelemetryResponse(rows));
+    render(<EntitiesConsumptionTree title="Entities" getData={getData} />);
+
+    await waitFor(() => {
+      const grid = screen.getByTestId('tree-grid');
+      // One root (the long-named app); its gpt-4o child is collapsed.
+      expect(Number(grid.getAttribute('data-row-count'))).toBe(1);
+    });
+  });
+
+  test('NEW BE format: escaped `\\/` inside execution_path correctly links rows whose name contains "/"', async () => {
+    // BE rolled out an escape for slashes inside segments
+    // (epam/ai-dial-analytics-realtime#245). A deployment named "a/b" under "x"
+    // is now emitted as ep "x/a\/b" instead of the ambiguous "x/a/b". The tree
+    // must still attach the child to its parent — i.e., stripDeploymentSuffix
+    // must recognize the escaped form.
+    const rows = [
+      {
+        deployment: 'x',
+        parent_deployment: '',
+        execution_path: 'x',
+        count: '1',
+        money: '0',
+        aggregated_money: '0',
+        tokens_p: '0',
+        tokens_c: '0',
+      },
+      {
+        deployment: 'a/b',
+        parent_deployment: 'x',
+        execution_path: 'x/a\\/b',
+        count: '2',
+        money: '0',
+        aggregated_money: '0',
+        tokens_p: '0',
+        tokens_c: '0',
+      },
+      {
+        deployment: 'c',
+        parent_deployment: 'a/b',
+        execution_path: 'x/a\\/b/c',
+        count: '3',
+        money: '0',
+        aggregated_money: '0',
+        tokens_p: '0',
+        tokens_c: '0',
+      },
+    ];
+    getData = vi.fn<GetDataFn>().mockResolvedValue(makeTelemetryResponse(rows));
+    render(<EntitiesConsumptionTree title="Entities" getData={getData} />);
+
+    await waitFor(() => {
+      const grid = screen.getByTestId('tree-grid');
+      // Single root "x" with one direct child ("a/b"). Grandchild "c" is nested
+      // under "a/b" and not visible while collapsed.
+      expect(Number(grid.getAttribute('data-row-count'))).toBe(1);
+      expect(grid.getAttribute('data-summary')).toBe('x(1)');
+    });
+  });
+
+  test('OLD BE format: legacy `/`-only paths with slashy names still nest single-level', async () => {
+    // Pre-escape data: a deployment "a/b" under "x" was emitted as "x/a/b".
+    // We can't always disambiguate, but the row's own name + endsWith works at
+    // the single-level boundary, so the child must still attach to its parent.
+    const rows = [
+      {
+        deployment: 'x',
+        parent_deployment: '',
+        execution_path: 'x',
+        count: '1',
+        money: '0',
+        aggregated_money: '0',
+        tokens_p: '0',
+        tokens_c: '0',
+      },
+      {
+        deployment: 'a/b',
+        parent_deployment: 'x',
+        execution_path: 'x/a/b',
+        count: '2',
+        money: '0',
+        aggregated_money: '0',
+        tokens_p: '0',
+        tokens_c: '0',
+      },
+    ];
+    getData = vi.fn<GetDataFn>().mockResolvedValue(makeTelemetryResponse(rows));
+    render(<EntitiesConsumptionTree title="Entities" getData={getData} />);
+
+    await waitFor(() => {
+      const grid = screen.getByTestId('tree-grid');
+      expect(grid.getAttribute('data-summary')).toBe('x(1)');
+    });
+  });
+
+  test('3-level execution_path with missing intermediate ancestors stays distinct from siblings', async () => {
+    // Two chains share an intermediate router but lead to the same final leaf name.
+    // The two leaves must remain distinct tree nodes — they live on different paths.
+    const rows = [
+      {
+        deployment: 'leaf',
+        parent_deployment: 'router',
+        execution_path: 'app-A/router/leaf',
+        count: '5',
+        money: '1',
+        aggregated_money: '1',
+        tokens_p: '10',
+        tokens_c: '20',
+      },
+      {
+        deployment: 'leaf',
+        parent_deployment: 'router',
+        execution_path: 'app-B/router/leaf',
+        count: '7',
+        money: '2',
+        aggregated_money: '2',
+        tokens_p: '15',
+        tokens_c: '30',
+      },
+    ];
+    getData = vi.fn<GetDataFn>().mockResolvedValue(makeTelemetryResponse(rows));
+    render(<EntitiesConsumptionTree title="Entities" getData={getData} />);
+
+    await waitFor(() => {
+      const grid = screen.getByTestId('tree-grid');
+      // Two synthetic roots: app-A and app-B. Each has its own router → leaf chain.
+      expect(Number(grid.getAttribute('data-row-count'))).toBe(2);
+    });
+  });
+});

--- a/apps/ai-dial-admin/src/constants/grid-columns/grid-columns.tsx
+++ b/apps/ai-dial-admin/src/constants/grid-columns/grid-columns.tsx
@@ -78,6 +78,8 @@ import { dateTimeColumn, numericColumn, priceColumn } from './configs';
 import { baseNumberFilter, baseStringFilter, dateFilter, evalStringFilter } from './filters';
 import RowExpanderCellRenderer from '@/src/components/Grid/CellRenderers/RowExpanderCellRenderer';
 import ChildrenActivityTypeCellRenderer from '@/src/components/Grid/CellRenderers/ChildrenActivityTypeCellRenderer';
+import { TreeRow } from '@/src/components/Common/TreeGrid/types';
+import { EntityRow } from '@/src/models/telemetry';
 import { ActivityAuditView } from '@/src/types/activity-audit';
 import { GridFilterType } from '@/src/types/grid-filter';
 
@@ -456,6 +458,21 @@ export const TELEMETRY_GRID_COLUMNS: ColDef[] = [
       numberValueFormatter(priceValueFormatter(params.data[params.colDef.field || '']) as string),
   },
 ];
+
+export const ENTITIES_CONSUMPTION_TREE_COLUMNS: ColDef[] = TELEMETRY_GRID_COLUMNS.map((col) => {
+  if (col.field === 'name') {
+    return {
+      ...col,
+      valueFormatter: (params) => {
+        const row = params.data as TreeRow<EntityRow> | undefined;
+        const n = row?.children?.length ?? 0;
+        const suffix = n > 0 ? ` (+${n})` : '';
+        return `${params.value ?? ''}${suffix}`;
+      },
+    };
+  }
+  return col;
+});
 
 const completionTimeColumn = (headerName: string): ColDef => ({
   field: 'completion_time',

--- a/apps/ai-dial-admin/src/constants/telemetry.tsx
+++ b/apps/ai-dial-admin/src/constants/telemetry.tsx
@@ -65,6 +65,24 @@ export const ENTITY_CONSUMPTION_QUERY: TelemetryQuery = {
   },
 };
 
+export const ENTITY_CONSUMPTION_TREE_QUERY: TelemetryQuery = {
+  $type: 'json',
+  query: {
+    expressions: [
+      'deployment',
+      'parent_deployment',
+      'execution_path',
+      'count()',
+      'sum(deployment_price) as money',
+      'sum(price) as aggregated_money',
+      'sum(prompt_tokens) as tokens_p',
+      'sum(completion_tokens) as tokens_c',
+    ],
+    from: ANALYTICS_TABLE_NAME,
+    groupBy: ['deployment', 'parent_deployment', 'execution_path'],
+  },
+};
+
 export const getEntityQuery = (tableName = ANALYTICS_TABLE_NAME): TelemetryQuery => ({
   $type: 'json',
   query: {
@@ -285,6 +303,7 @@ export const TELEMETRY_GRID_HEADERS_MAP: Record<string, string> = {
   tokens_c: 'completions',
   mcp_tool_call_name: 'mcp_tool_call_name',
   parent_deployment: 'parent_deployment',
+  execution_path: 'execution_path',
   tool_calls: 'tool_calls',
   mcp_calls: 'mcp_calls',
   route_path: 'route_path',

--- a/apps/ai-dial-admin/src/models/telemetry.ts
+++ b/apps/ai-dial-admin/src/models/telemetry.ts
@@ -8,6 +8,18 @@ export interface TelemetryData {
   data?: string[][] | string[];
 }
 
+export interface EntityRow {
+  name?: string;
+  parent_deployment?: string;
+  execution_path?: string;
+  requests?: string;
+  cost?: string;
+  deployment_cost?: string;
+  prompts?: string;
+  completions?: string;
+  synthetic?: boolean;
+}
+
 export interface TelemetryQuery {
   $type: string;
   fillGaps?: boolean;

--- a/apps/ai-dial-admin/src/utils/entities-consumption-tree.ts
+++ b/apps/ai-dial-admin/src/utils/entities-consumption-tree.ts
@@ -1,0 +1,57 @@
+import { TreeRow } from '@/src/components/Common/TreeGrid/types';
+import { buildTreeFromParentPointer } from '@/src/components/Common/TreeGrid/utils';
+import { EntityRow } from '@/src/models/telemetry';
+
+export const escapeSegment = (name: string): string => name.replaceAll('/', '\\/');
+
+export function stripDeploymentSuffix(ep: string, name: string): string | null {
+  if (!ep || !name) return null;
+  if (ep === name || ep === escapeSegment(name)) return null;
+  const newSuffix = '/' + escapeSegment(name);
+  if (ep.endsWith(newSuffix)) return ep.slice(0, ep.length - newSuffix.length);
+  const oldSuffix = '/' + name;
+  if (ep.endsWith(oldSuffix)) return ep.slice(0, ep.length - oldSuffix.length);
+  return null;
+}
+
+export function withSyntheticAncestors(rows: EntityRow[]): EntityRow[] {
+  const byPath = new Map<string, EntityRow>();
+  for (const r of rows) if (r.execution_path) byPath.set(r.execution_path, r);
+
+  const additions: EntityRow[] = [];
+  for (const r of rows) {
+    if (!r.execution_path || !r.name) continue;
+    const parentPath = stripDeploymentSuffix(r.execution_path, r.name);
+    if (parentPath === null || parentPath === '' || byPath.has(parentPath)) continue;
+    const parentName = (r.parent_deployment ?? '').trim();
+    if (!parentName) continue;
+    const synthetic: EntityRow = {
+      name: parentName,
+      execution_path: parentPath,
+      parent_deployment: '',
+      requests: '0',
+      cost: '0',
+      deployment_cost: '0',
+      prompts: '0',
+      completions: '0',
+      synthetic: true,
+    };
+    byPath.set(parentPath, synthetic);
+    additions.push(synthetic);
+  }
+  return additions.length > 0 ? [...rows, ...additions] : rows;
+}
+
+export function buildEntitiesConsumptionTree(rows: EntityRow[]): TreeRow<EntityRow>[] {
+  const usable = rows.filter((r) => !!r.execution_path);
+  const withAncestors = withSyntheticAncestors(usable);
+  return buildTreeFromParentPointer<EntityRow>(withAncestors, {
+    getId: (r) => `${r.execution_path ?? ''}|${r.name ?? ''}`,
+    getParentId: (r) => {
+      const parentPath = stripDeploymentSuffix(r.execution_path ?? '', r.name ?? '');
+      if (parentPath === null) return null;
+      const parentName = (r.parent_deployment ?? '').trim();
+      return `${parentPath}|${parentName}`;
+    },
+  });
+}

--- a/openspec/changes/archive/2026-05-19-dashboard-entities-tree-grid/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-19-dashboard-entities-tree-grid/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-18

--- a/openspec/changes/archive/2026-05-19-dashboard-entities-tree-grid/design.md
+++ b/openspec/changes/archive/2026-05-19-dashboard-entities-tree-grid/design.md
@@ -1,0 +1,251 @@
+## Context
+
+The Dashboard's Entities Consumption grid is rendered in `apps/ai-dial-admin/src/components/Telemetry/Dashboards/View/SimpleDashboard.tsx`:
+
+```tsx
+<TelemetryGrid
+  getData={getData}
+  refreshTime={effectiveRefreshTime}
+  query={ENTITY_CONSUMPTION_QUERY}
+  columnDefs={TELEMETRY_GRID_COLUMNS}
+  title={t(TelemetryI18nKey.EntitiesConsumption)}
+/>
+```
+
+The query (`src/constants/telemetry.tsx:52`) is:
+
+```ts
+ENTITY_CONSUMPTION_QUERY = {
+  $type: 'json',
+  query: {
+    expressions: [
+      'deployment',
+      'count()',
+      'sum(deployment_price) as money',
+      'sum(price) as aggregated_money',
+      'sum(prompt_tokens) as tokens_p',
+      'sum(completion_tokens) as tokens_c',
+    ],
+    from: ANALYTICS_TABLE_NAME,
+    groupBy: ['deployment'],
+  },
+};
+```
+
+`parent_deployment` is already a known column — it appears in `TRACES_QUERY.expressions` (`src/constants/telemetry.tsx:119`) and `CONVERSATIONS_QUERY.expressions` (`src/constants/telemetry.tsx:180`), and is declared as a hidden column in `USAGE_LOG_TRACES_COLUMNS` (`src/constants/grid-columns/grid-columns.tsx:501`) and `MCP_CALLS_BY_DEPLOYMENT_COLUMNS` (`src/constants/grid-columns/grid-columns.tsx:604`). The grouping in `MCP_CALLS_BY_DEPLOYMENT_QUERY` (`src/constants/telemetry.tsx:242-250`) already pioneers `groupBy: ['parent_deployment', 'deployment']` for a different chart, confirming the backend handles the shape.
+
+Two existing tree implementations in the codebase guide this work — and they motivate the extraction:
+
+- **`ActivityAudit/List/List.tsx`** (`getProcessedActivityMap`, lines 140-175): builds `Record<activityId, DialActivity & { children, expanded, canToggleExpand }>` from a flat list, then inline-flattens parent-then-children when feeding rows into AG Grid's infinite datasource. Handles exactly one level of nesting. Tied to `parentActivityId` / `activityId` / `DialActivity`. Accumulates rows across paginated `getRows` calls in `fullActivityList` state — fragile when the user changes filters mid-scroll, but works for the audit use case.
+
+- **`Common/SchemaGrid/SchemaGrid.tsx`** (`flattenFields`, `updateFieldInList`, the whole `SchemaFieldRow` machinery in `./utils.ts`): builds an N-level tree of JSON schema fields with `children`, `depth`, `expanded`, recurses through `updateFieldInList` to mutate by id, flattens depth-first into AG Grid rows, and draws indented carets in the leftmost column. The flatten/expand pattern is exactly what Entities Consumption needs; the row type and column set are JSONSchema7-specific and not reusable for telemetry rows.
+
+The natural reuse is **the SchemaGrid pattern** (N-level, indent + caret) — not the audit list pattern (one-level, no indent). Lifting it into a generic primitive captures the right abstraction once and lets the audit list adopt it later if/when its accumulated-state quirks become a problem worth fixing.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Dashboard users SHALL be able to see deployment call chains in the Entities Consumption grid grouped by `parent_deployment → deployment`, with expand/collapse on each parent.
+- A single generic `TreeGrid<T>` primitive SHALL exist under `Common/TreeGrid/` and be the only place tree-flatten/expand logic lives for any *future* tree consumer in the app.
+- The change SHALL be opt-in via a toggle persisted per-user; flat behavior is the default and unchanged for users who never toggle.
+- Dashboard refresh (`refreshTime`) SHALL preserve expanded-state across refetches.
+
+**Non-Goals:**
+- **Migrating the audit list to `TreeGrid` is out of scope.** It works today; its accumulated-state and infinite-row coupling are a separate refactor with its own risk profile. The new primitive is designed to support a future migration, but proving that fit lives in a follow-up change.
+- **Migrating `SchemaGrid` to `TreeGrid` is out of scope.** Same reasoning. The primitive's API is informed by SchemaGrid's needs (N-level, indent), so it can swap in, but the migration is a separate change.
+- **Tree behavior on the Usage Log raw traces grid is out of scope.** Usage Log uses AG Grid's server-side infinite-row model with `IDatasource`; combining infinite rows with tree flattening has its own design problem and would block this change. The Entities Consumption grid is client-paginated over a bounded aggregation, which is what makes a tree feasible here.
+- **A path-based tree (parsing `execution_path` as a `/`-delimited string) is out of scope.** The user chose `parent_deployment` pointer over execution_path. Path-based decoding is documented as a potential future enhancement when chains routinely exceed 2-3 levels and pointer chains become awkward to follow.
+- **Per-leaf drill-down to raw traces is out of scope.** Clicking a leaf does NOT open a filtered Usage Log view. That would be a separate "open in Usage Log" affordance, mirroring the audit shortcut pattern. Worth doing later; not this change.
+- **Server-side computation of subtree totals is out of scope.** The frontend sums descendant metrics in `buildTreeFromParentPointer`. The backend returns leaf-level aggregations only. Acceptable because the result set is bounded (one row per (deployment, parent_deployment) tuple, typically <500 rows even on large installations).
+
+## Decisions
+
+### Decision 1: New generic primitive `TreeGrid<T>` instead of extending `GridView` or `SchemaGrid`
+
+Three placement options were considered:
+
+| Option | Description |
+|---|---|
+| **A** | Add a `tree` prop to the existing `GridView` and hide the flatten algorithm behind it |
+| **B** | Generalize `SchemaGrid` to accept arbitrary row types and column definitions |
+| **C** | New `TreeGrid<T>` primitive next to `GridView` under `Common/`, composing it internally |
+
+**Chosen: C.** `GridView` is a small AG Grid wrapper with no opinion about row structure; adding tree semantics to it would balloon its surface and force every flat-grid consumer to opt out. `SchemaGrid` is a leaf component with a domain-specific row type, hardcoded column set, and JSONSchema7 round-trip logic — generalizing it means stripping nearly everything except the flatten/expand bits, at which point it's not `SchemaGrid` anymore. A new primitive that *composes* `GridView` keeps the layering clean: `TreeGrid<T>` owns tree state and indentation; `GridView` owns AG Grid configuration; feature components own their domain.
+
+**Naming:** `TreeGrid` is unambiguous, matches the existing naming style (`GridView`, `SchemaGrid`), and doesn't collide with AG Grid's built-in `treeData` mode (which this primitive deliberately does not use — see Decision 4).
+
+### Decision 2: Tree built from `parent_deployment` pointer, not parsed from `execution_path`
+
+The user explicitly chose pointer over path. Reasoning captured here for posterity:
+
+- `parent_deployment` is a single value per row — trivial to group by in ClickHouse. `execution_path` is a string like `"chat-orch/gpt-4-router/tool-fs"`; grouping by it requires a substring/split aggregation that ClickHouse can do but not cheaply, and it produces one row per *exact path* rather than per (deployment, caller) pair.
+- The codebase's other "grouped by parent" view (`MCP_CALLS_BY_DEPLOYMENT_QUERY`) uses the pointer shape — adopting it here gives us a consistent backend pattern across two views.
+- Pointer-based trees mirror the audit list's approach, so reviewers already familiar with that pattern have less new ground to cover.
+- Deep deployment chains (>2-3 levels) are rare in practice for the dashboard's audience; when they happen, the pointer model handles them correctly, it just renders as a deeper indent. The only case it doesn't handle as well as `execution_path` is when an intermediate deployment is missing from the result set entirely — covered by Decision 5 (synthetic parents).
+
+**Trade-off:** if a deployment is called by two different parents within the same time window, it appears twice in the tree (once under each parent). This is *correct* — they are different call paths with different aggregate metrics — but visually unusual if you expect a strict tree. We accept this; the alternative (DAG rendering) is far more UI complexity for a marginal case. The Name column makes the parent context obvious through indentation.
+
+### Decision 3: Aggregation level = `(deployment, parent_deployment)` tuple, NOT raw traces
+
+The user chose aggregated per (parent, child) tuple over per-trace leaves. This shapes the entire query:
+
+```sql
+SELECT deployment, parent_deployment,
+       count(),
+       sum(deployment_price) AS money,
+       sum(price) AS aggregated_money,
+       sum(prompt_tokens) AS tokens_p,
+       sum(completion_tokens) AS tokens_c
+FROM analytics
+GROUP BY deployment, parent_deployment
+```
+
+One row per (deployment, caller) tuple. The frontend never sees individual traces in this view. Per-trace drill-down lives in the Usage Log and is reachable from a future "open traces for this row" affordance — not part of this change.
+
+**Why this is the right call:** the dashboard is for monitoring *consumption*, not investigating individual calls. The user already has Usage Log for traces. Mixing aggregated parents with raw-trace leaves would couple two query shapes in one grid, complicate refresh, and confuse the column meaning (a "money" column shows different things at different levels).
+
+### Decision 4: Hand-rolled flatten, NOT AG Grid's `treeData` mode
+
+AG Grid has a built-in `treeData: true` mode that takes a flat row array and a `getDataPath` accessor and renders a tree. We are deliberately not using it.
+
+| Reason | Detail |
+|---|---|
+| **License** | `treeData` is an **enterprise** feature — requires a license key. The repo's AG Grid is community edition (verified via `package.json`); enabling enterprise across an open dependency tree is its own decision. |
+| **Consistency** | Both existing tree views (audit list, SchemaGrid) hand-roll the flatten. Adopting `treeData` would split the codebase into two tree paradigms. |
+| **Control** | Hand-flatten gives us full control over the row id ordering, the indent rendering, expand/collapse animation, and the synthetic-parent behavior (Decision 5). |
+
+The hand-roll is six lines:
+
+```ts
+const flattenTree = <T>(rows: TreeRow<T>[]): TreeRow<T>[] => {
+  const out: TreeRow<T>[] = [];
+  for (const row of rows) {
+    out.push(row);
+    if (row.expanded && row.children.length) out.push(...flattenTree(row.children));
+  }
+  return out;
+};
+```
+
+Plus an indent-aware first-column cell renderer (`ExpanderCell`). Total primitive surface stays under ~200 lines.
+
+### Decision 5: Synthetic parent rows when `parent_deployment` is not in the result set
+
+Suppose the query returns:
+
+```
+{ deployment: 'gpt-4-router', parent_deployment: 'chat-orch', count: 320, money: 8.00 }
+{ deployment: 'claude-fb',    parent_deployment: 'chat-orch', count: 180, money: 4.00 }
+```
+
+…but no row with `deployment: 'chat-orch'`. This happens if `chat-orch` was used only as a router and never logged a direct call itself within the window. The naïve `buildTreeFromParentPointer` would orphan the two rows; they have a parent pointer but no parent node.
+
+**Resolution:** synthesis is **consumer-side**, not a feature of the primitive. `EntitiesConsumptionTree` runs a pre-processing step (`withSyntheticAncestors`) over the rows from `getGridData` and appends synthetic placeholder rows for any ancestor `execution_path` not represented in the result set. Each synthetic row carries:
+- `name`: the parent name taken from the child's `parent_deployment` field
+- `execution_path`: the parent path (computed by stripping the child's deployment name from its own ep)
+- `synthetic: true` — the input row carries this directly, and `buildTreeFromParentPointer` propagates it onto the resulting `TreeRow<T>`
+
+The cell renderer marks synthetic rows visually (italic deployment name, no tooltip suggesting a missing direct-call count). This keeps the tree well-formed and gives users an aggregate view of indirect deployments that would otherwise be invisible.
+
+**Why the primitive doesn't synthesize:** an earlier iteration had `makeSyntheticRow` + `sumFields` options on `buildTreeFromParentPointer`. With this consumer's adoption of `execution_path` as the unique node id (instead of just the deployment name), the primitive's name-based synthesis couldn't generate the composite `${path}|${name}` ids the consumer needs. Removing the dead options keeps the primitive minimal; the only consumer that needs synthesis (`EntitiesConsumptionTree`) does it itself.
+
+**Alternative considered: orphan rows at depth 0 with a "called by: chat-orch (not in set)" badge.** Rejected — looks like a bug; users don't read badges. Synthetic parent gives the same information through structure.
+
+### Decision 6: Parent rows show direct aggregates with subtree-sum tooltip
+
+A parent deployment can have both its own direct calls (rows where it was called with no parent) AND a set of child rows. The visible numeric cells SHALL show the *direct* aggregate; tooltips on those cells SHALL show the subtree sum.
+
+Why direct + tooltip rather than subtree-sum + tooltip:
+
+- The System Usage chart above the grid shows total request count from the same analytics table. If parent rows showed subtree sums, the numbers in the grid would double-count (each call is counted at the leaf and at every ancestor), breaking reconciliation with the chart.
+- Direct aggregates are what the backend actually returns — the frontend doesn't have to compute them. Subtree sums are the layer of synthesis the tree adds, and they belong in a tooltip / secondary affordance.
+- For synthetic parents (no direct calls), the cell shows the subtree sum (because there's no direct aggregate to show), with an italic marker — see Decision 5.
+
+The Name column SHALL display a subtle `(+N)` suffix where N is the immediate-child count, so the user can see at a glance that a row has children without having to expand it.
+
+### Decision 7: Flat/tree toggle, default flat, persisted per-user
+
+A toggle above the grid lets the user pick:
+- **Flat** (default) — current behavior; query uses `groupBy: ['deployment']`; no tree rendering. Identical to today.
+- **Tree** — new behavior; query uses `groupBy: ['deployment', 'parent_deployment']`; rows rendered through `TreeGrid`.
+
+Persistence: `localStorage['dashboard:entities-consumption:groupByParent']` = `'true'` | `'false'` | absent. Absent = flat. The key is per-grid, not per-route, so introducing similar toggles elsewhere later is a clean copy-paste.
+
+**Why default flat:**
+- No visible diff for users who don't care about call structure.
+- Reviewers and ops teams see the dashboard they know on day one.
+- The toggle is in the user's hands; opting in is a single click with persistence.
+
+**Alternative considered: default tree, with a "flatten" escape hatch.** Rejected — too aggressive for a UX change on a high-visibility view. Default flat is the safer rollout, and adoption can be measured before flipping the default in a future change.
+
+### Decision 8: Bounded recursion depth (8) and cycle detection in tree build
+
+`parent_deployment` is user data — nothing prevents a misconfiguration where a→b→a, or a deployment self-references. `buildTreeFromParentPointer` SHALL:
+
+- Detect cycles by tracking the set of ancestor IDs walking down each branch. If a child's id is in its own ancestor set, the edge SHALL be dropped (the child becomes a root) and a single `console.warn` SHALL list the offending chain.
+- Cap depth at 8. Any row that would land at depth > 8 SHALL be rendered as a flat sibling at depth 8 (no further indent). Single `console.warn` per render summarizing how many rows hit the cap.
+
+Why 8: deeper than any plausible real call chain, generous enough to give us headroom, small enough to keep indent rendering readable. Adjustable as a single constant if real data later argues for more.
+
+**This is the only bit of "error handling" in the primitive.** Per the project's CLAUDE.md guidance, internal code is trusted; we add these guards only because the tree-building input is shaped by user-configured deployments and the failure mode without them (stack overflow) is severe.
+
+### Decision 9: Expanded-state survival across refresh
+
+`useTreeRows` SHALL key expanded-state by row id (i.e., `deployment` name in this consumer). When `refreshTime` fires and the query re-runs:
+
+1. New rows arrive from the server.
+2. `buildTreeFromParentPointer` rebuilds the tree.
+3. `useTreeRows` overlays the previous expanded-state map (`Map<id, boolean>`) onto the new tree — any row whose id matches a previously-expanded id keeps `expanded: true`.
+4. Rows in the previous state but no longer present (e.g., a deployment stopped being called) drop from the map; rows newly arrived inherit the primitive's default (`expanded: false`).
+
+This is the same pattern the audit list deliberately attempts via its accumulated `fullActivityList`, but at the right layer (the primitive, not the consumer) and without the filter-reset fragility.
+
+### Decision 10: Column set — extend `TELEMETRY_GRID_COLUMNS` with an indent renderer on Name, not a parallel constant
+
+Two options for hosting the tree-mode columns:
+
+| Option | Effect |
+|---|---|
+| **A** | New `TELEMETRY_TREE_GRID_COLUMNS` constant — identical except the Name column has the `ExpanderCell` renderer |
+| **B** | Reuse `TELEMETRY_GRID_COLUMNS` and let `EntitiesConsumptionTree` override the Name column's `cellRenderer` at runtime |
+
+**Chosen: B.** Avoids the constant duplication and the drift hazard (someone adds a column to one but forgets the other). The override is a single-line `useMemo` in the new component.
+
+**Trade-off:** the column definition no longer fully describes its rendering — the consumer has to know it can be augmented. Acceptable because the augmentation is mechanical (replace one cell renderer) and lives next to the consumer.
+
+### Decision 11: TreeGrid MUST strip column `sort` and disable `sortable` / `filter` on every column
+
+**Root cause this guards against (discovered during browser verification):**
+
+`TELEMETRY_GRID_COLUMNS` declares `sort: 'desc'` on the cost column (`apps/ai-dial-admin/src/constants/grid-columns/grid-columns.tsx:439`). `TreeGrid` was passing column defs through almost verbatim — overriding only the expander column's `cellRenderer`. The downstream chain was:
+
+1. `flattenTree` produces `[parent, child1, child2, …]` in correct tree order.
+2. `TreeGrid` → `GridView` → `AgGridWrapper`.
+3. `AgGridWrapper`, with `isLiveData` unset, runs the imperative path on every `rowData` change — calling `gridApi.updateGridOptions({rowData})` AND `applyGridState(gridApi, model, defaultSorts)` (`AgGridWrapper.tsx:162-163, 174-177`).
+4. `defaultSorts` includes `{colId: 'cost', sort: 'desc'}`. AG Grid re-applies it on every expand/collapse, scrambling tree order — children get sorted to wherever their cost value lands and are visually separated from their parent.
+
+To the user this presents as "expand flickers but nothing appears" — actually the children DO appear, just sorted into the wrong rows somewhere else in the table.
+
+**Why unit tests didn't catch it:** the test suite shallow-mocks `GridView` and exercises `useTreeRows` / `flattenTree` in isolation. The real `AgGridWrapper` sort-reapplication only fires inside a live AG Grid runtime, so the bug only surfaces in the browser. Task 7.5 (manual verify) is the only task this guards.
+
+**The fix (`TreeGrid.tsx`):** before forwarding column defs to `GridView`, strip every column's `sort` and force `sortable: false`. Tree row order IS the answer that `flattenTree` provides; column sort cannot coexist with hand-flattened tree rows. (AG Grid Enterprise's `treeData` mode handles this natively, but Decision 4 deliberately doesn't use it.) The same logic applies to column filters — filtering a column would hide children but keep parents (and vice versa), breaking the tree just as badly — so `filter` is also disabled.
+
+**Regression coverage (mandatory):** `TreeGrid.spec.tsx` SHALL include a test that mounts `TreeGrid` with a column carrying `sort: 'desc'`, supplies rows whose tree order does NOT match that sort, and asserts the rendered order matches `flattenTree` output (parent then children). Without this test the next refactor reintroduces the bug.
+
+## Risks / Trade-offs
+
+- **Risk:** the `groupBy` extension multiplies result row count by the average number of distinct callers per deployment. For typical installations this is 2-5x; for unusual ones it could be 20x. → **Mitigation:** result set is still bounded (one row per (deployment, caller) tuple, not per trace); the existing query is already client-paginated by `TelemetryGrid`. We add a `console.warn` if the response exceeds 5000 rows so we can see this in dev tools before users do.
+
+- **Risk:** synthetic parents (Decision 5) hide the fact that a deployment is misconfigured / unobservable. → **Mitigation:** the italic styling and the tooltip text "aggregated from descendants — no direct calls in this window" make the partial-data state explicit. Users investigating consumption know what they're looking at.
+
+- **Risk:** the toggle adds a small UI element to a high-visibility dashboard. → **Mitigation:** placed inline with the existing grid title bar, label keys are short, doesn't move other content. Default-flat means no immediate visual diff.
+
+- **Risk:** `TreeGrid` primitive is over-engineered for a single consumer. → **Mitigation:** the primitive is ~200 lines; the alternative (inline in `EntitiesConsumptionTree`) is the same code, just less reusable. The cost of the abstraction is small and the path to a second consumer (audit list, SchemaGrid) is short.
+
+- **Trade-off:** `parent_deployment` cardinality varies across deployments. Some deployments have hundreds of distinct callers (popular models), some have one. The tree grid happily renders both; the user just sees taller trees in popular branches. No special handling for "very wide" parents — pagination remains client-side over the same result set, and AG Grid's row virtualization keeps render cost bounded.
+
+- **Trade-off:** the `console.warn` on cycle / depth-cap is dev-tools-only. There is no user-visible signal beyond the affected branch being slightly truncated. Users who hit this case will likely be DIAL admins debugging their own deployment graph; the warning surface is the right channel.
+
+- **Trade-off:** localStorage toggle persistence is per-browser, not per-user-account. Two devs sharing an account see different defaults. Same trade-off every other localStorage preference in the app makes; no reason to be the first to break the pattern.
+
+- **Open question:** the audit list and `SchemaGrid` migrations to `TreeGrid` are explicitly out of scope. Each follow-up change SHALL re-validate that the primitive's API still fits before adopting. We accept the risk that one of those migrations surfaces a missing primitive feature; the cost of adding a feature later is small compared to designing for unspecified future consumers now.

--- a/openspec/changes/archive/2026-05-19-dashboard-entities-tree-grid/proposal.md
+++ b/openspec/changes/archive/2026-05-19-dashboard-entities-tree-grid/proposal.md
@@ -1,0 +1,64 @@
+## Why
+
+The Dashboard's **Entities Consumption** grid (`SimpleDashboard.tsx` → `TelemetryGrid` with `ENTITY_CONSUMPTION_QUERY` + `TELEMETRY_GRID_COLUMNS`) shows one flat row per deployment with aggregated call counts, money, and tokens. It tells the user *how much* each deployment was used, but not *who called whom*. In real DIAL deployments, deployments invoke other deployments — an application calls a model, a router calls multiple downstream models, an agent calls tool deployments. Today that call structure is invisible on the dashboard; users have to drop into the Usage Log and read raw traces to reconstruct it.
+
+The telemetry rows already carry `parent_deployment` (immediate caller) and `execution_path` (the full chain), and both fields are even already declared as hidden columns in the `USAGE_LOG_TRACES_COLUMNS` set — they just aren't aggregated or visualized anywhere. Two other parts of the codebase already implement expandable hierarchical rows on AG Grid (the audit list flattens parent→children one level deep via `parentActivityId`; `SchemaGrid` flattens N levels deep via `children[]` + `depth` + `expanded`), but each ships its own copy of the flatten/expand machinery.
+
+This change turns Entities Consumption into a tree grid grouped by `parent_deployment → deployment`, and extracts a single shared `TreeGrid` primitive that both this new view and (later) the audit list and `SchemaGrid` can consume.
+
+## What Changes
+
+- **Extract a generic `TreeGrid<T>` primitive under `src/components/Common/TreeGrid/`.** A thin wrapper over `GridView` that owns expand/collapse UI state, indented row rendering, and the flatten-with-children algorithm. Generic over the row type. No knowledge of deployments, schemas, or activities. The primitive SHALL expose: a `TreeRow<T>` shape (`T & { id, parentId, depth, expanded, children: TreeRow<T>[] }`), a `buildTreeFromParentPointer` builder, a `flattenTree` flattener that honors per-node `expanded` state, an `ExpanderCell` cellRenderer that draws the indent + caret, and a `useTreeRows` hook that owns expanded-state mutation and pushes flattened rows into the AG Grid api.
+
+- **Extend `ENTITY_CONSUMPTION_QUERY` to group by `(deployment, parent_deployment)`.** Add `parent_deployment` to `expressions` and to `groupBy`. The backend already understands these columns (they're declared in `TRACES_QUERY` / `CONVERSATIONS_QUERY`). Each row in the response now represents one (deployment, caller) pair with its own aggregated metrics. Top-level rows (deployments called directly with no parent) come back with `parent_deployment = null` or `''`; both SHALL be normalized to `null` at the boundary.
+
+- **Add a new component `Telemetry/EntitiesConsumptionTree.tsx` that replaces the flat `TelemetryGrid` for this slot.** It owns the data fetch (reuses the existing `getDashboardData` request shape via `getData`), builds the tree from the response via `buildTreeFromParentPointer`, feeds the resulting `TreeRow<EntityRow>[]` into `TreeGrid<EntityRow>`, and exposes the same `query` / `getData` / `refreshTime` / `title` props the current `TelemetryGrid` consumes so the wiring in `SimpleDashboard.tsx` is a one-line swap.
+
+- **Add synthetic parent nodes when a `parent_deployment` value is not itself present in the result set.** If row R cites `parent_deployment = "foo"` but no row has `deployment = "foo"`, a synthetic parent row SHALL be inserted as a root with metrics computed as the sum of its descendant rows' metrics. Synthetic rows SHALL carry a flag so the cell renderer can mark them visually (italic name, no link) and the user understands the aggregate-only nature.
+
+- **Show direct-call metrics + descendant rollup on parent rows.** A row whose deployment also has children represents (a) the rows where that deployment was called directly with no parent in the response set, and (b) the implicit total across its subtree. The Name column SHALL display the deployment name with a subtle suffix when descendants exist (e.g. `chat-orch (+3)` where 3 is the count of children); the numeric columns SHALL display the *direct* aggregate (what the backend returned for that row), and a tooltip on parent numeric cells SHALL show the subtree sum. This keeps the visible numbers reconcile-able with System Usage above, while making the tree structure useful.
+
+- **Add a "Group by parent" toggle above the grid.** The same `TelemetryGrid` slot can render in two modes: flat (legacy behavior — `groupBy: ['deployment']` only) and tree (this change — `groupBy: ['deployment', 'parent_deployment']`). Default is **flat** on first ever load (no regression), with the user's choice persisted in localStorage under `dashboard:entities-consumption:groupByParent`. This is the smallest gate that protects users who don't care about call structure and reviewers who don't want a visual diff on production dashboards.
+
+- **Drop cycles in tree construction with a bounded depth limit (8).** Defensive guard against dirty data where `parent_deployment` forms a cycle (a→b→a). Cycles SHALL be detected during build and the back-edge SHALL be dropped; a single `console.warn` SHALL be emitted naming the offending deployment IDs. Tree depth SHALL be capped at 8; rows beyond that limit are rendered as flat siblings at depth 8 (no further nesting).
+
+## Capabilities
+
+### New Capabilities
+
+- `tree-grid`: A generic, capability-agnostic tree-grid primitive (component + hook + utilities) that turns flat rows with parent pointers into an AG Grid view with indented expandable rows. Owns expand/collapse state, the flatten algorithm, the expander cell renderer, and cycle/depth safety. Consumed by feature capabilities — owns no domain logic.
+
+- `entities-consumption-tree`: The Dashboard's Entities Consumption grid SHALL support a tree view grouped by `parent_deployment → deployment`, derived from a single ClickHouse aggregation over the analytics table. Includes the synthetic-parent rule, the direct-vs-rollup metric display, and the flat/tree toggle.
+
+### Modified Capabilities
+
+<!-- None today. The audit list (`ActivityAudit/List/List.tsx`) and `SchemaGrid` (`Common/SchemaGrid/SchemaGrid.tsx`) each maintain their own tree-flatten logic. Migrating them to the new `tree-grid` primitive is **explicitly out of scope** for this change — see Non-Goals in design.md. A follow-up change can adopt the primitive once it has shipped and stabilized in one consumer. -->
+
+## Impact
+
+- **Affected files:**
+  - `apps/ai-dial-admin/src/components/Common/TreeGrid/TreeGrid.tsx` *(new)*
+  - `apps/ai-dial-admin/src/components/Common/TreeGrid/use-tree-rows.ts` *(new)*
+  - `apps/ai-dial-admin/src/components/Common/TreeGrid/ExpanderCell.tsx` *(new)*
+  - `apps/ai-dial-admin/src/components/Common/TreeGrid/utils.ts` *(new — `buildTreeFromParentPointer`, `flattenTree`, `updateRowInTree`, `findRowInTree`)*
+  - `apps/ai-dial-admin/src/components/Common/TreeGrid/types.ts` *(new — `TreeRow<T>` and synthetic-row flag)*
+  - `apps/ai-dial-admin/src/components/Common/TreeGrid/tests/utils.spec.ts` *(new)*
+  - `apps/ai-dial-admin/src/components/Common/TreeGrid/tests/TreeGrid.spec.tsx` *(new)*
+  - `apps/ai-dial-admin/src/components/Telemetry/EntitiesConsumptionTree.tsx` *(new)*
+  - `apps/ai-dial-admin/src/components/Telemetry/tests/EntitiesConsumptionTree.spec.tsx` *(new)*
+  - `apps/ai-dial-admin/src/components/Telemetry/Dashboards/View/SimpleDashboard.tsx` — swap `<TelemetryGrid>` for the new component in the Entities Consumption slot
+  - `apps/ai-dial-admin/src/constants/telemetry.tsx` — modify `ENTITY_CONSUMPTION_QUERY` expressions + groupBy
+  - `apps/ai-dial-admin/src/constants/grid-columns/grid-columns.tsx` — extend `TELEMETRY_GRID_COLUMNS` with the indent-aware Name cell renderer when used in tree mode (or define a sibling column set `TELEMETRY_TREE_GRID_COLUMNS`)
+  - No i18n changes required. Synthetic placeholder rows show backend `0` values verbatim; the `(+N)` suffix on the Name column is locale-neutral.
+
+- **No backend changes.** `parent_deployment` and `execution_path` are existing columns in the analytics table (verified via `TRACES_QUERY` expressions). The new `groupBy` is supported by the existing query shape.
+
+- **No new dependencies.** Reuses AG Grid, the existing `GridView` wrapper, and the existing telemetry `getDashboardData` action.
+
+- **No data migration.** The flat/tree toggle defaults to flat on first load; existing dashboard users see no change unless they opt in. The toggle preference is persisted under a new localStorage key; absence equals flat.
+
+- **Cross-feature risk:** the query change adds a column and a groupBy clause. Any consumer that depends on the *current* `ENTITY_CONSUMPTION_QUERY` shape (one row per deployment) needs to either keep using the old shape via a flat variant constant, or be updated. A search confirms only `SimpleDashboard.tsx` imports this query — the migration is local. The flat-mode toggle delivers the legacy shape unchanged when active.
+
+- **Performance:** the new groupBy expands result row count from `O(deployments)` to `O(deployments × distinct callers)`. For typical DIAL installations this is a constant-factor increase (~2-5x). The tree build is `O(rows)` with a hashmap lookup; flatten is `O(visible rows)`. No infinite scrolling — Entities Consumption is already client-paginated in `TelemetryGrid` over a bounded aggregation result.
+
+- **No breaking changes** to existing dashboards or stored grid state. The flat-mode toggle defaults to flat for existing users; the column set is the same in flat mode; the new tree-mode column adds the indent in the Name column only.

--- a/openspec/changes/archive/2026-05-19-dashboard-entities-tree-grid/specs/entities-consumption-tree/spec.md
+++ b/openspec/changes/archive/2026-05-19-dashboard-entities-tree-grid/specs/entities-consumption-tree/spec.md
@@ -1,0 +1,136 @@
+## ADDED Requirements
+
+### Requirement: Entities Consumption grid offers a "Group by parent deployment" toggle
+
+The Dashboard's Entities Consumption section SHALL render a toggle inline with the section title labelled "Group by parent deployment" (i18n key `TelemetryI18nKey.GroupByParent`). The toggle SHALL be off by default on first load. The toggle's value SHALL be persisted across page reloads under the localStorage key `dashboard:entities-consumption:groupByParent` with values `'true'` / `'false'`; absence of the key SHALL be interpreted as `'false'`. The toggle SHALL be available only when the current route is `ApplicationRoute.Dashboard` — entity-scoped dashboards (Applications, Toolsets) SHALL NOT render the toggle and SHALL continue to use the flat view.
+
+#### Scenario: Default state on first ever load is flat
+
+- **GIVEN** a user with no value for `dashboard:entities-consumption:groupByParent` in localStorage
+- **WHEN** the user opens the Dashboard route
+- **THEN** the Entities Consumption section SHALL render in flat mode, identical to the current production behavior
+- **AND** the toggle SHALL render in the off position
+
+#### Scenario: Toggle on switches to tree mode and persists
+
+- **GIVEN** the user is viewing Entities Consumption in flat mode
+- **WHEN** the user activates the "Group by parent deployment" toggle
+- **THEN** the grid SHALL re-fetch using `ENTITY_CONSUMPTION_TREE_QUERY` (with `parent_deployment` in groupBy)
+- **AND** localStorage SHALL contain `dashboard:entities-consumption:groupByParent = 'true'`
+- **AND** the grid SHALL render as a tree with expand/collapse on parent rows
+
+#### Scenario: Toggle off returns to flat mode and persists
+
+- **GIVEN** the user is viewing Entities Consumption in tree mode
+- **WHEN** the user deactivates the toggle
+- **THEN** the grid SHALL re-fetch using `ENTITY_CONSUMPTION_QUERY` (groupBy `['deployment']` only)
+- **AND** localStorage SHALL contain `dashboard:entities-consumption:groupByParent = 'false'`
+- **AND** the grid SHALL render flat, identical to the default
+
+#### Scenario: Toggle preference applies on next visit
+
+- **GIVEN** the user previously enabled tree mode (localStorage value is `'true'`)
+- **WHEN** the user reloads the page or returns to the Dashboard route from another route
+- **THEN** the toggle SHALL render in the on position
+- **AND** the grid SHALL fetch using `ENTITY_CONSUMPTION_TREE_QUERY` on first load
+
+### Requirement: Tree-mode query groups by parent_deployment in addition to deployment
+
+When the toggle is on, the Entities Consumption section SHALL issue `ENTITY_CONSUMPTION_TREE_QUERY` to `getDashboardData`. The query SHALL be identical to `ENTITY_CONSUMPTION_QUERY` except that `expressions` SHALL additionally include `'parent_deployment'` and `groupBy` SHALL be `['deployment', 'parent_deployment']`. Numeric aggregates (`count()`, `sum(deployment_price) as money`, `sum(price) as aggregated_money`, `sum(prompt_tokens) as tokens_p`, `sum(completion_tokens) as tokens_c`) SHALL be unchanged. The `from` clause SHALL remain `ANALYTICS_TABLE_NAME`.
+
+#### Scenario: Tree query shape
+
+- **WHEN** tree mode is active
+- **THEN** the request payload to `getDashboardData` SHALL contain `query.expressions` including `'parent_deployment'` alongside the existing aggregates
+- **AND** `query.groupBy` SHALL equal `['deployment', 'parent_deployment']`
+
+#### Scenario: Flat query shape unchanged
+
+- **WHEN** flat mode is active
+- **THEN** the request payload SHALL match the existing `ENTITY_CONSUMPTION_QUERY` byte-for-byte (no `parent_deployment` in `expressions` or `groupBy`)
+
+### Requirement: Tree-mode rows are built from parent_deployment pointers and grouped per (deployment, caller) tuple
+
+When tree mode is active, the response rows from the server (one per (deployment, parent_deployment) tuple) SHALL be transformed into a tree by `buildTreeFromParentPointer` using `getId: r => r.deployment`, `getParentId: r => r.parent_deployment ?? null`, and `sumFields: ['count', 'money', 'aggregated_money', 'tokens_p', 'tokens_c']`. Empty-string `parent_deployment` values SHALL be normalized to `null` before tree construction (the backend may return either depending on the column NULL semantics). When a `parent_deployment` value references a deployment that has no row of its own in the response, a synthetic parent row SHALL be inserted with the sum of its descendants' metrics and `synthetic: true`.
+
+#### Scenario: Flat response with parent pointers becomes a two-level tree
+
+- **GIVEN** the server returns rows:
+    `{ deployment: 'chat-orch', parent_deployment: null, count: 50 }`,
+    `{ deployment: 'gpt-4-router', parent_deployment: 'chat-orch', count: 320 }`,
+    `{ deployment: 'claude-fb', parent_deployment: 'chat-orch', count: 180 }`,
+    `{ deployment: 'embed-pipe', parent_deployment: null, count: 90 }`
+- **WHEN** the tree is built
+- **THEN** the output SHALL contain two roots: `chat-orch` (depth 0, count 50, children: [`gpt-4-router`, `claude-fb`]) and `embed-pipe` (depth 0, count 90, no children)
+
+#### Scenario: Missing intermediate deployment is synthesized as a parent
+
+- **GIVEN** the server returns rows:
+    `{ deployment: 'gpt-4-router', parent_deployment: 'chat-orch', count: 320 }`,
+    `{ deployment: 'claude-fb', parent_deployment: 'chat-orch', count: 180 }`,
+    (no row for `chat-orch` itself)
+- **WHEN** the tree is built
+- **THEN** the output SHALL contain one synthetic root `chat-orch` with `synthetic: true`, `count: 500` (sum of its descendants)
+- **AND** `gpt-4-router` and `claude-fb` SHALL be children of that synthetic root
+
+#### Scenario: Empty parent_deployment value normalizes to null
+
+- **GIVEN** a server row `{ deployment: 'a', parent_deployment: '', count: 10 }`
+- **WHEN** the tree is built
+- **THEN** the row SHALL be treated as a root (parent normalized to `null`)
+- **AND** SHALL NOT be confused with a child whose parent id is the empty string
+
+#### Scenario: Same deployment called by multiple parents appears in multiple branches
+
+- **GIVEN** the server returns:
+    `{ deployment: 'gpt-4', parent_deployment: 'app-A', count: 100 }`,
+    `{ deployment: 'gpt-4', parent_deployment: 'app-B', count: 200 }`,
+    `{ deployment: 'app-A', parent_deployment: null, count: 0 }`,
+    `{ deployment: 'app-B', parent_deployment: null, count: 0 }`
+- **WHEN** the tree is built
+- **THEN** `gpt-4` SHALL appear once under `app-A` (count 100) and once under `app-B` (count 200)
+- **AND** the two appearances SHALL have distinct `id` values in the tree representation (composite of deployment + parent) so AG Grid's row identity is unique
+
+### Requirement: Rows display backend values as-is
+
+Each numeric column on every row (real or synthetic) SHALL display the value returned by the backend for that (deployment, parent) tuple verbatim — the frontend SHALL NOT compute subtree sums and SHALL NOT substitute zero-valued synthetic rows with descendant aggregates. Synthetic rows therefore display `0` in every numeric column, signaling that no backend data exists for that placeholder. The Name column SHALL display the deployment name followed by a `(+N)` suffix where N is the immediate child count, when N ≥ 1.
+
+#### Scenario: Direct-call parent shows direct backend count
+
+- **GIVEN** a row `chat-orch` with `count: 50` and two children with counts 320 and 180
+- **WHEN** the row renders
+- **THEN** the count column SHALL display `50`
+- **AND** the Name column SHALL display `chat-orch (+2)`
+
+#### Scenario: Synthetic parent shows zeros
+
+- **GIVEN** a synthetic `chat-orch` row with `count: 0` (placeholder for missing backend row) and two children
+- **WHEN** the row renders
+- **THEN** the count column SHALL display `0`
+- **AND** the Name column SHALL display `chat-orch (+2)` in italic typography
+
+#### Scenario: Leaf row shows direct aggregate with no suffix
+
+- **GIVEN** a row `gpt-4-router` at depth 1 with `count: 320` and no children
+- **WHEN** the row renders
+- **THEN** the count column SHALL display `320`
+- **AND** the Name column SHALL display `gpt-4-router` (no `(+N)` suffix, no italic)
+- **AND** numeric columns SHALL NOT carry the subtree-total or synthetic-parent tooltip
+
+### Requirement: Expanded state survives auto-refresh
+
+When `refreshTime` triggers an automatic refetch of the tree-mode query, the new response SHALL replace the previous tree, but rows whose `id` matches a previously-expanded row SHALL retain `expanded: true` after the rebuild. This SHALL hold even if intermediate rows have appeared or disappeared between refreshes. Rows present before but absent in the new response SHALL be dropped from the expanded-state map.
+
+#### Scenario: Refresh keeps previously expanded nodes open
+
+- **GIVEN** the user has expanded `chat-orch` in tree mode
+- **WHEN** the auto-refresh fires and the new response still contains a `chat-orch` row
+- **THEN** the rebuilt tree SHALL render with `chat-orch` already expanded
+- **AND** the user SHALL see no visible collapse-then-re-expand flicker
+
+#### Scenario: Refresh drops vanished rows from the expanded-state map
+
+- **GIVEN** the user previously expanded `chat-orch`, and the new response no longer contains any row with `deployment === 'chat-orch'`
+- **WHEN** the rebuild completes
+- **THEN** the expanded-state map SHALL no longer carry `chat-orch`
+- **AND** if `chat-orch` later reappears in a future refresh, it SHALL start collapsed (not silently restored)

--- a/openspec/changes/archive/2026-05-19-dashboard-entities-tree-grid/specs/tree-grid/spec.md
+++ b/openspec/changes/archive/2026-05-19-dashboard-entities-tree-grid/specs/tree-grid/spec.md
@@ -1,0 +1,141 @@
+## ADDED Requirements
+
+### Requirement: TreeGrid primitive renders flat rows with parent pointers as an expandable tree
+
+A generic `TreeGrid<T>` component SHALL live at `apps/ai-dial-admin/src/components/Common/TreeGrid/TreeGrid.tsx`. It SHALL accept a `TreeRow<T>[]` (where `TreeRow<T> = T & { id, parentId, depth, expanded, children: TreeRow<T>[], synthetic? }`), a `columnDefs: ColDef[]`, and an `expanderColumnField: keyof T` identifying which column receives the indent + caret renderer. It SHALL compose the existing `GridView` component without modifying it. The primitive SHALL NOT depend on AG Grid's enterprise `treeData` mode — flattening is hand-rolled to keep the codebase on the community edition and consistent with the existing audit and SchemaGrid tree implementations.
+
+The primitive SHALL be capability-agnostic: no knowledge of deployments, schemas, activities, telemetry, or any other domain concept. Domain knowledge lives in feature components that consume `TreeGrid`.
+
+#### Scenario: Component renders rows in depth-first flatten order honoring expanded state
+
+- **GIVEN** a tree with one root, two children of that root, and one grandchild under the first child, where all rows are `expanded: true`
+- **WHEN** the component renders
+- **THEN** AG Grid SHALL receive rows in the order [root, child-1, grandchild, child-2]
+
+#### Scenario: Collapsing a parent hides its descendants without removing them from the tree
+
+- **GIVEN** an expanded parent row with two children
+- **WHEN** the user clicks the expander chevron on the parent
+- **THEN** the parent's `expanded` flag SHALL flip to `false`
+- **AND** the flatten output SHALL contain only the parent
+- **AND** the tree data structure SHALL retain the children (re-expanding restores them without a refetch)
+
+#### Scenario: Indent depth matches row depth
+
+- **WHEN** a row at depth N is rendered
+- **THEN** the indent in the expander column SHALL be `N * 24` pixels of left padding (matching the spacing used by `SchemaGrid`)
+
+#### Scenario: Leaf rows render no chevron
+
+- **WHEN** a row has an empty `children` array
+- **THEN** no expander chevron SHALL render in the expander column
+- **AND** the indent SHALL still apply at `depth * 24` so leaves align with the cells of their siblings that have children
+
+#### Scenario: Synthetic rows render with italic name
+
+- **GIVEN** a `TreeRow<T>` with `synthetic: true`
+- **WHEN** the row is rendered
+- **THEN** the expander column value SHALL appear in italic typography
+- **AND** the chevron (if any) SHALL render in a disabled / muted style
+
+#### Scenario: TreeGrid strips column sort and disables sortable/filter on every column
+
+- **GIVEN** a `columnDefs` array where one or more columns declare `sort: 'desc'` (or `sort: 'asc'`), and where columns inherit `sortable: true` / `filter: 'agTextColumnFilter'` from `GridView`'s defaults
+- **WHEN** `TreeGrid` augments `columnDefs` before forwarding them to `GridView`
+- **THEN** every column SHALL have its `sort` property removed
+- **AND** every column SHALL have `sortable: false`
+- **AND** every column SHALL have `filter: false`
+- **AND** the rendered row order SHALL match `flattenTree` output exactly (parent immediately followed by its visible children), regardless of any sort/filter that was declared on the input column defs
+
+**Why:** tree row order IS the answer that `flattenTree` provides. Column sort would re-order the flat list and visually scatter children away from their parents on every `rowData` update (`AgGridWrapper`'s non-live path re-applies `defaultSorts` on each tick via `applyGridState`). Column filters would hide children but keep parents (and vice versa), breaking the tree just as badly. AG Grid Enterprise's `treeData` mode handles both natively, but Decision 4 deliberately does not use it.
+
+### Requirement: buildTreeFromParentPointer constructs a tree from flat rows with parent ids
+
+A pure utility `buildTreeFromParentPointer<T>(rows: T[], opts)` SHALL live at `apps/ai-dial-admin/src/components/Common/TreeGrid/utils.ts`. It SHALL take a flat array of source rows and an options object specifying `getId`, `getParentId`, and an optional `maxDepth` (default 8). It SHALL return a `TreeRow<T>[]` where each input row is wrapped with `id`, `parentId`, `depth`, `expanded: false`, and `children: TreeRow<T>[]`. If an input row carries a `synthetic: true` property it SHALL be propagated to the resulting `TreeRow<T>`.
+
+The function SHALL be pure: same inputs produce same outputs, no observable side effects beyond the cycle/depth-cap warnings.
+
+Synthesis of intermediate ancestors (when `parent_deployment` references a deployment with no own row) is the **consumer's** responsibility — see Decision 5. The primitive does NOT synthesize rows on its own; consumers pre-process their input array, append synthetic placeholder rows with `synthetic: true`, and pass the augmented array in.
+
+#### Scenario: Rows with null parent become roots
+
+- **GIVEN** input rows `[{ id: 'a', parent: null }, { id: 'b', parent: null }]`
+- **WHEN** `buildTreeFromParentPointer` runs
+- **THEN** both rows SHALL be returned as roots at depth 0
+- **AND** each SHALL have `children: []`
+
+#### Scenario: Rows with a parent id pointing into the set are nested
+
+- **GIVEN** input rows `[{ id: 'a', parent: null }, { id: 'b', parent: 'a' }, { id: 'c', parent: 'b' }]`
+- **WHEN** the builder runs
+- **THEN** the output SHALL contain one root `a` at depth 0 with one child `b` at depth 1, and `b` SHALL have one child `c` at depth 2
+
+#### Scenario: Input rows pre-flagged as synthetic propagate to the built tree
+
+- **GIVEN** input rows `[{ id: 'a', parent: null, synthetic: true }, { id: 'b', parent: 'a' }]`
+- **WHEN** the builder runs
+- **THEN** the resulting `TreeRow<T>` for `a` SHALL carry `synthetic: true`
+- **AND** the resulting `TreeRow<T>` for `b` SHALL NOT carry `synthetic`
+
+#### Scenario: Orphan row whose parent id is not in the input set becomes a root
+
+- **GIVEN** input rows `[{ id: 'b', parent: 'a' }]` (no row for `a`)
+- **WHEN** the builder runs
+- **THEN** `b` SHALL be returned as a root at depth 0 (the primitive does NOT synthesize a parent — consumers do that pre-processing if they want it)
+
+#### Scenario: Cycle detection drops the back-edge
+
+- **GIVEN** input rows `[{ id: 'a', parent: 'b' }, { id: 'b', parent: 'a' }]`
+- **WHEN** the builder runs
+- **THEN** the back-edge SHALL be dropped: one of the two rows SHALL become a root and the other SHALL be its child (deterministic by input order)
+- **AND** a single `console.warn` SHALL be emitted naming the cycle members
+- **AND** the builder SHALL NOT infinite-recurse
+
+#### Scenario: Depth cap flattens overflow at the cap depth
+
+- **GIVEN** a linear chain of 12 rows where each row's parent is the previous one
+- **WHEN** the builder runs with default `maxDepth: 8`
+- **THEN** rows at logical depth ≤ 7 SHALL nest normally
+- **AND** rows at logical depth ≥ 8 SHALL be siblings at depth 8 (no further nesting)
+- **AND** a single `console.warn` SHALL be emitted summarizing how many rows hit the cap
+
+### Requirement: flattenTree emits rows in depth-first order honoring expanded flags
+
+A pure utility `flattenTree<T>(rows: TreeRow<T>[]): TreeRow<T>[]` SHALL emit each input row followed by its descendants if and only if the row's `expanded` flag is `true`. Order SHALL be parent before children, siblings in array order. The function SHALL be pure: no mutation of input, no side effects.
+
+#### Scenario: Collapsed parent skips its subtree
+
+- **GIVEN** a tree `[{ id: 'a', expanded: false, children: [{ id: 'b' }] }]`
+- **WHEN** `flattenTree` runs
+- **THEN** the output SHALL be `[{ id: 'a' ... }]`
+- **AND** `b` SHALL NOT appear
+
+#### Scenario: Expanded parent emits its subtree before the next sibling
+
+- **GIVEN** a tree `[a (expanded, children: [b]), c]`
+- **WHEN** `flattenTree` runs
+- **THEN** the output order SHALL be `[a, b, c]`
+
+### Requirement: useTreeRows hook owns expanded-state and pushes flat rows to AG Grid
+
+A React hook `useTreeRows<T>(tree: TreeRow<T>[], opts?)` SHALL own the expanded-state map keyed by row id and the side-effect of pushing flat rows into the AG Grid api. It SHALL expose `{ flatRows, onToggleExpand, gridApiRef, onGridReady }`. Expanded-state SHALL survive tree reference changes (e.g., a refetch produces a new tree object with the same row ids).
+
+#### Scenario: Toggle on a row flips its expanded flag and re-pushes rows to the grid
+
+- **GIVEN** a mounted `useTreeRows` with a collapsed parent and ready `gridApiRef`
+- **WHEN** `onToggleExpand(parent)` is called
+- **THEN** the parent's `expanded` flag SHALL flip to `true`
+- **AND** the grid api SHALL receive a new `rowData` containing the parent followed by its children
+
+#### Scenario: Re-render with a new tree object preserves expanded state by id
+
+- **GIVEN** a `useTreeRows` where row `a` was previously toggled expanded
+- **WHEN** the parent component re-renders with a freshly built tree whose row `a` has `expanded: false` from `buildTreeFromParentPointer`
+- **THEN** the overlay step SHALL restore `expanded: true` for row `a` before flattening
+- **AND** the user SHALL see no flicker / no collapse of previously-expanded subtrees
+
+#### Scenario: Removed row id is dropped from the expanded-state map
+
+- **GIVEN** a `useTreeRows` where row `a` was expanded
+- **WHEN** a refetch returns a tree no longer containing row `a`
+- **THEN** subsequent renders SHALL NOT carry `a` in the expanded-state map (memory bound is the size of currently-visible rows, not historical rows)

--- a/openspec/changes/archive/2026-05-19-dashboard-entities-tree-grid/tasks.md
+++ b/openspec/changes/archive/2026-05-19-dashboard-entities-tree-grid/tasks.md
@@ -1,0 +1,54 @@
+## 1. TreeGrid primitive — types and utilities
+
+- [x] 1.1 Create `apps/ai-dial-admin/src/components/Common/TreeGrid/types.ts` exporting `TreeRow<T> = T & { id: string; parentId: string | null; depth: number; expanded: boolean; children: TreeRow<T>[]; synthetic?: boolean }`. Mirror the field set used by SchemaGrid's `SchemaFieldRow` so the migration is mechanical when we do it; add `synthetic` for the synthetic-parent flag (Decision 5).
+- [x] 1.2 Create `apps/ai-dial-admin/src/components/Common/TreeGrid/utils.ts` exporting:
+    - `buildTreeFromParentPointer<T>(rows: T[], opts: { getId: (r: T) => string; getParentId: (r: T) => string | null; maxDepth?: number }): TreeRow<T>[]` — builds the tree from `(getId, getParentId)` pointers, drops cyclic back-edges, caps depth at `maxDepth` (default 8). Logs `console.warn` once per cycle and once for cap hits. Input rows pre-flagged with `synthetic: true` SHALL have that flag propagated to the resulting `TreeRow<T>`. Synthesis of missing intermediate ancestors is the consumer's responsibility (Decision 5).
+    - `flattenTree<T>(rows: TreeRow<T>[]): TreeRow<T>[]` — depth-first walk emitting `row` then (if `expanded`) its children recursively.
+    - `updateRowInTree<T>(rows: TreeRow<T>[], id: string, updater: (row: TreeRow<T>) => TreeRow<T>): TreeRow<T>[]` — immutable map-by-id, recursing into children. Mirrors SchemaGrid's `updateFieldInList` (`SchemaGrid.tsx:69-80`).
+    - `findRowInTree<T>(rows: TreeRow<T>[], id: string): TreeRow<T> | undefined` — same recursion shape as SchemaGrid's `findFieldById`.
+    - `overlayExpandedState<T>(tree: TreeRow<T>[], prev: Map<string, boolean>): TreeRow<T>[]` — applies a saved expanded-id map to a freshly built tree. Used by `useTreeRows` on refresh (Decision 9).
+- [x] 1.3 Create `apps/ai-dial-admin/src/components/Common/TreeGrid/tests/utils.spec.ts` covering: linear chain (a→b→c), branching (a → b, c), input rows pre-flagged with `synthetic: true` propagate to built tree, cycle detection (a→b→a) drops the back-edge and warns, depth cap at 8 with overflow rendered as flat siblings at depth 8, empty input returns empty array, multiple roots, orphan rows (parent id not in input set) become roots.
+
+## 2. TreeGrid primitive — UI
+
+- [x] 2.1 Create `apps/ai-dial-admin/src/components/Common/TreeGrid/ExpanderCell.tsx` rendering an indent (`paddingLeft: depth * 24` matching SchemaGrid's spacing at `SchemaGrid.tsx:288`), a chevron toggle (`IconChevronDown` / `IconChevronRight` from `@tabler/icons-react`, matching the kit's `Accordion` icon pattern referenced in the `adaptive-value-grid-collapsible` spec), and the cell value. Synthetic rows SHALL render the value in italic and SHALL render the chevron disabled-styled. Leaf rows (no children) render no chevron, just the indent. Accepts `params: ICellRendererParams<TreeRow<T>>`.
+- [x] 2.2 Create `apps/ai-dial-admin/src/components/Common/TreeGrid/use-tree-rows.ts` exporting `useTreeRows<T>(tree: TreeRow<T>[], opts?: { defaultExpandDepth?: number })` returning `{ flatRows, onToggleExpand, gridApiRef, onGridReady }`. The hook owns:
+    - A `useRef<Map<string, boolean>>` of expanded-state keyed by row id, surviving rebuilds via `overlayExpandedState` (Decision 9).
+    - The `onToggleExpand(row)` callback that flips a single row's expanded state and pushes new flat rows into the AG Grid api via `updateGridOptions({ rowData })` — same flow as SchemaGrid's `onToggleExpand` (`SchemaGrid.tsx:82-96`) which deliberately bypasses any parent `onChange` because expand is UI-only.
+    - A side effect that re-flattens and re-pushes rows when the input `tree` reference changes (e.g., after a query refetch).
+- [x] 2.3 Create `apps/ai-dial-admin/src/components/Common/TreeGrid/TreeGrid.tsx` — a thin component composing `GridView` and `useTreeRows`. Props: `rows: TreeRow<T>[]`, `columnDefs: ColDef[]`, `expanderColumnField: keyof T` (which column gets `ExpanderCell` as `cellRenderer`), `additionalGridOptions?: GridOptions`. The component SHALL clone the column with `field === expanderColumnField` and inject the `ExpanderCell` renderer at construction. It SHALL ALSO strip every column's `sort` and set `sortable: false` + `filter: false` on every column before forwarding to `GridView` — see Decision 11. `getRowId` uses `TreeRow<T>.id`.
+- [x] 2.4 Create `apps/ai-dial-admin/src/components/Common/TreeGrid/tests/TreeGrid.spec.tsx` covering: renders flattened tree in row order parent→children, click expander toggles row, indent matches depth, synthetic rows rendered italic, refresh preserves expanded state, leaf rows render no chevron, empty tree shows the existing `GridView` empty state, **AND a column carrying `sort: 'desc'` does NOT reorder rendered rows away from `flattenTree` order (Decision 11 regression)**.
+
+## 3. Query and column changes
+
+- [x] 3.1 In `apps/ai-dial-admin/src/constants/telemetry.tsx`, add a new constant `ENTITY_CONSUMPTION_TREE_QUERY` that mirrors `ENTITY_CONSUMPTION_QUERY` but with `'parent_deployment'` added to `expressions` and `groupBy`. Keep `ENTITY_CONSUMPTION_QUERY` unchanged so flat mode continues to work without a column shape diff. Co-locate a `TypeScript` comment pointing to this design doc.
+- [x] 3.2 In `apps/ai-dial-admin/src/constants/grid-columns/grid-columns.tsx`, no constant edit — the consumer (`EntitiesConsumptionTree.tsx`) will swap the Name column's `cellRenderer` at runtime via `TreeGrid`'s `expanderColumnField` prop. Verify the existing `TELEMETRY_GRID_COLUMNS` has a Name column with `field: 'name'` (it does — `grid-columns.tsx:447-458` extends from `NAME_COLUMN`).
+- [x] 3.3 No additional i18n keys are required. Synthetic placeholder rows display backend `0` values directly with no client-side substitution or tooltip text; the `(+N)` suffix on the Name column is locale-neutral.
+
+## 4. EntitiesConsumptionTree component
+
+- [x] 4.1 Create `apps/ai-dial-admin/src/components/Telemetry/EntitiesConsumptionTree.tsx`. Props mirror the current `TelemetryGrid` props: `getData`, `refreshTime`, `title`, plus `query` and `treeQuery` (`ENTITY_CONSUMPTION_QUERY` and `ENTITY_CONSUMPTION_TREE_QUERY`).
+- [x] 4.2 In the component, use `useState<boolean>(() => readGroupByParentPref())` for the toggle state, where `readGroupByParentPref` reads from `localStorage['dashboard:entities-consumption:groupByParent']` (returns `false` for absent / `'false'`). When the user toggles, write the new value back via `localStorage.setItem`.
+- [x] 4.3 Use the existing `getData(query)` shape to fetch. Call `getData(ENTITY_CONSUMPTION_TREE_QUERY)`, run the response through `getGridData`, then `withSyntheticAncestors` (consumer-local pre-processing that walks each row's `execution_path` and appends `synthetic: true` placeholder rows for any missing intermediate ancestor — Decision 5). Pass the augmented array to `buildTreeFromParentPointer` with `getId: r => ${r.execution_path}|${r.name}` and `getParentId: r => stripDeploymentSuffix(r.execution_path, r.name) + '|' + r.parent_deployment` (composite-id matching, avoids name-collision when the same deployment appears under multiple parents — Decision 5 explanation).
+- [x] 4.4 Compute `columnDefs` for tree mode by spreading `TELEMETRY_GRID_COLUMNS` and replacing the Name column's `cellRenderer`. The replacement renderer SHALL show `row.name` followed by a subtle `(+N)` suffix where N is `row.children.length` if non-zero (Decision 6). Pass `expanderColumnField: 'name'` to `TreeGrid`.
+- [x] 4.5 Numeric columns require no per-row overrides — the default `TELEMETRY_GRID_COLUMNS` definitions are passed through unchanged. Synthetic placeholder rows display the literal `0` values they were created with; no `tooltipValueGetter` or subtree-sum computation is performed.
+- [x] 4.6 Add the toggle UI: a `DialSelect` (size `Sm`, variant `Secondary`) or `DialCheckbox` above the grid title, label = `t(TelemetryI18nKey.GroupByParent)`. Position: inline with the existing grid title bar; the existing `TelemetryGrid` does not own that bar, so this component renders its own header div that includes the title from props and the toggle to the right. Use the same heading typography as existing telemetry titles (check `TelemetryGrid.tsx`).
+- [x] 4.7 Refresh handling: when `refreshTime` triggers a refetch, the new response replaces the previous tree. `useTreeRows`'s `overlayExpandedState` preserves expanded state across the rebuild (Decision 9).
+
+## 5. Wire into the dashboard
+
+- [x] 5.1 In `apps/ai-dial-admin/src/components/Telemetry/Dashboards/View/SimpleDashboard.tsx`, replace the existing `<TelemetryGrid query={ENTITY_CONSUMPTION_QUERY} columnDefs={TELEMETRY_GRID_COLUMNS} title={...} />` for `route === ApplicationRoute.Dashboard` with `<EntitiesConsumptionTree getData={...} refreshTime={...} title={...} query={ENTITY_CONSUMPTION_QUERY} treeQuery={ENTITY_CONSUMPTION_TREE_QUERY} />`. Verify Projects Consumption below it is untouched.
+- [x] 5.2 Verify the Entities Consumption slot only renders for `route === ApplicationRoute.Dashboard` (`SimpleDashboard.tsx:37`). Other routes that use `SimpleDashboard` (Applications, AssetsToolsets, etc.) do not see Entities Consumption; no migration needed for those routes.
+
+## 6. Tests
+
+- [x] 6.1 Add `apps/ai-dial-admin/src/components/Telemetry/tests/EntitiesConsumptionTree.spec.tsx` covering: initial render in flat mode when no localStorage pref (parity with current `TelemetryGrid` snapshot of column count and row format); toggle on switches to tree mode and triggers the tree query; tree rows render expanded state and indented Name; synthetic-parent insertion when a `parent_deployment` value lacks its own row; toggle preference persists via localStorage; refresh preserves expanded state.
+- [x] 6.2 Verify `TreeGrid` unit tests from Task 2.4 and `utils` tests from Task 1.3 cover the synthetic-parent and cycle-detection paths end-to-end. The `EntitiesConsumptionTree` spec MAY shallow-mock `TreeGrid` and assert on its props if the e2e DOM assertions become brittle — prefer integration where reasonable.
+- [x] 6.3 No spec change for `TelemetryGrid` or `GridView` — both are untouched.
+
+## 7. Validation
+
+- [x] 7.1 Run `npm run lint` from repo root and resolve any issues.
+- [x] 7.2 Run `npm run format:write` from repo root.
+- [x] 7.3 Run `npm run test` from `apps/ai-dial-admin/` (required for `@/` alias resolution) and resolve any failures.
+- [x] 7.4 Run `openspec validate dashboard-entities-tree-grid --strict` and resolve any reported issues.

--- a/openspec/specs/entities-consumption-tree/spec.md
+++ b/openspec/specs/entities-consumption-tree/spec.md
@@ -1,0 +1,142 @@
+# entities-consumption-tree Specification
+
+## Purpose
+
+Add a "Group by parent deployment" mode to the Dashboard's Entities Consumption section so admins can see which parent deployments (orchestrators, applications, agents) are driving traffic into downstream deployments. Tree mode is opt-in, persisted per browser, and Dashboard-route-only — entity-scoped dashboards (Applications, Toolsets) continue to show the flat view. Tree rendering reuses the `tree-grid` primitive; this capability owns the toggle, the query shape, the row transform (including synthetic-parent insertion), display rules, and expanded-state continuity across auto-refresh.
+
+## Requirements
+
+### Requirement: Entities Consumption grid offers a "Group by parent deployment" toggle
+
+The Dashboard's Entities Consumption section SHALL render a toggle inline with the section title labelled "Group by parent deployment" (i18n key `TelemetryI18nKey.GroupByParent`). The toggle SHALL be off by default on first load. The toggle's value SHALL be persisted across page reloads under the localStorage key `dashboard:entities-consumption:groupByParent` with values `'true'` / `'false'`; absence of the key SHALL be interpreted as `'false'`. The toggle SHALL be available only when the current route is `ApplicationRoute.Dashboard` — entity-scoped dashboards (Applications, Toolsets) SHALL NOT render the toggle and SHALL continue to use the flat view.
+
+#### Scenario: Default state on first ever load is flat
+
+- **GIVEN** a user with no value for `dashboard:entities-consumption:groupByParent` in localStorage
+- **WHEN** the user opens the Dashboard route
+- **THEN** the Entities Consumption section SHALL render in flat mode, identical to the current production behavior
+- **AND** the toggle SHALL render in the off position
+
+#### Scenario: Toggle on switches to tree mode and persists
+
+- **GIVEN** the user is viewing Entities Consumption in flat mode
+- **WHEN** the user activates the "Group by parent deployment" toggle
+- **THEN** the grid SHALL re-fetch using `ENTITY_CONSUMPTION_TREE_QUERY` (with `parent_deployment` in groupBy)
+- **AND** localStorage SHALL contain `dashboard:entities-consumption:groupByParent = 'true'`
+- **AND** the grid SHALL render as a tree with expand/collapse on parent rows
+
+#### Scenario: Toggle off returns to flat mode and persists
+
+- **GIVEN** the user is viewing Entities Consumption in tree mode
+- **WHEN** the user deactivates the toggle
+- **THEN** the grid SHALL re-fetch using `ENTITY_CONSUMPTION_QUERY` (groupBy `['deployment']` only)
+- **AND** localStorage SHALL contain `dashboard:entities-consumption:groupByParent = 'false'`
+- **AND** the grid SHALL render flat, identical to the default
+
+#### Scenario: Toggle preference applies on next visit
+
+- **GIVEN** the user previously enabled tree mode (localStorage value is `'true'`)
+- **WHEN** the user reloads the page or returns to the Dashboard route from another route
+- **THEN** the toggle SHALL render in the on position
+- **AND** the grid SHALL fetch using `ENTITY_CONSUMPTION_TREE_QUERY` on first load
+
+### Requirement: Tree-mode query groups by parent_deployment in addition to deployment
+
+When the toggle is on, the Entities Consumption section SHALL issue `ENTITY_CONSUMPTION_TREE_QUERY` to `getDashboardData`. The query SHALL be identical to `ENTITY_CONSUMPTION_QUERY` except that `expressions` SHALL additionally include `'parent_deployment'` and `groupBy` SHALL be `['deployment', 'parent_deployment']`. Numeric aggregates (`count()`, `sum(deployment_price) as money`, `sum(price) as aggregated_money`, `sum(prompt_tokens) as tokens_p`, `sum(completion_tokens) as tokens_c`) SHALL be unchanged. The `from` clause SHALL remain `ANALYTICS_TABLE_NAME`.
+
+#### Scenario: Tree query shape
+
+- **WHEN** tree mode is active
+- **THEN** the request payload to `getDashboardData` SHALL contain `query.expressions` including `'parent_deployment'` alongside the existing aggregates
+- **AND** `query.groupBy` SHALL equal `['deployment', 'parent_deployment']`
+
+#### Scenario: Flat query shape unchanged
+
+- **WHEN** flat mode is active
+- **THEN** the request payload SHALL match the existing `ENTITY_CONSUMPTION_QUERY` byte-for-byte (no `parent_deployment` in `expressions` or `groupBy`)
+
+### Requirement: Tree-mode rows are built from parent_deployment pointers and grouped per (deployment, caller) tuple
+
+When tree mode is active, the response rows from the server (one per (deployment, parent_deployment) tuple) SHALL be transformed into a tree by `buildTreeFromParentPointer` using `getId: r => r.deployment`, `getParentId: r => r.parent_deployment ?? null`, and `sumFields: ['count', 'money', 'aggregated_money', 'tokens_p', 'tokens_c']`. Empty-string `parent_deployment` values SHALL be normalized to `null` before tree construction (the backend may return either depending on the column NULL semantics). When a `parent_deployment` value references a deployment that has no row of its own in the response, a synthetic parent row SHALL be inserted with the sum of its descendants' metrics and `synthetic: true`.
+
+#### Scenario: Flat response with parent pointers becomes a two-level tree
+
+- **GIVEN** the server returns rows:
+    `{ deployment: 'chat-orch', parent_deployment: null, count: 50 }`,
+    `{ deployment: 'gpt-4-router', parent_deployment: 'chat-orch', count: 320 }`,
+    `{ deployment: 'claude-fb', parent_deployment: 'chat-orch', count: 180 }`,
+    `{ deployment: 'embed-pipe', parent_deployment: null, count: 90 }`
+- **WHEN** the tree is built
+- **THEN** the output SHALL contain two roots: `chat-orch` (depth 0, count 50, children: [`gpt-4-router`, `claude-fb`]) and `embed-pipe` (depth 0, count 90, no children)
+
+#### Scenario: Missing intermediate deployment is synthesized as a parent
+
+- **GIVEN** the server returns rows:
+    `{ deployment: 'gpt-4-router', parent_deployment: 'chat-orch', count: 320 }`,
+    `{ deployment: 'claude-fb', parent_deployment: 'chat-orch', count: 180 }`,
+    (no row for `chat-orch` itself)
+- **WHEN** the tree is built
+- **THEN** the output SHALL contain one synthetic root `chat-orch` with `synthetic: true`, `count: 500` (sum of its descendants)
+- **AND** `gpt-4-router` and `claude-fb` SHALL be children of that synthetic root
+
+#### Scenario: Empty parent_deployment value normalizes to null
+
+- **GIVEN** a server row `{ deployment: 'a', parent_deployment: '', count: 10 }`
+- **WHEN** the tree is built
+- **THEN** the row SHALL be treated as a root (parent normalized to `null`)
+- **AND** SHALL NOT be confused with a child whose parent id is the empty string
+
+#### Scenario: Same deployment called by multiple parents appears in multiple branches
+
+- **GIVEN** the server returns:
+    `{ deployment: 'gpt-4', parent_deployment: 'app-A', count: 100 }`,
+    `{ deployment: 'gpt-4', parent_deployment: 'app-B', count: 200 }`,
+    `{ deployment: 'app-A', parent_deployment: null, count: 0 }`,
+    `{ deployment: 'app-B', parent_deployment: null, count: 0 }`
+- **WHEN** the tree is built
+- **THEN** `gpt-4` SHALL appear once under `app-A` (count 100) and once under `app-B` (count 200)
+- **AND** the two appearances SHALL have distinct `id` values in the tree representation (composite of deployment + parent) so AG Grid's row identity is unique
+
+### Requirement: Rows display backend values as-is
+
+Each numeric column on every row (real or synthetic) SHALL display the value returned by the backend for that (deployment, parent) tuple verbatim — the frontend SHALL NOT compute subtree sums and SHALL NOT substitute zero-valued synthetic rows with descendant aggregates. Synthetic rows therefore display `0` in every numeric column, signaling that no backend data exists for that placeholder. The Name column SHALL display the deployment name followed by a `(+N)` suffix where N is the immediate child count, when N ≥ 1.
+
+#### Scenario: Direct-call parent shows direct backend count
+
+- **GIVEN** a row `chat-orch` with `count: 50` and two children with counts 320 and 180
+- **WHEN** the row renders
+- **THEN** the count column SHALL display `50`
+- **AND** the Name column SHALL display `chat-orch (+2)`
+
+#### Scenario: Synthetic parent shows zeros
+
+- **GIVEN** a synthetic `chat-orch` row with `count: 0` (placeholder for missing backend row) and two children
+- **WHEN** the row renders
+- **THEN** the count column SHALL display `0`
+- **AND** the Name column SHALL display `chat-orch (+2)` in italic typography
+
+#### Scenario: Leaf row shows direct aggregate with no suffix
+
+- **GIVEN** a row `gpt-4-router` at depth 1 with `count: 320` and no children
+- **WHEN** the row renders
+- **THEN** the count column SHALL display `320`
+- **AND** the Name column SHALL display `gpt-4-router` (no `(+N)` suffix, no italic)
+- **AND** numeric columns SHALL NOT carry the subtree-total or synthetic-parent tooltip
+
+### Requirement: Expanded state survives auto-refresh
+
+When `refreshTime` triggers an automatic refetch of the tree-mode query, the new response SHALL replace the previous tree, but rows whose `id` matches a previously-expanded row SHALL retain `expanded: true` after the rebuild. This SHALL hold even if intermediate rows have appeared or disappeared between refreshes. Rows present before but absent in the new response SHALL be dropped from the expanded-state map.
+
+#### Scenario: Refresh keeps previously expanded nodes open
+
+- **GIVEN** the user has expanded `chat-orch` in tree mode
+- **WHEN** the auto-refresh fires and the new response still contains a `chat-orch` row
+- **THEN** the rebuilt tree SHALL render with `chat-orch` already expanded
+- **AND** the user SHALL see no visible collapse-then-re-expand flicker
+
+#### Scenario: Refresh drops vanished rows from the expanded-state map
+
+- **GIVEN** the user previously expanded `chat-orch`, and the new response no longer contains any row with `deployment === 'chat-orch'`
+- **WHEN** the rebuild completes
+- **THEN** the expanded-state map SHALL no longer carry `chat-orch`
+- **AND** if `chat-orch` later reappears in a future refresh, it SHALL start collapsed (not silently restored)

--- a/openspec/specs/tree-grid/spec.md
+++ b/openspec/specs/tree-grid/spec.md
@@ -1,0 +1,147 @@
+# tree-grid Specification
+
+## Purpose
+
+Provide a domain-agnostic primitive for rendering flat row arrays (with parent-id pointers) as an expandable tree on top of the existing community-edition `GridView` / AG Grid integration. The primitive owns flattening, depth-first ordering, indent rendering, expander chevrons, synthetic-row styling, and the disabling of column sort/filter that would otherwise scatter children away from parents. Domain features (e.g., entities consumption, audit) consume this primitive and supply their own data transforms and column defs.
+
+## Requirements
+
+### Requirement: TreeGrid primitive renders flat rows with parent pointers as an expandable tree
+
+A generic `TreeGrid<T>` component SHALL live at `apps/ai-dial-admin/src/components/Common/TreeGrid/TreeGrid.tsx`. It SHALL accept a `TreeRow<T>[]` (where `TreeRow<T> = T & { id, parentId, depth, expanded, children: TreeRow<T>[], synthetic? }`), a `columnDefs: ColDef[]`, and an `expanderColumnField: keyof T` identifying which column receives the indent + caret renderer. It SHALL compose the existing `GridView` component without modifying it. The primitive SHALL NOT depend on AG Grid's enterprise `treeData` mode — flattening is hand-rolled to keep the codebase on the community edition and consistent with the existing audit and SchemaGrid tree implementations.
+
+The primitive SHALL be capability-agnostic: no knowledge of deployments, schemas, activities, telemetry, or any other domain concept. Domain knowledge lives in feature components that consume `TreeGrid`.
+
+#### Scenario: Component renders rows in depth-first flatten order honoring expanded state
+
+- **GIVEN** a tree with one root, two children of that root, and one grandchild under the first child, where all rows are `expanded: true`
+- **WHEN** the component renders
+- **THEN** AG Grid SHALL receive rows in the order [root, child-1, grandchild, child-2]
+
+#### Scenario: Collapsing a parent hides its descendants without removing them from the tree
+
+- **GIVEN** an expanded parent row with two children
+- **WHEN** the user clicks the expander chevron on the parent
+- **THEN** the parent's `expanded` flag SHALL flip to `false`
+- **AND** the flatten output SHALL contain only the parent
+- **AND** the tree data structure SHALL retain the children (re-expanding restores them without a refetch)
+
+#### Scenario: Indent depth matches row depth
+
+- **WHEN** a row at depth N is rendered
+- **THEN** the indent in the expander column SHALL be `N * 24` pixels of left padding (matching the spacing used by `SchemaGrid`)
+
+#### Scenario: Leaf rows render no chevron
+
+- **WHEN** a row has an empty `children` array
+- **THEN** no expander chevron SHALL render in the expander column
+- **AND** the indent SHALL still apply at `depth * 24` so leaves align with the cells of their siblings that have children
+
+#### Scenario: Synthetic rows render with italic name
+
+- **GIVEN** a `TreeRow<T>` with `synthetic: true`
+- **WHEN** the row is rendered
+- **THEN** the expander column value SHALL appear in italic typography
+- **AND** the chevron (if any) SHALL render in a disabled / muted style
+
+#### Scenario: TreeGrid strips column sort and disables sortable/filter on every column
+
+- **GIVEN** a `columnDefs` array where one or more columns declare `sort: 'desc'` (or `sort: 'asc'`), and where columns inherit `sortable: true` / `filter: 'agTextColumnFilter'` from `GridView`'s defaults
+- **WHEN** `TreeGrid` augments `columnDefs` before forwarding them to `GridView`
+- **THEN** every column SHALL have its `sort` property removed
+- **AND** every column SHALL have `sortable: false`
+- **AND** every column SHALL have `filter: false`
+- **AND** the rendered row order SHALL match `flattenTree` output exactly (parent immediately followed by its visible children), regardless of any sort/filter that was declared on the input column defs
+
+**Why:** tree row order IS the answer that `flattenTree` provides. Column sort would re-order the flat list and visually scatter children away from their parents on every `rowData` update (`AgGridWrapper`'s non-live path re-applies `defaultSorts` on each tick via `applyGridState`). Column filters would hide children but keep parents (and vice versa), breaking the tree just as badly. AG Grid Enterprise's `treeData` mode handles both natively, but Decision 4 deliberately does not use it.
+
+### Requirement: buildTreeFromParentPointer constructs a tree from flat rows with parent ids
+
+A pure utility `buildTreeFromParentPointer<T>(rows: T[], opts)` SHALL live at `apps/ai-dial-admin/src/components/Common/TreeGrid/utils.ts`. It SHALL take a flat array of source rows and an options object specifying `getId`, `getParentId`, and an optional `maxDepth` (default 8). It SHALL return a `TreeRow<T>[]` where each input row is wrapped with `id`, `parentId`, `depth`, `expanded: false`, and `children: TreeRow<T>[]`. If an input row carries a `synthetic: true` property it SHALL be propagated to the resulting `TreeRow<T>`.
+
+The function SHALL be pure: same inputs produce same outputs, no observable side effects beyond the cycle/depth-cap warnings.
+
+Synthesis of intermediate ancestors (when `parent_deployment` references a deployment with no own row) is the **consumer's** responsibility — see Decision 5. The primitive does NOT synthesize rows on its own; consumers pre-process their input array, append synthetic placeholder rows with `synthetic: true`, and pass the augmented array in.
+
+#### Scenario: Rows with null parent become roots
+
+- **GIVEN** input rows `[{ id: 'a', parent: null }, { id: 'b', parent: null }]`
+- **WHEN** `buildTreeFromParentPointer` runs
+- **THEN** both rows SHALL be returned as roots at depth 0
+- **AND** each SHALL have `children: []`
+
+#### Scenario: Rows with a parent id pointing into the set are nested
+
+- **GIVEN** input rows `[{ id: 'a', parent: null }, { id: 'b', parent: 'a' }, { id: 'c', parent: 'b' }]`
+- **WHEN** the builder runs
+- **THEN** the output SHALL contain one root `a` at depth 0 with one child `b` at depth 1, and `b` SHALL have one child `c` at depth 2
+
+#### Scenario: Input rows pre-flagged as synthetic propagate to the built tree
+
+- **GIVEN** input rows `[{ id: 'a', parent: null, synthetic: true }, { id: 'b', parent: 'a' }]`
+- **WHEN** the builder runs
+- **THEN** the resulting `TreeRow<T>` for `a` SHALL carry `synthetic: true`
+- **AND** the resulting `TreeRow<T>` for `b` SHALL NOT carry `synthetic`
+
+#### Scenario: Orphan row whose parent id is not in the input set becomes a root
+
+- **GIVEN** input rows `[{ id: 'b', parent: 'a' }]` (no row for `a`)
+- **WHEN** the builder runs
+- **THEN** `b` SHALL be returned as a root at depth 0 (the primitive does NOT synthesize a parent — consumers do that pre-processing if they want it)
+
+#### Scenario: Cycle detection drops the back-edge
+
+- **GIVEN** input rows `[{ id: 'a', parent: 'b' }, { id: 'b', parent: 'a' }]`
+- **WHEN** the builder runs
+- **THEN** the back-edge SHALL be dropped: one of the two rows SHALL become a root and the other SHALL be its child (deterministic by input order)
+- **AND** a single `console.warn` SHALL be emitted naming the cycle members
+- **AND** the builder SHALL NOT infinite-recurse
+
+#### Scenario: Depth cap flattens overflow at the cap depth
+
+- **GIVEN** a linear chain of 12 rows where each row's parent is the previous one
+- **WHEN** the builder runs with default `maxDepth: 8`
+- **THEN** rows at logical depth ≤ 7 SHALL nest normally
+- **AND** rows at logical depth ≥ 8 SHALL be siblings at depth 8 (no further nesting)
+- **AND** a single `console.warn` SHALL be emitted summarizing how many rows hit the cap
+
+### Requirement: flattenTree emits rows in depth-first order honoring expanded flags
+
+A pure utility `flattenTree<T>(rows: TreeRow<T>[]): TreeRow<T>[]` SHALL emit each input row followed by its descendants if and only if the row's `expanded` flag is `true`. Order SHALL be parent before children, siblings in array order. The function SHALL be pure: no mutation of input, no side effects.
+
+#### Scenario: Collapsed parent skips its subtree
+
+- **GIVEN** a tree `[{ id: 'a', expanded: false, children: [{ id: 'b' }] }]`
+- **WHEN** `flattenTree` runs
+- **THEN** the output SHALL be `[{ id: 'a' ... }]`
+- **AND** `b` SHALL NOT appear
+
+#### Scenario: Expanded parent emits its subtree before the next sibling
+
+- **GIVEN** a tree `[a (expanded, children: [b]), c]`
+- **WHEN** `flattenTree` runs
+- **THEN** the output order SHALL be `[a, b, c]`
+
+### Requirement: useTreeRows hook owns expanded-state and pushes flat rows to AG Grid
+
+A React hook `useTreeRows<T>(tree: TreeRow<T>[], opts?)` SHALL own the expanded-state map keyed by row id and the side-effect of pushing flat rows into the AG Grid api. It SHALL expose `{ flatRows, onToggleExpand, gridApiRef, onGridReady }`. Expanded-state SHALL survive tree reference changes (e.g., a refetch produces a new tree object with the same row ids).
+
+#### Scenario: Toggle on a row flips its expanded flag and re-pushes rows to the grid
+
+- **GIVEN** a mounted `useTreeRows` with a collapsed parent and ready `gridApiRef`
+- **WHEN** `onToggleExpand(parent)` is called
+- **THEN** the parent's `expanded` flag SHALL flip to `true`
+- **AND** the grid api SHALL receive a new `rowData` containing the parent followed by its children
+
+#### Scenario: Re-render with a new tree object preserves expanded state by id
+
+- **GIVEN** a `useTreeRows` where row `a` was previously toggled expanded
+- **WHEN** the parent component re-renders with a freshly built tree whose row `a` has `expanded: false` from `buildTreeFromParentPointer`
+- **THEN** the overlay step SHALL restore `expanded: true` for row `a` before flattening
+- **AND** the user SHALL see no flicker / no collapse of previously-expanded subtrees
+
+#### Scenario: Removed row id is dropped from the expanded-state map
+
+- **GIVEN** a `useTreeRows` where row `a` was expanded
+- **WHEN** a refetch returns a tree no longer containing row `a`
+- **THEN** subsequent renders SHALL NOT carry `a` in the expanded-state map (memory bound is the size of currently-visible rows, not historical rows)


### PR DESCRIPTION
**Description:**

Show entity consumption grid with tree (dependency) view for easy cost tracking

Issues:

- Issue #2559, #2710


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
