### PR TITLE
fix: [Eval - Test Suites] Stale input binding remains after renaming template variable back to original name  (Issue #3579)

### DIFF
--- a/apps/ai-dial-admin/src/components/TestSuites/utils/request-template-params.ts
+++ b/apps/ai-dial-admin/src/components/TestSuites/utils/request-template-params.ts
@@ -47,7 +47,5 @@ export const filterParameterBindings = (
   }
 
   const set = new Set(paramNames);
-  return bindings.filter(
-    (binding) => set.has(binding.templateVariable) || paramNames.some((p) => binding.templateVariable?.includes(p)),
-  );
+  return bindings.filter((binding) => set.has(binding.templateVariable));
 };

--- a/apps/ai-dial-admin/src/components/TestSuites/utils/tests/request-template-params.spec.ts
+++ b/apps/ai-dial-admin/src/components/TestSuites/utils/tests/request-template-params.spec.ts
@@ -110,7 +110,7 @@ describe('filterParameterBindings', () => {
     ]);
   });
 
-  test('should keep bindings when template variable contains a parameter name', () => {
+  test('should keep bindings when template variable exact parameter name', () => {
     const bindings: InputBinding[] = [
       { templateVariable: 'tenantId.raw', dataField: 'tenant.raw' },
       { templateVariable: 'tenant-id', dataField: 'tenant.id' },
@@ -118,7 +118,6 @@ describe('filterParameterBindings', () => {
     ];
 
     expect(filterParameterBindings(bindings, ['tenantId', 'tenant-id'])).toEqual([
-      { templateVariable: 'tenantId.raw', dataField: 'tenant.raw' },
       { templateVariable: 'tenant-id', dataField: 'tenant.id' },
     ]);
   });


### PR DESCRIPTION
**Description:**

correct bindings filtering

Issues:

- Issue #3579


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
