### PR TITLE
fix: [Eval > Datasets] Duplicate name conflict shown as notification instead of inline validation when renaming existing Dataset  (Issue #3580)

### DIFF
--- a/apps/ai-dial-admin/src/components/Datasets/View/TabsContent.tsx
+++ b/apps/ai-dial-admin/src/components/Datasets/View/TabsContent.tsx
@@ -20,6 +20,7 @@ interface Props {
   selectedDataset: Dataset;
   isSkipRefresh?: boolean;
   onChange: (dataset: Dataset, isSkipRefresh?: boolean) => void;
+  nameExistsError?: string;
 }
 
 const DatasetTabsContent: FC<Props> = ({
@@ -29,6 +30,7 @@ const DatasetTabsContent: FC<Props> = ({
   selectedDataset,
   isSkipRefresh,
   onChange,
+  nameExistsError,
 }) => {
   const t = useI18n();
 
@@ -51,7 +53,12 @@ const DatasetTabsContent: FC<Props> = ({
             )}
           </div>
           <div className="pt-8">
-            <DatasetProperties dataset={selectedDataset} onChange={onChange} isModal={false} />
+            <DatasetProperties
+              dataset={selectedDataset}
+              onChange={onChange}
+              isModal={false}
+              nameExistsError={nameExistsError}
+            />
           </div>
         </div>
       )}

--- a/apps/ai-dial-admin/src/components/Datasets/View/View.tsx
+++ b/apps/ai-dial-admin/src/components/Datasets/View/View.tsx
@@ -6,12 +6,18 @@ import { createPortal } from 'react-dom';
 import { DialConfirmationPopup, DialNeutralButton } from '@epam/ai-dial-ui-kit';
 import { useRouter } from 'next/navigation';
 
-import { removeDataset, transitionVisibility, updateDataset, updateTestCases } from '@/src/app/[lang]/datasets/actions';
+import {
+  getDatasetByName,
+  removeDataset,
+  transitionVisibility,
+  updateDataset,
+  updateTestCases,
+} from '@/src/app/[lang]/datasets/actions';
 import { DatasetTestCasesActions } from '@/src/components/Datasets/TestCases/TestCasesList';
 import { JsonConfiguration } from '@/src/components/EntityHeaderControls/models';
 import SimpleEntityHeader from '@/src/components/EntityHeaderControls/SimpleHeader';
 import EntityJsonEditor from '@/src/components/EntityTabs/JsonEditor/JsonEditor';
-import { DatasetsI18nKey } from '@/src/constants/i18n';
+import { DatasetsI18nKey, ErrorI18nKey } from '@/src/constants/i18n';
 import { useNotification } from '@/src/context/NotificationContext';
 import { useI18n } from '@/src/locales/client';
 import { Dataset, DatasetVisibility, DatasetVisibilityTransition } from '@/src/models/evaluation/dataset';
@@ -45,6 +51,7 @@ const DatasetView: FC<Props> = ({ originalDataset, etag: initialEtag }) => {
   const [isMakePrivateOpen, setIsMakePrivateOpen] = useState(false);
   const [isMakePublicOpen, setIsMakePublicOpen] = useState(false);
   const [isEditorEnabled, setIsEditorEnabled] = useState(false);
+  const [nameExistsError, setNameExistsError] = useState<string>();
 
   const jsonConfiguration = useMemo<JsonConfiguration>(
     () => ({
@@ -58,6 +65,7 @@ const DatasetView: FC<Props> = ({ originalDataset, etag: initialEtag }) => {
 
   useEffect(() => {
     setIsChanged(!isEqualSkippingUndefined(originalDataset, selectedDataset) || hasTestCaseChanges);
+    setNameExistsError(undefined);
   }, [originalDataset, selectedDataset, hasTestCaseChanges]);
 
   useEffect(() => {
@@ -77,65 +85,71 @@ const DatasetView: FC<Props> = ({ originalDataset, etag: initialEtag }) => {
   }, [originalDataset]);
 
   const onSave = useCallback(() => {
-    let prepareNotificationId: string | undefined;
+    getDatasetByName(selectedDataset.name!).then((res) => {
+      if (res && res.content?.length > 0) {
+        setNameExistsError(t(ErrorI18nKey.DisplayNameExists));
+      } else {
+        let prepareNotificationId: string | undefined;
 
-    const dismissPrepareNotification = () => {
-      if (prepareNotificationId) {
-        removeNotification(prepareNotificationId);
-        prepareNotificationId = undefined;
-      }
-    };
+        const dismissPrepareNotification = () => {
+          if (prepareNotificationId) {
+            removeNotification(prepareNotificationId);
+            prepareNotificationId = undefined;
+          }
+        };
 
-    const handleError = (header: string | undefined, message: string | undefined, requestId?: string) => {
-      dismissPrepareNotification();
-      showNotification(getErrorNotification(header, message, requestId));
-      router.refresh();
-    };
+        const handleError = (header: string | undefined, message: string | undefined, requestId?: string) => {
+          dismissPrepareNotification();
+          showNotification(getErrorNotification(header, message, requestId));
+          router.refresh();
+        };
 
-    const showSuccessAndRefresh = () => {
-      dismissPrepareNotification();
-      showNotification(
-        getSuccessNotification(
-          getUpdateNotificationTitle(ApplicationRoute.Datasets, t),
-          getUpdateNotificationDescription(ApplicationRoute.Datasets, selectedDataset.id, t),
-        ),
-      );
-      router.refresh();
-    };
+        const showSuccessAndRefresh = () => {
+          dismissPrepareNotification();
+          showNotification(
+            getSuccessNotification(
+              getUpdateNotificationTitle(ApplicationRoute.Datasets, t),
+              getUpdateNotificationDescription(ApplicationRoute.Datasets, selectedDataset.id, t),
+            ),
+          );
+          router.refresh();
+        };
 
-    updateDataset(selectedDataset, etag).then((datasetRes) => {
-      if (!datasetRes.success) {
-        handleError(datasetRes.errorHeader, datasetRes.errorMessage, datasetRes.requestId);
-        return;
-      }
-
-      if (datasetRes.etag) {
-        setEtag(datasetRes.etag);
-      }
-
-      const schemaChanged =
-        JSON.stringify(selectedDataset.testCaseSchema) !== JSON.stringify(originalDataset.testCaseSchema);
-
-      if (schemaChanged) {
-        prepareNotificationId = showNotification(getPrepareNotification(t(DatasetsI18nKey.RevalidatingTestCases)));
-      }
-
-      const dirtyTestCases = testCasesActionsRef.current?.getDirtyTestCases() ?? [];
-
-      if (dirtyTestCases.length > 0 && selectedDataset.id) {
-        updateTestCases(selectedDataset.id, dirtyTestCases).then((testCasesRes) => {
-          if (!testCasesRes.success) {
-            handleError(testCasesRes.errorHeader, testCasesRes.errorMessage, testCasesRes.requestId);
+        updateDataset(selectedDataset, etag).then((datasetRes) => {
+          if (!datasetRes.success) {
+            handleError(datasetRes.errorHeader, datasetRes.errorMessage, datasetRes.requestId);
             return;
           }
-          testCasesActionsRef.current?.clearDirtyAndRefresh();
-          setHasTestCaseChanges(false);
-          showSuccessAndRefresh();
+
+          if (datasetRes.etag) {
+            setEtag(datasetRes.etag);
+          }
+
+          const schemaChanged =
+            JSON.stringify(selectedDataset.testCaseSchema) !== JSON.stringify(originalDataset.testCaseSchema);
+
+          if (schemaChanged) {
+            prepareNotificationId = showNotification(getPrepareNotification(t(DatasetsI18nKey.RevalidatingTestCases)));
+          }
+
+          const dirtyTestCases = testCasesActionsRef.current?.getDirtyTestCases() ?? [];
+
+          if (dirtyTestCases.length > 0 && selectedDataset.id) {
+            updateTestCases(selectedDataset.id, dirtyTestCases).then((testCasesRes) => {
+              if (!testCasesRes.success) {
+                handleError(testCasesRes.errorHeader, testCasesRes.errorMessage, testCasesRes.requestId);
+                return;
+              }
+              testCasesActionsRef.current?.clearDirtyAndRefresh();
+              setHasTestCaseChanges(false);
+              showSuccessAndRefresh();
+            });
+          } else {
+            testCasesActionsRef.current?.clearDirtyAndRefresh();
+            setHasTestCaseChanges(false);
+            showSuccessAndRefresh();
+          }
         });
-      } else {
-        testCasesActionsRef.current?.clearDirtyAndRefresh();
-        setHasTestCaseChanges(false);
-        showSuccessAndRefresh();
       }
     });
   }, [selectedDataset, etag, originalDataset, showNotification, removeNotification, t, router]);
@@ -218,6 +232,7 @@ const DatasetView: FC<Props> = ({ originalDataset, etag: initialEtag }) => {
               activeTab={activeTab}
               selectedDataset={selectedDataset}
               onChange={onChangeDataset}
+              nameExistsError={nameExistsError}
             />
           )}
         </div>


### PR DESCRIPTION
**Description:**

added display name check on update

Issues:

- Issue #3580


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
