### PR TITLE
fix: Config delivery and forward-per-request key fields visible for non-application runner mcp apps (Issue #3243)

### DIFF
--- a/apps/ai-dial-admin/src/components/SourceField/Endpoints/ApplicationEndpoint.tsx
+++ b/apps/ai-dial-admin/src/components/SourceField/Endpoints/ApplicationEndpoint.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { DialCheckbox, DialSelectField } from '@epam/ai-dial-ui-kit';
+import { DialCheckbox, DialSelectField, DialSwitch } from '@epam/ai-dial-ui-kit';
 import classNames from 'classnames';
 import { FC, useCallback, useEffect, useState } from 'react';
 
@@ -7,12 +7,17 @@ import EditorUrlControl from '@/src/components/BaseControls/Endpoint/EditorUrl';
 import EndpointControl from '@/src/components/BaseControls/Endpoint/Endpoint';
 import ViewerUrlControl from '@/src/components/BaseControls/Endpoint/ViewerUrl';
 import ComplexInput from '@/src/components/Common/ComplexInput/ComplexInput';
+import { SOURCE_FIELD } from '@/src/components/SourceField/types';
 import { EntityFieldsI18nKey, EntityPlaceholdersI18nKey, SourceI18nKey } from '@/src/constants/i18n';
 import { CONTROL_WIDTH, CONTROL_WITH_BUTTON_WIDTH } from '@/src/constants/main-layout';
 import { ONLY_HTTP_TRANSPORTS } from '@/src/constants/transport';
 import { useI18n } from '@/src/locales/client';
-import { ApplicationMCPContainer, DialApplication } from '@/src/models/dial/application';
-import { SOURCE_FIELD } from '@/src/components/SourceField/types';
+import {
+  ApplicationMCPConfigDelivery,
+  ApplicationMCPContainer,
+  DialApplication,
+  MCP_CONFIG_DELIVERY_I18N_MAP,
+} from '@/src/models/dial/application';
 
 enum ApplicationEndpointCheckbox {
   CHAT_ENDPOINT = 'chat_endpoint',
@@ -78,7 +83,7 @@ const ApplicationEndpoint: FC<Props> = ({
             ...(entity.source as SOURCE_FIELD),
             mcpEndpointPath: mcpEnabled ? entity.source?.mcpEndpointPath : null,
           } as SOURCE_FIELD,
-          mcp: mcpEnabled ? { ...(entity.mcp || { endpoint: '' }) } : undefined,
+          mcp: mcpEnabled ? { ...(entity.mcp || { endpoint: '' }), forwardPerRequestKey: true } : undefined,
         });
       } else {
         onChange({
@@ -88,7 +93,7 @@ const ApplicationEndpoint: FC<Props> = ({
             ? entity?.responsesEndpoint
             : undefined,
           mcp: newCheckboxStates[ApplicationEndpointCheckbox.MCP_ENDPOINT]
-            ? ({ ...entity?.mcp } as ApplicationMCPContainer)
+            ? ({ ...entity?.mcp, forwardPerRequestKey: true } as ApplicationMCPContainer)
             : undefined,
         });
       }
@@ -119,6 +124,32 @@ const ApplicationEndpoint: FC<Props> = ({
         ...entity,
         source: { ...(entity.source as SOURCE_FIELD), mcpEndpointPath: mcpPath || '' } as SOURCE_FIELD,
       });
+    },
+    [entity, onChange],
+  );
+
+  const onChangeForwardPerRequestKey = useCallback(
+    (newValue?: boolean) => {
+      const updatedMCPContainer: ApplicationMCPContainer = {
+        ...(entity?.mcp || { endpoint: '' }),
+        forwardPerRequestKey: newValue,
+      };
+      onChange({ ...entity, mcp: updatedMCPContainer });
+    },
+    [entity, onChange],
+  );
+
+  const onChangeMCPConfigDelivery = useCallback(
+    (configDeliveryId: string | string[]) => {
+      const selectedConfigDelivery =
+        Object.values(ApplicationMCPConfigDelivery).find((source) => source === configDeliveryId) ||
+        Object.values(ApplicationMCPConfigDelivery)[0];
+      const updatedMCPContainer: ApplicationMCPContainer = {
+        ...(entity?.mcp || {}),
+        endpoint: entity?.mcp?.endpoint || '',
+        configDelivery: selectedConfigDelivery,
+      };
+      onChange({ ...entity, mcp: updatedMCPContainer });
     },
     [entity, onChange],
   );
