### PR TITLE
chore(deps): bump @epam/ai-dial-ui-kit from 0.12.0-dev.12 to 0.12.0-dev.15 (Issue #3805)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@epam/ai-dial-shared": "^0.44.8",
-        "@epam/ai-dial-ui-kit": "0.12.0-dev.12",
+        "@epam/ai-dial-ui-kit": "0.12.0-dev.15",
         "@epam/ai-dial-visualizer-connector": "^0.44.8",
         "@floating-ui/react": "^0.27.19",
         "@monaco-editor/react": "^4.7.0",
@@ -2232,9 +2232,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@epam/ai-dial-ui-kit": {
-      "version": "0.12.0-dev.12",
-      "resolved": "https://registry.npmjs.org/@epam/ai-dial-ui-kit/-/ai-dial-ui-kit-0.12.0-dev.12.tgz",
-      "integrity": "sha512-reKFsKiwq+AMyTFHBJnHE/0IRc/MdTTY3Dep0bEuvf5ArUFCMxG7BaPHt2hcwnJ1WOiikwAUl2YU+iiQVu68PQ==",
+      "version": "0.12.0-dev.15",
+      "resolved": "https://registry.npmjs.org/@epam/ai-dial-ui-kit/-/ai-dial-ui-kit-0.12.0-dev.15.tgz",
+      "integrity": "sha512-oC/UgXwpJIRVyREOHwnwE0duBCZlMmI+aeaMOL0yn/t7jWL7vnCj+yFQR3dmzHkw+lJSD01HuMTrcXTROxDi/Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "ag-grid-community": "^35.2.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@epam/ai-dial-shared": "^0.44.8",
-    "@epam/ai-dial-ui-kit": "0.12.0-dev.12",
+    "@epam/ai-dial-ui-kit": "0.12.0-dev.15",
     "@epam/ai-dial-visualizer-connector": "^0.44.8",
     "@floating-ui/react": "^0.27.19",
     "@monaco-editor/react": "^4.7.0",


### PR DESCRIPTION
**Description:**

Updates @epam/ai-dial-ui-kit dependency to the latest dev version (0.12.0-dev.15). This includes bug fixes and improvements from the UI kit team.

**Issues:**

- Issue #3805

**Key Changes:**

- [package.json](https://github.com/epam/ai-dial-admin-frontend/blob/chore/bump-ai-dial-ui-kit-0-12-0-dev-15/package.json) — bumped @epam/ai-dial-ui-kit from 0.12.0-dev.12 to 0.12.0-dev.15
- [package-lock.json](https://github.com/epam/ai-dial-admin-frontend/blob/chore/bump-ai-dial-ui-kit-0-12-0-dev-15/package-lock.json) — updated lock file

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with \`(Issue #3805)\`