### PR TITLE
fix(Audit/ActivityAudit): surface real backend errorHeader/errorMessage/requestId instead of generic message on rollback error (Issue #3810)

### DIFF
--- a/apps/ai-dial-admin/src/components/ActivityAudit/List/List.tsx
+++ b/apps/ai-dial-admin/src/components/ActivityAudit/List/List.tsx
@@ -440,12 +440,7 @@ const ActivityAuditList: FC<Props> = ({
               onRefresh();
             }
           } else {
-            showNotification(
-              getErrorNotification(
-                getRollbackErrorTitle(selectedActivity.resourceType, t),
-                getRollbackErrorDescription(selectedActivity.resourceType, t),
-              ),
-            );
+            showNotification(getErrorNotification(res?.errorHeader, res?.errorMessage, res?.requestId));
           }
         })
         .catch(() => {


### PR DESCRIPTION
## Summary

When a rollback fails with `res.success===false`, the UI now displays the actual backend error details (errorHeader, errorMessage, requestId) instead of a generic message. This provides users with more actionable debugging information about why the rollback operation failed.

## Issues

- Issue #3810

## Key Changes

- [apps/ai-dial-admin/src/components/ActivityAudit/List/List.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/fix/surface-real-rollback-error-details/apps/ai-dial-admin/src/components/ActivityAudit/List/List.tsx) — replaced generic error notification with real backend error details (errorHeader, errorMessage, requestId)

## Checklist

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with \`(Issue #3810)\`