### PR TITLE
fix: QuickApp 2.0 Runner schema — orchestrator deployment field parsed as empty string instead of empty object  (Issue #3748)

### DIFF
--- a/apps/ai-dial-admin/src/utils/schema.ts
+++ b/apps/ai-dial-admin/src/utils/schema.ts
@@ -136,7 +136,8 @@ function getDefaultOrEmptyValue(
   if (effective.default !== undefined) return effective.default;
 
   const variants = effective.anyOf ?? effective.oneOf;
-  if (Array.isArray(variants) && variants.length) {
+  const hasOwnShape = effective.type !== undefined || effective.properties !== undefined;
+  if (!hasOwnShape && Array.isArray(variants) && variants.length) {
     const branch = pickVariant(
       variants.filter((v): v is JSONSchema7 => typeof v === 'object') as JSONSchema7[],
       options?.variantChoice ?? 'preferNullIfNullableUnion',

--- a/apps/ai-dial-admin/src/utils/tests/schema.spec.ts
+++ b/apps/ai-dial-admin/src/utils/tests/schema.spec.ts
@@ -246,4 +246,36 @@ describe('getSchemaDefaults', () => {
     };
     expect(getSchemaDefaults(root)).toEqual({ model: 'gemini-2.5-flash-lite' });
   });
+
+  test('should use properties when anyOf is a required-set constraint alongside type/properties', () => {
+    const root: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        deployment: { $ref: '#/$defs/DialDeploymentConfig' },
+      },
+      $defs: {
+        DialDeploymentConfig: {
+          anyOf: [{ required: ['deployment_id'] }, { required: ['name'] }],
+          type: 'object',
+          properties: {
+            deployment_id: { type: 'string' },
+            name: { type: 'string' },
+          },
+        },
+      },
+    };
+    expect(getSchemaDefaults(root)).toEqual({
+      deployment: { deployment_id: '', name: '' },
+    });
+  });
+
+  test('should still treat anyOf/oneOf as type union when schema has no own type/properties', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        value: { anyOf: [{ type: 'integer' }, { type: 'null' }] },
+      },
+    };
+    expect(getSchemaDefaults(schema)).toEqual({ value: null });
+  });
 });


### PR DESCRIPTION
**Description:**

added correct support of schema with anyof/typeof without default

Issues:

- Issue #3748


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
