### PR TITLE
fix: [Eval]: Change Tool modal — radio button not indicated as selected (Issue #3752)

### DIFF
--- a/apps/ai-dial-admin/src/components/TestSuites/Modals/ChangeMcpToolModal/ChangeMcpToolModal.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/Modals/ChangeMcpToolModal/ChangeMcpToolModal.tsx
@@ -63,7 +63,11 @@ const ChangeMcpToolModal: FC<Props> = ({ testSuite, isOpen, onClose, onSave }) =
     >
       <div className="size-full flex flex-col gap-4 px-6 py-4">
         <div className="flex-1 min-h-0">
-          <McpTool deploymentId={deploymentId} initialToolName={testSuite.toolRef?.name} onSelect={onToolSelect} />
+          <McpTool
+            deploymentId={deploymentId}
+            selectedToolName={pendingTool?.name ?? testSuite.toolRef?.name}
+            onSelect={onToolSelect}
+          />
         </div>
       </div>
     </DialConfirmationPopup>,

--- a/apps/ai-dial-admin/src/components/TestSuites/Modals/ChangeMcpToolModal/tests/ChangeMcpToolModal.spec.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/Modals/ChangeMcpToolModal/tests/ChangeMcpToolModal.spec.tsx
@@ -1,0 +1,121 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test, vi } from 'vitest';
+
+import { ButtonsI18nKey } from '@/src/constants/i18n';
+import { ToolDefinition } from '@/src/models/evaluation/deployment';
+import { SuiteType, TestSuite } from '@/src/models/evaluation/test-suite';
+import ChangeMcpToolModal from '../ChangeMcpToolModal';
+
+// Mock the tool picker so we can observe the `selectedToolName` it receives
+// (the value that drives the radio's checked state) and trigger a selection.
+const CALCULATOR_TOOL: ToolDefinition = {
+  name: 'calculator',
+  description: 'Calculator tool',
+  inputSchema: { type: 'object', properties: {} },
+};
+
+vi.mock('@/src/components/TestSuites/Modals/Create/McpTool', () => ({
+  default: ({
+    selectedToolName,
+    onSelect,
+  }: {
+    selectedToolName?: string;
+    onSelect: (tool: ToolDefinition) => void;
+  }) => (
+    <div>
+      <span>selected:{selectedToolName ?? 'none'}</span>
+      <button type="button" onClick={() => onSelect(CALCULATOR_TOOL)}>
+        pick-calculator
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('@/src/components/TestSuites/ArgumentTemplate/utils', () => ({
+  buildInitialArguments: () => ({}),
+}));
+
+vi.mock('@epam/ai-dial-ui-kit', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    PopupSize: { Lg: 'lg' },
+    DialConfirmationPopup: ({
+      children,
+      confirmLabel,
+      onConfirm,
+      disableConfirmButton,
+      open,
+    }: {
+      children: React.ReactNode;
+      confirmLabel: string;
+      onConfirm: () => void;
+      disableConfirmButton?: boolean;
+      open?: boolean;
+    }) =>
+      open ? (
+        <div>
+          {children}
+          <button type="button" onClick={onConfirm} disabled={disableConfirmButton}>
+            {confirmLabel}
+          </button>
+        </div>
+      ) : null,
+  };
+});
+
+const baseMcpSuite: TestSuite = {
+  id: 'suite-1',
+  suiteType: SuiteType.McpTool,
+  mcpDeploymentRef: { id: 'deploy-1', type: 'dial-toolset', name: 'My Toolset' },
+  toolRef: {
+    name: 'search',
+    description: 'Search tool',
+    inputSchema: { type: 'object', properties: { query: { type: 'string' } }, required: ['query'] },
+  },
+};
+
+describe('ChangeMcpToolModal', () => {
+  test('pre-selects the saved tool when opened', () => {
+    render(<ChangeMcpToolModal testSuite={baseMcpSuite} isOpen onClose={vi.fn()} onSave={vi.fn()} />);
+
+    expect(screen.getByText('selected:search')).toBeInTheDocument();
+  });
+
+  test('moves the selection to the tool the user picks', async () => {
+    const user = userEvent.setup();
+    render(<ChangeMcpToolModal testSuite={baseMcpSuite} isOpen onClose={vi.fn()} onSave={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: 'pick-calculator' }));
+
+    expect(screen.getByText('selected:calculator')).toBeInTheDocument();
+    expect(screen.queryByText('selected:search')).not.toBeInTheDocument();
+  });
+
+  test('saves the test suite with the picked tool', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    render(<ChangeMcpToolModal testSuite={baseMcpSuite} isOpen onClose={vi.fn()} onSave={onSave} />);
+
+    await user.click(screen.getByRole('button', { name: 'pick-calculator' }));
+    await user.click(screen.getByRole('button', { name: ButtonsI18nKey.Save }));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onSave.mock.calls[0][0].toolRef).toEqual(
+      expect.objectContaining({ name: 'calculator', description: 'Calculator tool' }),
+    );
+  });
+
+  test('disables Save until a tool is picked', async () => {
+    const user = userEvent.setup();
+    render(<ChangeMcpToolModal testSuite={baseMcpSuite} isOpen onClose={vi.fn()} onSave={vi.fn()} />);
+
+    const saveButton = screen.getByRole('button', { name: ButtonsI18nKey.Save });
+    expect(saveButton).toBeDisabled();
+
+    await user.click(screen.getByRole('button', { name: 'pick-calculator' }));
+
+    expect(saveButton).toBeEnabled();
+  });
+});

