### PR TITLE
fix: [Eval > Runs] Side panel title shows 0-based run index instead of 1-based  (issue #3494)

### DIFF
--- a/apps/ai-dial-admin/src/components/Runs/View/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/Runs/View/tests/utils.spec.ts
@@ -175,15 +175,15 @@ describe('Runs View :: getFormattedDuration', () => {
 
 describe('Runs View :: getPanelTitle', () => {
   test('Should format title with test case name and run index', () => {
-    expect(getPanelTitle({ testCaseName: 'Login Test', runIndex: 3 } as any)).toBe('Login Test - Run #3');
+    expect(getPanelTitle({ testCaseName: 'Login Test', runIndex: 3 } as any)).toBe('Login Test - Run #4');
   });
 
   test('Should default run index to 0 when missing', () => {
-    expect(getPanelTitle({ testCaseName: 'Test' } as any)).toBe('Test - Run #0');
+    expect(getPanelTitle({ testCaseName: 'Test' } as any)).toBe('Test - Run #1');
   });
 
   test('Should handle null result', () => {
-    expect(getPanelTitle(null)).toBe('undefined - Run #0');
+    expect(getPanelTitle(null)).toBe('undefined - Run #1');
   });
 });
 

--- a/apps/ai-dial-admin/src/components/Runs/View/utils.ts
+++ b/apps/ai-dial-admin/src/components/Runs/View/utils.ts
@@ -425,7 +425,7 @@ export const getFormattedDuration = (durationMs: number | undefined) => {
 };
 
 export const getPanelTitle = (result: ExtractionResult | AnalyticsResult | null) => {
-  return `${result?.testCaseName} - Run #${result?.runIndex ?? 0}`;
+  return `${result?.testCaseName} - Run #${(result?.runIndex ?? 0) + 1}`;
 };
 
 export const getDetailEntries = (data: Record<string, unknown>): Array<[string, unknown]> => {


### PR DESCRIPTION
**Description:**

correct run index on details

Issues:

- Issue #3494


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
