### PR TITLE
fix: Long folder name breaks layout in permissions panel (Issue #3636)

### DIFF
--- a/apps/ai-dial-admin/src/components/FoldersStorage/FolderInfo.tsx
+++ b/apps/ai-dial-admin/src/components/FoldersStorage/FolderInfo.tsx
@@ -82,7 +82,7 @@ const FolderInfo: FC<Props> = ({ isReadonly }) => {
   return !currentFolder ? (
     <DialNoDataContent title={t(EntitiesI18nKey.NoFolders)} />
   ) : (
-    <div className="size-full bg-layer-3 rounded p-4 flex flex-col gap-4">
+    <div className="size-full bg-layer-3 rounded p-4 flex flex-col gap-4 overflow-hidden">
       <FolderInfoHeader
         isChanged={isChanged}
         title={currentFolder?.name as string}

--- a/apps/ai-dial-admin/src/components/FoldersStorage/FolderInfoHeader.tsx
+++ b/apps/ai-dial-admin/src/components/FoldersStorage/FolderInfoHeader.tsx
@@ -2,6 +2,8 @@
 
 import { FC } from 'react';
 
+import { DialEllipsisTooltip } from '@epam/ai-dial-ui-kit';
+
 import ChangedEntityButtons from '../EntityHeaderControls/Buttons/ChangedEntityButtons';
 
 interface Props {
@@ -14,8 +16,10 @@ interface Props {
 
 const FolderInfoHeader: FC<Props> = ({ isChanged, isSaveDisable, title, onSave, onDiscard }) => {
   return (
-    <div className="flex justify-between items-center">
-      <h2 className="flex flex-1 w-full">{title}</h2>
+    <div className="flex justify-between items-center w-full gap-5">
+      <h2 className="flex-1 min-w-0">
+        <DialEllipsisTooltip contentClassName="truncate" text={title} />
+      </h2>
       {isChanged && <ChangedEntityButtons onDiscard={onDiscard} onSave={onSave} disableSave={isSaveDisable} />}
     </div>
   );

--- a/apps/ai-dial-admin/src/components/Rules/Item/RulesItem.tsx
+++ b/apps/ai-dial-admin/src/components/Rules/Item/RulesItem.tsx
@@ -61,13 +61,13 @@ const RulesItem: FC<Props> = ({
   }, [isAlwaysToggled, setLastRuleHeight]);
 
   return (
-    <div ref={ref} className={classNames('flex flex-1', !folderName && 'border border-primary')}>
-      <div style={{ width: `${RULE_INDENT * indentIndex}px` }} className="flex items-center">
+    <div ref={ref} className={classNames('flex flex-1 min-w-0', !folderName && 'border border-primary')}>
+      <div style={{ width: `${RULE_INDENT * indentIndex}px` }} className="flex items-center shrink-0">
         <div className="h-px w-full bg-accent-secondary"></div>
       </div>
       <div
         className={classNames(
-          'flex-1 flex flex-col bg-layer-2 py-4 px-6 rounded',
+          'flex-1 min-w-0 flex flex-col bg-layer-2 py-4 px-6 rounded',
           isAlwaysToggled && folderName && 'bg-layer-3',
         )}
       >

--- a/apps/ai-dial-admin/src/components/Rules/Item/RulesItemHeader.tsx
+++ b/apps/ai-dial-admin/src/components/Rules/Item/RulesItemHeader.tsx
@@ -3,6 +3,7 @@
 import { FC, ReactNode } from 'react';
 
 import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
+import { DialEllipsisTooltip } from '@epam/ai-dial-ui-kit';
 import classNames from 'classnames';
 
 import { FoldersI18nKey } from '@/src/constants/i18n';
@@ -32,7 +33,7 @@ const RulesItemHeader: FC<Props> = ({
     <div
       role="button"
       className={classNames(
-        'flex items-center',
+        'flex items-center min-w-0',
         !isCollapsed && 'mb-4',
         isAlwaysToggled && 'cursor-default justify-between',
       )}
@@ -40,13 +41,15 @@ const RulesItemHeader: FC<Props> = ({
     >
       {!isAlwaysToggled &&
         (isCollapsed ? (
-          <IconChevronRight className="text-secondary" {...BASE_BUTTON_ICON_PROPS} />
+          <IconChevronRight className="text-secondary shrink-0" {...BASE_BUTTON_ICON_PROPS} />
         ) : (
-          <IconChevronDown className="text-secondary" {...BASE_BUTTON_ICON_PROPS} />
+          <IconChevronDown className="text-secondary shrink-0" {...BASE_BUTTON_ICON_PROPS} />
         ))}
-      <div className="flex flex-col gap-1">
-        <h3 className={classNames(!isAlwaysToggled && 'mx-2')}>{folderName || t(FoldersI18nKey.Permissions)}</h3>
-        {folderDescription && <span className="tiny text-secondary">{folderDescription}</span>}
+      <div className="flex flex-col gap-1 min-w-0 overflow-hidden">
+        <h3 className={classNames('min-w-0', !isAlwaysToggled && 'mx-2')}>
+          <DialEllipsisTooltip contentClassName="truncate" text={folderName || t(FoldersI18nKey.Permissions)} />
+        </h3>
+        {folderDescription && <span className="tiny text-secondary truncate">{folderDescription}</span>}
       </div>
       {children}
     </div>

--- a/apps/ai-dial-admin/src/components/Rules/RulesList.tsx
+++ b/apps/ai-dial-admin/src/components/Rules/RulesList.tsx
@@ -39,10 +39,10 @@ const RulesList: FC<Props> = ({ rulesMap, isReadonly, onChange }) => {
       {!isEmpty && rulesMap && (
         <div className="relative flex flex-row">
           <div
-            style={{ height: `calc(100% - ${lastRuleHeight / 2}px)` }}
-            className={classNames('w-[1px] ml-1 bg-accent-secondary', isSingle && 'hidden')}
+            style={{ bottom: `${lastRuleHeight / 2}px` }}
+            className={classNames('absolute top-0 left-1 w-[1px] bg-accent-secondary', isSingle && 'hidden')}
           ></div>
-          <div className={classNames('flex-1 flex flex-col gap-4', !isSingle && 'mt-4')}>
+          <div className={classNames('flex-1 flex flex-col gap-4 ml-[5px] overflow-hidden', !isSingle && 'mt-4')}>
             {isSingle ? (
               <div className="small">{t(FoldersI18nKey.AllRules)}</div>
             ) : (


### PR DESCRIPTION
**Description:**

<img width="1887" height="870" alt="image" src="https://github.com/user-attachments/assets/0d6d0e7d-d3b1-4b4d-a390-434e6caa842e" />

Issues:

- Issue #3636


**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
