### PR TITLE
feat(analytics/QueryBuilder): sort field lists alphabetically, searchable field dropdowns, vertical select layout (Issue #3844)

### DIFF
--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Aggregate/Aggregates.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Aggregate/Aggregates.tsx
@@ -10,10 +10,11 @@ import {
 } from '@epam/ai-dial-ui-kit';
 
 import { AGGREGATE_FN_OPTIONS } from '@/src/constants/analytics/query-builder';
-import { QueryBuilderI18nKey } from '@/src/constants/i18n';
+import { BasicI18nKey, QueryBuilderI18nKey } from '@/src/constants/i18n';
 import { STANDARD_CONTROL_WIDTH } from '@/src/constants/main-layout';
 import { useI18n } from '@/src/locales/client';
 import { useQueryBuilder } from '@/src/components/Analytics/QueryBuilder/context';
+import { sortByName } from '@/src/components/Analytics/QueryBuilder/utils/fields';
 import { createAggregate } from '@/src/components/Analytics/QueryBuilder/utils/state';
 import { QueryAggregateFn } from '@/src/models/analytics/query';
 
@@ -23,7 +24,7 @@ const Aggregates: FC = () => {
 
   const fieldOptions: SelectOption[] = [
     { value: '', label: t(QueryBuilderI18nKey.NoArgCountAll) },
-    ...state.fields.map((f) => ({ value: f.name, label: f.name })),
+    ...sortByName(state.fields).map((f) => ({ value: f.name, label: f.name })),
   ];
 
   const addAggregate = () => {
@@ -53,6 +54,8 @@ const Aggregates: FC = () => {
               label={index === 0 ? t(QueryBuilderI18nKey.Field) : undefined}
               options={fieldOptions}
               value={agg.field}
+              searchable
+              searchPlaceholder={t(BasicI18nKey.Search)}
               onChange={(v) => {
                 agg.field = v as string;
                 refresh();

--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Aggregate/TimeBuckets.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Aggregate/TimeBuckets.tsx
@@ -3,7 +3,7 @@ import { FC } from 'react';
 import { DialGhostButton, DialInput, DialNumberInput, DialRemoveButton, DialSelectField } from '@epam/ai-dial-ui-kit';
 
 import { BUCKET_UNIT_OPTIONS } from '@/src/constants/analytics/query-builder';
-import { QueryBuilderI18nKey } from '@/src/constants/i18n';
+import { BasicI18nKey, QueryBuilderI18nKey } from '@/src/constants/i18n';
 import { STANDARD_CONTROL_WIDTH } from '@/src/constants/main-layout';
 import { useI18n } from '@/src/locales/client';
 import { useQueryBuilder } from '@/src/components/Analytics/QueryBuilder/context';
@@ -54,6 +54,8 @@ const TimeBuckets: FC = () => {
               options={fieldOptions.map((f) => ({ value: f.name, label: f.name }))}
               value={bucket.field}
               placeholder={t(QueryBuilderI18nKey.TimestampFieldPlaceholder)}
+              searchable
+              searchPlaceholder={t(BasicI18nKey.Search)}
               onChange={(v) => {
                 bucket.field = v as string;
                 refresh();

--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Fields/FieldCheckboxGrid.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Fields/FieldCheckboxGrid.tsx
@@ -5,6 +5,7 @@ import { DialCheckbox } from '@epam/ai-dial-ui-kit';
 import { AnalyticsEntityField } from '@/src/models/analytics/entity';
 import { QueryBuilderI18nKey } from '@/src/constants/i18n';
 import { useI18n } from '@/src/locales/client';
+import { sortByName } from '@/src/components/Analytics/QueryBuilder/utils/fields';
 
 interface Props {
   idPrefix: string;
@@ -16,21 +17,23 @@ interface Props {
 const FieldCheckboxGrid: FC<Props> = ({ idPrefix, fields, selected, onToggle }) => {
   const t = useI18n();
   const selectedSet = new Set(selected);
+  const sortedFields = sortByName(fields);
 
   if (!fields.length) {
     return <span className="text-secondary dial-tiny-text">{t(QueryBuilderI18nKey.NoFields)}</span>;
   }
 
   return (
-    <div className="grid grid-cols-2 gap-x-6 gap-y-2 md:grid-cols-3 xl:grid-cols-4">
-      {fields.map((field) => (
-        <DialCheckbox
-          key={field.name}
-          id={`${idPrefix}-${field.name}`}
-          label={field.name}
-          checked={selectedSet.has(field.name)}
-          onChange={() => onToggle(field.name)}
-        />
+    <div className="columns-2 gap-x-6 md:columns-3 xl:columns-4">
+      {sortedFields.map((field) => (
+        <div key={field.name} className="mb-2 break-inside-avoid">
+          <DialCheckbox
+            id={`${idPrefix}-${field.name}`}
+            label={field.name}
+            checked={selectedSet.has(field.name)}
+            onChange={() => onToggle(field.name)}
+          />
+        </div>
       ))}
     </div>
   );

--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Filter/FilterCondition.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Filter/FilterCondition.tsx
@@ -3,7 +3,7 @@ import { FC } from 'react';
 import { DialInput, DialRemoveButton, DialSelectField, SelectOption } from '@epam/ai-dial-ui-kit';
 
 import { OPERATOR_OPTIONS, VALUE_TYPE_OPTIONS } from '@/src/constants/analytics/query-builder';
-import { QueryBuilderI18nKey } from '@/src/constants/i18n';
+import { BasicI18nKey, QueryBuilderI18nKey } from '@/src/constants/i18n';
 import { useI18n } from '@/src/locales/client';
 import { useQueryBuilder } from '@/src/components/Analytics/QueryBuilder/context';
 import { defaultValueType } from '@/src/components/Analytics/QueryBuilder/utils/fields';
@@ -62,6 +62,8 @@ const FilterCondition: FC<Props> = ({ node, parent, fieldOptions, showLabels }) 
         options={fieldOptions.map((o) => ({ value: o.name, label: o.name }))}
         value={node.field}
         placeholder={t(QueryBuilderI18nKey.FieldPlaceholder)}
+        searchable
+        searchPlaceholder={t(BasicI18nKey.Search)}
         onChange={(v) => onChangeField(v as string)}
       />
       <DialSelectField

--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/QueryBuilder.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/QueryBuilder.tsx
@@ -23,7 +23,7 @@ import SortKeys from '@/src/components/Analytics/QueryBuilder/Sort/SortKeys';
 import PageSection from '@/src/components/Analytics/QueryBuilder/Page/PageSection';
 import CopyButton from '@/src/components/Common/CopyButton/CopyButton';
 import QueryResultSidebar from '@/src/components/Analytics/QueryBuilder/Result/QueryResultSidebar';
-import { havingFieldOptions } from '@/src/components/Analytics/QueryBuilder/utils/fields';
+import { havingFieldOptions, sortByName } from '@/src/components/Analytics/QueryBuilder/utils/fields';
 import { buildQuery, getAggregateWarnings } from '@/src/components/Analytics/QueryBuilder/utils/serialize';
 import { parseQuery } from '@/src/components/Analytics/QueryBuilder/utils/deserialize';
 import { createInitialState } from '@/src/components/Analytics/QueryBuilder/utils/state';
@@ -275,7 +275,7 @@ const QueryBuilder: FC<Props> = ({ initialEntities, initialEntityName, initialFi
                   <FilterGroup
                     node={state.filter}
                     parent={null}
-                    fieldOptions={state.fields.map((f) => ({ name: f.name, type: f.type }))}
+                    fieldOptions={sortByName(state.fields).map((f) => ({ name: f.name, type: f.type }))}
                   />
                 </LabeledField>
 

--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Sort/SortKeys.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Sort/SortKeys.tsx
@@ -3,7 +3,7 @@ import { FC } from 'react';
 import { DialGhostButton, DialRemoveButton, DialSelectField } from '@epam/ai-dial-ui-kit';
 
 import { SORT_DIRECTION_OPTIONS, SORT_NULLS_OPTIONS } from '@/src/constants/analytics/query-builder';
-import { QueryBuilderI18nKey } from '@/src/constants/i18n';
+import { BasicI18nKey, QueryBuilderI18nKey } from '@/src/constants/i18n';
 import { STANDARD_CONTROL_WIDTH } from '@/src/constants/main-layout';
 import { useI18n } from '@/src/locales/client';
 import { useQueryBuilder } from '@/src/components/Analytics/QueryBuilder/context';
@@ -28,6 +28,8 @@ const SortKeys: FC = () => {
               options={fieldOptions.map((f) => ({ value: f.name, label: f.name }))}
               value={sort.field}
               placeholder={t(QueryBuilderI18nKey.FieldPlaceholder)}
+              searchable
+              searchPlaceholder={t(BasicI18nKey.Search)}
               onChange={(v) => {
                 sort.field = v as string;
                 refresh();

--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/utils/fields.ts
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/utils/fields.ts
@@ -32,6 +32,9 @@ export const defaultValueType = (fieldType?: string): QueryValueType => {
   }
 };
 
+export const sortByName = <T extends { name: string }>(items: T[]): T[] =>
+  [...items].sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
+
 export const tagOf = (field: AnalyticsEntityField): string => field.tag || UNTAGGED_KEY;
 
 export const distinctTags = (fields: AnalyticsEntityField[]): string[] => {
@@ -55,7 +58,7 @@ export const filterFieldsByTags = (fields: AnalyticsEntityField[], selectedTags:
 
 export const bucketFieldOptions = (fields: AnalyticsEntityField[]): AnalyticsEntityField[] => {
   const temporal = fields.filter((f) => f.type === AnalyticsFieldType.Timestamp || f.type === AnalyticsFieldType.Date);
-  return temporal.length ? temporal : fields;
+  return sortByName(temporal.length ? temporal : fields);
 };
 
 export const havingFieldOptions = (state: QueryBuilderState): FieldOption[] => {
@@ -66,10 +69,10 @@ export const havingFieldOptions = (state: QueryBuilderState): FieldOption[] => {
   const aggAliases = state.aggregates
     .filter((a) => a.alias)
     .map((a) => ({ name: a.alias, type: AnalyticsFieldType.Decimal }));
-  return [...groupBy, ...bucketAliases, ...aggAliases];
+  return sortByName([...groupBy, ...bucketAliases, ...aggAliases]);
 };
 
 export const sortFieldOptions = (state: QueryBuilderState): FieldOption[] => {
-  if (state.mode === QueryMode.Row) return state.fields.map((f) => ({ name: f.name, type: f.type }));
+  if (state.mode === QueryMode.Row) return sortByName(state.fields.map((f) => ({ name: f.name, type: f.type })));
   return havingFieldOptions(state);
 };

--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/utils/tests/fields.spec.ts
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/utils/tests/fields.spec.ts
@@ -7,6 +7,7 @@ import {
   family,
   filterFieldsByTags,
   havingFieldOptions,
+  sortByName,
   sortFieldOptions,
 } from '@/src/components/Analytics/QueryBuilder/utils/fields';
 import { createAggregate, createBucket, createInitialState } from '@/src/components/Analytics/QueryBuilder/utils/state';
@@ -80,9 +81,26 @@ describe('filterFieldsByTags', () => {
   });
 });
 
+describe('sortByName', () => {
+  test('orders alphabetically, case-insensitively', () => {
+    const items = [{ name: 'banana' }, { name: 'Apple' }, { name: 'cherry' }];
+    expect(sortByName(items).map((i) => i.name)).toEqual(['Apple', 'banana', 'cherry']);
+  });
+
+  test('does not mutate the input array', () => {
+    const items = [{ name: 'b' }, { name: 'a' }];
+    sortByName(items);
+    expect(items.map((i) => i.name)).toEqual(['b', 'a']);
+  });
+
+  test('empty array returns empty', () => {
+    expect(sortByName([])).toEqual([]);
+  });
+});
+
 describe('bucketFieldOptions', () => {
-  test('prefers temporal fields', () => {
-    expect(bucketFieldOptions(FIELDS).map((f) => f.name)).toEqual(['request_time', '_ingested_at']);
+  test('prefers temporal fields, sorted by name', () => {
+    expect(bucketFieldOptions(FIELDS).map((f) => f.name)).toEqual(['_ingested_at', 'request_time']);
   });
 
   test('falls back to all fields when none are temporal', () => {
@@ -102,14 +120,20 @@ describe('having/sort field options', () => {
     const agg = createAggregate();
     agg.alias = 'cnt';
     s.aggregates = [agg];
-    expect(havingFieldOptions(s).map((o) => o.name)).toEqual(['project_id', 'bucket', 'cnt']);
+    expect(havingFieldOptions(s).map((o) => o.name)).toEqual(['bucket', 'cnt', 'project_id']);
   });
 
   test('sortFieldOptions uses schema fields in row mode, aggregate outputs in aggregate mode', () => {
     const s = createInitialState();
     s.fields = FIELDS;
     s.groupBy = ['project_id'];
-    expect(sortFieldOptions(s).map((o) => o.name)).toEqual(FIELDS.map((f) => f.name));
+    expect(sortFieldOptions(s).map((o) => o.name)).toEqual([
+      '_ingested_at',
+      'event_id',
+      'orphan',
+      'project_id',
+      'request_time',
+    ]);
     s.mode = QueryMode.Aggregate;
     expect(sortFieldOptions(s).map((o) => o.name)).toEqual(['project_id']);
   });


### PR DESCRIPTION
## Summary

Follow-up UX improvements for the Analytics Query Builder (Issue #3844), continuing from #3855.

- **Alphabetical field ordering** — all table-field lists now render A→Z (case-insensitive) via a shared `sortByName` helper: Filter (WHERE/HAVING), Sort, Aggregate, and Time bucket dropdowns, plus the SELECT projection & GROUP BY checkbox pickers. Sorting is applied at the display layer only; query semantics (projection/group-by output order) are unchanged.
- **Searchable field dropdowns** — the four table-field selects (Filter, Sort, Aggregate, Time bucket) now enable `DialSelectField`'s built-in `searchable` filter so long field lists are easy to search. Short fixed-enum dropdowns (operator, direction, aggregate fn, unit) are left as-is.
- **Vertical SELECT/GROUP BY layout** — the field checkbox picker now flows column-major (CSS multi-column), so the alphabetical order reads top-to-bottom within each column instead of across rows. Responsive 2/3/4 column count preserved.

## Tests

- Added `sortByName` unit tests (ordering, no-mutation, empty input).
- Updated order-dependent assertions in `fields.spec.ts`.
- Full suite: 5754 passed; lint 0 errors; prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)