### PR TITLE
fix: [Eval > Runs] In comparison mode, CONFIG BINDINGS and INPUT BINDINGS of the compared run always show values from the current run (Issue #3407)

### DIFF
--- a/apps/ai-dial-admin/src/components/Runs/Details/BottomDrawer/AnalyticsBottomDrawer.tsx
+++ b/apps/ai-dial-admin/src/components/Runs/Details/BottomDrawer/AnalyticsBottomDrawer.tsx
@@ -31,6 +31,7 @@ interface Props {
   onSwitchToSidebar: () => void;
   runCompareNames?: { current: string; compared: string };
   metricBindings?: Record<string, MetricBindings>;
+  comparedMetricBindings?: Record<string, MetricBindings>;
 }
 
 const AnalyticsBottomDrawer: FC<Props> = ({
@@ -41,6 +42,7 @@ const AnalyticsBottomDrawer: FC<Props> = ({
   onSwitchToSidebar,
   runCompareNames,
   metricBindings,
+  comparedMetricBindings,
 }) => {
   const t = useI18n();
   const [activeDetail, setActiveDetail] = useState<AnalyticsResult | null>(null);
@@ -92,8 +94,8 @@ const AnalyticsBottomDrawer: FC<Props> = ({
   // Build comparison sections
   const sections = useMemo(() => {
     if (!activeDetail) return [];
-    return buildComparisonSections(activeDetail, pinnedDetail, {}, [], {}, metricBindings);
-  }, [activeDetail, pinnedDetail, metricBindings]);
+    return buildComparisonSections(activeDetail, pinnedDetail, {}, [], {}, metricBindings, comparedMetricBindings);
+  }, [activeDetail, pinnedDetail, metricBindings, comparedMetricBindings]);
 
   const fieldSelector = useFieldSelector(sections);
 
@@ -107,6 +109,7 @@ const AnalyticsBottomDrawer: FC<Props> = ({
       fieldSelector.sectionOrder,
       fieldSelector.sectionHidden,
       metricBindings,
+      comparedMetricBindings,
     );
   }, [
     activeDetail,
@@ -115,6 +118,7 @@ const AnalyticsBottomDrawer: FC<Props> = ({
     fieldSelector.sectionOrder,
     fieldSelector.sectionHidden,
     metricBindings,
+    comparedMetricBindings,
   ]);
 
   // Init section order when sections change

--- a/apps/ai-dial-admin/src/components/Runs/Details/BottomDrawer/CellValue.tsx
+++ b/apps/ai-dial-admin/src/components/Runs/Details/BottomDrawer/CellValue.tsx
@@ -2,7 +2,10 @@
 
 import { FC } from 'react';
 
-import { ButtonsI18nKey } from '@/src/constants/i18n';
+import { DialTooltip } from '@epam/ai-dial-ui-kit';
+import { IconExclamationCircle } from '@tabler/icons-react';
+
+import { ButtonsI18nKey, RunsI18nKey } from '@/src/constants/i18n';
 import { useI18n } from '@/src/locales/client';
 
 const PREVIEW_LENGTH = 200;
@@ -10,15 +13,23 @@ const PREVIEW_LENGTH = 200;
 interface Props {
   text: string;
   raw: string | null;
+  isFailed?: boolean;
   isLong: boolean;
   isExpanded: boolean;
   cellKey: string;
   onToggleExpand: (key: string) => void;
 }
 
-const CellValue: FC<Props> = ({ text, raw, isLong, isExpanded, cellKey, onToggleExpand }) => {
+const CellValue: FC<Props> = ({ text, raw, isFailed, isLong, isExpanded, cellKey, onToggleExpand }) => {
   const t = useI18n();
   if (raw === null) {
+    if (isFailed) {
+      return (
+        <DialTooltip tooltip={t(RunsI18nKey.MetricFailedText)}>
+          <IconExclamationCircle size={14} className="text-error" />
+        </DialTooltip>
+      );
+    }
     return <span className="dial-tiny-text text-secondary">—</span>;
   }
 

--- a/apps/ai-dial-admin/src/components/Runs/Details/BottomDrawer/ComparisonPivotView.tsx
+++ b/apps/ai-dial-admin/src/components/Runs/Details/BottomDrawer/ComparisonPivotView.tsx
@@ -4,6 +4,9 @@ import { FC, useCallback, useMemo, useState } from 'react';
 
 import { CellClickedEvent, ColDef, ColGroupDef, ICellRendererParams } from 'ag-grid-community';
 
+import { DialTooltip } from '@epam/ai-dial-ui-kit';
+import { IconExclamationCircle } from '@tabler/icons-react';
+
 import AgGridWrapper from '@/src/components/Grid/AgGridWrapper';
 import { RunsI18nKey } from '@/src/constants/i18n';
 import { useI18n } from '@/src/locales/client';
@@ -44,6 +47,7 @@ interface PivotRow {
 
 interface FieldValueCell {
   raw: string | null;
+  isFailed: boolean;
   diffClass: string;
 }
 
@@ -61,13 +65,21 @@ const TestCaseCellRenderer: FC<ICellRendererParams<PivotRow>> = (params) => {
 
 // ── Cell renderer for field value columns ───────────────────────────────────
 const FieldValueCellRenderer: FC<ICellRendererParams<PivotRow>> = (params) => {
+  const t = useI18n();
   const cell = params.value as FieldValueCell | undefined;
   if (!cell) return <span className="dial-caption-text text-secondary">—</span>;
 
-  const { raw } = cell;
+  const { raw, isFailed } = cell;
   const displayText = formatFieldValue(raw);
 
   if (raw === null) {
+    if (isFailed) {
+      return (
+        <DialTooltip tooltip={t(RunsI18nKey.MetricFailedText)}>
+          <IconExclamationCircle size={14} className="text-error" />
+        </DialTooltip>
+      );
+    }
     return <span className="dial-caption-text text-secondary">—</span>;
   }
   if (raw.includes('\n') || raw.length > 100) {
@@ -132,17 +144,20 @@ const ComparisonPivotView: FC<Props> = ({
       for (const field of flatFields) {
         const val = field.values[rowIdx];
         const raw = val?.raw ?? null;
+        const isFailed = val?.isFailed ?? false;
 
         // Diff highlighting on compared row (pinned)
         let diffClass = '';
         if (hasTwoRows && isPinnedRow && field.values.length >= 2) {
-          const currentRaw = field.values[0]?.raw ?? null;
-          if (!valuesAreEqual(currentRaw, raw)) {
+          const currentVal = field.values[0];
+          const currentRaw = currentVal?.raw ?? null;
+          const currentFailed = currentVal?.isFailed ?? false;
+          if (currentFailed !== isFailed || !valuesAreEqual(currentRaw, raw)) {
             diffClass = field.isNumeric ? 'bg-warning' : 'bg-accent-secondary-alpha';
           }
         }
 
-        row[field.fullKey] = { raw, diffClass } satisfies FieldValueCell;
+        row[field.fullKey] = { raw, isFailed, diffClass } satisfies FieldValueCell;
       }
 
       return row;

--- a/apps/ai-dial-admin/src/components/Runs/Details/BottomDrawer/SectionGroup.tsx
+++ b/apps/ai-dial-admin/src/components/Runs/Details/BottomDrawer/SectionGroup.tsx
@@ -101,6 +101,7 @@ const SectionGroup: FC<Props> = ({
                     <CellValue
                       text={displayText}
                       raw={raw}
+                      isFailed={val.isFailed}
                       isLong={isLong}
                       isExpanded={isExpanded}
                       cellKey={cellKey}

--- a/apps/ai-dial-admin/src/components/Runs/Details/BottomDrawer/models.ts
+++ b/apps/ai-dial-admin/src/components/Runs/Details/BottomDrawer/models.ts
@@ -9,6 +9,8 @@ export enum DetailMode {
 
 export interface CellValue {
   raw: string | null;
+  /** true = metric was evaluated but produced null (failed); false/undefined = not evaluated or has a value */
+  isFailed?: boolean;
 }
 
 export interface ComparisonRow {

--- a/apps/ai-dial-admin/src/components/Runs/Details/BottomDrawer/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/Runs/Details/BottomDrawer/tests/utils.spec.ts
@@ -246,12 +246,18 @@ describe('buildComparisonSections', () => {
     expect(configSection.rows[0].values[0].raw).toBe('[Constant]');
   });
 
-  it('repeats binding values in both columns when both runs have the metric', () => {
+  it("shows each run's own binding value in its column when both runs have the metric", () => {
     const active = makeResult({ id: 'a', metricValues: { myMetric: { score: 1 } } });
     const pinned = makeResult({ id: 'b', metricValues: { myMetric: { score: 0.8 } } });
-    const metricBindings: Record<string, MetricBindings> = {
+    const activeBindings: Record<string, MetricBindings> = {
       myMetric: {
         configBindings: [{ property: 'model', source: { $type: 'Constant', value: 'gpt-4' } }],
+        inputBindings: [],
+      },
+    };
+    const pinnedBindings: Record<string, MetricBindings> = {
+      myMetric: {
+        configBindings: [{ property: 'model', source: { $type: 'Constant', value: 'gpt-3.5' } }],
         inputBindings: [],
       },
     };
@@ -261,13 +267,14 @@ describe('buildComparisonSections', () => {
       defaultVisibility,
       defaultOrder,
       defaultHidden,
-      metricBindings,
+      activeBindings,
+      pinnedBindings,
     );
 
     const configSection = sections.find((s) => s.key === 'binding:config:myMetric')!;
     expect(configSection.rows[0].values).toHaveLength(2);
     expect(configSection.rows[0].values[0].raw).toBe('[Constant] gpt-4');
-    expect(configSection.rows[0].values[1].raw).toBe('[Constant] gpt-4');
+    expect(configSection.rows[0].values[1].raw).toBe('[Constant] gpt-3.5');
   });
 
   it('shows null for compared binding column when compared run lacks the metric', () => {
@@ -300,7 +307,7 @@ describe('buildComparisonSections', () => {
   it('shows null for current binding column when current run lacks the metric', () => {
     const active = makeResult({ id: 'a', metricValues: {} });
     const pinned = makeResult({ id: 'b', metricValues: { myMetric: { score: 0.9 } } });
-    const metricBindings: Record<string, MetricBindings> = {
+    const pinnedBindings: Record<string, MetricBindings> = {
       myMetric: {
         configBindings: [{ property: 'model', source: { $type: 'Constant', value: 'gpt-4' } }],
         inputBindings: [{ property: 'actual', source: { $type: 'Response', columnName: 'answer' } }],
@@ -312,7 +319,8 @@ describe('buildComparisonSections', () => {
       defaultVisibility,
       defaultOrder,
       defaultHidden,
-      metricBindings,
+      undefined,
+      pinnedBindings,
     );
 
     const configSection = sections.find((s) => s.key === 'binding:config:myMetric')!;

--- a/apps/ai-dial-admin/src/components/Runs/Details/BottomDrawer/utils.ts
+++ b/apps/ai-dial-admin/src/components/Runs/Details/BottomDrawer/utils.ts
@@ -35,7 +35,8 @@ export function buildComparisonSections(
   fieldVisibility: Record<string, boolean>,
   sectionOrder: string[],
   sectionHidden: Record<string, boolean>,
-  metricBindings?: Record<string, MetricBindings>,
+  activeMetricBindings?: Record<string, MetricBindings>,
+  pinnedMetricBindings?: Record<string, MetricBindings>,
 ): ComparisonSection[] {
   const isDuplicate = pinned != null && pinned.id === active.id;
   const effectivePinned = isDuplicate ? null : pinned;
@@ -116,15 +117,22 @@ export function buildComparisonSections(
   for (const groupKey of [...metricGroupKeys].sort()) {
     const activeGroup = active.metricValues?.[groupKey];
     const pinnedGroup = effectivePinned?.metricValues?.[groupKey];
+    const activeGroupExists = active.metricValues != null && groupKey in active.metricValues;
+    const pinnedGroupExists = effectivePinned?.metricValues != null && groupKey in effectivePinned.metricValues;
 
     const fieldKeys = new Set<string>();
     if (activeGroup) Object.keys(activeGroup).forEach((k) => fieldKeys.add(k));
     if (pinnedGroup) Object.keys(pinnedGroup).forEach((k) => fieldKeys.add(k));
 
     const rows: ComparisonRow[] = [...fieldKeys].sort().map((fieldKey) => {
+      const activeRaw = serializeValue(activeGroup?.[fieldKey]);
+      const pinnedRaw = serializeValue(pinnedGroup?.[fieldKey]);
       const values: ComparisonRow['values'] = hasTwoResults
-        ? [{ raw: serializeValue(activeGroup?.[fieldKey]) }, { raw: serializeValue(pinnedGroup?.[fieldKey]) }]
-        : [{ raw: serializeValue(activeGroup?.[fieldKey]) }];
+        ? [
+            { raw: activeRaw, isFailed: activeGroupExists && activeRaw === null },
+            { raw: pinnedRaw, isFailed: pinnedGroupExists && pinnedRaw === null },
+          ]
+        : [{ raw: activeRaw, isFailed: activeGroupExists && activeRaw === null }];
 
       return {
         fieldKey,
@@ -139,42 +147,54 @@ export function buildComparisonSections(
   }
 
   // Binding sections (config and input) per metric group
-  if (metricBindings) {
-    for (const [groupKey, bindings] of Object.entries(metricBindings).sort(([a], [b]) => a.localeCompare(b))) {
-      const activeHasMetric = active.metricValues?.[groupKey] != null;
-      const pinnedHasMetric = effectivePinned?.metricValues?.[groupKey] != null;
+  const allBindingGroupKeys = new Set<string>();
+  if (activeMetricBindings) Object.keys(activeMetricBindings).forEach((k) => allBindingGroupKeys.add(k));
+  if (pinnedMetricBindings) Object.keys(pinnedMetricBindings).forEach((k) => allBindingGroupKeys.add(k));
 
-      if (bindings.configBindings.length > 0) {
-        const sectionKey = `binding:config:${groupKey}`;
-        const rows: ComparisonRow[] = bindings.configBindings.map((binding) => ({
-          fieldKey: binding.property,
-          label: binding.property,
-          isNumeric: false,
-          values: hasTwoResults
-            ? [
-                { raw: activeHasMetric ? formatBindingValue(binding) : null },
-                { raw: pinnedHasMetric ? formatBindingValue(binding) : null },
-              ]
-            : [{ raw: formatBindingValue(binding) }],
-        }));
-        sectionsMap.set(sectionKey, { key: sectionKey, label: `${groupKey} · Config bindings`, rows });
-      }
+  for (const groupKey of [...allBindingGroupKeys].sort()) {
+    const activeBindings = activeMetricBindings?.[groupKey];
+    const pinnedBindings = hasTwoResults ? pinnedMetricBindings?.[groupKey] : undefined;
+    const activeHasMetric = active.metricValues?.[groupKey] != null;
+    const pinnedHasMetric = effectivePinned?.metricValues?.[groupKey] != null;
 
-      if (bindings.inputBindings.length > 0) {
-        const sectionKey = `binding:input:${groupKey}`;
-        const rows: ComparisonRow[] = bindings.inputBindings.map((binding) => ({
-          fieldKey: binding.property,
-          label: binding.property,
-          isNumeric: false,
-          values: hasTwoResults
-            ? [
-                { raw: activeHasMetric ? formatBindingValue(binding) : null },
-                { raw: pinnedHasMetric ? formatBindingValue(binding) : null },
-              ]
-            : [{ raw: formatBindingValue(binding) }],
-        }));
-        sectionsMap.set(sectionKey, { key: sectionKey, label: `${groupKey} · Input bindings`, rows });
-      }
+    const configProps = new Set<string>();
+    activeBindings?.configBindings.forEach((b) => configProps.add(b.property));
+    pinnedBindings?.configBindings.forEach((b) => configProps.add(b.property));
+
+    if (configProps.size > 0) {
+      const sectionKey = `binding:config:${groupKey}`;
+      const rows: ComparisonRow[] = [...configProps].sort().map((prop) => {
+        const activeBinding = activeBindings?.configBindings.find((b) => b.property === prop);
+        const pinnedBinding = pinnedBindings?.configBindings.find((b) => b.property === prop);
+        const values: ComparisonRow['values'] = hasTwoResults
+          ? [
+              { raw: activeHasMetric && activeBinding ? formatBindingValue(activeBinding) : null },
+              { raw: pinnedHasMetric && pinnedBinding ? formatBindingValue(pinnedBinding) : null },
+            ]
+          : [{ raw: activeBinding ? formatBindingValue(activeBinding) : null }];
+        return { fieldKey: prop, label: prop, isNumeric: false, values };
+      });
+      sectionsMap.set(sectionKey, { key: sectionKey, label: `${groupKey} · Config bindings`, rows });
+    }
+
+    const inputProps = new Set<string>();
+    activeBindings?.inputBindings.forEach((b) => inputProps.add(b.property));
+    pinnedBindings?.inputBindings.forEach((b) => inputProps.add(b.property));
+
+    if (inputProps.size > 0) {
+      const sectionKey = `binding:input:${groupKey}`;
+      const rows: ComparisonRow[] = [...inputProps].sort().map((prop) => {
+        const activeBinding = activeBindings?.inputBindings.find((b) => b.property === prop);
+        const pinnedBinding = pinnedBindings?.inputBindings.find((b) => b.property === prop);
+        const values: ComparisonRow['values'] = hasTwoResults
+          ? [
+              { raw: activeHasMetric && activeBinding ? formatBindingValue(activeBinding) : null },
+              { raw: pinnedHasMetric && pinnedBinding ? formatBindingValue(pinnedBinding) : null },
+            ]
+          : [{ raw: activeBinding ? formatBindingValue(activeBinding) : null }];
+        return { fieldKey: prop, label: prop, isNumeric: false, values };
+      });
+      sectionsMap.set(sectionKey, { key: sectionKey, label: `${groupKey} · Input bindings`, rows });
     }
   }
 
@@ -272,7 +292,7 @@ export function valuesAreEqual(a: string | null, b: string | null): boolean {
 export function getDiffClass(row: ComparisonRow): string {
   if (row.values.length < 2) return '';
   const [active, pinned] = row.values;
-  if (valuesAreEqual(active.raw, pinned.raw)) return '';
+  if (active.isFailed === pinned.isFailed && valuesAreEqual(active.raw, pinned.raw)) return '';
   return row.isNumeric ? 'bg-warning' : 'bg-accent-secondary-alpha';
 }
 
@@ -281,7 +301,8 @@ export function countDiffs(sections: ComparisonSection[]): number {
   for (const section of sections) {
     for (const row of section.rows) {
       if (row.values.length < 2) continue;
-      if (!valuesAreEqual(row.values[0].raw, row.values[1].raw)) {
+      const [a, b] = row.values;
+      if (a.isFailed !== b.isFailed || !valuesAreEqual(a.raw, b.raw)) {
         count++;
       }
     }

--- a/apps/ai-dial-admin/src/components/Runs/View/Analytics.tsx
+++ b/apps/ai-dial-admin/src/components/Runs/View/Analytics.tsx
@@ -52,10 +52,6 @@ const AnalyticsTab: FC<Props> = ({ run }) => {
   const [comparedSnapshots, setComparedSnapshots] = useState<MetricSnapshot[]>([]);
   const metricBindings = useMemo(() => snapshotsToBindingsMap(snapshots), [snapshots]);
   const comparedMetricBindings = useMemo(() => snapshotsToBindingsMap(comparedSnapshots), [comparedSnapshots]);
-  const mergedMetricBindings = useMemo(
-    () => ({ ...comparedMetricBindings, ...metricBindings }),
-    [comparedMetricBindings, metricBindings],
-  );
   const detailMode = useDetailMode(metricBindings);
   const drawerPanel = useDrawerPanel();
 
@@ -352,7 +348,8 @@ const AnalyticsTab: FC<Props> = ({ run }) => {
           onClose={onDrawerClose}
           onSwitchToSidebar={detailMode.switchToSidebar}
           runCompareNames={runCompareNames}
-          metricBindings={isCompareMode ? mergedMetricBindings : metricBindings}
+          metricBindings={metricBindings}
+          comparedMetricBindings={isCompareMode ? comparedMetricBindings : undefined}
         />
       )}
       <ColorScale />

--- a/apps/ai-dial-admin/src/components/Runs/View/utils.ts
+++ b/apps/ai-dial-admin/src/components/Runs/View/utils.ts
@@ -77,12 +77,16 @@ const getMetricsColumns = (metrics: Record<string, Record<string, unknown>>, err
           field: key,
           headerName: key,
           cellRendererSelector: (params) => {
+            const groupExists = params.data?.metricValues != null && groupKey in params.data.metricValues;
+            if (!groupExists) return;
             const value = params.data?.metricValues?.[groupKey]?.[key];
             if (value == null) {
               return { component: ErrorCellRenderer, params: { errorText } };
             }
           },
           valueGetter: (params) => {
+            const groupExists = params.data?.metricValues != null && groupKey in params.data.metricValues;
+            if (!groupExists) return '—';
             const value = params.data?.metricValues?.[groupKey]?.[key];
             if (typeof value === 'object') return JSON.stringify(value);
             if (value != null) {
@@ -269,6 +273,9 @@ const buildMetricColDef = (
     headerName: headerNameOverride ?? key,
     cellRendererSelector: (params) => {
       if (isCompared && !params.data?._compared) return;
+      const source = isCompared ? params.data?._compared : params.data;
+      const groupExists = source?.metricValues != null && groupKey in source.metricValues;
+      if (!groupExists) return;
       const value = getValue(params);
       if (value == null) {
         return { component: ErrorCellRenderer, params: { errorText } };
@@ -276,6 +283,9 @@ const buildMetricColDef = (
     },
     valueGetter: (params) => {
       if (isCompared && !params.data?._compared) return '—';
+      const source = isCompared ? params.data?._compared : params.data;
+      const groupExists = source?.metricValues != null && groupKey in source.metricValues;
+      if (!groupExists) return '—';
       const value = getValue(params);
       if (typeof value === 'object') return JSON.stringify(value);
       if (value != null) return +(value as number).toFixed(3);


### PR DESCRIPTION
**Description:**

eval metric values and bindings

Issues:

- Issue #3407
- Issue #3410


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
