### PR TITLE
fix(Deployments): sanitize invalid startup probe config before save (Issue #3816)

### DIFF
--- a/apps/ai-dial-admin/src/components/Containers/View/ContainerView.tsx
+++ b/apps/ai-dial-admin/src/components/Containers/View/ContainerView.tsx
@@ -26,7 +26,7 @@ import { Toolset } from '@/src/models/dial/toolset';
 import { ServerActionResponse } from '@/src/models/server-action';
 import { CONTAINER_STATUS, KubEventType } from '@/src/types/deployments/containers';
 import { ApplicationRoute } from '@/src/types/routes';
-import { getContainerRedeploySnapshot } from '@/src/utils/deployments/containers';
+import { getContainerRedeploySnapshot, sanitizeContainerProbe } from '@/src/utils/deployments/containers';
 import { decodeVariables } from '@/src/utils/deployments/variables';
 import { getTranslatedDeploymentType, getTranslatedType } from '@/src/utils/deployments/entity';
 import { isImageNotInstalled } from '@/src/utils/deployments/images';
@@ -103,17 +103,19 @@ const ContainerView: FC<Props> = ({
   }, [container, isEditorEnabled]);
 
   const onSave = useCallback(() => {
-    updateContainer(selectedContainer).then(({ success, errorMessage, errorHeader, response, requestId }) => {
-      if (success) {
-        const updatedContainer = response as Container | undefined;
-        if (updatedContainer) {
-          setSelectedContainer(decodeVariables(cloneDeep(updatedContainer)));
+    updateContainer(sanitizeContainerProbe(selectedContainer)).then(
+      ({ success, errorMessage, errorHeader, response, requestId }) => {
+        if (success) {
+          const updatedContainer = response as Container | undefined;
+          if (updatedContainer) {
+            setSelectedContainer(decodeVariables(cloneDeep(updatedContainer)));
+          }
+          router.refresh();
+        } else {
+          showNotification(getErrorNotification(errorHeader, errorMessage, requestId));
         }
-        router.refresh();
-      } else {
-        showNotification(getErrorNotification(errorHeader, errorMessage, requestId));
-      }
-    });
+      },
+    );
   }, [router, selectedContainer, showNotification]);
 
   useEffect(() => {

--- a/apps/ai-dial-admin/src/utils/deployments/containers.ts
+++ b/apps/ai-dial-admin/src/utils/deployments/containers.ts
@@ -10,6 +10,7 @@ import {
   Autoscaling,
   Container,
   ContainerRedeploySnapshot,
+  ProbeProperties,
   ResourcesDefaults,
 } from '@/src/models/deployments/containers';
 import { ServerActionResponse } from '@/src/models/server-action';
@@ -21,7 +22,9 @@ import {
   ContainerResources,
   ContainerSource,
   MODEL_FORMAT,
+  PROBE_TYPE,
 } from '@/src/types/deployments/containers';
+import { getPathError, getPortError } from '@/src/utils/deployments/validation';
 import { DEFAULT_SCALING, DEFAULT_STRATEGY, SERVING_SCALING } from '@/src/constants/deployments/containers';
 import { SOURCE_TYPE } from '@/src/components/SourceField/types';
 import { SourceI18nKey } from '@/src/constants/i18n';
@@ -250,6 +253,40 @@ export const deriveScaling = (
  * if the route has no container source concept. Supported routes: Models, Applications,
  * Toolsets, Interceptors, Adapters.
  */
+/**
+ * A startup probe is only savable when its required fields are valid: a port in range, plus a path
+ * when the probe type is HTTP GET. Timings are optional and don't gate saving.
+ */
+export const isProbeSavable = (probeProperties?: ProbeProperties): boolean => {
+  const probe = probeProperties?.probe;
+  if (!probe) {
+    return false;
+  }
+  if (getPortError(probe.port as number, undefined, true)) {
+    return false;
+  }
+  if (probe.$type === PROBE_TYPE.HTTP_GET && getPathError(probe.path, undefined, true)) {
+    return false;
+  }
+  return true;
+};
+
+/**
+ * Prepares a container's startup probe for save. When the required probe fields aren't in place
+ * (e.g. the probe was enabled then disabled without a port), the invalid probe config is dropped and
+ * only `{ enabled: false }` is sent, so the backend doesn't reject an incomplete probe. A container
+ * with no probe, or with a valid probe, is returned unchanged.
+ */
+export const sanitizeContainerProbe = (container: Container): Container => {
+  if (!container.probeProperties) {
+    return container;
+  }
+  if (isProbeSavable(container.probeProperties)) {
+    return container;
+  }
+  return { ...container, probeProperties: { enabled: false } };
+};
+
 export const getContainersByView = (
   view: ApplicationRoute,
 ): (() => Promise<ServerActionResponse<Container[]>>) | null => {

--- a/apps/ai-dial-admin/src/utils/deployments/tests/containers.spec.ts
+++ b/apps/ai-dial-admin/src/utils/deployments/tests/containers.spec.ts
@@ -17,7 +17,11 @@ import {
   isErrorPresent,
   isAutoscalingEnabled,
   deriveScaling,
+  isProbeSavable,
+  sanitizeContainerProbe,
 } from '../containers';
+import { getPathError, getPortError } from '@/src/utils/deployments/validation';
+import { ErrorType } from '@/src/types/error-type';
 import {
   getApplicationContainers,
   getInterceptorContainers,
@@ -33,6 +37,7 @@ import {
   CONTAINER_STATUS,
   CONTAINER_TRANSPORT,
   CONTAINER_TYPE,
+  PROBE_TYPE,
   SCALING_STRATEGY_TYPE,
 } from '@/src/types/deployments/containers';
 import { Container } from '@/src/models/deployments/containers';
@@ -701,6 +706,68 @@ describe('containers utils', () => {
 
     test('returns null for an unsupported route', () => {
       expect(getContainersByView(ApplicationRoute.Home)).toBeNull();
+    });
+  });
+
+  describe('isProbeSavable', () => {
+    test('returns false when there is no probe config', () => {
+      expect(isProbeSavable(undefined)).toBe(false);
+      expect(isProbeSavable({ enabled: false })).toBe(false);
+    });
+
+    test('returns false when the port is invalid', () => {
+      vi.mocked(getPortError).mockReturnValue({ type: ErrorType.EMPTY, text: '' });
+      expect(isProbeSavable({ enabled: true, probe: { $type: PROBE_TYPE.TCP } })).toBe(false);
+    });
+
+    test('returns true for a TCP probe with a valid port', () => {
+      vi.mocked(getPortError).mockReturnValue(null);
+      expect(isProbeSavable({ enabled: true, probe: { $type: PROBE_TYPE.TCP, port: 8080 } })).toBe(true);
+    });
+
+    test('returns false for an HTTP GET probe with a valid port but invalid path', () => {
+      vi.mocked(getPortError).mockReturnValue(null);
+      vi.mocked(getPathError).mockReturnValue({ type: ErrorType.EMPTY, text: '' });
+      expect(isProbeSavable({ enabled: true, probe: { $type: PROBE_TYPE.HTTP_GET, port: 8080 } })).toBe(false);
+    });
+
+    test('returns true for an HTTP GET probe with a valid port and path', () => {
+      vi.mocked(getPortError).mockReturnValue(null);
+      vi.mocked(getPathError).mockReturnValue(null);
+      expect(
+        isProbeSavable({ enabled: true, probe: { $type: PROBE_TYPE.HTTP_GET, port: 8080, path: '/health' } }),
+      ).toBe(true);
+    });
+  });
+
+  describe('sanitizeContainerProbe', () => {
+    const baseContainer: Container = {
+      name: 'c',
+      $type: CONTAINER_TYPE.ADAPTER,
+      source: { $type: CONTAINER_SOURCE_TYPE.INTERNAL_IMAGE, imageDefinitionId: '' },
+      status: CONTAINER_STATUS.RUNNING,
+    };
+
+    test('returns the container unchanged when it has no probe properties', () => {
+      expect(sanitizeContainerProbe(baseContainer)).toBe(baseContainer);
+    });
+
+    test('drops an invalid probe and sends only enabled=false', () => {
+      vi.mocked(getPortError).mockReturnValue({ type: ErrorType.EMPTY, text: '' });
+      const container: Container = {
+        ...baseContainer,
+        probeProperties: { enabled: false, probe: { $type: PROBE_TYPE.TCP } },
+      };
+      expect(sanitizeContainerProbe(container).probeProperties).toEqual({ enabled: false });
+    });
+
+    test('keeps the container unchanged when the probe is valid', () => {
+      vi.mocked(getPortError).mockReturnValue(null);
+      const container: Container = {
+        ...baseContainer,
+        probeProperties: { enabled: true, probe: { $type: PROBE_TYPE.TCP, port: 8080 } },
+      };
+      expect(sanitizeContainerProbe(container)).toBe(container);
     });
   });
 });


### PR DESCRIPTION
**Description:**

Fixed a validation issue where users could enable the startup probe, enter an invalid configuration (e.g., no port or missing HTTP path), then disable it without clearing the invalid probe data. This caused the backend to reject the save. The fix now sanitizes the probe before sending: if required fields are missing or invalid, we send only `{ enabled: false }` instead of the malformed probe.

**Issues:**

- Issue #3816

**Key Changes:**

- [apps/ai-dial-admin/src/utils/deployments/containers.ts](https://github.com/epam/ai-dial-admin-frontend/blob/fix/sanitize-startup-probe/apps/ai-dial-admin/src/utils/deployments/containers.ts) — added `isProbeSavable` and `sanitizeContainerProbe` utilities
- [apps/ai-dial-admin/src/components/Containers/View/ContainerView.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/fix/sanitize-startup-probe/apps/ai-dial-admin/src/components/Containers/View/ContainerView.tsx) — integrated sanitization into the save flow
- [apps/ai-dial-admin/src/utils/deployments/tests/containers.spec.ts](https://github.com/epam/ai-dial-admin-frontend/blob/fix/sanitize-startup-probe/apps/ai-dial-admin/src/utils/deployments/tests/containers.spec.ts) — added comprehensive tests for both utilities

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with \`(Issue #3816)\`