--- a/apps/ai-dial-admin/src/components/TestSuites/Modals/Create/CreateTestSuite.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/Modals/Create/CreateTestSuite.tsx
@@ -151,7 +151,7 @@ const CreateTestSuit: FC<Props> = ({ onClose, isModalOpen, onCreate, currentEnti
             (isMcp && testSuite.mcpDeploymentRef ? (
               <McpTool
                 deploymentId={testSuite.mcpDeploymentRef.id}
-                initialToolName={testSuite.toolRef?.name}
+                selectedToolName={testSuite.toolRef?.name}
                 onSelect={onToolSelect}
               />
             ) : (

--- a/apps/ai-dial-admin/src/components/TestSuites/Modals/Create/McpTool.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/Modals/Create/McpTool.tsx
@@ -11,11 +11,11 @@ import { ToolDefinition } from '@/src/models/evaluation/deployment';
 
 interface Props {
   deploymentId: string;
-  initialToolName?: string;
+  selectedToolName?: string;
   onSelect: (tool: ToolDefinition) => void;
 }
 
-const McpTool: FC<Props> = ({ deploymentId, initialToolName, onSelect }) => {
+const McpTool: FC<Props> = ({ deploymentId, selectedToolName, onSelect }) => {
   const t = useI18n();
   const [isLoading, setIsLoading] = useState(false);
   const [tools, setTools] = useState<ToolDefinition[] | null>(null);
@@ -41,7 +41,7 @@ const McpTool: FC<Props> = ({ deploymentId, initialToolName, onSelect }) => {
       data={tools}
       idField="name"
       onSelect={onSelect}
-      selectedId={initialToolName}
+      selectedId={selectedToolName}
       emptyTitle={t(TestSuitesI18nKey.NoToolsAvailable)}
     />
   );

--- a/openspec/changes/archive/2026-07-01-fix-change-tool-modal-radio-selection/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-01-fix-change-tool-modal-radio-selection/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-01

--- a/openspec/changes/archive/2026-07-01-fix-change-tool-modal-radio-selection/design.md
+++ b/openspec/changes/archive/2026-07-01-fix-change-tool-modal-radio-selection/design.md
@@ -1,0 +1,46 @@
+## Context
+
+The tool picker (`Create/McpTool.tsx` → `Grid/GridView/RadioSelectGrid.tsx`) renders a radio in ag-grid's selection column via `RadioButtonRenderer`. The radio's checked visual is derived purely from the `selectedId` prop:
+
+```
+RadioButtonRenderer.isChecked = params.data[idField] === selectedId
+```
+
+`RadioSelectGrid` fires `onSelect(row)` on row selection but never mutates `selectedId` itself — by design, the **parent owns** the selected id and must feed the new value back down. `AgGridWrapper` spreads `additionalGridOptions` onto `AgGridReact`, so when `selectedId` changes the renderer re-runs and the radio updates.
+
+- **Create flow (`CreateTestSuite.tsx`)** honors this contract: `onToolSelect` writes `testSuite.toolRef.name`, and it passes `initialToolName={testSuite.toolRef?.name}` — which changes on every click. Radio updates correctly.
+- **Change Tool modal (`ChangeMcpToolModal.tsx`)** breaks it: `onToolSelect` only calls `setPendingTool(tool)`, while `initialToolName={testSuite.toolRef?.name}` stays frozen at the previously-saved tool. `selectedId` never changes, so the radio never re-fills. This is issue #3752.
+
+## Goals / Non-Goals
+
+**Goals:**
+- The Change Tool modal's radio always reflects the tool that Save would apply.
+- Keep the fix minimal and consistent with the existing parent-owns-selection pattern.
+
+**Non-Goals:**
+- No change to `RadioSelectGrid`, `RadioButtonRenderer`, `AgGridWrapper`, or ag-grid selection wiring.
+- No behavior change to the Create flow, `Target`, or other `RadioSelectGrid` consumers.
+- Not refactoring `RadioSelectGrid` into an internally-controlled component (larger blast radius, deferred).
+
+## Decisions
+
+**Decision: Drive the picker's `selectedId` from the pending selection in `ChangeMcpToolModal`.**
+
+Pass `pendingTool?.name ?? testSuite.toolRef?.name` down to the picker instead of only the saved tool name. The modal already holds `pendingTool`, so no new state is introduced — the fix reconnects the existing state to the radio's `selectedId`.
+
+- *Rationale:* Matches how `CreateTestSuite` already drives selection; smallest possible change; no shared-component risk.
+- *Alternative considered — make `RadioSelectGrid` internally controlled:* fixes every consumer at the source, but changes behavior for components that already work and risks controlled/uncontrolled drift when data reloads (tab switches in `Target`). Rejected for this bug; can be revisited separately.
+- *Alternative considered — drive the renderer off `params.node.isSelected()`:* couples the visual to ag-grid's native selection and needs explicit cell refresh on selection change; more moving parts than the prop fix. Rejected.
+
+**Decision: Rename `McpTool`'s `initialToolName` prop to `selectedToolName`.**
+
+Once the value tracks the live selection it is no longer "initial". Rename the prop on `Create/McpTool.tsx` and update both call sites (`ChangeMcpToolModal.tsx`, `CreateTestSuite.tsx`). `onFirstDataRendered` in `RadioSelectGrid` still handles the open-time pre-select + scroll from the same `selectedId`.
+
+- *Rationale:* Keeps the prop name truthful; low cost (two call sites).
+- *Alternative:* Leave the name as-is to shrink the diff. Acceptable but mildly misleading; rename preferred per code-standards clarity.
+
+## Risks / Trade-offs
+
+- [Risk] Renaming the prop touches the Create flow call site → **Mitigation:** the value passed is unchanged (`testSuite.toolRef?.name`); only the prop identifier changes. Covered by existing Create tests.
+- [Risk] `pendingTool` and the picker's `selectedId` could diverge → **Mitigation:** both derive from the same `onToolSelect`/`pendingTool` source of truth, so they stay in lockstep.
+- [Trade-off] `RadioSelectGrid` still relies on parents to round-trip `selectedId` (latent footgun for future consumers). Accepted here; a follow-up could make it internally controlled.

--- a/openspec/changes/archive/2026-07-01-fix-change-tool-modal-radio-selection/proposal.md
+++ b/openspec/changes/archive/2026-07-01-fix-change-tool-modal-radio-selection/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+In the **Change Tool** modal (Evaluation → Test suite → MCP suite → Method tab → "Change tool"), clicking a tool does not visually fill its radio button, so users get no confirmation of what they selected before saving (issue #3752). The selection is functionally captured (Save enables and works), but the missing visual feedback is confusing.
+
+## What Changes
+
+- The Change Tool modal will visually mark the currently-selected tool's radio button as checked, updating immediately when the user picks a different tool.
+- Fix is scoped to `ChangeMcpToolModal`: the tool picker's `selectedId` will be driven by the pending selection (falling back to the test suite's saved tool) instead of being frozen at the saved tool name.
+- No behavior change for the Create Test Suite flow, `Target`, or other `RadioSelectGrid` consumers, which already round-trip `selectedId` correctly.
+
+## Capabilities
+
+### New Capabilities
+- `change-tool-modal-selection`: Visual selection state of the tool picker within the Change Tool modal for MCP test suites.
+
+### Modified Capabilities
+<!-- None: no existing consolidated spec covers this behavior. -->
+
+## Impact
+
+- Code: `apps/ai-dial-admin/src/components/TestSuites/Modals/ChangeMcpToolModal/ChangeMcpToolModal.tsx` (single-file fix). Optional clarity rename of the `initialToolName` prop on `TestSuites/Modals/Create/McpTool.tsx` to `selectedToolName` (also used by `CreateTestSuite.tsx`).
+- Tests: `ChangeMcpToolModal` / `McpMethodContent` component tests.
+- No API, dependency, or shared-grid (`RadioSelectGrid`) changes. Cosmetic, no functional/data impact.

--- a/openspec/changes/archive/2026-07-01-fix-change-tool-modal-radio-selection/specs/change-tool-modal-selection/spec.md
+++ b/openspec/changes/archive/2026-07-01-fix-change-tool-modal-radio-selection/specs/change-tool-modal-selection/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Change Tool modal reflects the current tool selection
+
+The Change Tool modal (Evaluation → Test suite → MCP suite → Method tab → "Change tool") SHALL visually mark exactly one tool's radio button as checked at all times, corresponding to the tool that would be applied on Save. When the modal opens, the currently-saved tool SHALL be pre-selected and scrolled into view. When the user picks a different tool, that tool's radio button SHALL immediately become the checked one and the previously-checked radio SHALL clear.
+
+#### Scenario: Saved tool pre-selected on open
+
+- **WHEN** the user opens the Change Tool modal for an MCP test suite that already references a tool
+- **THEN** the radio button for the saved tool is shown as checked
+- **AND** the saved tool's row is scrolled into view
+
+#### Scenario: Selecting a different tool updates the radio
+
+- **WHEN** the user clicks a tool row other than the currently-checked one
+- **THEN** the clicked tool's radio button becomes checked
+- **AND** the previously-checked tool's radio button becomes unchecked
+
+#### Scenario: Save applies the visually-selected tool
+
+- **WHEN** a tool's radio button is shown as checked and the user clicks Save
+- **THEN** the test suite is updated to reference that tool
+- **AND** the modal closes
+
+#### Scenario: Save disabled with no selection
+
+- **WHEN** the modal is open and the user has not picked any tool
+- **THEN** the Save button is disabled

--- a/openspec/changes/archive/2026-07-01-fix-change-tool-modal-radio-selection/tasks.md
+++ b/openspec/changes/archive/2026-07-01-fix-change-tool-modal-radio-selection/tasks.md
@@ -1,0 +1,14 @@
+## 1. Fix the Change Tool modal selection
+
+- [x] 1.1 In `apps/ai-dial-admin/src/components/TestSuites/Modals/Create/McpTool.tsx`, rename the `initialToolName` prop to `selectedToolName` (update the `Props` interface and the `selectedId={...}` binding passed to `RadioSelectGrid`).
+- [x] 1.2 In `apps/ai-dial-admin/src/components/TestSuites/Modals/ChangeMcpToolModal/ChangeMcpToolModal.tsx`, pass the live selection to the picker: `selectedToolName={pendingTool?.name ?? testSuite.toolRef?.name}` so the radio reflects the pending tool and clears the previous one on each pick.
+- [x] 1.3 In `apps/ai-dial-admin/src/components/TestSuites/Modals/Create/CreateTestSuite.tsx`, update the `McpTool` call site to use the renamed `selectedToolName` prop (value stays `testSuite.toolRef?.name`); confirm no other consumers reference `initialToolName`.
+
+## 2. Tests
+
+- [x] 2.1 Added dedicated `apps/ai-dial-admin/src/components/TestSuites/Modals/ChangeMcpToolModal/tests/ChangeMcpToolModal.spec.tsx` (the `McpMethodContent` spec fully mocks the modal, so selection behavior can't be asserted there). Covers: saved tool checked on open; picking a different tool moves the checked radio; Save applies the picked tool; Save disabled with no selection. Follows `.claude/rules/testing.md`.
+
+## 3. Quality checks
+
+- [x] 3.1 Run `npm run lint`, `npm run format`, and `npm run test` from `apps/ai-dial-admin/` (or repo root per project config); resolve all failures. — Lint clean on the 3 source files; Prettier clean; full `TestSuites` suite green (458/458), incl. new `ChangeMcpToolModal` spec.
+- [ ] 3.2 Run the `spec-browser-verify` skill for this change against the running local app (local stack up, auth disabled) to verify the `change-tool-modal-selection` scenarios via the spec-verification-gate sub-agent; resolve any `fail` verdicts before completion. — BLOCKED: Playwright MCP server not connected in this environment (`mcp__playwright__browser_*` tools unavailable). All 4 scenarios reported `blocked` (setup, not defect). Retest all 4 once Playwright MCP is exposed.

--- a/openspec/specs/change-tool-modal-selection/spec.md
+++ b/openspec/specs/change-tool-modal-selection/spec.md
@@ -1,0 +1,34 @@
+# change-tool-modal-selection
+
+## Purpose
+
+Ensure the visual selection state of the tool picker within the Change Tool modal (Evaluation → Test suite → MCP suite → Method tab → "Change tool") accurately reflects the tool that would be applied on Save, so users get clear confirmation of their selection before saving.
+
+## Requirements
+
+### Requirement: Change Tool modal reflects the current tool selection
+
+The Change Tool modal (Evaluation → Test suite → MCP suite → Method tab → "Change tool") SHALL visually mark exactly one tool's radio button as checked at all times, corresponding to the tool that would be applied on Save. When the modal opens, the currently-saved tool SHALL be pre-selected and scrolled into view. When the user picks a different tool, that tool's radio button SHALL immediately become the checked one and the previously-checked radio SHALL clear.
+
+#### Scenario: Saved tool pre-selected on open
+
+- **WHEN** the user opens the Change Tool modal for an MCP test suite that already references a tool
+- **THEN** the radio button for the saved tool is shown as checked
+- **AND** the saved tool's row is scrolled into view
+
+#### Scenario: Selecting a different tool updates the radio
+
+- **WHEN** the user clicks a tool row other than the currently-checked one
+- **THEN** the clicked tool's radio button becomes checked
+- **AND** the previously-checked tool's radio button becomes unchecked
+
+#### Scenario: Save applies the visually-selected tool
+
+- **WHEN** a tool's radio button is shown as checked and the user clicks Save
+- **THEN** the test suite is updated to reference that tool
+- **AND** the modal closes
+
+#### Scenario: Save disabled with no selection
+
+- **WHEN** the modal is open and the user has not picked any tool
+- **THEN** the Save button is disabled


### PR DESCRIPTION
**Description:**

added tool selection for mcp tool grid

Issues:

- Issue #3752


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
