### PR TITLE
fix(audit): refetch consumption widgets on time period change

### DIFF
--- a/apps/ai-dial-admin/src/components/Telemetry/Dashboards/ConsumptionDashboard.tsx
+++ b/apps/ai-dial-admin/src/components/Telemetry/Dashboards/ConsumptionDashboard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FC, useEffect, useRef, useState } from 'react';
+import { FC, useEffect, useState } from 'react';
 
 import EntitiesConsumptionTree from '@/src/components/Telemetry/EntitiesConsumptionTree';
 import TelemetryGrid from '@/src/components/Telemetry/TelemetryGrid';
@@ -26,18 +26,11 @@ const ConsumptionDashboard: FC<Props> = ({ route, getData, refreshTime }) => {
   const [deploymentRows, setDeploymentRows] = useState<EntityRow[] | null>(null);
   const [projectRows, setProjectRows] = useState<Record<string, string>[] | null>(null);
 
-  // Keep getData in a ref so the fetch effect doesn't re-run (and re-fetch)
-  // every time an ancestor passes a fresh function reference.
-  const getDataRef = useRef(getData);
-  useEffect(() => {
-    getDataRef.current = getData;
-  });
-
   useEffect(() => {
     setLoading(true);
     const fetch = async () => {
       try {
-        const response = await getDataRef.current(ENTITY_CONSUMPTION_TREE_QUERY);
+        const response = await getData(ENTITY_CONSUMPTION_TREE_QUERY);
         if (response?.success) {
           const raw = response.response as TelemetryData;
           setDeploymentRows(aggregateByDeployment(raw));
@@ -64,7 +57,7 @@ const ConsumptionDashboard: FC<Props> = ({ route, getData, refreshTime }) => {
     }, timeout);
 
     return () => clearInterval(intervalId);
-  }, [refreshTime]);
+  }, [refreshTime, getData]);
 
   return (
     <div className="flex flex-col w-full">

--- a/apps/ai-dial-admin/src/components/Telemetry/Dashboards/tests/ConsumptionDashboard.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Telemetry/Dashboards/tests/ConsumptionDashboard.spec.tsx
@@ -138,17 +138,14 @@ describe('ConsumptionDashboard', () => {
     expect(Number(screen.getByTestId('projects-grid').getAttribute('data-row-count'))).toBe(0);
   });
 
-  test('does not refetch when only the getData function reference changes', async () => {
+  test('refetches when the getData reference changes (time period / filter change)', async () => {
     const { rerender } = render(<ConsumptionDashboard route={ApplicationRoute.Dashboard} getData={getData} />);
     await waitFor(() => expect(getData).toHaveBeenCalledTimes(1));
 
     const replacement = vi.fn<GetDataFn>().mockResolvedValue(makeResponse([row({})]));
     rerender(<ConsumptionDashboard route={ApplicationRoute.Dashboard} getData={replacement} />);
 
-    // Give any rogue effect a chance to fire.
-    await new Promise((resolve) => setTimeout(resolve, 30));
-
+    await waitFor(() => expect(replacement).toHaveBeenCalledTimes(1));
     expect(getData).toHaveBeenCalledTimes(1);
-    expect(replacement).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
**Description:**

When changing the time period on Audit / Dashboard, the "Calls by Entities" and "Calls by Project" widgets did not refresh. `ConsumptionDashboard` stored `getData` in a ref and depended only on `refreshTime`, so it never re-ran when the parent passed a new `getData` reference. Call `getData` directly and include it in the effect deps to match the `LineChart` pattern; the parent already memoizes `getData` on `[entityFilterName, filters, getCurrentTimeRange]`, so the effect now re-runs exactly when time period, filters, or entity change.

Issues:

- Issue #<TICKET_ID>


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)