### PR TITLE
fix: incorrect checkbox sync in Assets/Applications (Issue #3311)

### DIFF
--- a/apps/ai-dial-admin/src/components/SourceField/Application/EndpointAndMCPContainer.tsx
+++ b/apps/ai-dial-admin/src/components/SourceField/Application/EndpointAndMCPContainer.tsx
@@ -32,6 +32,12 @@ export interface Props {
   isModal?: boolean;
 }
 
+const getCheckboxStatesFromEntity = (entity: DialApplicationScheme): Record<SourceType, boolean> => ({
+  [SourceType.CHAT_ENDPOINT]:
+    !!entity?.['dial:applicationTypeCompletionEndpoint'] || !entity?.['dial:applicationTypeMcp'],
+  [SourceType.MCP_ENDPOINT]: !!entity?.['dial:applicationTypeMcp'],
+});
+
 const EndpointAndMCPContainer: FC<Props> = ({
   entity,
   onChangeEntity,
@@ -39,22 +45,17 @@ const EndpointAndMCPContainer: FC<Props> = ({
   isReadOnlyAdmin,
   isModal,
 }) => {
-  const [checkboxStates, setCheckboxStates] = useState<Record<SourceType, boolean>>(() => ({
-    [SourceType.CHAT_ENDPOINT]:
-      !!entity?.['dial:applicationTypeCompletionEndpoint'] || !entity?.['dial:applicationTypeMcp'],
-    [SourceType.MCP_ENDPOINT]: !!entity?.['dial:applicationTypeMcp'],
-  }));
+  const entityKey = entity.$id ?? '';
+  const [checkboxStates, setCheckboxStates] = useState<Record<SourceType, boolean>>(() =>
+    getCheckboxStatesFromEntity(entity),
+  );
 
   const t = useI18n();
 
   useEffect(() => {
-    const isEndpointExisting = !!entity?.['dial:applicationTypeCompletionEndpoint'];
-    const isMCPContainerExisting = !!entity?.['dial:applicationTypeMcp'];
-    setCheckboxStates((prev) => ({
-      [SourceType.CHAT_ENDPOINT]: prev[SourceType.CHAT_ENDPOINT] || isEndpointExisting,
-      [SourceType.MCP_ENDPOINT]: prev[SourceType.MCP_ENDPOINT] || isMCPContainerExisting,
-    }));
-  }, [entity]);
+    setCheckboxStates(getCheckboxStatesFromEntity(entity));
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- reset only when runner identity changes, not on every field edit
+  }, [entityKey]);
 
   const toggleCheckbox = useCallback(
     (value?: boolean, id?: string) => {

--- a/apps/ai-dial-admin/src/components/SourceField/Endpoints/ApplicationEndpoint.tsx
+++ b/apps/ai-dial-admin/src/components/SourceField/Endpoints/ApplicationEndpoint.tsx
@@ -33,28 +33,30 @@ interface Props {
   prefix?: string;
 }
 
+const getCheckboxStatesFromEntity = (
+  entity: DialApplication,
+  isContainerMode: boolean,
+): Record<ApplicationEndpointCheckbox, boolean> => ({
+  [ApplicationEndpointCheckbox.CHAT_ENDPOINT]: isContainerMode ? true : !!entity?.endpoint || !entity?.mcp,
+  [ApplicationEndpointCheckbox.MCP_ENDPOINT]: isContainerMode
+    ? !!(entity?.source?.mcpEndpointPath || entity?.mcp)
+    : !!entity?.mcp,
+});
+
 const ApplicationEndpoint: FC<Props> = ({ entity, onChange, isEntityImmutable, isModal, disabled, prefix }) => {
   const t = useI18n();
   const isContainerMode = !!prefix;
+  const versionKey = `${(entity as { path?: string }).path ?? ''}@${(entity as { version?: string }).version ?? ''}`;
 
-  const [checkboxStates, setCheckboxStates] = useState<Record<ApplicationEndpointCheckbox, boolean>>(() => ({
-    [ApplicationEndpointCheckbox.CHAT_ENDPOINT]: isContainerMode ? true : !!entity?.endpoint || !entity?.mcp,
-    [ApplicationEndpointCheckbox.MCP_ENDPOINT]: isContainerMode
-      ? !!(entity?.source?.mcpEndpointPath || entity?.mcp)
-      : !!entity?.mcp,
-  }));
+  const [checkboxStates, setCheckboxStates] = useState<Record<ApplicationEndpointCheckbox, boolean>>(() =>
+    getCheckboxStatesFromEntity(entity, isContainerMode),
+  );
 
   useEffect(() => {
     if (isContainerMode) return;
-    const isEndpointExisting = !!entity?.endpoint;
-    const isMCPContainerExisting = !!entity?.mcp;
-    setCheckboxStates((prev) => ({
-      [ApplicationEndpointCheckbox.CHAT_ENDPOINT]:
-        prev[ApplicationEndpointCheckbox.CHAT_ENDPOINT] || isEndpointExisting,
-      [ApplicationEndpointCheckbox.MCP_ENDPOINT]:
-        prev[ApplicationEndpointCheckbox.MCP_ENDPOINT] || isMCPContainerExisting,
-    }));
-  }, [entity, isContainerMode]);
+    setCheckboxStates(getCheckboxStatesFromEntity(entity, isContainerMode));
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- reset only when asset version/path changes, not on every field edit
+  }, [versionKey, isContainerMode]);
 
   const toggleCheckbox = useCallback(
     (value?: boolean, id?: string) => {

--- a/apps/ai-dial-admin/src/components/SourceField/Endpoints/tests/ApplicationEndpoint.spec.tsx
+++ b/apps/ai-dial-admin/src/components/SourceField/Endpoints/tests/ApplicationEndpoint.spec.tsx
@@ -105,7 +105,7 @@ vi.mock('@/src/components/Common/ComplexInput/ComplexInput', () => ({
   ),
 }));
 
-const makeEntity = (fields: Partial<DialApplication> = {}): DialApplication =>
+const makeEntity = (fields: Partial<DialApplication & { version?: string; path?: string }> = {}): DialApplication =>
   ({
     name: 'test-app',
     displayName: 'Test App',
@@ -212,6 +212,26 @@ describe('ApplicationEndpoint', () => {
     rerender(<ApplicationEndpoint entity={makeEntity()} onChange={vi.fn()} isEntityImmutable />);
     expect(screen.getByTestId('viewer-url')).toBeInTheDocument();
     expect(screen.getByTestId('editor-url')).toBeInTheDocument();
+  });
+
+  test('chat checkbox resets when switching to another version without chat endpoint', () => {
+    const v1 = makeEntity({ version: '1.0.0', mcp: { endpoint: 'https://mcp.example.com' } });
+    const { rerender } = render(<ApplicationEndpoint entity={v1} onChange={vi.fn()} />);
+
+    const chatCheckbox = screen.getByTestId('checkbox-chat_endpoint') as HTMLInputElement;
+    expect(chatCheckbox.checked).toBe(false);
+
+    fireEvent.click(chatCheckbox);
+    expect(chatCheckbox.checked).toBe(true);
+
+    const v2 = makeEntity({
+      version: '2.0.0',
+      path: 'folder/app__2.0.0',
+      mcp: { endpoint: 'https://mcp.example.com' },
+    });
+    rerender(<ApplicationEndpoint entity={v2} onChange={vi.fn()} />);
+
+    expect((screen.getByTestId('checkbox-chat_endpoint') as HTMLInputElement).checked).toBe(false);
   });
 
   test('ViewerUrl writes to entity.viewerUrl; EditorUrl writes to entity.editorUrl', () => {


### PR DESCRIPTION
… versions

**Description:**

[Assets --> Applications] Checkbox state for "Chat Endpoint" and "MCP Endpoint" is incorrectly synced between different versions

Issues:

- Issue #3311


**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
