### PR TITLE
fix: Remove "Preview" badges from completed menu items

### DIFF
--- a/apps/ai-dial-admin/src/components/Menu/MenuItem/MenuItemContent.tsx
+++ b/apps/ai-dial-admin/src/components/Menu/MenuItem/MenuItemContent.tsx
@@ -8,7 +8,7 @@ import { MenuI18nKey } from '@/src/constants/i18n';
 import { useI18n } from '@/src/locales/client';
 import { MenuItem } from '../menu-configuration';
 
-const PREVIEW_TAG_MENU_ITEMS = new Set([MenuI18nKey.TestSuites, MenuI18nKey.Datasets, MenuI18nKey.Runs]);
+const PREVIEW_TAG_MENU_ITEMS = new Set<MenuI18nKey>([]);
 interface Props {
   menuItem: MenuItem;
   isActive: boolean;


### PR DESCRIPTION
**Description:**

Removes the `Preview` badge from the three items in the section.
These items are no longer under development, so they should no longer be marked as preview.

Issues:

- Issue #<TICKET_ID>


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
