### PR TITLE
fix(Deployments/ModelServings): allow "/" in Hugging Face model search (Issue #3727)

### DIFF
--- a/apps/ai-dial-admin/src/components/Deployments/HFRegistryGrid/HFRegistryGrid.tsx
+++ b/apps/ai-dial-admin/src/components/Deployments/HFRegistryGrid/HFRegistryGrid.tsx
@@ -74,7 +74,7 @@ const HfRegistryGrid: FC<Props> = ({ route, infoPanel, modelName, setModelName, 
         sorts = currentSorts;
 
         const requestFilters = Object.fromEntries(
-          currentFilters.map(({ column, value }) => [column === 'id' ? 'search' : column, encodeURIComponent(value)]),
+          currentFilters.map(({ column, value }) => [column === 'id' ? 'search' : column, value]),
         );
 
         getHuggingFaceModels({


### PR DESCRIPTION
**Description:**

When searching for models in the Hugging Face registry by full name (e.g., `protectai/deberta-v3-base-prompt-injection`), the search fails because the `/` character was being URL-encoded as `%2F`. The backend cannot properly parse this encoded value. Removed the `encodeURIComponent` call on the search filter to allow the slash character to be transmitted as-is.

Issues:

- Issue #3727

**Key Changes:**

- [apps/ai-dial-admin/src/components/Deployments/HFRegistryGrid/HFRegistryGrid.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/development/apps/ai-dial-admin/src/components/Deployments/HFRegistryGrid/HFRegistryGrid.tsx) — removed `encodeURIComponent` wrapper on search filter value

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)