### PR TITLE
fix(Deployments): use instant scroll for validation error (Issue #3766)

### DIFF
--- a/apps/ai-dial-admin/src/components/Deployments/Common/ItemsList/Item.tsx
+++ b/apps/ai-dial-admin/src/components/Deployments/Common/ItemsList/Item.tsx
@@ -41,10 +41,12 @@ const Item = forwardRef<HTMLLIElement, Props>(
     );
 
     // Keep the validation error in view: when the error appears, the item grows and its
-    // message can fall outside the scrollable list — scroll it back into view.
+    // message can fall outside the scrollable list — scroll it back into view. Use an
+    // instant scroll (not smooth): while typing, the browser keeps the focused input in
+    // view, and a smooth (animated) scroll gets reverted by it before it completes.
     useEffect(() => {
       if (error) {
-        liRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+        liRef.current?.scrollIntoView({ block: 'nearest' });
       }
     }, [error]);
 


### PR DESCRIPTION
## Summary

The smooth scroll animation gets reverted by the browser keeping the focused input in view while the user is typing. Switch to an instant scroll (block: 'nearest') for consistent behavior — the error message now stays visible while typing.

## Test plan

- Navigate to a deployment with a list of items (containers, images, etc.)
- Add validation errors by exceeding max character length or breaking validation rules
- Verify the error message stays visible in the scrollable area while typing
- Confirm the error message doesn't animate away before completing the scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)