### PR TITLE
fix(Deployments): scroll validation error into view when error appears (Issue #3765)

### DIFF
--- a/apps/ai-dial-admin/src/components/Deployments/Common/ItemsList/Item.tsx
+++ b/apps/ai-dial-admin/src/components/Deployments/Common/ItemsList/Item.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback, useEffect, useMemo, useState } from 'react';
+import { forwardRef, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { DialInput, DialRemoveButton } from '@epam/ai-dial-ui-kit';
 import classNames from 'classnames';
 
@@ -24,8 +24,29 @@ const Item = forwardRef<HTMLLIElement, Props>(
     const t = useI18n();
     const { dispatch, resetCounter } = useSaveValidationContext();
     const [error, setError] = useState<FieldError | null>(null);
+    const liRef = useRef<HTMLLIElement | null>(null);
 
     const containerClassName = useMemo(() => getControlClassName(isModal), [isModal]);
+
+    const setLiRef = useCallback(
+      (node: HTMLLIElement | null) => {
+        liRef.current = node;
+        if (typeof ref === 'function') {
+          ref(node);
+        } else if (ref) {
+          ref.current = node;
+        }
+      },
+      [ref],
+    );
+
+    // Keep the validation error in view: when the error appears, the item grows and its
+    // message can fall outside the scrollable list — scroll it back into view.
+    useEffect(() => {
+      if (error) {
+        liRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      }
+    }, [error]);
 
     useEffect(() => {
       if (resetCounter) {
@@ -63,7 +84,7 @@ const Item = forwardRef<HTMLLIElement, Props>(
       <li
         className={classNames('flex flex-row gap-2 w-full', error ? 'items-start' : 'items-center')}
         key={`item-${index}`}
-        ref={ref}
+        ref={setLiRef}
       >
         <DialInput
           id={`item-${index}`}

--- a/apps/ai-dial-admin/src/components/Deployments/Common/ItemsList/ItemsList.tsx
+++ b/apps/ai-dial-admin/src/components/Deployments/Common/ItemsList/ItemsList.tsx
@@ -18,6 +18,7 @@ interface Props {
 
 const ItemsList: FC<Props> = ({ items, setItems, addItemLabel, validate, isModal = false, disabled = false }) => {
   const lastItemRef = useRef<HTMLLIElement | null>(null);
+  const prevItemsCount = useRef(0);
 
   const onChangeItem = useCallback(
     (item: string | undefined, index: number) => {
@@ -44,8 +45,12 @@ const ItemsList: FC<Props> = ({ items, setItems, addItemLabel, validate, isModal
   }, [items, setItems]);
 
   useEffect(() => {
-    lastItemRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-  }, []);
+    const count = items?.length ?? 0;
+    if (count > prevItemsCount.current) {
+      lastItemRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+    prevItemsCount.current = count;
+  }, [items?.length]);
 
   return (
     <div className="flex flex-col items-start gap-4 h-full">

--- a/apps/ai-dial-admin/src/components/Deployments/Common/ItemsList/tests/Item.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Deployments/Common/ItemsList/tests/Item.spec.tsx
@@ -41,6 +41,34 @@ describe('Common Item component', () => {
     });
   });
 
+  test('scrolls the item into view when a validation error appears', async () => {
+    const scrollSpy = vi.spyOn(HTMLLIElement.prototype, 'scrollIntoView').mockImplementation(vi.fn());
+    const validate = vi.fn().mockReturnValue({ type: 'LENGTH', text: 'too short' });
+
+    render(
+      <Item
+        item=""
+        index={1}
+        onChange={onChange}
+        onRemove={onRemove}
+        isModal={false}
+        disabled={false}
+        validate={validate}
+      />,
+    );
+
+    const input = screen.getByRole('textbox');
+    await user.click(input);
+    await user.paste('co');
+
+    await waitFor(() => {
+      expect(screen.getByText('too short')).toBeInTheDocument();
+      expect(scrollSpy).toHaveBeenCalled();
+    });
+
+    scrollSpy.mockRestore();
+  });
+
   test('onRemove called', async () => {
     render(<Item item="" index={1} onChange={onChange} onRemove={onRemove} isModal={false} disabled={false} />);
 


### PR DESCRIPTION
**Description:**

When a validation error appears on an item in a scrollable list, the item grows in height and the error message can fall outside the visible area. This fix ensures that when an error is detected, the item is automatically scrolled into view using `scrollIntoView()` with smooth behavior. Additionally, the `ItemsList` component was fixed to avoid unnecessary scrolling of the last item on mount — it now only scrolls when the items count actually increases.

Issues:

- Issue #3765

**Key Changes:**

- [Item.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/development/apps/ai-dial-admin/src/components/Deployments/Common/ItemsList/Item.tsx) — added `useRef` to track the list item DOM node and `useEffect` to trigger scroll when error appears
- [ItemsList.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/development/apps/ai-dial-admin/src/components/Deployments/Common/ItemsList/ItemsList.tsx) — changed scroll trigger from mount to only when items count increases
- [Item.spec.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/development/apps/ai-dial-admin/src/components/Deployments/Common/ItemsList/tests/Item.spec.tsx) — added test verifying scroll behavior when validation error appears

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with \`(Issue #3765)\`