### PR TITLE
fix(Models): match inferenceTask enum to backend lowercase wire format (Issues #1994, #2502)

### DIFF
--- a/apps/ai-dial-admin/src/components/SourceField/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/SourceField/tests/utils.spec.ts
@@ -15,6 +15,14 @@ import {
   INFERENCE_TASK,
 } from '@/src/types/deployments/containers';
 
+describe('INFERENCE_TASK wire values', () => {
+  test('match the backend wire format', () => {
+    expect(INFERENCE_TASK.TEXT_GENERATION).toBe('text_generation');
+    expect(INFERENCE_TASK.TEXT_CLASSIFICATION).toBe('text_classification');
+    expect(INFERENCE_TASK.NONE).toBe('none');
+  });
+});
+
 describe('isModelCapableContainer', () => {
   const container = (inferenceTask?: INFERENCE_TASK): Container =>
     ({ name: 'c', $type: CONTAINER_TYPE.HF, inferenceTask }) as Container;

--- a/apps/ai-dial-admin/src/types/deployments/containers.ts
+++ b/apps/ai-dial-admin/src/types/deployments/containers.ts
@@ -34,9 +34,9 @@ export enum CreateSteps {
 }
 
 export enum INFERENCE_TASK {
-  TEXT_GENERATION = 'TEXT_GENERATION',
-  TEXT_CLASSIFICATION = 'TEXT_CLASSIFICATION',
-  NONE = 'NONE',
+  TEXT_GENERATION = 'text_generation',
+  TEXT_CLASSIFICATION = 'text_classification',
+  NONE = 'none',
 }
 
 export enum CONTAINER_SOURCE_TYPE {

--- a/openspec/changes/archive/2026-06-30-gate-model-serving-by-capability/design.md
+++ b/openspec/changes/archive/2026-06-30-gate-model-serving-by-capability/design.md
@@ -33,7 +33,7 @@ Two FE surfaces consume containers for model creation:
 Rule: block/filter only when `inferenceTask` is explicitly `NONE` or `TEXT_CLASSIFICATION` (for the model path). `undefined` means non-inference (NIM) and keeps today's behavior. This avoids regressing NIM model-servings, which never carry the field. Inference is never null, so there is no ambiguity for inference containers.
 
 **Model the field as an enum, not a string union.**
-Add `INFERENCE_TASK` enum in `types/deployments/containers.ts` (string values equal to the BE enum names) and `inferenceTask?: INFERENCE_TASK` on `Container`. Follows the repo enum-over-union standard.
+Add `INFERENCE_TASK` enum in `types/deployments/containers.ts` (values `text_generation`/`text_classification`/`none`, matching the backend wire format) and `inferenceTask?: INFERENCE_TASK` on `Container`. Follows the repo enum-over-union standard.
 
 **Filter at the picker, not in `isValidSourceField`.**
 Excluding incompatible containers from the list (`Containers.tsx`, alongside the `status === 'running'` filter) is simpler and clearer than adding capability logic to validation, and means the user can't select an invalid option in the first place. Validation stays as-is.

--- a/openspec/changes/archive/2026-06-30-gate-model-serving-by-capability/tasks.md
+++ b/openspec/changes/archive/2026-06-30-gate-model-serving-by-capability/tasks.md
@@ -1,6 +1,6 @@
 ## 1. Model the backend capability field
 
-- [x] 1.1 Add `INFERENCE_TASK` enum (`TEXT_GENERATION` / `TEXT_CLASSIFICATION` / `NONE`, string values = enum names) to `src/types/deployments/containers.ts`
+- [x] 1.1 Add `INFERENCE_TASK` enum (`text_generation` / `text_classification` / `none`, matching the backend wire format) to `src/types/deployments/containers.ts`
 - [x] 1.2 Add optional `inferenceTask?: INFERENCE_TASK` to the `Container` interface in `src/models/deployments/containers.ts`
 
 ## 2. Filter the Model-Serving source picker


### PR DESCRIPTION
**Description:**

Follow-up fix to #3794. The `INFERENCE_TASK` enum shipped with uppercase string values (`TEXT_CLASSIFICATION`), but the deployment-manager backend serializes enums **lowercase** (`WRITE_ENUMS_TO_LOWERCASE`), so the API returns `text_classification` / `text_generation` / `none`. As a result the capability comparisons never matched and the Model-Serving gating was a silent no-op against the real API (verified on dev: a `deberta-v3-base-prompt-injection` serving reporting `inferenceTask: "text_classification"` still showed the Create Model button).

**Issues:**

- Issue #1994
- Issue #2502

**Key Changes:**

- `types/deployments/containers.ts` — `INFERENCE_TASK` values changed to the lowercase wire format (`text_generation` / `text_classification` / `none`)
- `SourceField/tests/utils.spec.ts` — regression test pinning the enum values to the wire format
- Minor accuracy tweak to the archived change's design/tasks notes

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<ticket>)` (comma-separated list of issues)
