### PR TITLE
fix: [Eval - Test Suites] Long dataset name overflows layout in Test Cases tab  (Issue #3681)

### DIFF
--- a/apps/ai-dial-admin/src/components/TestSuites/TestCases/Header.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/TestCases/Header.tsx
@@ -178,6 +178,7 @@ const HeaderButtons: FC<Props> = ({
           isOpen={isAttachModalOpen}
           onClose={() => setIsAttachModalOpen(false)}
           onConfirm={onChangeDatasetConfirm}
+          showWarning={!isReadOnly}
         />
       )}
 

--- a/apps/ai-dial-admin/src/components/TestSuites/TestCases/PickPublicDataset.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/TestCases/PickPublicDataset.tsx
@@ -2,7 +2,14 @@
 
 import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 
-import { DialPopup, DialSteps, PopupSize, StepStatus } from '@epam/ai-dial-ui-kit';
+import {
+  DialNotification,
+  DialPopup,
+  DialSteps,
+  NotificationVariant,
+  PopupSize,
+  StepStatus,
+} from '@epam/ai-dial-ui-kit';
 import { ColDef } from 'ag-grid-community';
 
 import { getDataset, getDatasets, getTestCases } from '@/src/app/[lang]/datasets/actions';
@@ -20,9 +27,10 @@ interface Props {
   isOpen: boolean;
   onClose: () => void;
   onConfirm: (datasetId: string) => void;
+  showWarning?: boolean;
 }
 
-const PickPublicDataset: FC<Props> = ({ isOpen, onClose, onConfirm }) => {
+const PickPublicDataset: FC<Props> = ({ isOpen, onClose, onConfirm, showWarning }) => {
   const t = useI18n();
   const [datasets, setDatasets] = useState<Dataset[]>([]);
   const [isLoadingDatasets, setIsLoadingDatasets] = useState(true);
@@ -116,6 +124,9 @@ const PickPublicDataset: FC<Props> = ({ isOpen, onClose, onConfirm }) => {
       size={PopupSize.Lg}
     >
       <div className="flex flex-col py-4 px-6 overflow-auto gap-y-6 h-[600px]">
+        {showWarning && (
+          <DialNotification variant={NotificationVariant.Warning} message={t(TestSuitesI18nKey.AttachDatasetWarning)} />
+        )}
         <DialSteps steps={steps} currentStep={currentStepId} onChangeStep={onChangeStep} />
         <div className="flex-1 min-h-0">
           {currentStepId === AttachDatasetTab.SelectDataset && (

--- a/apps/ai-dial-admin/src/components/TestSuites/TestCases/TestCasesList.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/TestCases/TestCasesList.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import { FC, RefObject, useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
-import { DialConfirmationPopup, DialLoader, DialTag, DialTooltip } from '@epam/ai-dial-ui-kit';
+import { DialConfirmationPopup, DialEllipsisTooltip, DialLoader, DialTag, DialTooltip } from '@epam/ai-dial-ui-kit';
 import { IconDatabaseExport, IconExternalLink } from '@tabler/icons-react';
 import {
   CellClickedEvent,
@@ -492,7 +492,7 @@ const TestCasesList: FC<Props> = ({
       onClick={() => onOpenInNewTab(ApplicationRoute.Datasets, { id: selectedTestSuite.datasetId })}
     >
       <IconDatabaseExport size={12} className="text-accent-secondary" />
-      <span className="tiny">{dataset?.name}</span>
+      <DialEllipsisTooltip className="tiny max-w-[600px]" text={dataset?.name || ''} />
       <IconExternalLink size={12} />
     </button>
   );

--- a/apps/ai-dial-admin/src/constants/i18n.ts
+++ b/apps/ai-dial-admin/src/constants/i18n.ts
@@ -1750,6 +1750,7 @@ export enum TestSuitesI18nKey {
   DetachConfirmDescription = 'TestSuites.DetachConfirmDescription',
   DetachSuccess = 'TestSuites.DetachSuccess',
   DetachFailed = 'TestSuites.DetachFailed',
+  AttachDatasetWarning = 'TestSuites.AttachDatasetWarning',
   PublicDatasetInfo = 'TestSuites.PublicDatasetInfo',
 }
 

--- a/apps/ai-dial-admin/src/locales/en.ts
+++ b/apps/ai-dial-admin/src/locales/en.ts
@@ -1789,6 +1789,7 @@ export default {
       "When you detach test cases from the dataset, they become private to the current test suite. This lets you add, edit, or delete test cases without restrictions. The original dataset stays unchanged, so other suites using it won't be impacted.",
     DetachSuccess: 'Dataset detached successfully',
     DetachFailed: 'Failed to detach dataset',
+    AttachDatasetWarning: 'Attaching a public dataset will permanently remove all currently existing test cases.',
     PublicDatasetInfo:
       'Test cases related to dataset are fixed. To change the test cases open the dataset page or detach them from dataset.',
   },


### PR DESCRIPTION
**Description:**

 added tooltip for long dataset name

Issues:

- Issue #3681 
- Issue #3682


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
