### PR TITLE
fix(grid): add correct filterValueGetter for numeric columns (Issue #3452)

### DIFF
--- a/apps/ai-dial-admin/src/constants/grid-columns/configs.ts
+++ b/apps/ai-dial-admin/src/constants/grid-columns/configs.ts
@@ -3,11 +3,7 @@
 import { ColDef } from 'ag-grid-community';
 
 import { numberValueComparator } from '@/src/components/Grid/comparators/number-comparator';
-import {
-  currencyValueFormatter,
-  numberValueFormatter,
-  priceValueFormatter,
-} from '@/src/constants/grid-columns/formatters';
+import { currencyValueFormatter, numberValueFormatter, toNumberOrNull } from '@/src/constants/grid-columns/formatters';
 import { formatDateTimeToLocalString } from '@/src/utils/formatting/date';
 
 import HeaderWithHintButton from '@/src/components/Grid/HeaderComponents/HeaderWithHintButton';
@@ -23,6 +19,7 @@ export const numericColumn: Partial<ColDef> = {
   headerClass: 'align-right',
   comparator: numberValueComparator,
   valueFormatter: ({ value }) => numberValueFormatter(value),
+  filterValueGetter: ({ data, colDef }) => toNumberOrNull(data?.[colDef.field || '']),
 };
 
 export const priceColumn = (title: string): Partial<ColDef> => {
@@ -38,6 +35,5 @@ export const priceColumn = (title: string): Partial<ColDef> => {
       },
     },
     valueFormatter: ({ value }) => currencyValueFormatter(value),
-    filterValueGetter: (params) => priceValueFormatter(params.data?.[params.colDef.field || '']),
   };
 };

--- a/apps/ai-dial-admin/src/constants/grid-columns/tests/configs.spec.ts
+++ b/apps/ai-dial-admin/src/constants/grid-columns/tests/configs.spec.ts
@@ -1,0 +1,51 @@
+import { ColDef, ValueGetterParams } from 'ag-grid-community';
+import { describe, expect, test } from 'vitest';
+
+import { numericColumn, priceColumn } from '../configs';
+
+const callFilterValueGetter = (
+  col: Partial<ColDef>,
+  data: Record<string, unknown> | null | undefined,
+  field: string,
+) => {
+  const params = { data, colDef: { field } } as unknown as ValueGetterParams;
+  return (col.filterValueGetter as (p: ValueGetterParams) => unknown)(params);
+};
+
+describe('numericColumn.filterValueGetter', () => {
+  test('coerces numeric string cell values to numbers so agNumberColumnFilter equals matches', () => {
+    expect(callFilterValueGetter(numericColumn, { completion_tokens: '201' }, 'completion_tokens')).toBe(201);
+  });
+
+  test('returns 0 for the string "0" (not null)', () => {
+    expect(callFilterValueGetter(numericColumn, { prompt_tokens: '0' }, 'prompt_tokens')).toBe(0);
+  });
+
+  test('passes numbers through unchanged', () => {
+    expect(callFilterValueGetter(numericColumn, { tokens: 42 }, 'tokens')).toBe(42);
+  });
+
+  test('returns null for missing, empty, or non-numeric cell values', () => {
+    expect(callFilterValueGetter(numericColumn, {}, 'tokens')).toBeNull();
+    expect(callFilterValueGetter(numericColumn, { tokens: '' }, 'tokens')).toBeNull();
+    expect(callFilterValueGetter(numericColumn, { tokens: null }, 'tokens')).toBeNull();
+    expect(callFilterValueGetter(numericColumn, { tokens: 'abc' }, 'tokens')).toBeNull();
+  });
+
+  test('returns null when params.data is undefined (initial render before rows arrive)', () => {
+    expect(callFilterValueGetter(numericColumn, undefined, 'tokens')).toBeNull();
+  });
+});
+
+describe('priceColumn.filterValueGetter (inherited from numericColumn)', () => {
+  const col = priceColumn('Price');
+
+  test('coerces a price string into a number for filter equality', () => {
+    expect(callFilterValueGetter(col, { price: '0.00000228123' }, 'price')).toBe(0.00000228123);
+  });
+
+  test('keeps the numericColumn behavior for missing and empty values', () => {
+    expect(callFilterValueGetter(col, {}, 'price')).toBeNull();
+    expect(callFilterValueGetter(col, { price: '' }, 'price')).toBeNull();
+  });
+});


### PR DESCRIPTION
**Description:**

Set filterValueGetter to convert value to number for correct eq or !eq filters work

Issues:

- Issue #3452


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
