### PR TITLE
fix: Version field in header displays conversation name instead of version value (Issue #3732)

### DIFF
--- a/apps/ai-dial-admin/src/components/Assets/Conversations/View/Properties.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Conversations/View/Properties.tsx
@@ -11,7 +11,6 @@ import { BasicI18nKey, EntityFieldsI18nKey } from '@/src/constants/i18n';
 import { BASE_BUTTON_ICON_PROPS } from '@/src/constants/main-layout';
 import { useCurrentLocale, useI18n } from '@/src/locales/client';
 import { DialConversation } from '@/src/models/dial/conversation';
-import { getNameVersionFromAsset } from '@/src/utils/entities/versions';
 
 interface Props {
   selectedConversation: DialConversation;
@@ -24,7 +23,6 @@ const Properties: FC<Props> = ({ selectedConversation }) => {
   const [deployment, setDeployment] = useState<Record<string, string> | null>(null);
 
   const model = selectedConversation.model?.id as string;
-  const conversationName = getNameVersionFromAsset(selectedConversation?.name as string);
 
   const openResourceInNewTab = () => {
     window.open(getAgentLinkForConversation(deployment, currentLocale), '_blank');
@@ -45,9 +43,9 @@ const Properties: FC<Props> = ({ selectedConversation }) => {
 
   return (
     <div className="size-full flex flex-col gap-y-8">
-      {conversationName && (
+      {selectedConversation.name && (
         <LabelledText label={t(EntityFieldsI18nKey.name)}>
-          <DialTooltip tooltip={conversationName.name}>{conversationName.name}</DialTooltip>
+          <DialTooltip tooltip={selectedConversation.name}>{selectedConversation.name}</DialTooltip>
         </LabelledText>
       )}
 

--- a/apps/ai-dial-admin/src/components/Assets/Conversations/View/View.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Conversations/View/View.tsx
@@ -8,7 +8,6 @@ import { EntityViewTab, getTabsForAsset } from '@/src/utils/tabs/utils';
 import { DialConversation } from '@/src/models/dial/conversation';
 import { deleteConversation } from '@/src/app/[lang]/conversations/actions';
 import ConversationHeader from '@/src/components/EntityHeaderControls/ConversationHeader';
-import { getNameVersionFromAsset } from '@/src/utils/entities/versions';
 import { getConversationPathWithVersion, getConversationVersions } from './utils';
 import { getUrnForEntity } from '@/src/utils/open-in-new-tab';
 import { useRouter } from 'next/navigation';
@@ -32,10 +31,8 @@ const ConversationView: FC<Props> = ({ conversation, conversations }) => {
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
-    const fullName = conversation.path.split('/').pop() || '';
-    const { version } = getNameVersionFromAsset(fullName);
     setSelectedConversation(structuredClone(conversation));
-    setVersion(version);
+    setVersion(conversation?.version || '');
     setIsLoading(false);
   }, [conversation]);
 
@@ -50,13 +47,11 @@ const ConversationView: FC<Props> = ({ conversation, conversations }) => {
     (version: string) => {
       if (!conversation) return;
 
-      const fullName = conversation.path.split('/').pop() || '';
-      const { name: nameWithoutVersion } = getNameVersionFromAsset(fullName);
       setIsLoading(true);
 
       router.push(
         getUrnForEntity(ApplicationRoute.Conversations, {
-          name: nameWithoutVersion,
+          name: conversation?.name,
           path: getConversationPathWithVersion(conversation, version),
         }),
       );

--- a/apps/ai-dial-admin/src/components/EntityHeaderControls/ConversationHeader.tsx
+++ b/apps/ai-dial-admin/src/components/EntityHeaderControls/ConversationHeader.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FC, ReactNode, useMemo } from 'react';
+import { FC, ReactNode } from 'react';
 
 import { TabModel } from '@epam/ai-dial-ui-kit';
 
@@ -9,7 +9,6 @@ import { getHeaderClassName } from '@/src/utils/entities/view';
 import { EntityViewTab } from '@/src/utils/tabs/utils';
 import ConversationButtonsWrapper, { ConversationButtonsWrapperProps } from './Wrappers/ConversationButtonsWrapper';
 import { DialConversation } from '@/src/models/dial/conversation';
-import { getNameVersionFromAsset } from '@/src/utils/entities/versions';
 import ReadonlyId from '@/src/components/BaseControls/Id/ReadonlyId';
 
 interface Props extends ConversationButtonsWrapperProps<DialConversation> {
@@ -21,15 +20,10 @@ interface Props extends ConversationButtonsWrapperProps<DialConversation> {
 }
 
 const ConversationHeader: FC<Props> = ({ children, tabs, activeTab, onChangeActiveTab, ...props }) => {
-  const conversationName = useMemo(() => {
-    const { name } = getNameVersionFromAsset(props.entity.name || '');
-    return name || '';
-  }, [props.entity.name]);
-
   return (
     <div className="flex flex-col gap-y-4 mb-8">
       <div className={getHeaderClassName(false)}>
-        <ReadonlyId value={conversationName} />
+        <ReadonlyId value={props.entity.name || ''} />
         <ConversationButtonsWrapper {...props}>{children}</ConversationButtonsWrapper>
       </div>
       <Tabs isEditorEnabled={false} tabs={tabs} activeTab={activeTab} onChangeActiveTab={onChangeActiveTab} />

--- a/apps/ai-dial-admin/src/components/Publications/View/InfoHeader.tsx
+++ b/apps/ai-dial-admin/src/components/Publications/View/InfoHeader.tsx
@@ -10,7 +10,6 @@ import { useI18n } from '@/src/locales/client';
 import { ConversationPublication, Publication, ToolsetPublication } from '@/src/models/dial/publications';
 import { Toolset } from '@/src/models/dial/toolset';
 import { ApplicationRoute } from '@/src/types/routes';
-import { getNameVersionFromAsset } from '@/src/utils/entities/versions';
 import { useLocalDateTimeString } from '@/src/hooks/use-local-date-time-string';
 import { getActionClassName } from '@/src/utils/publications';
 
@@ -23,11 +22,9 @@ const PublicationInfoHeader: FC<Props> = ({ entity, view }) => {
   const t = useI18n();
   const createdAt = useLocalDateTimeString(entity?.createdAt);
   const indicatorClassName = classNames('flex w-2 h-2 mr-1 rounded no-user-select', getActionClassName(entity?.action));
-  const conversationName =
+  const conversationVersion =
     view === ApplicationRoute.ConversationPublications
-      ? getNameVersionFromAsset(
-          (entity as unknown as ConversationPublication)?.conversations?.[0]?.conversation?.name as string,
-        )
+      ? (entity as ConversationPublication)?.conversations?.[0]?.conversation?.version
       : undefined;
 
   return (
@@ -47,7 +44,7 @@ const PublicationInfoHeader: FC<Props> = ({ entity, view }) => {
       {view === ApplicationRoute.ToolsetPublications && (
         <AuthHeader toolset={(entity as ToolsetPublication).toolSetResources?.[0].toolSetResource as Toolset} />
       )}
-      {conversationName && <LabelledText label={t(EntityFieldsI18nKey.version)} text={conversationName.version} />}
+      {conversationVersion && <LabelledText label={t(EntityFieldsI18nKey.version)} text={conversationVersion} />}
     </div>
   );
 };


### PR DESCRIPTION
**Description:**

<SHORT_DESCRIPTION>
<img width="1911" height="908" alt="publications_conversations" src="https://github.com/user-attachments/assets/e038c763-e989-41e8-8b28-5545365828fb" />

<img width="1917" height="907" alt="asset_conversations" src="https://github.com/user-attachments/assets/e4b9cdb5-3e6f-4849-ac8c-8ebc1c8ef452" />


Issues:

- Issue #3732


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
