### PR TITLE
fix: update eval summary export column delimiter epam/ai-dial-admin-evaluation-framework-backend#61

### DIFF
--- a/apps/ai-dial-admin/src/components/Runs/Export/components/tests/Columns.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Runs/Export/components/tests/Columns.spec.tsx
@@ -13,8 +13,8 @@ function makeGroups(columnNames: string[]): ColumnGroup[] {
 
 describe('Columns', () => {
   it('renders group labels', () => {
-    const groups = makeGroups(['id', 'data:prompt']);
-    const checkedColumns = new Set(['id', 'data:prompt']);
+    const groups = makeGroups(['id', 'data::prompt']);
+    const checkedColumns = new Set(['id', 'data::prompt']);
 
     render(
       <Columns groups={groups} checkedColumns={checkedColumns} onToggleColumn={vi.fn()} onToggleGroup={vi.fn()} />,
@@ -76,8 +76,8 @@ describe('Columns', () => {
   });
 
   it('renders metric sub-group headers', () => {
-    const groups = makeGroups(['metric:Accuracy:score', 'metric:Recall:score']);
-    const checkedColumns = new Set(['metric:Accuracy:score', 'metric:Recall:score']);
+    const groups = makeGroups(['metric::Accuracy::score', 'metric::Recall::score']);
+    const checkedColumns = new Set(['metric::Accuracy::score', 'metric::Recall::score']);
 
     render(
       <Columns groups={groups} checkedColumns={checkedColumns} onToggleColumn={vi.fn()} onToggleGroup={vi.fn()} />,

--- a/apps/ai-dial-admin/src/components/Runs/Export/components/tests/GroupSection.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Runs/Export/components/tests/GroupSection.spec.tsx
@@ -21,14 +21,14 @@ describe('GroupSection', () => {
   });
 
   it('shows leaf columns when expanded', () => {
-    const group = makeGroup(['data:prompt', 'data:systemPrompt'], ColumnGroupId.Data);
+    const group = makeGroup(['data::prompt', 'data::systemPrompt'], ColumnGroupId.Data);
     render(<GroupSection group={group} checkedColumns={new Set()} onToggleColumn={vi.fn()} onToggleGroup={vi.fn()} />);
     expect(screen.getByText('prompt')).toBeInTheDocument();
     expect(screen.getByText('systemPrompt')).toBeInTheDocument();
   });
 
   it('hides columns when collapsed', async () => {
-    const group = makeGroup(['data:prompt'], ColumnGroupId.Data);
+    const group = makeGroup(['data::prompt'], ColumnGroupId.Data);
     render(<GroupSection group={group} checkedColumns={new Set()} onToggleColumn={vi.fn()} onToggleGroup={vi.fn()} />);
     await userEvent.click(screen.getByRole('button'));
     expect(screen.queryByText('prompt')).not.toBeInTheDocument();
@@ -50,7 +50,7 @@ describe('GroupSection', () => {
   });
 
   it('renders metric sub-sections for the Metrics group', () => {
-    const group = makeGroup(['metric:Accuracy:score', 'metric:Recall:score'], ColumnGroupId.Metrics);
+    const group = makeGroup(['metric::Accuracy::score', 'metric::Recall::score'], ColumnGroupId.Metrics);
     render(<GroupSection group={group} checkedColumns={new Set()} onToggleColumn={vi.fn()} onToggleGroup={vi.fn()} />);
     expect(screen.getByText('metric:Accuracy')).toBeInTheDocument();
     expect(screen.getByText('metric:Recall')).toBeInTheDocument();

--- a/apps/ai-dial-admin/src/components/Runs/Export/components/tests/MetricSubSection.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Runs/Export/components/tests/MetricSubSection.spec.tsx
@@ -18,7 +18,7 @@ describe('MetricSubSection', () => {
     render(
       <MetricSubSection
         metricName="Accuracy"
-        items={makeItems(['metric:Accuracy:score'])}
+        items={makeItems(['metric::Accuracy::score'])}
         checkedColumns={new Set()}
         onToggleColumn={vi.fn()}
       />,
@@ -30,26 +30,26 @@ describe('MetricSubSection', () => {
     render(
       <MetricSubSection
         metricName="Accuracy"
-        items={makeItems(['metric:Accuracy:score', 'metric:Accuracy:value'])}
+        items={makeItems(['metric::Accuracy::score', 'metric::Accuracy::value'])}
         checkedColumns={new Set()}
         onToggleColumn={vi.fn()}
       />,
     );
-    expect(screen.getByText('metric:Accuracy:score')).toBeInTheDocument();
-    expect(screen.getByText('metric:Accuracy:value')).toBeInTheDocument();
+    expect(screen.getByText('metric::Accuracy::score')).toBeInTheDocument();
+    expect(screen.getByText('metric::Accuracy::value')).toBeInTheDocument();
   });
 
   it('hides items when collapsed', async () => {
     render(
       <MetricSubSection
         metricName="Accuracy"
-        items={makeItems(['metric:Accuracy:score'])}
+        items={makeItems(['metric::Accuracy::score'])}
         checkedColumns={new Set()}
         onToggleColumn={vi.fn()}
       />,
     );
     await userEvent.click(screen.getByRole('button'));
-    expect(screen.queryByText('metric:Accuracy:score')).not.toBeInTheDocument();
+    expect(screen.queryByText('metric::Accuracy::score')).not.toBeInTheDocument();
   });
 
   it('calls onToggleColumn when an item checkbox is clicked', async () => {
@@ -57,18 +57,18 @@ describe('MetricSubSection', () => {
     render(
       <MetricSubSection
         metricName="Accuracy"
-        items={makeItems(['metric:Accuracy:score'])}
-        checkedColumns={new Set(['metric:Accuracy:score'])}
+        items={makeItems(['metric::Accuracy::score'])}
+        checkedColumns={new Set(['metric::Accuracy::score'])}
         onToggleColumn={onToggleColumn}
       />,
     );
-    await userEvent.click(screen.getByLabelText('metric:Accuracy:score'));
-    expect(onToggleColumn).toHaveBeenCalledWith('metric:Accuracy:score', expect.any(Boolean));
+    await userEvent.click(screen.getByLabelText('metric::Accuracy::score'));
+    expect(onToggleColumn).toHaveBeenCalledWith('metric::Accuracy::score', expect.any(Boolean));
   });
 
   it('calls onToggleColumn for every item when the group header is toggled', async () => {
     const onToggleColumn = vi.fn();
-    const items = makeItems(['metric:Accuracy:score', 'metric:Accuracy:value']);
+    const items = makeItems(['metric::Accuracy::score', 'metric::Accuracy::value']);
     render(
       <MetricSubSection
         metricName="Accuracy"

--- a/apps/ai-dial-admin/src/components/Runs/Export/tests/ExportRunModal.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Runs/Export/tests/ExportRunModal.spec.tsx
@@ -18,7 +18,7 @@ vi.mock('@/src/context/NotificationContext', () => ({
 }));
 
 const PREVIEW_DATA: unknown[][] = [
-  ['id', 'data:prompt', 'response:answer'],
+  ['id', 'data::prompt', 'response::answer'],
   ['run-1', 'hello', 'world'],
 ];
 

--- a/apps/ai-dial-admin/src/components/Runs/Export/tests/group-columns.spec.ts
+++ b/apps/ai-dial-admin/src/components/Runs/Export/tests/group-columns.spec.ts
@@ -3,28 +3,28 @@ import { describe, expect, it } from 'vitest';
 import { ColumnGroupId, groupColumns } from '@/src/components/Runs/Export/utils/group-columns';
 
 describe('groupColumns', () => {
-  it('assigns data: prefix to Data group', () => {
-    const groups = groupColumns(['data:prompt', 'data:attachment']);
+  it('assigns data:: prefix to Data group', () => {
+    const groups = groupColumns(['data::prompt', 'data::attachment']);
     const dataGroup = groups.find((g) => g.id === ColumnGroupId.Data);
     expect(dataGroup).toBeDefined();
-    expect(dataGroup!.columns.map((c) => c.name)).toEqual(['data:prompt', 'data:attachment']);
+    expect(dataGroup!.columns.map((c) => c.name)).toEqual(['data::prompt', 'data::attachment']);
   });
 
-  it('strips data: prefix for display name', () => {
-    const groups = groupColumns(['data:prompt']);
+  it('strips data:: prefix for display name', () => {
+    const groups = groupColumns(['data::prompt']);
     const dataGroup = groups.find((g) => g.id === ColumnGroupId.Data)!;
     expect(dataGroup.columns[0].displayName).toBe('prompt');
   });
 
-  it('assigns response: prefix to Response group', () => {
-    const groups = groupColumns(['response:answer', 'response:file']);
+  it('assigns response:: prefix to Response group', () => {
+    const groups = groupColumns(['response::answer', 'response::file']);
     const responseGroup = groups.find((g) => g.id === ColumnGroupId.Response);
     expect(responseGroup).toBeDefined();
     expect(responseGroup!.columns).toHaveLength(2);
   });
 
-  it('assigns metric: to Metrics group and sub-groups by metric name', () => {
-    const groups = groupColumns(['metric:Accuracy:score', 'metric:Accuracy:details', 'metric:Recall:score']);
+  it('assigns metric:: to Metrics group and sub-groups by metric name', () => {
+    const groups = groupColumns(['metric::Accuracy::score', 'metric::Accuracy::details', 'metric::Recall::score']);
     const metricsGroup = groups.find((g) => g.id === ColumnGroupId.Metrics)!;
     expect(metricsGroup).toBeDefined();
     expect(metricsGroup.columns).toHaveLength(3);
@@ -32,15 +32,27 @@ describe('groupColumns', () => {
     expect(metricsGroup.columns[2].subGroup).toBe('Recall');
   });
 
-  it('assigns metricInfo: to Metrics group', () => {
-    const groups = groupColumns(['metricInfo:Accuracy:score']);
+  it('preserves a single colon embedded in the metric name', () => {
+    const groups = groupColumns([
+      'metric::Ragas: Faithfulness::score',
+      'metricInfo::Ragas: Faithfulness::score',
+      'metricError::Ragas: Faithfulness',
+    ]);
+    const metricsGroup = groups.find((g) => g.id === ColumnGroupId.Metrics)!;
+    expect(metricsGroup).toBeDefined();
+    expect(metricsGroup.columns).toHaveLength(3);
+    expect(metricsGroup.columns.every((c) => c.subGroup === 'Ragas: Faithfulness')).toBe(true);
+  });
+
+  it('assigns metricInfo:: to Metrics group', () => {
+    const groups = groupColumns(['metricInfo::Accuracy::score']);
     const metricsGroup = groups.find((g) => g.id === ColumnGroupId.Metrics);
     expect(metricsGroup).toBeDefined();
     expect(metricsGroup!.columns[0].subGroup).toBe('Accuracy');
   });
 
-  it('assigns metricError: to Metrics group', () => {
-    const groups = groupColumns(['metricError:Accuracy']);
+  it('assigns metricError:: to Metrics group', () => {
+    const groups = groupColumns(['metricError::Accuracy']);
     const metricsGroup = groups.find((g) => g.id === ColumnGroupId.Metrics);
     expect(metricsGroup).toBeDefined();
     expect(metricsGroup!.columns[0].subGroup).toBe('Accuracy');
@@ -67,14 +79,14 @@ describe('groupColumns', () => {
   });
 
   it('defaults non-body columns to checked', () => {
-    const groups = groupColumns(['id', 'data:prompt', 'response:answer', 'metric:Accuracy:score']);
+    const groups = groupColumns(['id', 'data::prompt', 'response::answer', 'metric::Accuracy::score']);
     const nonBodyGroups = groups.filter((g) => g.id !== ColumnGroupId.Body);
     const allChecked = nonBodyGroups.flatMap((g) => g.columns).every((c) => c.defaultChecked === true);
     expect(allChecked).toBe(true);
   });
 
   it('preserves group order: identification, data, response, metrics, body', () => {
-    const groups = groupColumns(['id', 'data:prompt', 'response:answer', 'metric:Accuracy:score', 'requestBody']);
+    const groups = groupColumns(['id', 'data::prompt', 'response::answer', 'metric::Accuracy::score', 'requestBody']);
     const ids = groups.map((g) => g.id);
     expect(ids).toEqual([
       ColumnGroupId.Identification,
@@ -91,8 +103,8 @@ describe('groupColumns', () => {
     expect(groups[0].id).toBe(ColumnGroupId.Identification);
   });
 
-  it('strips metric: prefix for display name (returns third segment)', () => {
-    const groups = groupColumns(['metric:Accuracy:score']);
+  it('strips metric:: prefix for display name (returns third segment)', () => {
+    const groups = groupColumns(['metric::Accuracy::score']);
     const metricsGroup = groups.find((g) => g.id === ColumnGroupId.Metrics)!;
     expect(metricsGroup.columns[0].displayName).toBe('score');
   });

--- a/apps/ai-dial-admin/src/components/Runs/Export/utils/group-columns.ts
+++ b/apps/ai-dial-admin/src/components/Runs/Export/utils/group-columns.ts
@@ -1,7 +1,22 @@
 import { ColumnGroup, ColumnItem } from '@/src/components/Runs/Export/models';
+import { CSV_COLUMN_SEPARATOR } from '@/src/constants/eval-export';
 import { ExportRunI18nKey } from '@/src/constants/i18n';
 
 const BODY_COLUMNS = new Set(['requestBody', 'responseBody', 'extractionWarnings']);
+
+const DATA_PREFIX = `data${CSV_COLUMN_SEPARATOR}`;
+const RESPONSE_PREFIX = `response${CSV_COLUMN_SEPARATOR}`;
+const METRIC_PREFIX = `metric${CSV_COLUMN_SEPARATOR}`;
+const METRIC_INFO_PREFIX = `metricInfo${CSV_COLUMN_SEPARATOR}`;
+const METRIC_ERROR_PREFIX = `metricError${CSV_COLUMN_SEPARATOR}`;
+
+function isMetricColumn(columnName: string): boolean {
+  return (
+    columnName.startsWith(METRIC_PREFIX) ||
+    columnName.startsWith(METRIC_INFO_PREFIX) ||
+    columnName.startsWith(METRIC_ERROR_PREFIX)
+  );
+}
 
 export type CheckState = 'checked' | 'unchecked' | 'indeterminate';
 
@@ -31,22 +46,18 @@ export const GROUP_LABEL_KEY: Record<ColumnGroupId, ExportRunI18nKey> = {
 
 function getGroupId(columnName: string): ColumnGroupId {
   if (BODY_COLUMNS.has(columnName)) return ColumnGroupId.Body;
-  if (columnName.startsWith('data:')) return ColumnGroupId.Data;
-  if (columnName.startsWith('response:')) return ColumnGroupId.Response;
-  if (
-    columnName.startsWith('metric:') ||
-    columnName.startsWith('metricInfo:') ||
-    columnName.startsWith('metricError:')
-  ) {
+  if (columnName.startsWith(DATA_PREFIX)) return ColumnGroupId.Data;
+  if (columnName.startsWith(RESPONSE_PREFIX)) return ColumnGroupId.Response;
+  if (isMetricColumn(columnName)) {
     return ColumnGroupId.Metrics;
   }
   return ColumnGroupId.Identification;
 }
 
 function getDisplayName(columnName: string): string {
-  const parts = columnName.split(':');
+  const parts = columnName.split(CSV_COLUMN_SEPARATOR);
   if (parts.length >= 3) {
-    return parts.slice(2).join(':');
+    return parts.slice(2).join(CSV_COLUMN_SEPARATOR);
   }
   if (parts.length === 2) {
     return parts[1];
@@ -55,13 +66,8 @@ function getDisplayName(columnName: string): string {
 }
 
 function getMetricSubGroup(columnName: string): string | undefined {
-  const parts = columnName.split(':');
-  if (
-    (columnName.startsWith('metric:') ||
-      columnName.startsWith('metricInfo:') ||
-      columnName.startsWith('metricError:')) &&
-    parts.length >= 2
-  ) {
+  const parts = columnName.split(CSV_COLUMN_SEPARATOR);
+  if (isMetricColumn(columnName) && parts.length >= 2) {
     return parts[1];
   }
   return undefined;

--- a/apps/ai-dial-admin/src/components/TestSuites/Metrics/AddMetric/Configuration.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/Metrics/AddMetric/Configuration.tsx
@@ -53,7 +53,7 @@ const MetricConfiguration: FC<Props> = ({
   const t = useI18n();
   const [isJsonView, setIsJsonView] = useState(false);
 
-  const metricNameError = metricName?.includes(':') ? t(TestSuitesI18nKey.MetricNameInvalidChars) : undefined;
+  const metricNameError = metricName?.includes('::') ? t(TestSuitesI18nKey.MetricNameInvalidChars) : undefined;
 
   const description = selectedMetric?.description || selectedMetricDetails?.description || '';
 

--- a/apps/ai-dial-admin/src/components/TestSuites/Metrics/AddMetric/Configuration.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/Metrics/AddMetric/Configuration.tsx
@@ -9,6 +9,7 @@ import ContentWithLinks from '@/src/components/Common/ContentWithLinks/ContentWi
 import ExpandableText from '@/src/components/Common/ExpandableText/ExpandableText';
 import { jsonSchemaToFields } from '@/src/components/Common/SchemaGrid/utils';
 import JsonEditor from '@/src/components/EntityTabs/JsonEditor/JsonEditor';
+import { CSV_COLUMN_SEPARATOR } from '@/src/constants/eval-export';
 import { CompareI18nKey, EntityFieldsI18nKey, TestSuitesI18nKey } from '@/src/constants/i18n';
 import { useI18n } from '@/src/locales/client';
 import { Metric, MetricBinding } from '@/src/models/evaluation/metric';
@@ -53,7 +54,9 @@ const MetricConfiguration: FC<Props> = ({
   const t = useI18n();
   const [isJsonView, setIsJsonView] = useState(false);
 
-  const metricNameError = metricName?.includes('::') ? t(TestSuitesI18nKey.MetricNameInvalidChars) : undefined;
+  const metricNameError = metricName?.includes(CSV_COLUMN_SEPARATOR)
+    ? t(TestSuitesI18nKey.MetricNameInvalidChars)
+    : undefined;
 
   const description = selectedMetric?.description || selectedMetricDetails?.description || '';
 

--- a/apps/ai-dial-admin/src/components/TestSuites/Metrics/AddMetric/utils.ts
+++ b/apps/ai-dial-admin/src/components/TestSuites/Metrics/AddMetric/utils.ts
@@ -1,6 +1,7 @@
 import { JSONSchema7 } from 'json-schema';
 
 import { jsonSchemaToFields } from '@/src/components/Common/SchemaGrid/utils';
+import { CSV_COLUMN_SEPARATOR } from '@/src/constants/eval-export';
 import { MetricBinding } from '@/src/models/evaluation/metric';
 import { MetricBindingType } from '@/src/types/evaluation';
 
@@ -15,7 +16,7 @@ export const validateMetricBindings = (
     return false;
   }
 
-  if (metricName.includes('::')) {
+  if (metricName.includes(CSV_COLUMN_SEPARATOR)) {
     return false;
   }
 

--- a/apps/ai-dial-admin/src/components/TestSuites/Metrics/AddMetric/utils.ts
+++ b/apps/ai-dial-admin/src/components/TestSuites/Metrics/AddMetric/utils.ts
@@ -15,7 +15,7 @@ export const validateMetricBindings = (
     return false;
   }
 
-  if (metricName.includes(':')) {
+  if (metricName.includes('::')) {
     return false;
   }
 

--- a/apps/ai-dial-admin/src/constants/eval-export.ts
+++ b/apps/ai-dial-admin/src/constants/eval-export.ts
@@ -1,0 +1,4 @@
+/**
+ * Column-family separator used by the eval-summary CSV export
+ */
+export const CSV_COLUMN_SEPARATOR = '::';

--- a/apps/ai-dial-admin/src/locales/en.ts
+++ b/apps/ai-dial-admin/src/locales/en.ts
@@ -1745,7 +1745,7 @@ export default {
     EditField: 'Edit field',
     NoSchemaFields: 'No schema fields',
     DuplicateFieldName: 'Field name already exists',
-    MetricNameInvalidChars: 'Name must not contain ":" symbol',
+    MetricNameInvalidChars: 'Name must not contain "::" symbols',
     SchemaDescription: 'Define the data fields available in test cases',
     FinalPath: 'Final path',
     Tool: 'Tool',


### PR DESCRIPTION
**Description:**

Aligns the eval-summary CSV export frontend with the backend's switch of the column-family separator from `:` to `::`.

#### Changes                                                                                                                                                                
                                                                                                                                                                         
  - Parsing fix (Runs/Export/utils/group-columns.ts): split/match headers on `::` so metrics group by name and colon-containing names are preserved.                       
  - Shared constant (constants/eval-export.ts): extracted `CSV_COLUMN_SEPARATOR = '::'`, reused across the parser and both metric-name validators.                         
  - Validation + locale: metric name now rejects `::` (was `:`); error message updated.                                                                                      
  - Tests: migrated export-grouping fixtures to `::`, added a regression case for an embedded single colon.

Issues:

- epam/ai-dial-admin-evaluation-framework-backend#61


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
