### PR TITLE
fix: [Eval > Runs] Compare mode shows asymmetric metric columns — metrics from the compared run are hidden when current run lacks them (Issue #3388)

### DIFF
--- a/apps/ai-dial-admin/src/components/Runs/Details/BottomDrawer/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/Runs/Details/BottomDrawer/tests/utils.spec.ts
@@ -246,9 +246,9 @@ describe('buildComparisonSections', () => {
     expect(configSection.rows[0].values[0].raw).toBe('[Constant]');
   });
 
-  it('repeats binding values in both columns when two results', () => {
-    const active = makeResult({ id: 'a' });
-    const pinned = makeResult({ id: 'b' });
+  it('repeats binding values in both columns when both runs have the metric', () => {
+    const active = makeResult({ id: 'a', metricValues: { myMetric: { score: 1 } } });
+    const pinned = makeResult({ id: 'b', metricValues: { myMetric: { score: 0.8 } } });
     const metricBindings: Record<string, MetricBindings> = {
       myMetric: {
         configBindings: [{ property: 'model', source: { $type: 'Constant', value: 'gpt-4' } }],
@@ -268,6 +268,60 @@ describe('buildComparisonSections', () => {
     expect(configSection.rows[0].values).toHaveLength(2);
     expect(configSection.rows[0].values[0].raw).toBe('[Constant] gpt-4');
     expect(configSection.rows[0].values[1].raw).toBe('[Constant] gpt-4');
+  });
+
+  it('shows null for compared binding column when compared run lacks the metric', () => {
+    const active = makeResult({ id: 'a', metricValues: { myMetric: { score: 1 } } });
+    const pinned = makeResult({ id: 'b', metricValues: {} });
+    const metricBindings: Record<string, MetricBindings> = {
+      myMetric: {
+        configBindings: [{ property: 'model', source: { $type: 'Constant', value: 'gpt-4' } }],
+        inputBindings: [{ property: 'actual', source: { $type: 'Response', columnName: 'answer' } }],
+      },
+    };
+    const sections = buildComparisonSections(
+      active,
+      pinned,
+      defaultVisibility,
+      defaultOrder,
+      defaultHidden,
+      metricBindings,
+    );
+
+    const configSection = sections.find((s) => s.key === 'binding:config:myMetric')!;
+    expect(configSection.rows[0].values[0].raw).toBe('[Constant] gpt-4');
+    expect(configSection.rows[0].values[1].raw).toBeNull();
+
+    const inputSection = sections.find((s) => s.key === 'binding:input:myMetric')!;
+    expect(inputSection.rows[0].values[0].raw).toBe('[Response] answer');
+    expect(inputSection.rows[0].values[1].raw).toBeNull();
+  });
+
+  it('shows null for current binding column when current run lacks the metric', () => {
+    const active = makeResult({ id: 'a', metricValues: {} });
+    const pinned = makeResult({ id: 'b', metricValues: { myMetric: { score: 0.9 } } });
+    const metricBindings: Record<string, MetricBindings> = {
+      myMetric: {
+        configBindings: [{ property: 'model', source: { $type: 'Constant', value: 'gpt-4' } }],
+        inputBindings: [{ property: 'actual', source: { $type: 'Response', columnName: 'answer' } }],
+      },
+    };
+    const sections = buildComparisonSections(
+      active,
+      pinned,
+      defaultVisibility,
+      defaultOrder,
+      defaultHidden,
+      metricBindings,
+    );
+
+    const configSection = sections.find((s) => s.key === 'binding:config:myMetric')!;
+    expect(configSection.rows[0].values[0].raw).toBeNull();
+    expect(configSection.rows[0].values[1].raw).toBe('[Constant] gpt-4');
+
+    const inputSection = sections.find((s) => s.key === 'binding:input:myMetric')!;
+    expect(inputSection.rows[0].values[0].raw).toBeNull();
+    expect(inputSection.rows[0].values[1].raw).toBe('[Response] answer');
   });
 
   it('does not add binding sections when metricBindings is undefined', () => {

--- a/apps/ai-dial-admin/src/components/Runs/Details/BottomDrawer/utils.ts
+++ b/apps/ai-dial-admin/src/components/Runs/Details/BottomDrawer/utils.ts
@@ -141,6 +141,9 @@ export function buildComparisonSections(
   // Binding sections (config and input) per metric group
   if (metricBindings) {
     for (const [groupKey, bindings] of Object.entries(metricBindings).sort(([a], [b]) => a.localeCompare(b))) {
+      const activeHasMetric = active.metricValues?.[groupKey] != null;
+      const pinnedHasMetric = effectivePinned?.metricValues?.[groupKey] != null;
+
       if (bindings.configBindings.length > 0) {
         const sectionKey = `binding:config:${groupKey}`;
         const rows: ComparisonRow[] = bindings.configBindings.map((binding) => ({
@@ -148,7 +151,10 @@ export function buildComparisonSections(
           label: binding.property,
           isNumeric: false,
           values: hasTwoResults
-            ? [{ raw: formatBindingValue(binding) }, { raw: formatBindingValue(binding) }]
+            ? [
+                { raw: activeHasMetric ? formatBindingValue(binding) : null },
+                { raw: pinnedHasMetric ? formatBindingValue(binding) : null },
+              ]
             : [{ raw: formatBindingValue(binding) }],
         }));
         sectionsMap.set(sectionKey, { key: sectionKey, label: `${groupKey} · Config bindings`, rows });
@@ -161,7 +167,10 @@ export function buildComparisonSections(
           label: binding.property,
           isNumeric: false,
           values: hasTwoResults
-            ? [{ raw: formatBindingValue(binding) }, { raw: formatBindingValue(binding) }]
+            ? [
+                { raw: activeHasMetric ? formatBindingValue(binding) : null },
+                { raw: pinnedHasMetric ? formatBindingValue(binding) : null },
+              ]
             : [{ raw: formatBindingValue(binding) }],
         }));
         sectionsMap.set(sectionKey, { key: sectionKey, label: `${groupKey} · Input bindings`, rows });

--- a/apps/ai-dial-admin/src/components/Runs/View/Analytics.tsx
+++ b/apps/ai-dial-admin/src/components/Runs/View/Analytics.tsx
@@ -49,7 +49,13 @@ interface Props {
 const AnalyticsTab: FC<Props> = ({ run }) => {
   const t = useI18n();
   const [snapshots, setSnapshots] = useState<MetricSnapshot[]>([]);
+  const [comparedSnapshots, setComparedSnapshots] = useState<MetricSnapshot[]>([]);
   const metricBindings = useMemo(() => snapshotsToBindingsMap(snapshots), [snapshots]);
+  const comparedMetricBindings = useMemo(() => snapshotsToBindingsMap(comparedSnapshots), [comparedSnapshots]);
+  const mergedMetricBindings = useMemo(
+    () => ({ ...comparedMetricBindings, ...metricBindings }),
+    [comparedMetricBindings, metricBindings],
+  );
   const detailMode = useDetailMode(metricBindings);
   const drawerPanel = useDrawerPanel();
 
@@ -108,15 +114,17 @@ const AnalyticsTab: FC<Props> = ({ run }) => {
   useEffect(() => {
     if (!comparedRunId) {
       setComparedResults(null);
+      setComparedSnapshots([]);
       return;
     }
     const comparedRun = siblingRuns.find((r) => r.id === comparedRunId);
     if (!comparedRun) return;
 
     setIsCompareLoading(true);
-    getTestCaseRunResults(RESULT_FILTERS(comparedRun))
-      .then((res) => {
+    Promise.all([getTestCaseRunResults(RESULT_FILTERS(comparedRun)), getMetricSnapshots(RUN_FILTER(comparedRunId))])
+      .then(([res, snapData]) => {
         setComparedResults(res?.content || []);
+        setComparedSnapshots(snapData || []);
       })
       .finally(() => {
         setIsCompareLoading(false);
@@ -344,7 +352,7 @@ const AnalyticsTab: FC<Props> = ({ run }) => {
           onClose={onDrawerClose}
           onSwitchToSidebar={detailMode.switchToSidebar}
           runCompareNames={runCompareNames}
-          metricBindings={metricBindings}
+          metricBindings={isCompareMode ? mergedMetricBindings : metricBindings}
         />
       )}
       <ColorScale />

--- a/apps/ai-dial-admin/src/components/Runs/View/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/Runs/View/tests/utils.spec.ts
@@ -581,7 +581,7 @@ describe('Runs View :: getAnalyticsColumnsCompare', () => {
     expect(blank.children).toHaveLength(2);
   });
 
-  test('EXECUTION group has field sub-groups each with Current and Compared leaves', () => {
+  test('EXECUTION group has field sub-groups each with Current and Compared leaves, without runIndex', () => {
     const cols = getAnalyticsColumnsCompare([makeRow()]);
     const exec = cols[1] as {
       headerName: string;
@@ -589,10 +589,9 @@ describe('Runs View :: getAnalyticsColumnsCompare', () => {
     };
 
     expect(exec.headerName).toBe('EXECUTION');
-    expect(exec.children).toHaveLength(3);
-    expect(exec.children[0].headerName).toBe('#');
-    expect(exec.children[1].headerName).toBe('HTTP');
-    expect(exec.children[2].headerName).toBe('Duration');
+    expect(exec.children).toHaveLength(2);
+    expect(exec.children[0].headerName).toBe('HTTP');
+    expect(exec.children[1].headerName).toBe('Duration');
 
     for (const fieldGroup of exec.children) {
       expect(fieldGroup.children).toHaveLength(2);
@@ -655,6 +654,24 @@ describe('Runs View :: getAnalyticsColumnsCompare', () => {
     // Each field key sub-group's second child is the Compared leaf
     const comparedLeaves = extracted.children.map((keyGroup) => keyGroup.children[1]);
     expect(comparedLeaves.every((c) => c.colId?.startsWith('cmp_extracted_'))).toBe(true);
+  });
+
+  test('includes metric columns that exist only in compared run', () => {
+    const rows = [
+      makeRow({
+        metricValues: undefined,
+        _compared: makeResult({ metricValues: { comparedOnly: { precision: 0.7 } } }),
+      }),
+    ];
+    const cols = getAnalyticsColumnsCompare(rows);
+
+    const comparedOnlyGroup = cols.find((c) => (c as { headerName: string }).headerName === 'comparedOnly') as {
+      children: { headerName: string; children: { headerName: string }[] }[];
+    };
+
+    expect(comparedOnlyGroup).toBeDefined();
+    expect(comparedOnlyGroup.children).toHaveLength(1);
+    expect(comparedOnlyGroup.children[0].headerName).toBe('precision');
   });
 
   test('Compared valueGetters return dash when _compared is null', () => {

--- a/apps/ai-dial-admin/src/components/Runs/View/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/Runs/View/tests/utils.spec.ts
@@ -675,10 +675,7 @@ describe('Runs View :: getAnalyticsColumnsCompare', () => {
   });
 
   test('includes INPUT BINDINGS columns from all rows, not only first row', () => {
-    const rows = [
-      makeRow({ testCaseData: { key1: 'a' } }),
-      makeRow({ testCaseData: { key2: 'b' } }),
-    ];
+    const rows = [makeRow({ testCaseData: { key1: 'a' } }), makeRow({ testCaseData: { key2: 'b' } })];
     const cols = getAnalyticsColumnsCompare(rows);
 
     const bindings = cols.find((c) => (c as { headerName: string }).headerName === 'INPUT BINDINGS') as {
@@ -709,10 +706,7 @@ describe('Runs View :: getAnalyticsColumnsCompare', () => {
   });
 
   test('includes EXTRACTED columns from all rows, not only first row', () => {
-    const rows = [
-      makeRow({ extractedColumns: { col1: 'a' } }),
-      makeRow({ extractedColumns: { col2: 'b' } }),
-    ];
+    const rows = [makeRow({ extractedColumns: { col1: 'a' } }), makeRow({ extractedColumns: { col2: 'b' } })];
     const cols = getAnalyticsColumnsCompare(rows);
 
     const extracted = cols.find((c) => (c as { headerName: string }).headerName === 'EXTRACTED') as {

--- a/apps/ai-dial-admin/src/components/Runs/View/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/Runs/View/tests/utils.spec.ts
@@ -656,6 +656,74 @@ describe('Runs View :: getAnalyticsColumnsCompare', () => {
     expect(comparedLeaves.every((c) => c.colId?.startsWith('cmp_extracted_'))).toBe(true);
   });
 
+  test('includes INPUT BINDINGS columns that exist only in compared run', () => {
+    const rows = [
+      makeRow({
+        testCaseData: undefined,
+        _compared: makeResult({ testCaseData: { comparedKey: 'val' } }),
+      }),
+    ];
+    const cols = getAnalyticsColumnsCompare(rows);
+
+    const bindings = cols.find((c) => (c as { headerName: string }).headerName === 'INPUT BINDINGS') as {
+      children: { headerName: string; children: { headerName: string }[] }[];
+    };
+
+    expect(bindings).toBeDefined();
+    expect(bindings.children).toHaveLength(1);
+    expect(bindings.children[0].headerName).toBe('comparedKey');
+  });
+
+  test('includes INPUT BINDINGS columns from all rows, not only first row', () => {
+    const rows = [
+      makeRow({ testCaseData: { key1: 'a' } }),
+      makeRow({ testCaseData: { key2: 'b' } }),
+    ];
+    const cols = getAnalyticsColumnsCompare(rows);
+
+    const bindings = cols.find((c) => (c as { headerName: string }).headerName === 'INPUT BINDINGS') as {
+      children: { headerName: string }[];
+    };
+
+    const keys = bindings.children.map((c) => c.headerName);
+    expect(keys).toContain('key1');
+    expect(keys).toContain('key2');
+  });
+
+  test('includes EXTRACTED columns that exist only in compared run', () => {
+    const rows = [
+      makeRow({
+        extractedColumns: undefined,
+        _compared: makeResult({ extractedColumns: { comparedCol: 'v' } }),
+      }),
+    ];
+    const cols = getAnalyticsColumnsCompare(rows);
+
+    const extracted = cols.find((c) => (c as { headerName: string }).headerName === 'EXTRACTED') as {
+      children: { headerName: string; children: { headerName: string }[] }[];
+    };
+
+    expect(extracted).toBeDefined();
+    expect(extracted.children).toHaveLength(1);
+    expect(extracted.children[0].headerName).toBe('comparedCol');
+  });
+
+  test('includes EXTRACTED columns from all rows, not only first row', () => {
+    const rows = [
+      makeRow({ extractedColumns: { col1: 'a' } }),
+      makeRow({ extractedColumns: { col2: 'b' } }),
+    ];
+    const cols = getAnalyticsColumnsCompare(rows);
+
+    const extracted = cols.find((c) => (c as { headerName: string }).headerName === 'EXTRACTED') as {
+      children: { headerName: string }[];
+    };
+
+    const keys = extracted.children.map((c) => c.headerName);
+    expect(keys).toContain('col1');
+    expect(keys).toContain('col2');
+  });
+
   test('includes metric columns that exist only in compared run', () => {
     const rows = [
       makeRow({

--- a/apps/ai-dial-admin/src/components/Runs/View/utils.ts
+++ b/apps/ai-dial-admin/src/components/Runs/View/utils.ts
@@ -315,12 +315,14 @@ const buildMetricColDef = (
 export const getAnalyticsColumnsCompare = (results: CompareAnalyticsRow[], errorText?: string) => {
   const allResults: AnalyticsResult[] = [...results, ...results.flatMap((r) => (r._compared ? [r._compared] : []))];
   const metrics = mergeMetricValuesSchema(allResults);
-  const currentInput = results[0]?.testCaseData || {};
-  const comparedInput = results[0]?._compared?.testCaseData || {};
-  const inputSchema = { ...currentInput, ...comparedInput };
-  const currentExtracted = results[0]?.extractedColumns || {};
-  const comparedExtracted = results[0]?._compared?.extractedColumns || {};
-  const extractedSchema = { ...currentExtracted, ...comparedExtracted };
+  const inputSchema = allResults.reduce<Record<string, unknown>>(
+    (acc, r) => ({ ...acc, ...(r.testCaseData || {}) }),
+    {},
+  );
+  const extractedSchema = allResults.reduce<Record<string, unknown>>(
+    (acc, r) => ({ ...acc, ...(r.extractedColumns || {}) }),
+    {},
+  );
 
   return [
     staticColumns[0],

--- a/apps/ai-dial-admin/src/components/Runs/View/utils.ts
+++ b/apps/ai-dial-admin/src/components/Runs/View/utils.ts
@@ -313,7 +313,8 @@ const buildMetricColDef = (
 };
 
 export const getAnalyticsColumnsCompare = (results: CompareAnalyticsRow[], errorText?: string) => {
-  const metrics = mergeMetricValuesSchema(results);
+  const allResults: AnalyticsResult[] = [...results, ...results.flatMap((r) => (r._compared ? [r._compared] : []))];
+  const metrics = mergeMetricValuesSchema(allResults);
   const currentInput = results[0]?.testCaseData || {};
   const comparedInput = results[0]?._compared?.testCaseData || {};
   const inputSchema = { ...currentInput, ...comparedInput };
@@ -325,13 +326,18 @@ export const getAnalyticsColumnsCompare = (results: CompareAnalyticsRow[], error
     staticColumns[0],
     {
       headerName: 'EXECUTION',
-      children: executionColumns.map((curr, i) => ({
-        headerName: curr.headerName,
-        children: [
-          { ...curr, headerName: 'Current' },
-          { ...comparedExecutionColumns[i], headerName: 'Compared' },
-        ],
-      })),
+      children: executionColumns
+        .filter((col) => col.colId !== 'runIndex')
+        .map((curr) => {
+          const cmpCol = comparedExecutionColumns.find((c) => c.colId === `cmp_${curr.colId}`);
+          return {
+            headerName: curr.headerName,
+            children: [
+              { ...curr, headerName: 'Current' },
+              { ...cmpCol, headerName: 'Compared' },
+            ],
+          };
+        }),
     },
     ...getComparedMetricsColumns(metrics, errorText),
     {


### PR DESCRIPTION
**Description:**

show all value for both runs

Issues:

- Issue #3388


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
