### PR TITLE
fix(Deployments/ModelServings): mark Path field as required in probe endpoint validation (Issue #3744)

### DIFF
--- a/apps/ai-dial-admin/src/components/Deployments/Fields/ContainerStartupProbe/Endpoint.tsx
+++ b/apps/ai-dial-admin/src/components/Deployments/Fields/ContainerStartupProbe/Endpoint.tsx
@@ -139,15 +139,16 @@ const Endpoint: FC<Props> = ({ container, setContainer, disabled }) => {
   }, [container.probeProperties?.probe?.port, dispatch, resetCounter, t]);
 
   useEffect(() => {
+    const isHttpGet = container.probeProperties?.probe?.$type === PROBE_TYPE.HTTP_GET;
     if (
       resetCounter ||
       (container.probeProperties?.probe?.path != null && container.probeProperties?.probe?.path.length > 0)
     ) {
-      const error = getPathError(container.probeProperties?.probe?.path as string, t);
+      const error = getPathError(container.probeProperties?.probe?.path as string, t, isHttpGet);
       setPathError(error);
       dispatch({ type: ValidationActionType.SetField, field: 'path', isValid: !error });
     }
-  }, [container.probeProperties?.probe?.path, dispatch, resetCounter, t]);
+  }, [container.probeProperties?.probe?.$type, container.probeProperties?.probe?.path, dispatch, resetCounter, t]);
 
   return (
     <div className="flex flex-col gap-6">
@@ -164,7 +165,7 @@ const Endpoint: FC<Props> = ({ container, setContainer, disabled }) => {
         />
         <DialNumberInput
           id="port"
-          labelProps={{ label: t(EntityFieldsI18nKey.Port) }}
+          labelProps={{ label: t(EntityFieldsI18nKey.Port), required: true }}
           caption={!portError ? t(EntityCaptionsI18nKey.ProbePort) : ''}
           placeholder={t(EntityPlaceholdersI18nKey.Port)}
           value={container.probeProperties?.probe?.port}
@@ -177,7 +178,7 @@ const Endpoint: FC<Props> = ({ container, setContainer, disabled }) => {
         {container.probeProperties?.probe?.$type === PROBE_TYPE.HTTP_GET && (
           <DialInput
             id="path"
-            labelProps={{ label: t(EntityFieldsI18nKey.Path) }}
+            labelProps={{ label: t(EntityFieldsI18nKey.Path), required: true }}
             caption={!pathError ? t(EntityCaptionsI18nKey.ProbePath) : ''}
             placeholder={t(EntityPlaceholdersI18nKey.Path)}
             value={container.probeProperties?.probe?.path}


### PR DESCRIPTION
## Summary

The Path field in HTTP GET probe endpoints was not marked as required, and validation errors were only checked when the field contained a non-empty value. This caused the form to silently fail submission without showing an error to the user. Now the field is explicitly marked as required, validation runs for all probe types, and errors display consistently—matching the Port field behavior.

## Key Changes

- [src/components/Deployments/Fields/ContainerStartupProbe/Endpoint.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/development/apps/ai-dial-admin/src/components/Deployments/Fields/ContainerStartupProbe/Endpoint.tsx) — Mark Path field with `required: true`, add probe type check to validation effect, include `$type` in effect dependencies

## Checklist

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with \`(Issue #3744)\`