### PR TITLE
fix: [Assets-Applications/Toolsets/Prompts] Second save after creating a new version fails with "Conflict" error  (Issue #3533)

### DIFF
--- a/apps/ai-dial-admin/src/components/Assets/Apps/View.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Apps/View.tsx
@@ -119,6 +119,7 @@ const AppView: FC<Props> = ({ etag, originalApp, assets, models, applications, s
       }
       getReqRef.current(updateFunction, updatedEntity, etag).then((res) => {
         if (res.success) {
+          setAddedVersions([]);
           showNotification(
             getSuccessNotification(
               newVersion

--- a/apps/ai-dial-admin/src/components/Assets/Prompts/View/View.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Prompts/View/View.tsx
@@ -83,6 +83,7 @@ const PromptView: FC<Props> = ({ originalPrompt, etag, prompts }) => {
       }
       getReqRef.current(updateFunction, updatedEntity as DialPrompt, etag).then((res) => {
         if (res.success) {
+          setAddedVersions([]);
           showNotification(
             getSuccessNotification(
               newVersion

--- a/apps/ai-dial-admin/src/components/Assets/Toolsets/View/View.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Toolsets/View/View.tsx
@@ -93,6 +93,7 @@ const ToolsetView: FC<Props> = ({ oAuthCode, etag, originalToolset, toolsets }) 
       }
       getReqRef.current(updateFunction, updatedEntity, etag).then((res) => {
         if (res.success) {
+          setAddedVersions([]);
           showNotification(
             getSuccessNotification(
               newVersion


### PR DESCRIPTION
**Description:**

added newly created version change

Issues:

- Issue #3533

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