@@ -284,6 +315,27 @@ const ApplicationEndpoint: FC<Props> = ({
                   label={t(EntityFieldsI18nKey.Transport)}
                   onChange={onChangeMCPTransport}
                   disabled
+                />
+
+                <DialSwitch
+                  switchId="forwardPerRequestKey"
+                  isOn={entity.mcp?.forwardPerRequestKey}
+                  label={t(EntityFieldsI18nKey.forwardPerRequestKey)}
+                  onChange={onChangeForwardPerRequestKey}
+                  disabled={disabled}
+                />
+
+                <DialSelectField
+                  id="configDelivery"
+                  value={entity.mcp?.configDelivery}
+                  options={Object.values(ApplicationMCPConfigDelivery).map((value) => ({
+                    value,
+                    label: t(MCP_CONFIG_DELIVERY_I18N_MAP[value]),
+                  }))}
+                  containerClassName="max-w-[160px]"
+                  label={t(EntityFieldsI18nKey.configDelivery)}
+                  onChange={onChangeMCPConfigDelivery}
+                  disabled={disabled}
                 />
               </div>
             )}

--- a/apps/ai-dial-admin/src/components/SourceField/Endpoints/tests/ApplicationEndpoint.spec.tsx
+++ b/apps/ai-dial-admin/src/components/SourceField/Endpoints/tests/ApplicationEndpoint.spec.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
 
 import ApplicationEndpoint from '@/src/components/SourceField/Endpoints/ApplicationEndpoint';
-import { DialApplication } from '@/src/models/dial/application';
+import { ApplicationMCPConfigDelivery, DialApplication } from '@/src/models/dial/application';
 
 vi.mock('@epam/ai-dial-ui-kit', async () => {
   const actual = await vi.importActual<Record<string, unknown>>('@epam/ai-dial-ui-kit');
@@ -17,6 +17,19 @@ vi.mock('@epam/ai-dial-ui-kit', async () => {
           checked={!!checked}
           disabled={!!disabled}
           onChange={(e) => onChange(e.target.checked, id)}
+        />
+        {label}
+      </label>
+    ),
+    DialSwitch: ({ switchId, isOn, onChange, label, disabled }: any) => (
+      <label>
+        <input
+          type="checkbox"
+          aria-label={label}
+          data-testid={`switch-${switchId}`}
+          checked={!!isOn}
+          disabled={!!disabled}
+          onChange={(e) => onChange(e.target.checked)}
         />
         {label}
       </label>
@@ -148,6 +161,34 @@ describe('ApplicationEndpoint', () => {
     const mcpCheckbox = screen.getByTestId('checkbox-mcp_endpoint') as HTMLInputElement;
     expect(mcpCheckbox.checked).toBe(true);
     expect(mcpCheckbox.disabled).toBe(true);
+  });
+
+  test('MCP forwardPerRequestKey switch writes to entity.mcp.forwardPerRequestKey', () => {
+    const onChange = vi.fn();
+    render(
+      <ApplicationEndpoint entity={makeEntity({ mcp: { endpoint: 'https://mcp.example.com' } })} onChange={onChange} />,
+    );
+
+    const switchEl = screen.getByTestId('switch-forwardPerRequestKey');
+    fireEvent.click(switchEl);
+
+    const last = onChange.mock.calls.at(-1)?.[0] as DialApplication;
+    expect(last.mcp?.forwardPerRequestKey).toBe(true);
+    expect(last.mcp?.endpoint).toBe('https://mcp.example.com');
+  });
+
+  test('MCP configDelivery select writes to entity.mcp.configDelivery', () => {
+    const onChange = vi.fn();
+    render(
+      <ApplicationEndpoint entity={makeEntity({ mcp: { endpoint: 'https://mcp.example.com' } })} onChange={onChange} />,
+    );
+
+    const select = screen.getByTestId('select-configDelivery');
+    const firstOption = Object.values(ApplicationMCPConfigDelivery)[0];
+    fireEvent.change(select, { target: { value: firstOption } });
+
+    const last = onChange.mock.calls.at(-1)?.[0] as DialApplication;
+    expect(last.mcp?.configDelivery).toBe(firstOption);
   });
 
   test('writes to entity.mcp (not entity.source)', () => {

--- a/apps/ai-dial-admin/src/models/dial/application.ts
+++ b/apps/ai-dial-admin/src/models/dial/application.ts
@@ -73,6 +73,8 @@ export interface ApplicationMCPContainer {
   endpoint: string;
   transport?: string;
   allowedTools?: string[];
+  forwardPerRequestKey?: boolean;
+  configDelivery?: ApplicationMCPConfigDelivery;
 }
 
 export enum ApplicationMCPConfigDelivery {


### PR DESCRIPTION
**Description:**

revert config delivery changes

Issues:

- Issue #3243


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
