### PR TITLE
feat(analytics/QueryBuilder): dockable result sidebar + field-list UX (Issue #3844)

### DIFF
--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Aggregate/Aggregates.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Aggregate/Aggregates.tsx
@@ -10,10 +10,11 @@ import {
 } from '@epam/ai-dial-ui-kit';
 
 import { AGGREGATE_FN_OPTIONS } from '@/src/constants/analytics/query-builder';
-import { QueryBuilderI18nKey } from '@/src/constants/i18n';
+import { BasicI18nKey, QueryBuilderI18nKey } from '@/src/constants/i18n';
 import { STANDARD_CONTROL_WIDTH } from '@/src/constants/main-layout';
 import { useI18n } from '@/src/locales/client';
 import { useQueryBuilder } from '@/src/components/Analytics/QueryBuilder/context';
+import { sortByName } from '@/src/components/Analytics/QueryBuilder/utils/fields';
 import { createAggregate } from '@/src/components/Analytics/QueryBuilder/utils/state';
 import { QueryAggregateFn } from '@/src/models/analytics/query';
 
@@ -23,7 +24,7 @@ const Aggregates: FC = () => {
 
   const fieldOptions: SelectOption[] = [
     { value: '', label: t(QueryBuilderI18nKey.NoArgCountAll) },
-    ...state.fields.map((f) => ({ value: f.name, label: f.name })),
+    ...sortByName(state.fields).map((f) => ({ value: f.name, label: f.name })),
   ];
 
   const addAggregate = () => {
@@ -53,6 +54,8 @@ const Aggregates: FC = () => {
               label={index === 0 ? t(QueryBuilderI18nKey.Field) : undefined}
               options={fieldOptions}
               value={agg.field}
+              searchable
+              searchPlaceholder={t(BasicI18nKey.Search)}
               onChange={(v) => {
                 agg.field = v as string;
                 refresh();

--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Aggregate/TimeBuckets.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Aggregate/TimeBuckets.tsx
@@ -3,7 +3,7 @@ import { FC } from 'react';
 import { DialGhostButton, DialInput, DialNumberInput, DialRemoveButton, DialSelectField } from '@epam/ai-dial-ui-kit';
 
 import { BUCKET_UNIT_OPTIONS } from '@/src/constants/analytics/query-builder';
-import { QueryBuilderI18nKey } from '@/src/constants/i18n';
+import { BasicI18nKey, QueryBuilderI18nKey } from '@/src/constants/i18n';
 import { STANDARD_CONTROL_WIDTH } from '@/src/constants/main-layout';
 import { useI18n } from '@/src/locales/client';
 import { useQueryBuilder } from '@/src/components/Analytics/QueryBuilder/context';
@@ -54,6 +54,8 @@ const TimeBuckets: FC = () => {
               options={fieldOptions.map((f) => ({ value: f.name, label: f.name }))}
               value={bucket.field}
               placeholder={t(QueryBuilderI18nKey.TimestampFieldPlaceholder)}
+              searchable
+              searchPlaceholder={t(BasicI18nKey.Search)}
               onChange={(v) => {
                 bucket.field = v as string;
                 refresh();

--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Fields/FieldCheckboxGrid.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Fields/FieldCheckboxGrid.tsx
@@ -5,6 +5,7 @@ import { DialCheckbox } from '@epam/ai-dial-ui-kit';
 import { AnalyticsEntityField } from '@/src/models/analytics/entity';
 import { QueryBuilderI18nKey } from '@/src/constants/i18n';
 import { useI18n } from '@/src/locales/client';
+import { sortByName } from '@/src/components/Analytics/QueryBuilder/utils/fields';
 
 interface Props {
   idPrefix: string;
@@ -16,21 +17,23 @@ interface Props {
 const FieldCheckboxGrid: FC<Props> = ({ idPrefix, fields, selected, onToggle }) => {
   const t = useI18n();
   const selectedSet = new Set(selected);
+  const sortedFields = sortByName(fields);
 
   if (!fields.length) {
     return <span className="text-secondary dial-tiny-text">{t(QueryBuilderI18nKey.NoFields)}</span>;
   }
 
   return (
-    <div className="grid grid-cols-2 gap-x-6 gap-y-2 md:grid-cols-3 xl:grid-cols-4">
-      {fields.map((field) => (
-        <DialCheckbox
-          key={field.name}
-          id={`${idPrefix}-${field.name}`}
-          label={field.name}
-          checked={selectedSet.has(field.name)}
-          onChange={() => onToggle(field.name)}
-        />
+    <div className="columns-2 gap-x-6 md:columns-3 xl:columns-4">
+      {sortedFields.map((field) => (
+        <div key={field.name} className="mb-2 break-inside-avoid">
+          <DialCheckbox
+            id={`${idPrefix}-${field.name}`}
+            label={field.name}
+            checked={selectedSet.has(field.name)}
+            onChange={() => onToggle(field.name)}
+          />
+        </div>
       ))}
     </div>
   );

--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Filter/FilterCondition.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Filter/FilterCondition.tsx
@@ -3,7 +3,7 @@ import { FC } from 'react';
 import { DialInput, DialRemoveButton, DialSelectField, SelectOption } from '@epam/ai-dial-ui-kit';
 
 import { OPERATOR_OPTIONS, VALUE_TYPE_OPTIONS } from '@/src/constants/analytics/query-builder';
-import { QueryBuilderI18nKey } from '@/src/constants/i18n';
+import { BasicI18nKey, QueryBuilderI18nKey } from '@/src/constants/i18n';
 import { useI18n } from '@/src/locales/client';
 import { useQueryBuilder } from '@/src/components/Analytics/QueryBuilder/context';
 import { defaultValueType } from '@/src/components/Analytics/QueryBuilder/utils/fields';
@@ -62,6 +62,8 @@ const FilterCondition: FC<Props> = ({ node, parent, fieldOptions, showLabels }) 
         options={fieldOptions.map((o) => ({ value: o.name, label: o.name }))}
         value={node.field}
         placeholder={t(QueryBuilderI18nKey.FieldPlaceholder)}
+        searchable
+        searchPlaceholder={t(BasicI18nKey.Search)}
         onChange={(v) => onChangeField(v as string)}
       />
       <DialSelectField

--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/QueryBuilder.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/QueryBuilder.tsx
@@ -23,7 +23,7 @@ import SortKeys from '@/src/components/Analytics/QueryBuilder/Sort/SortKeys';
 import PageSection from '@/src/components/Analytics/QueryBuilder/Page/PageSection';
 import CopyButton from '@/src/components/Common/CopyButton/CopyButton';
 import QueryResultSidebar from '@/src/components/Analytics/QueryBuilder/Result/QueryResultSidebar';
-import { havingFieldOptions } from '@/src/components/Analytics/QueryBuilder/utils/fields';
+import { havingFieldOptions, sortByName } from '@/src/components/Analytics/QueryBuilder/utils/fields';
 import { buildQuery, getAggregateWarnings } from '@/src/components/Analytics/QueryBuilder/utils/serialize';
 import { parseQuery } from '@/src/components/Analytics/QueryBuilder/utils/deserialize';
 import { createInitialState } from '@/src/components/Analytics/QueryBuilder/utils/state';
@@ -275,7 +275,7 @@ const QueryBuilder: FC<Props> = ({ initialEntities, initialEntityName, initialFi
                   <FilterGroup
                     node={state.filter}
                     parent={null}
-                    fieldOptions={state.fields.map((f) => ({ name: f.name, type: f.type }))}
+                    fieldOptions={sortByName(state.fields).map((f) => ({ name: f.name, type: f.type }))}
                   />
                 </LabeledField>
 

--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/QueryBuilder.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/QueryBuilder.tsx
@@ -27,7 +27,7 @@ import { havingFieldOptions, sortByName } from '@/src/components/Analytics/Query
 import { buildQuery, getAggregateWarnings } from '@/src/components/Analytics/QueryBuilder/utils/serialize';
 import { parseQuery } from '@/src/components/Analytics/QueryBuilder/utils/deserialize';
 import { createInitialState } from '@/src/components/Analytics/QueryBuilder/utils/state';
-import { BASE_BUTTON_ICON_PROPS } from '@/src/constants/main-layout';
+import { BASE_BUTTON_ICON_PROPS, LOCAL_STORAGE_QUERY_RESULT_DOCK_KEY } from '@/src/constants/main-layout';
 import { ButtonsI18nKey, MenuI18nKey, QueryBuilderI18nKey } from '@/src/constants/i18n';
 import { useAppContext } from '@/src/context/AppContext';
 import { useNotification } from '@/src/context/NotificationContext';
@@ -186,7 +186,10 @@ const QueryBuilder: FC<Props> = ({ initialEntities, initialEntityName, initialFi
       }
       request = { kind: QueryRequestKind.Structured, query: runQuery };
     }
-    sidebar.showSidebar(<QueryResultSidebar request={request} />, 'w-1/2 max-w-[800px]');
+    sidebar.showSidebar(<QueryResultSidebar request={request} />, 'w-1/2 max-w-[800px]', {
+      dockable: true,
+      persistKey: LOCAL_STORAGE_QUERY_RESULT_DOCK_KEY,
+    });
   };
 
   return (

--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Result/QueryResultSidebar.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Result/QueryResultSidebar.tsx
@@ -3,18 +3,20 @@
 import { FC, useEffect, useMemo, useState } from 'react';
 
 import { ColDef } from 'ag-grid-community';
-import { DialCloseButton, DialLoader, DialNoDataContent } from '@epam/ai-dial-ui-kit';
+import { DialCloseButton, DialGhostIconButton, DialLoader, DialNoDataContent, ElementSize } from '@epam/ai-dial-ui-kit';
+import { IconChevronDown, IconChevronUp, IconLayoutBottombar, IconLayoutSidebarRight } from '@tabler/icons-react';
 
 import { executeQuery, executeSqlQuery } from '@/src/app/[lang]/query-builder/actions';
 import GridView from '@/src/components/Grid/GridView/GridView';
 import StatChip from '@/src/components/Analytics/QueryBuilder/Result/StatChip';
 import { getResultColumns, getResultTotal } from '@/src/components/Analytics/QueryBuilder/utils/result';
-import { QueryBuilderI18nKey } from '@/src/constants/i18n';
+import { BasicI18nKey, QueryBuilderI18nKey } from '@/src/constants/i18n';
 import { useAppContext } from '@/src/context/AppContext';
 import { useNotification } from '@/src/context/NotificationContext';
 import { useI18n } from '@/src/locales/client';
 import { StructuredQueryResult } from '@/src/models/analytics/query';
 import { QueryRequestKind, QueryRunRequest } from '@/src/models/analytics/query-builder';
+import { DockPosition } from '@/src/components/Common/Sidebar/models';
 import { getErrorNotification } from '@/src/utils/notification';
 
 interface Props {
@@ -56,12 +58,30 @@ const QueryResultSidebar: FC<Props> = ({ request }) => {
   const columns = useMemo(() => getResultColumns(result), [result]);
   const rows = result?.rows ?? [];
   const total = getResultTotal(result);
+  const isDockedBottom = sidebar.dockPosition === DockPosition.Bottom;
+  const isCollapsed = sidebar.dockCollapsed;
 
   return (
     <div className="flex size-full min-h-0 flex-col gap-y-4">
       <div className="flex items-center justify-between">
         <h3>{t(QueryBuilderI18nKey.Result)}</h3>
-        <DialCloseButton onClose={() => sidebar.closeSidebar()} />
+        <div className="flex items-center gap-2">
+          {isDockedBottom && (
+            <DialGhostIconButton
+              size={ElementSize.Small}
+              icon={isCollapsed ? <IconChevronUp size={16} /> : <IconChevronDown size={16} />}
+              title={isCollapsed ? t(BasicI18nKey.Expand) : t(BasicI18nKey.Collapse)}
+              onClick={() => sidebar.toggleDockCollapsed()}
+            />
+          )}
+          <DialGhostIconButton
+            size={ElementSize.Small}
+            icon={isDockedBottom ? <IconLayoutSidebarRight size={16} /> : <IconLayoutBottombar size={16} />}
+            title={isDockedBottom ? t(QueryBuilderI18nKey.DockToRight) : t(QueryBuilderI18nKey.DockToBottom)}
+            onClick={() => sidebar.toggleDock()}
+          />
+          <DialCloseButton onClose={() => sidebar.closeSidebar()} />
+        </div>
       </div>
 
       <div className="flex min-h-0 flex-1 flex-col">

--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Sort/SortKeys.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Sort/SortKeys.tsx
@@ -3,7 +3,7 @@ import { FC } from 'react';
 import { DialGhostButton, DialRemoveButton, DialSelectField } from '@epam/ai-dial-ui-kit';
 
 import { SORT_DIRECTION_OPTIONS, SORT_NULLS_OPTIONS } from '@/src/constants/analytics/query-builder';
-import { QueryBuilderI18nKey } from '@/src/constants/i18n';
+import { BasicI18nKey, QueryBuilderI18nKey } from '@/src/constants/i18n';
 import { STANDARD_CONTROL_WIDTH } from '@/src/constants/main-layout';
 import { useI18n } from '@/src/locales/client';
 import { useQueryBuilder } from '@/src/components/Analytics/QueryBuilder/context';
@@ -28,6 +28,8 @@ const SortKeys: FC = () => {
               options={fieldOptions.map((f) => ({ value: f.name, label: f.name }))}
               value={sort.field}
               placeholder={t(QueryBuilderI18nKey.FieldPlaceholder)}
+              searchable
+              searchPlaceholder={t(BasicI18nKey.Search)}
               onChange={(v) => {
                 sort.field = v as string;
                 refresh();

--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/tests/QueryResultSidebar.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/tests/QueryResultSidebar.spec.tsx
@@ -1,9 +1,11 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, test, vi, type Mock } from 'vitest';
 
 import * as actions from '@/src/app/[lang]/query-builder/actions';
 import QueryResultSidebar from '@/src/components/Analytics/QueryBuilder/Result/QueryResultSidebar';
-import { QueryBuilderI18nKey } from '@/src/constants/i18n';
+import { DockPosition } from '@/src/components/Common/Sidebar/models';
+import { BasicI18nKey, QueryBuilderI18nKey } from '@/src/constants/i18n';
 import { QueryMode, StructuredQuery } from '@/src/models/analytics/query';
 import { QueryRequestKind, QueryRunRequest } from '@/src/models/analytics/query-builder';
 
@@ -12,12 +14,32 @@ vi.mock('@/src/components/Grid/GridView/GridView', () => ({
   default: ({ rowData }: { rowData?: unknown[] }) => <div>grid rows: {rowData?.length ?? 0}</div>,
 }));
 
+const toggleDock = vi.fn();
+const toggleDockCollapsed = vi.fn();
+const mockSidebar = {
+  show: true,
+  content: null,
+  showSidebar: vi.fn(),
+  closeSidebar: vi.fn(),
+  dockable: true,
+  dockPosition: DockPosition.Right,
+  dockCollapsed: false,
+  toggleDock,
+  toggleDockCollapsed,
+};
+
+vi.mock('@/src/context/AppContext', () => ({
+  useAppContext: () => ({ sidebar: mockSidebar }),
+}));
+
 const QUERY: StructuredQuery = { entity: 'dial_usage_log', mode: QueryMode.Row };
 const STRUCTURED_REQUEST: QueryRunRequest = { kind: QueryRequestKind.Structured, query: QUERY };
 const SQL_REQUEST: QueryRunRequest = { kind: QueryRequestKind.Sql, sql: 'SELECT event_id FROM dial_usage_log' };
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockSidebar.dockPosition = DockPosition.Right;
+  mockSidebar.dockCollapsed = false;
 });
 
 describe('QueryResultSidebar', () => {
@@ -70,5 +92,58 @@ describe('QueryResultSidebar', () => {
     render(<QueryResultSidebar request={STRUCTURED_REQUEST} />);
 
     expect(await screen.findByText(QueryBuilderI18nKey.NoRows)).toBeInTheDocument();
+  });
+
+  test('renders a "dock to bottom" toggle when docked right and calls toggleDock on click', async () => {
+    (actions.executeQuery as Mock).mockResolvedValue({ success: true, response: { columns: [], rows: [] } });
+    const user = userEvent.setup();
+
+    render(<QueryResultSidebar request={STRUCTURED_REQUEST} />);
+
+    const toggle = await screen.findByRole('button', { name: QueryBuilderI18nKey.DockToBottom });
+    expect(toggle).toBeInTheDocument();
+
+    await user.click(toggle);
+    expect(toggleDock).toHaveBeenCalledTimes(1);
+  });
+
+  test('shows a "dock to right" toggle when currently docked to the bottom', async () => {
+    mockSidebar.dockPosition = DockPosition.Bottom;
+    (actions.executeQuery as Mock).mockResolvedValue({ success: true, response: { columns: [], rows: [] } });
+
+    render(<QueryResultSidebar request={STRUCTURED_REQUEST} />);
+
+    expect(await screen.findByRole('button', { name: QueryBuilderI18nKey.DockToRight })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: QueryBuilderI18nKey.DockToBottom })).not.toBeInTheDocument();
+  });
+
+  test('shows a collapse toggle only when docked to the bottom and calls toggleDockCollapsed', async () => {
+    (actions.executeQuery as Mock).mockResolvedValue({ success: true, response: { columns: [], rows: [] } });
+    const user = userEvent.setup();
+
+    // Right dock → no collapse control.
+    const { unmount } = render(<QueryResultSidebar request={STRUCTURED_REQUEST} />);
+    await screen.findByRole('button', { name: QueryBuilderI18nKey.DockToBottom });
+    expect(screen.queryByRole('button', { name: BasicI18nKey.Collapse })).not.toBeInTheDocument();
+    unmount();
+
+    // Bottom dock → collapse control present and wired.
+    mockSidebar.dockPosition = DockPosition.Bottom;
+    render(<QueryResultSidebar request={STRUCTURED_REQUEST} />);
+
+    const collapse = await screen.findByRole('button', { name: BasicI18nKey.Collapse });
+    await user.click(collapse);
+    expect(toggleDockCollapsed).toHaveBeenCalledTimes(1);
+  });
+
+  test('shows an expand toggle when the bottom overlay is collapsed', async () => {
+    mockSidebar.dockPosition = DockPosition.Bottom;
+    mockSidebar.dockCollapsed = true;
+    (actions.executeQuery as Mock).mockResolvedValue({ success: true, response: { columns: [], rows: [] } });
+
+    render(<QueryResultSidebar request={STRUCTURED_REQUEST} />);
+
+    expect(await screen.findByRole('button', { name: BasicI18nKey.Expand })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: BasicI18nKey.Collapse })).not.toBeInTheDocument();
   });
 });

--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/utils/fields.ts
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/utils/fields.ts
@@ -32,6 +32,9 @@ export const defaultValueType = (fieldType?: string): QueryValueType => {
   }
 };
 
+export const sortByName = <T extends { name: string }>(items: T[]): T[] =>
+  [...items].sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
+
 export const tagOf = (field: AnalyticsEntityField): string => field.tag || UNTAGGED_KEY;
 
 export const distinctTags = (fields: AnalyticsEntityField[]): string[] => {
@@ -55,7 +58,7 @@ export const filterFieldsByTags = (fields: AnalyticsEntityField[], selectedTags:
 
 export const bucketFieldOptions = (fields: AnalyticsEntityField[]): AnalyticsEntityField[] => {
   const temporal = fields.filter((f) => f.type === AnalyticsFieldType.Timestamp || f.type === AnalyticsFieldType.Date);
-  return temporal.length ? temporal : fields;
+  return sortByName(temporal.length ? temporal : fields);
 };
 
 export const havingFieldOptions = (state: QueryBuilderState): FieldOption[] => {
@@ -66,10 +69,10 @@ export const havingFieldOptions = (state: QueryBuilderState): FieldOption[] => {
   const aggAliases = state.aggregates
     .filter((a) => a.alias)
     .map((a) => ({ name: a.alias, type: AnalyticsFieldType.Decimal }));
-  return [...groupBy, ...bucketAliases, ...aggAliases];
+  return sortByName([...groupBy, ...bucketAliases, ...aggAliases]);
 };
 
 export const sortFieldOptions = (state: QueryBuilderState): FieldOption[] => {
-  if (state.mode === QueryMode.Row) return state.fields.map((f) => ({ name: f.name, type: f.type }));
+  if (state.mode === QueryMode.Row) return sortByName(state.fields.map((f) => ({ name: f.name, type: f.type })));
   return havingFieldOptions(state);
 };

--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/utils/tests/fields.spec.ts
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/utils/tests/fields.spec.ts
@@ -7,6 +7,7 @@ import {
   family,
   filterFieldsByTags,
   havingFieldOptions,
+  sortByName,
   sortFieldOptions,
 } from '@/src/components/Analytics/QueryBuilder/utils/fields';
 import { createAggregate, createBucket, createInitialState } from '@/src/components/Analytics/QueryBuilder/utils/state';
@@ -80,9 +81,26 @@ describe('filterFieldsByTags', () => {
   });
 });
 
+describe('sortByName', () => {
+  test('orders alphabetically, case-insensitively', () => {
+    const items = [{ name: 'banana' }, { name: 'Apple' }, { name: 'cherry' }];
+    expect(sortByName(items).map((i) => i.name)).toEqual(['Apple', 'banana', 'cherry']);
+  });
+
+  test('does not mutate the input array', () => {
+    const items = [{ name: 'b' }, { name: 'a' }];
+    sortByName(items);
+    expect(items.map((i) => i.name)).toEqual(['b', 'a']);
+  });
+
+  test('empty array returns empty', () => {
+    expect(sortByName([])).toEqual([]);
+  });
+});
+
 describe('bucketFieldOptions', () => {
-  test('prefers temporal fields', () => {
-    expect(bucketFieldOptions(FIELDS).map((f) => f.name)).toEqual(['request_time', '_ingested_at']);
+  test('prefers temporal fields, sorted by name', () => {
+    expect(bucketFieldOptions(FIELDS).map((f) => f.name)).toEqual(['_ingested_at', 'request_time']);
   });
 
   test('falls back to all fields when none are temporal', () => {
@@ -102,14 +120,20 @@ describe('having/sort field options', () => {
     const agg = createAggregate();
     agg.alias = 'cnt';
     s.aggregates = [agg];
-    expect(havingFieldOptions(s).map((o) => o.name)).toEqual(['project_id', 'bucket', 'cnt']);
+    expect(havingFieldOptions(s).map((o) => o.name)).toEqual(['bucket', 'cnt', 'project_id']);
   });
 
   test('sortFieldOptions uses schema fields in row mode, aggregate outputs in aggregate mode', () => {
     const s = createInitialState();
     s.fields = FIELDS;
     s.groupBy = ['project_id'];
-    expect(sortFieldOptions(s).map((o) => o.name)).toEqual(FIELDS.map((f) => f.name));
+    expect(sortFieldOptions(s).map((o) => o.name)).toEqual([
+      '_ingested_at',
+      'event_id',
+      'orphan',
+      'project_id',
+      'request_time',
+    ]);
     s.mode = QueryMode.Aggregate;
     expect(sortFieldOptions(s).map((o) => o.name)).toEqual(['project_id']);
   });

--- a/apps/ai-dial-admin/src/components/Common/Sidebar/Sidebar.tsx
+++ b/apps/ai-dial-admin/src/components/Common/Sidebar/Sidebar.tsx
@@ -1,12 +1,57 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+import { Resizable } from 're-resizable';
+
 import { useAppContext } from '@/src/context/AppContext';
 import { SaveValidationContextProvider } from '@/src/context/SaveValidationContext';
+import { BasicI18nKey } from '@/src/constants/i18n';
+import { useI18n } from '@/src/locales/client';
 import { mergeClasses } from '@/src/utils/merge-classes';
 
+import { COLLAPSED_DOCK_HEIGHT, DEFAULT_DOCK_HEIGHT, MAX_DOCK_OFFSET, MIN_DOCK_HEIGHT } from './constants';
+import { DockPosition } from './models';
+
 const Sidebar = () => {
+  const t = useI18n();
   const { sidebar } = useAppContext();
-  const { show, content, className } = sidebar;
+  const { show, content, className, dockable, dockPosition, dockCollapsed } = sidebar;
+
+  const [dockHeight, setDockHeight] = useState(DEFAULT_DOCK_HEIGHT);
+
+  const maxDockHeight = useMemo(
+    () => (typeof window !== 'undefined' ? window.innerHeight - MAX_DOCK_OFFSET : DEFAULT_DOCK_HEIGHT),
+    [],
+  );
 
   if (!show || !content) return null;
+
+  const isBottom = dockable && dockPosition === DockPosition.Bottom;
+
+  if (isBottom) {
+    const height = dockCollapsed ? COLLAPSED_DOCK_HEIGHT : dockHeight;
+    return (
+      <SaveValidationContextProvider>
+        {/* Absolute (not fixed) so the overlay stays within the main content area and does not cover the left menu. */}
+        <Resizable
+          size={{ width: '100%', height }}
+          minHeight={dockCollapsed ? COLLAPSED_DOCK_HEIGHT : MIN_DOCK_HEIGHT}
+          maxHeight={maxDockHeight}
+          enable={{ top: !dockCollapsed }}
+          handleComponent={
+            dockCollapsed ? undefined : { top: <DockResizeHandle label={t(BasicI18nKey.ResizePanel)} /> }
+          }
+          handleStyles={{ top: { height: '10px', top: 0 } }}
+          onResizeStop={(_e, _dir, _ref, delta) => setDockHeight((prev) => prev + delta.height)}
+          className="absolute !bottom-0 !inset-x-0 z-[35] flex flex-col border-t border-primary bg-layer-0"
+          style={{ position: 'absolute', bottom: 0, left: 0, right: 0, top: 'auto' }}
+        >
+          <div className="flex size-full flex-col overflow-hidden p-4">{content}</div>
+        </Resizable>
+      </SaveValidationContextProvider>
+    );
+  }
 
   return (
     <SaveValidationContextProvider>
@@ -20,3 +65,20 @@ const Sidebar = () => {
 };
 
 export default Sidebar;
+
+interface DockResizeHandleProps {
+  label: string;
+}
+
+const DockResizeHandle = ({ label }: DockResizeHandleProps) => {
+  return (
+    <div
+      className="flex h-2.5 cursor-ns-resize items-center justify-center transition-colors hover:bg-layer-2"
+      role="separator"
+      aria-orientation="horizontal"
+      aria-label={label}
+    >
+      <div className="h-1 w-10 rounded-full bg-tertiary" />
+    </div>
+  );
+};

--- a/apps/ai-dial-admin/src/components/Common/Sidebar/constants.ts
+++ b/apps/ai-dial-admin/src/components/Common/Sidebar/constants.ts
@@ -1,0 +1,6 @@
+// Bottom-dock overlay sizing (mirrors Runs/Details/BottomDrawer so the overlay matches eval).
+export const DEFAULT_DOCK_HEIGHT = 380;
+export const MIN_DOCK_HEIGHT = 200;
+export const MAX_DOCK_OFFSET = 100;
+// Height of the bottom overlay when collapsed — just enough to keep the caller's header row visible.
+export const COLLAPSED_DOCK_HEIGHT = 52;

--- a/apps/ai-dial-admin/src/components/Common/Sidebar/models.ts
+++ b/apps/ai-dial-admin/src/components/Common/Sidebar/models.ts
@@ -1,0 +1,11 @@
+export enum DockPosition {
+  Right = 'right',
+  Bottom = 'bottom',
+}
+
+export interface ShowSidebarOptions {
+  /** Enables the right/bottom dock toggle for this sidebar content. Default: false. */
+  dockable?: boolean;
+  /** When set, the chosen dock position is persisted to localStorage under this key. */
+  persistKey?: string;
+}

--- a/apps/ai-dial-admin/src/components/Common/Sidebar/tests/Sidebar.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Common/Sidebar/tests/Sidebar.spec.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { AppContextType, useAppContext } from '@/src/context/AppContext';
 
 import Sidebar from '@/src/components/Common/Sidebar/Sidebar';
+import { DockPosition } from '@/src/components/Common/Sidebar/models';
 
 vi.mock('@/src/context/AppContext', () => ({
   useAppContext: vi.fn(() => {
@@ -26,5 +27,30 @@ describe('Sidebar', () => {
     render(<Sidebar />);
 
     expect(screen.queryByRole('complementary')).not.toBeInTheDocument();
+  });
+
+  test('renders a right-side aside (not a bottom overlay) when not dockable', () => {
+    vi.mocked(useAppContext).mockReturnValue({
+      sidebar: { show: true, content: <div>content</div>, dockable: false, dockPosition: DockPosition.Bottom },
+    } as AppContextType);
+
+    render(<Sidebar />);
+
+    // Not dockable → position is ignored, standard right aside is used.
+    expect(screen.getByRole('complementary')).toBeInTheDocument();
+    expect(screen.queryByRole('separator')).not.toBeInTheDocument();
+  });
+
+  test('renders a fixed bottom overlay with a resize handle when docked to the bottom', () => {
+    vi.mocked(useAppContext).mockReturnValue({
+      sidebar: { show: true, content: <div>content</div>, dockable: true, dockPosition: DockPosition.Bottom },
+    } as AppContextType);
+
+    render(<Sidebar />);
+
+    // Bottom overlay is not the right-side aside; it exposes a resize separator handle.
+    expect(screen.queryByRole('complementary')).not.toBeInTheDocument();
+    expect(screen.getByRole('separator')).toBeInTheDocument();
+    expect(screen.getByText('content')).toBeInTheDocument();
   });
 });

--- a/apps/ai-dial-admin/src/constants/i18n.ts
+++ b/apps/ai-dial-admin/src/constants/i18n.ts
@@ -153,6 +153,9 @@ export enum BasicI18nKey {
   HighAccuracy = 'Basic.HighAccuracy',
   LowAccuracy = 'Basic.LowAccuracy',
   DeselectAll = 'Basic.DeselectAll',
+  ResizePanel = 'Basic.ResizePanel',
+  Collapse = 'Basic.Collapse',
+  Expand = 'Basic.Expand',
 }
 
 export enum EntitiesI18nKey {
@@ -2167,6 +2170,8 @@ export enum QueryBuilderI18nKey {
   ViewSql = 'QueryBuilder.ViewSql',
   ViewSwitcher = 'QueryBuilder.ViewSwitcher',
   SqlQuery = 'QueryBuilder.SqlQuery',
+  DockToBottom = 'QueryBuilder.DockToBottom',
+  DockToRight = 'QueryBuilder.DockToRight',
 }
 
 export enum AnalyticsTablesI18nKey {

--- a/apps/ai-dial-admin/src/constants/main-layout.ts
+++ b/apps/ai-dial-admin/src/constants/main-layout.ts
@@ -3,6 +3,7 @@ export const CENTRAL_WINDOW_MIN_WIDTH = 800;
 // local storage keys
 export const LOCAL_STORAGE_CENTRAL_WINDOW_KEY = 'central-window-width';
 export const LOCAL_STORAGE_SIDEBAR_OPEN_KEY = 'sidebar-open';
+export const LOCAL_STORAGE_QUERY_RESULT_DOCK_KEY = 'query-result-dock-position';
 
 // icons
 export const BASE_BUTTON_ICON_SIZE = 20;

--- a/apps/ai-dial-admin/src/context/AppContext.tsx
+++ b/apps/ai-dial-admin/src/context/AppContext.tsx
@@ -5,6 +5,7 @@ import { VisualizerConnector } from '@epam/ai-dial-visualizer-connector';
 
 import { getFromLocalStorage, setToLocalStorage } from '@/src/utils/local-storage';
 import { LOCAL_STORAGE_SIDEBAR_OPEN_KEY } from '@/src/constants/main-layout';
+import { DockPosition, ShowSidebarOptions } from '@/src/components/Common/Sidebar/models';
 import { ResourcesDefaults } from '@/src/models/deployments/containers';
 import { UserInfo, UserRole } from '@/src/models/user-info';
 import { FeatureFlags } from '@/src/models/feature-flags';
@@ -35,8 +36,18 @@ interface AppContextSidebar {
   content: ReactNode | null;
   isMenuClosed?: boolean;
   className?: string;
-  showSidebar: (content: ReactNode, className?: string) => void;
+  /** True when the current content opted into the right/bottom dock toggle. */
+  dockable: boolean;
+  /** Current dock position for the active content (defaults to Right). */
+  dockPosition: DockPosition;
+  /** Whether the bottom-docked overlay is collapsed to its header. Only meaningful in Bottom position. */
+  dockCollapsed: boolean;
+  showSidebar: (content: ReactNode, className?: string, options?: ShowSidebarOptions) => void;
   closeSidebar: () => void;
+  /** Toggles the dock position between Right and Bottom, persisting when a persistKey was supplied. */
+  toggleDock: () => void;
+  /** Collapses/expands the bottom-docked overlay. */
+  toggleDockCollapsed: () => void;
   toggleIsMenuClosed?: () => void;
 }
 
@@ -75,6 +86,10 @@ export const AppContextProvider = ({
   const [show, setShow] = useState(false);
   const [content, setContent] = useState<ReactNode | null>(null);
   const [sideBarClassName, setSideBarClassName] = useState<string | undefined>(undefined);
+  const [dockable, setDockable] = useState(false);
+  const [dockPosition, setDockPosition] = useState<DockPosition>(DockPosition.Right);
+  const [dockPersistKey, setDockPersistKey] = useState<string | undefined>(undefined);
+  const [dockCollapsed, setDockCollapsed] = useState(false);
 
   const [isMenuClosed, setIsMenuClosed] = useState(false);
 
@@ -92,15 +107,42 @@ export const AppContextProvider = ({
     setIsMenuClosed(!isMenuClosed);
   };
 
-  const showSidebar = (c: ReactNode, className?: string) => {
+  const showSidebar = (c: ReactNode, className?: string, options?: ShowSidebarOptions) => {
     setContent(c);
     setSideBarClassName(className);
     setShow(true);
+
+    const nextDockable = options?.dockable ?? false;
+    setDockable(nextDockable);
+    setDockPersistKey(options?.persistKey);
+    setDockCollapsed(false);
+
+    // Initialize dock position: Right by default, or the persisted choice when a key is supplied.
+    // showSidebar only runs on the client (event/effect), so reading localStorage here is SSR-safe.
+    const stored = nextDockable && options?.persistKey ? getFromLocalStorage(options.persistKey) : null;
+    setDockPosition(stored === DockPosition.Bottom ? DockPosition.Bottom : DockPosition.Right);
   };
 
   const closeSidebar = () => {
     setContent(null);
     setShow(false);
+    setDockable(false);
+    setDockPersistKey(undefined);
+    setDockPosition(DockPosition.Right);
+    setDockCollapsed(false);
+  };
+
+  const toggleDock = () => {
+    const next = dockPosition === DockPosition.Right ? DockPosition.Bottom : DockPosition.Right;
+    setDockPosition(next);
+    setDockCollapsed(false);
+    if (dockPersistKey) {
+      setToLocalStorage(dockPersistKey, next);
+    }
+  };
+
+  const toggleDockCollapsed = () => {
+    setDockCollapsed((prev) => !prev);
   };
 
   const isReadOnlyAdmin =
@@ -120,6 +162,11 @@ export const AppContextProvider = ({
       content,
       showSidebar,
       className: sideBarClassName,
+      dockable,
+      dockPosition,
+      dockCollapsed,
+      toggleDock,
+      toggleDockCollapsed,
       closeSidebar,
       isMenuClosed,
       toggleIsMenuClosed,

--- a/apps/ai-dial-admin/src/context/tests/AppContext.spec.tsx
+++ b/apps/ai-dial-admin/src/context/tests/AppContext.spec.tsx
@@ -1,0 +1,149 @@
+import { act, render } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { AppContextProvider, AppContextType, useAppContext } from '@/src/context/AppContext';
+import { DockPosition } from '@/src/components/Common/Sidebar/models';
+import { FeatureFlags } from '@/src/models/feature-flags';
+
+vi.unmock('@/src/context/AppContext');
+
+const FEATURE_FLAGS = {} as FeatureFlags;
+
+const renderWithCapture = () => {
+  let captured: AppContextType | null = null;
+
+  const Capture = () => {
+    captured = useAppContext();
+    return null;
+  };
+
+  render(
+    <AppContextProvider featureFlags={FEATURE_FLAGS}>
+      <Capture />
+    </AppContextProvider>,
+  );
+
+  return () => captured as AppContextType;
+};
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.clearAllMocks();
+});
+
+describe('AppContext sidebar docking', () => {
+  test('defaults to a non-dockable right position', () => {
+    const get = renderWithCapture();
+
+    expect(get().sidebar.dockable).toBe(false);
+    expect(get().sidebar.dockPosition).toBe(DockPosition.Right);
+  });
+
+  test('showSidebar with options enables docking; toggleDock flips and persists', () => {
+    const get = renderWithCapture();
+
+    act(() => {
+      get().sidebar.showSidebar(<div>result</div>, 'w-1/2', { dockable: true, persistKey: 'key-a' });
+    });
+
+    expect(get().sidebar.dockable).toBe(true);
+    expect(get().sidebar.dockPosition).toBe(DockPosition.Right);
+
+    act(() => {
+      get().sidebar.toggleDock();
+    });
+
+    expect(get().sidebar.dockPosition).toBe(DockPosition.Bottom);
+    expect(localStorage.getItem('key-a')).toBe(DockPosition.Bottom);
+  });
+
+  test('restores the persisted position on the next open', () => {
+    localStorage.setItem('key-a', DockPosition.Bottom);
+    const get = renderWithCapture();
+
+    act(() => {
+      get().sidebar.showSidebar(<div>result</div>, undefined, { dockable: true, persistKey: 'key-a' });
+    });
+
+    expect(get().sidebar.dockPosition).toBe(DockPosition.Bottom);
+  });
+
+  test('does not persist when no persistKey is supplied', () => {
+    const get = renderWithCapture();
+
+    act(() => {
+      get().sidebar.showSidebar(<div>result</div>, undefined, { dockable: true });
+    });
+    act(() => {
+      get().sidebar.toggleDock();
+    });
+
+    expect(get().sidebar.dockPosition).toBe(DockPosition.Bottom);
+    expect(localStorage.length).toBe(0);
+  });
+
+  test('toggleDockCollapsed flips collapse; toggleDock and close reset it', () => {
+    const get = renderWithCapture();
+
+    act(() => {
+      get().sidebar.showSidebar(<div>result</div>, undefined, { dockable: true, persistKey: 'key-a' });
+    });
+    act(() => {
+      get().sidebar.toggleDock();
+    });
+    expect(get().sidebar.dockCollapsed).toBe(false);
+
+    act(() => {
+      get().sidebar.toggleDockCollapsed();
+    });
+    expect(get().sidebar.dockCollapsed).toBe(true);
+
+    // Switching dock position clears the collapsed state.
+    act(() => {
+      get().sidebar.toggleDock();
+    });
+    expect(get().sidebar.dockCollapsed).toBe(false);
+  });
+
+  test('closeSidebar resets dockable and position', () => {
+    const get = renderWithCapture();
+
+    act(() => {
+      get().sidebar.showSidebar(<div>result</div>, undefined, { dockable: true, persistKey: 'key-a' });
+      get().sidebar.toggleDock();
+    });
+    act(() => {
+      get().sidebar.closeSidebar();
+    });
+
+    expect(get().sidebar.dockable).toBe(false);
+    expect(get().sidebar.dockPosition).toBe(DockPosition.Right);
+  });
+
+  test('persists per key so callers do not interfere', () => {
+    localStorage.setItem('key-b', DockPosition.Bottom);
+    const get = renderWithCapture();
+
+    // Caller A toggles to bottom under key-a; key-b is untouched.
+    act(() => {
+      get().sidebar.showSidebar(<div>a</div>, undefined, { dockable: true, persistKey: 'key-a' });
+    });
+    act(() => {
+      get().sidebar.toggleDock();
+    });
+
+    expect(localStorage.getItem('key-a')).toBe(DockPosition.Bottom);
+    expect(localStorage.getItem('key-b')).toBe(DockPosition.Bottom);
+
+    // Caller B opens under key-b and toggles back to right; key-a is untouched.
+    act(() => {
+      get().sidebar.showSidebar(<div>b</div>, undefined, { dockable: true, persistKey: 'key-b' });
+    });
+    act(() => {
+      get().sidebar.toggleDock();
+    });
+
+    expect(localStorage.getItem('key-b')).toBe(DockPosition.Right);
+    expect(localStorage.getItem('key-a')).toBe(DockPosition.Bottom);
+  });
+});

--- a/apps/ai-dial-admin/src/locales/en.ts
+++ b/apps/ai-dial-admin/src/locales/en.ts
@@ -94,6 +94,9 @@ export default {
     HighAccuracy: 'High accuracy',
     LowAccuracy: 'Low accuracy',
     DeselectAll: 'Deselect all',
+    ResizePanel: 'Resize panel',
+    Collapse: 'Collapse',
+    Expand: 'Expand',
   },
   Menu: {
     Entities: 'Entities',
@@ -2220,6 +2223,8 @@ export default {
     ViewSql: 'SQL',
     ViewSwitcher: 'View',
     SqlQuery: 'SQL query',
+    DockToBottom: 'Dock to bottom',
+    DockToRight: 'Dock to right',
   },
   AnalyticsTables: {
     CreateSource: 'Create source',

--- a/apps/ai-dial-admin/test-setup.tsx
+++ b/apps/ai-dial-admin/test-setup.tsx
@@ -64,7 +64,17 @@ vi.mock('@/src/context/RuleFolderContext', () => ({ useRuleFolder: createFnConte
 
 vi.mock('@/src/context/AppContext', () => ({
   useAppContext: () => ({
-    sidebar: { show: false, content: null, showSidebar: vi.fn(), closeSidebar: vi.fn() },
+    sidebar: {
+      show: false,
+      content: null,
+      showSidebar: vi.fn(),
+      closeSidebar: vi.fn(),
+      dockable: false,
+      dockPosition: 'right',
+      dockCollapsed: false,
+      toggleDock: vi.fn(),
+      toggleDockCollapsed: vi.fn(),
+    },
     featureFlags: { deploymentsEnabled: true },
     isReadOnlyAdmin: false,
   }),

--- a/openspec/changes/archive/2026-07-10-add-dockable-sidebar/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-10-add-dockable-sidebar/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-10

--- a/openspec/changes/archive/2026-07-10-add-dockable-sidebar/design.md
+++ b/openspec/changes/archive/2026-07-10-add-dockable-sidebar/design.md
@@ -1,0 +1,134 @@
+## Context
+
+The shared right sidebar is a **context-driven singleton**. `AppContext` holds `{ show, content, className }` and exposes `showSidebar(content, className?)` / `closeSidebar()` (`context/AppContext.tsx:38-39, 95-104`). A single `Common/Sidebar/Sidebar.tsx` reads that state and renders an `<aside>` inside a flex **row** in `Content.tsx:83-89`:
+
+```
+Content.tsx  (flex-row)
+┌────────────────────────────┬──────────────┐
+│  {children}  (the page)    │  <aside>     │  ← Common/Sidebar/Sidebar
+│  flex-1                    │  content     │     reads AppContext.sidebar
+└────────────────────────────┴──────────────┘
+```
+
+The Query Builder opens its result here: `sidebar.showSidebar(<QueryResultSidebar request={...} />, 'w-1/2 max-w-[800px]')` (`QueryBuilder.tsx:189`). `QueryResultSidebar` renders its own header (`<h3>` + `DialCloseButton`) and body (`StatChips + <GridView>`).
+
+Eval's bottom drawer (`AnalyticsBottomDrawer.tsx:197`) is a **fixed overlay** — `position: fixed; bottom: 0; inset-x-0; z-[35]`, portaled to `document.body`, resizable in height. That is the exact "horizontal" layout requested. Eval reaches it via a separate `use-detail-mode` state machine (`DetailMode.Sidebar | DetailMode.Drawer`) and shows **different content per mode** (single detail vs. pinned/active comparison), and it does **not** persist the choice (`use-detail-mode.tsx:26` is a plain `useState`).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add an opt-in dock mode to the shared `Common/Sidebar/Sidebar` with two positions: `Right` (default, unchanged) and `Bottom` (fixed overlay, eval-identical).
+- Let callers opt in without affecting any other sidebar usage (default off).
+- Expose a context-driven `toggleDock()` + `dockPosition` so callers render the toggle in their own header.
+- Persist the chosen position per caller in `localStorage`.
+- Make Query Builder the first consumer; keep its content identical.
+- Keep the primitive content-agnostic so eval can adopt it later.
+
+**Non-Goals:**
+- Reflow/split layout (grid shrinking) — explicitly chosen against; bottom mode is a floating overlay.
+- Migrating eval's `use-detail-mode` / `AnalyticsBottomDrawer` onto the primitive (future follow-up).
+- Persisting the bottom-drawer **height** (only the dock **position** is persisted; height uses a default with in-session resize).
+- Multiple simultaneous dockable sidebars (the sidebar is a singleton — one at a time).
+- Responsive/mobile tuning of the bottom overlay (desktop-first, matching eval).
+
+## Decisions
+
+### 1. Dock state lives in `AppContext`, threaded through `showSidebar` options
+
+Because `Common/Sidebar/Sidebar` is a singleton that only renders "whatever `showSidebar` last set", a per-caller opt-in has to travel with the `showSidebar` call. Extend the signature additively:
+
+```ts
+// context/AppContext.tsx
+showSidebar: (content: ReactNode, className?: string, options?: ShowSidebarOptions) => void;
+
+interface ShowSidebarOptions {
+  dockable?: boolean;   // default false — enables the right/bottom toggle
+  persistKey?: string;  // when set, dock position is read/written to localStorage under this key
+}
+```
+
+Context state adds `dockable: boolean`, `dockPosition: DockPosition`, `persistKey?: string`, and `toggleDock(): void`. `showSidebar` sets `dockable`/`persistKey` and initializes `dockPosition` (see Decision 4). `closeSidebar` resets `dockable` to `false`. Every existing `showSidebar(content, className)` call is untouched (third arg optional).
+
+**Why context, not a local prop:** the render component receives no props (it reads context). Threading through `showSidebar` keeps the opt-in at the call site while the singleton stays prop-free, consistent with how `className` already flows.
+
+### 2. `DockPosition` enum, not a string union
+
+Per repo standard (enums over string-literal unions). Placed in a sidebar models file:
+
+```ts
+// components/Common/Sidebar/models.ts
+export enum DockPosition {
+  Right = 'right',
+  Bottom = 'bottom',
+}
+```
+
+### 3. Bottom mode is an absolute overlay scoped to the content area, so `Content.tsx` is untouched
+
+`Common/Sidebar/Sidebar` branches on `dockPosition`:
+
+- **`Right`** (default): current `<aside>` in the flex row, honoring the `className` width (`w-1/2 max-w-[800px]`, etc.). No behavior change.
+- **`Bottom`**: render the same `content` inside a `re-resizable` `Resizable` positioned `absolute; bottom:0; left:0; right:0; top:auto; z-[35]`, with `border-t border-primary bg-layer-0`, a top resize handle, default height, `MIN`/`MAX` height clamps mirroring `AnalyticsBottomDrawer` constants. Width `className` is ignored in this mode.
+
+`position: absolute` (not `fixed`) is deliberate: the sidebar renders inside `Content.tsx`'s content region (`layout.tsx:90-95` places `<Menu>` and `<Content>` as flex-row siblings; `Content.tsx`'s root is `relative overflow-hidden`). Absolute-positioning the overlay against that region makes it span **only the main content area** — it does not cover the left navigation menu. A `fixed` overlay (viewport-relative, as the eval drawer uses) would sit on top of the menu; `absolute` respects it. Because the overlay is taken out of flow, the page content in `Content.tsx` still needs **no change** and does not reflow.
+
+```
+ Right (default)                         Bottom (absolute overlay, right of menu)
+┌──────────────┬──────────┐             ┌──────┬─────────────────────────┐
+│  page        │  aside   │             │ menu │  page (unchanged)       │
+│  flex-1      │  content │             │      │░░ overlay over content ░│
+└──────────────┴──────────┘             │      ├─────────────────────────┤ ← resize
+                                        │      │  content  [Resizable]   │
+                                        └──────┴─────────────────────────┘
+```
+
+### 3a. Collapse for the bottom overlay
+
+Because the bottom overlay covers the lower part of the query form, the user needs a way to peek at the full form without closing the results. The overlay supports a **collapse** state: `AppContext` holds `dockCollapsed` + `toggleDockCollapsed()`, reset to `false` on `showSidebar`, `closeSidebar`, and `toggleDock` (position change). When collapsed, the overlay shrinks to `COLLAPSED_DOCK_HEIGHT` (just the caller's header row, via `overflow-hidden`) and the top resize handle is disabled. Mirroring the dock toggle, the caller renders the collapse/expand button in its own header (shown only in `Bottom` position): `IconChevronDown` (collapse) when expanded, `IconChevronUp` (expand) when collapsed.
+
+### 4. Persistence: position only, per-caller key, SSR-safe
+
+Reuse `getFromLocalStorage` / `setToLocalStorage` (`utils/local-storage.ts` — both guard `typeof window`). Follow the exact pattern `SideBar.tsx:136-140` uses for width:
+
+- Initialize `dockPosition` state to `DockPosition.Right` (stable server render → no hydration mismatch).
+- In a `useEffect` (client only), if `persistKey` is set, read the stored value and, if valid, apply it.
+- `toggleDock()` flips `Right ↔ Bottom` and, when `persistKey` is set, writes the new value.
+
+The query result uses a dedicated constant key (query-builder scoped) so it remembers its choice independently of any future dockable caller:
+
+```ts
+// constants for the query builder
+export const LOCAL_STORAGE_QUERY_RESULT_DOCK_KEY = 'query-result-dock-position';
+```
+
+**Why per-caller (not one global key):** the two surfaces are conceptually separate; a global key would make toggling one move the other. The key is supplied by the caller, keeping the primitive generic.
+
+### 5. Toggle rendered by the caller, mechanism owned by the sidebar
+
+Mirroring eval's proven `onSwitchMode` pattern, the toggle button lives in the caller's header, not injected by the wrapper (the wrapper renders no chrome today — the caller owns its header). Dockable callers read `{ dockPosition, toggleDock }` from context and render a `DialGhostIconButton` next to their existing close button:
+
+- position `Right` → show `IconLayoutBottombar`, title "Dock to bottom"
+- position `Bottom` → show `IconLayoutSidebarRight`, title "Dock to right"
+
+The button is keyboard-focusable/activatable (ui-kit button default). Non-dockable callers render nothing new.
+
+### 6. Query Builder wiring
+
+- `QueryBuilder.tsx:189` → `sidebar.showSidebar(<QueryResultSidebar request={request} />, 'w-1/2 max-w-[800px]', { dockable: true, persistKey: LOCAL_STORAGE_QUERY_RESULT_DOCK_KEY })`.
+- `QueryResultSidebar` adds the toggle button in its header row (`QueryResultSidebar.tsx:62-65`), reading `dockPosition` / `toggleDock` from `useAppContext().sidebar`. Content below is unchanged; `min-h-0 flex-1` already lets the `GridView` fill whatever container (right or bottom) it lands in.
+
+## Risks / Trade-offs
+
+- **Signature change to `showSidebar`** touches a widely-used context method. Mitigated by making `options` optional and additive; no existing call site changes. A quick audit of `showSidebar(` call sites confirms all pass ≤2 args.
+- **Fixed overlay z-index / footer overlap**: bottom overlay uses `z-[35]` (same as eval, below the header at `z-40`). Verify it sits above the `Footer` (`Content.tsx:90`) or accept covering it, matching eval behavior.
+- **Singleton means one dockable sidebar at a time**: acceptable — only one sidebar is ever open.
+- **Height not persisted**: intentional scope trim; can be added later with a second key if requested.
+
+## Migration / Rollout
+
+Purely additive. Default path (`dockable` absent) is unchanged, so no migration for existing callers. Query Builder is the only opt-in. Feature is discoverable via the new header toggle.
+
+## Future Work (out of scope)
+
+- Migrate eval's `use-detail-mode` + `AnalyticsBottomDrawer` onto this primitive. Eval shows *different* content per mode (single detail vs. comparison), so it would supply mode-specific content to the primitive rather than "same content re-docked"; the payoff is a single docking implementation and eval gaining the position persistence it lacks today.
+- Optional bottom-drawer height persistence via a companion key.

--- a/openspec/changes/archive/2026-07-10-add-dockable-sidebar/proposal.md
+++ b/openspec/changes/archive/2026-07-10-add-dockable-sidebar/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The Query Builder result opens in the shared right sidebar (`QueryBuilder.tsx` → `sidebar.showSidebar(<QueryResultSidebar/>, 'w-1/2 max-w-[800px]')`). For wide result sets the right sidebar is cramped, and users have already seen a better layout in the Evaluation → Run Analytics view: a **bottom-docked panel** that gives results the full horizontal width of the page.
+
+The eval bottom drawer (`AnalyticsBottomDrawer`) proves the UX but is welded to the eval domain — it fetches `AnalyticsResult`, renders a pinned-vs-active comparison, field selectors, and diff counts. None of that is reusable for a plain results grid. What *is* reusable is the **docking mechanism**: a fixed bottom overlay, a right↔bottom toggle, and a resize handle.
+
+Rather than copy that mechanism a second time, this change adds a **content-agnostic dockable capability to the shared `Common/Sidebar/Sidebar`** (opt-in, default off). The Query Builder result becomes the first consumer — same `StatChips + GridView` content, just re-dockable horizontally — and the chosen position is remembered per caller via `localStorage`. The eval view is deliberately left untouched; a future follow-up can migrate it onto the same primitive.
+
+## What Changes
+
+- **Dockable capability on the shared sidebar**: `Common/Sidebar/Sidebar` gains an opt-in dock mode with two positions — `Right` (current behavior, unchanged default) and `Bottom` (a fixed overlay: `position: fixed; bottom: 0; inset-x-0`, resizable height, border-top — matching the eval drawer's approach at `AnalyticsBottomDrawer.tsx:197`).
+- **Opt-in via `showSidebar` options**: `AppContext.showSidebar(content, className?, options?)` gains an optional `options` argument (`{ dockable?: boolean; persistKey?: string }`). Callers that don't pass it are completely unaffected — default is `Right`, non-dockable.
+- **Dock toggle exposed via context**: the sidebar context exposes `dockPosition` and `toggleDock()`. Dockable callers render a toggle icon button in their own header (mirroring eval's `onSwitchMode` prop pattern — `IconLayoutBottombar` / `IconLayoutSidebarRight`).
+- **Persistence per caller**: when a `persistKey` is supplied, the chosen dock position is read from `localStorage` on mount and written on every toggle, reusing the existing `getFromLocalStorage` / `setToLocalStorage` utils (SSR-safe).
+- **Query Builder result adoption**: `QueryBuilder.tsx` opens the result sidebar with `{ dockable: true, persistKey: <query-result key> }`; `QueryResultSidebar` renders the toggle button in its header. Content (`StatChips + GridView`) is unchanged.
+
+## Capabilities
+
+### New Capabilities
+- `dockable-sidebar`: An opt-in dock mode on the shared `Common/Sidebar/Sidebar` that lets a caller's content be docked to the right (default) or as a fixed bottom overlay, with a context-driven toggle, resizable bottom height, and per-caller `localStorage` persistence of the chosen position. Content-agnostic — the caller supplies the content and renders the toggle.
+
+### Modified Capabilities
+<!-- No existing spec-level requirements change. Non-dockable callers keep the current right-sidebar behavior byte-for-byte. -->
+
+## Impact
+
+- **Components affected**: `Common/Sidebar/Sidebar.tsx` (render right vs. fixed-bottom overlay), `context/AppContext.tsx` (extend `showSidebar` signature, add `dockPosition` + `toggleDock` state and persistence), `Analytics/QueryBuilder/QueryBuilder.tsx` (pass dock options), `Analytics/QueryBuilder/Result/QueryResultSidebar.tsx` (render toggle in header).
+- **New**: `DockPosition` enum (sidebar models), a `dockable-sidebar` localStorage key constant for the query result, i18n keys for the toggle button titles.
+- **Dependencies**: reuses `re-resizable` (already in project, used by `SideBar.tsx` and `AnalyticsBottomDrawer`) and `@tabler/icons-react`. No new external deps.
+- **Layout**: bottom mode is a fixed overlay floating over the page — **no change to `Content.tsx`** and no grid reflow. The query form stays put; the panel covers the bottom.
+- **Eval**: **not modified**. The primitive is intentionally content-agnostic so `use-detail-mode` + `AnalyticsBottomDrawer` *could* adopt it later (and gain the position persistence they lack today), but eval shows different content per mode, so that consolidation is a separate follow-up change — explicitly out of scope here.
+- **Backward compatibility**: the new `options` argument is optional and additive; every existing `showSidebar(content, className)` call keeps working with no change.

--- a/openspec/changes/archive/2026-07-10-add-dockable-sidebar/specs/dockable-sidebar/spec.md
+++ b/openspec/changes/archive/2026-07-10-add-dockable-sidebar/specs/dockable-sidebar/spec.md
@@ -1,0 +1,119 @@
+## ADDED Requirements
+
+### Requirement: Opt-in dock mode on the shared sidebar
+
+The shared `Common/Sidebar/Sidebar` SHALL support two dock positions, modeled by a `DockPosition` enum: `Right` (the existing right-side `<aside>`) and `Bottom` (a fixed overlay). Dock mode SHALL be **opt-in per caller** and disabled by default. When a caller does not opt in, the sidebar SHALL render exactly as it does today (right-side `<aside>`, honoring the width `className`) with no toggle affordance.
+
+#### Scenario: Default caller is unaffected
+
+- **WHEN** a caller invokes `sidebar.showSidebar(content, className)` with no dock options
+- **THEN** the sidebar renders as a right-side `<aside>` honoring `className`, no dock toggle is shown, and behavior is identical to before this change
+
+#### Scenario: Caller opts into dock mode
+
+- **WHEN** a caller invokes `sidebar.showSidebar(content, className, { dockable: true })`
+- **THEN** the sidebar renders dockable, exposing `dockPosition` and `toggleDock()` via the sidebar context for the caller's header to consume
+
+### Requirement: `showSidebar` accepts optional dock options additively
+
+`AppContext.showSidebar` SHALL accept an optional third argument `options` of shape `{ dockable?: boolean; persistKey?: string }`. The argument SHALL be optional so that every existing `showSidebar(content, className)` call site continues to work unchanged. The sidebar context SHALL expose `dockable: boolean`, `dockPosition: DockPosition`, and `toggleDock: () => void`.
+
+#### Scenario: Existing two-argument calls keep working
+
+- **WHEN** existing code calls `showSidebar(content, className)` without the options argument
+- **THEN** the sidebar opens as a non-dockable right sidebar and no runtime error occurs
+
+#### Scenario: closeSidebar resets dock opt-in
+
+- **WHEN** `closeSidebar()` is called
+- **THEN** `dockable` is reset to `false` so a subsequent non-dockable caller does not inherit the previous caller's toggle
+
+### Requirement: Bottom position renders as an overlay scoped to the content area
+
+When `dockPosition` is `Bottom`, the sidebar content SHALL be rendered inside a resizable container positioned `absolute` to the bottom of the main content region (`bottom: 0; left: 0; right: 0; top: auto`), with a top border and a top resize handle, layered above page content (e.g. `z-[35]`). The overlay SHALL span only the main content area and SHALL NOT cover the left navigation menu. The width `className` SHALL be ignored in this mode. The page content behind the overlay SHALL NOT reflow.
+
+#### Scenario: Bottom overlay floats over the content, not the menu
+
+- **WHEN** a dockable sidebar's `dockPosition` is `Bottom`
+- **THEN** the content appears as a panel docked to the bottom of the main content area (to the right of the left navigation menu), floating over the page, and the page layout (e.g. the query form) does not shift or shrink
+
+#### Scenario: Bottom overlay is resizable in height
+
+- **WHEN** the sidebar is docked to the bottom and the user drags the top resize handle
+- **THEN** the panel height changes between a minimum and a maximum clamp, and the content area adjusts to the new height
+
+### Requirement: Bottom overlay can be collapsed to its header
+
+When docked to the bottom, the overlay SHALL support a collapsed state exposed via the sidebar context (`dockCollapsed` + `toggleDockCollapsed()`). When collapsed, the overlay SHALL shrink to a height that shows only the caller's header row and SHALL disable the resize handle, so the user can see the page content behind it. The collapsed state SHALL reset to expanded when the sidebar is opened, closed, or the dock position changes. A dockable caller SHALL render a collapse/expand control in its header only while docked to the bottom.
+
+#### Scenario: Collapse reveals the page behind the overlay
+
+- **WHEN** the sidebar is docked to the bottom and the user activates the collapse control
+- **THEN** the overlay shrinks to its header row and the previously covered page content (e.g. the full query form) becomes visible
+
+#### Scenario: Expand restores the overlay
+
+- **WHEN** the bottom overlay is collapsed and the user activates the expand control
+- **THEN** the overlay returns to its prior height and the content area is shown again
+
+#### Scenario: Switching dock position clears the collapsed state
+
+- **WHEN** the bottom overlay is collapsed and the user toggles the dock position to `Right`
+- **THEN** the collapsed state is reset so the right sidebar shows its content normally
+
+### Requirement: Dock toggle switches position and is caller-rendered
+
+A dockable caller SHALL render a toggle control in its own header that calls `toggleDock()`. `toggleDock()` SHALL switch `dockPosition` between `Right` and `Bottom`. The toggle SHALL indicate the target position: showing a "dock to bottom" affordance when currently `Right`, and a "dock to right" affordance when currently `Bottom`. The toggle SHALL be keyboard-focusable and activatable via Enter or Space.
+
+#### Scenario: Toggle from right to bottom
+
+- **WHEN** the sidebar is docked `Right` and the user activates the dock toggle
+- **THEN** `dockPosition` becomes `Bottom` and the content re-renders as the fixed bottom overlay
+
+#### Scenario: Toggle from bottom to right
+
+- **WHEN** the sidebar is docked `Bottom` and the user activates the dock toggle
+- **THEN** `dockPosition` becomes `Right` and the content re-renders as the right-side `<aside>`
+
+#### Scenario: Toggle is keyboard operable
+
+- **WHEN** the user focuses the dock toggle and presses Enter or Space
+- **THEN** the dock position toggles, identically to a click
+
+### Requirement: Dock position persists per caller
+
+When a `persistKey` is supplied via the dock options, the sidebar SHALL read the persisted `dockPosition` from `localStorage` under that key on mount and SHALL write the new value on every toggle, reusing the shared `getFromLocalStorage` / `setToLocalStorage` utilities. Reads and writes SHALL be SSR-safe: the initial (server) render SHALL use the `Right` default and the persisted value SHALL be applied on the client after mount, avoiding hydration mismatch. When no `persistKey` is supplied, the position SHALL NOT be persisted and SHALL default to `Right` on each open.
+
+#### Scenario: Persisted bottom position is restored
+
+- **WHEN** a caller with `persistKey` previously toggled to `Bottom`, and the caller opens the sidebar again (including after a page reload)
+- **THEN** the sidebar opens docked to `Bottom`
+
+#### Scenario: No persistKey means no persistence
+
+- **WHEN** a dockable caller supplies no `persistKey` and toggles to `Bottom`, then closes and reopens the sidebar
+- **THEN** the sidebar opens docked to `Right` (the default) and nothing is written to `localStorage`
+
+#### Scenario: Per-caller isolation
+
+- **WHEN** two different dockable callers use different `persistKey` values
+- **THEN** toggling the dock position for one caller does not change the persisted position of the other
+
+### Requirement: Query Builder result is dockable and remembers its position
+
+The Query Builder result sidebar SHALL opt into dock mode with a dedicated `persistKey`, and `QueryResultSidebar` SHALL render the dock toggle in its header alongside the close button. The result content (row/total stat chips and the results grid) SHALL be unchanged and SHALL fill the available area in both dock positions.
+
+#### Scenario: Query result can be docked to the bottom
+
+- **WHEN** the user runs a query and activates the dock toggle in the result sidebar header
+- **THEN** the same result content (stat chips + grid) moves to a full-width fixed bottom overlay, and the query form above is not reflowed
+
+#### Scenario: Query result remembers the bottom choice
+
+- **WHEN** the user has docked the query result to the bottom, then runs another query (or reloads the page)
+- **THEN** the result opens docked to the bottom again
+
+#### Scenario: Result content is identical across positions
+
+- **WHEN** the query result is shown in either the right or the bottom position
+- **THEN** it renders the same stat chips and the same `GridView` of result rows, with the grid filling the panel

--- a/openspec/changes/archive/2026-07-10-add-dockable-sidebar/tasks.md
+++ b/openspec/changes/archive/2026-07-10-add-dockable-sidebar/tasks.md
@@ -1,0 +1,31 @@
+## 1. Types, constants, and i18n
+
+- [x] 1.1 Create `src/components/Common/Sidebar/models.ts` — define `DockPosition` enum (`Right = 'right'`, `Bottom = 'bottom'`) and a `ShowSidebarOptions` interface (`{ dockable?: boolean; persistKey?: string }`).
+- [x] 1.2 Add bottom-overlay layout constants to `src/components/Common/Sidebar/constants.ts` — `DEFAULT_DOCK_HEIGHT`, `MIN_DOCK_HEIGHT`, `MAX_DOCK_OFFSET` (mirror the values used by `Runs/Details/BottomDrawer/constants.ts` so the overlay matches eval).
+- [x] 1.3 Add the Query Builder dock persistence key constant `LOCAL_STORAGE_QUERY_RESULT_DOCK_KEY = 'query-result-dock-position'`. **Deviation:** placed in `src/constants/main-layout.ts` alongside the other `LOCAL_STORAGE_*` keys (no query-builder `constants.ts` exists; this keeps all localStorage keys together per existing convention).
+- [x] 1.4 Add i18n keys for the toggle button titles under `QueryBuilderI18nKey` (`DockToBottom`, `DockToRight`) with English values in `src/locales/en.ts`. Also added `BasicI18nKey.ResizePanel` for the generic bottom-dock resize handle aria-label (domain-free, lives in the Common component).
+
+## 2. AppContext: dock state, options, and persistence
+
+- [x] 2.1 Extend `AppContextSidebar` in `src/context/AppContext.tsx`: add `dockable: boolean`, `dockPosition: DockPosition`, and `toggleDock: () => void`; change `showSidebar` type to `(content: ReactNode, className?: string, options?: ShowSidebarOptions) => void`. (`persistKey` is held in private provider state `dockPersistKey`, not exposed on the context surface.)
+- [x] 2.2 Implement state: `showSidebar` stores `dockable`/`persistKey` from `options` and initializes `dockPosition` (`Right` by default); `closeSidebar` resets `dockable` to `false`, clears the persist key, and resets position to `Right`. `content`/`className`/`show` behavior unchanged.
+- [x] 2.3 Implement persistence with `getFromLocalStorage`/`setToLocalStorage`: `showSidebar` applies the persisted position when a `persistKey` is supplied (SSR-safe — `showSidebar` only runs client-side via events/effects, and the initial state is `Right`); `toggleDock` flips `Right ↔ Bottom` and writes the new value when a `persistKey` is set.
+- [x] 2.4 Add AppContext tests: default `dockPosition` is `Right`; `showSidebar` with `{ dockable, persistKey }` sets state; `toggleDock` flips and persists only when `persistKey` present; `closeSidebar` resets `dockable`; persisted value restored on next open; per-key isolation. File: `src/context/tests/AppContext.spec.tsx`.
+
+## 3. Common/Sidebar: render right vs. bottom overlay
+
+- [x] 3.1 Update `src/components/Common/Sidebar/Sidebar.tsx` to read `dockable` / `dockPosition` / `dockCollapsed` from context and branch: `Right` → existing `<aside>` honoring `className` (unchanged); `Bottom` → render `content` inside a `re-resizable` `Resizable` positioned **`absolute`** to the bottom (`bottom:0; left:0; right:0; top:auto; z-[35]`, `border-t border-primary bg-layer-0`), using the dock height constants; width `className` ignored in bottom mode. `SaveValidationContextProvider` wrapper kept in both branches. **Refinement (from verification):** `absolute` (not `fixed`) so the overlay stays within `Content.tsx`'s content region and does not cover the left navigation menu.
+- [x] 3.2 Implement the top resize handle for bottom mode (drag to resize between `MIN_DOCK_HEIGHT` and viewport − `MAX_DOCK_OFFSET`); reuses the `re-resizable` `enable`/`handleComponent` pattern from `AnalyticsBottomDrawer`. No `Content.tsx` change — the overlay does not reflow page content. Collapse: height → `COLLAPSED_DOCK_HEIGHT` and resize handle disabled when `dockCollapsed`.
+- [x] 3.3 Component tests for `Common/Sidebar/Sidebar`: renders right `<aside>` when not dockable (including when a stale `Bottom` position is present but `dockable` is false); renders bottom overlay with a resize `separator` when `dockPosition === Bottom`. File: `src/components/Common/Sidebar/tests/Sidebar.spec.tsx`.
+- [x] 3.4 Collapse support (added during verification — "can't see full query UI"): `AppContext` holds `dockCollapsed` + `toggleDockCollapsed()`, reset on `showSidebar`/`closeSidebar`/`toggleDock`; `COLLAPSED_DOCK_HEIGHT` constant added. Covered by an AppContext test.
+
+## 4. Query Builder adoption
+
+- [x] 4.1 Update `QueryBuilder.tsx` `showSidebar` call to pass `{ dockable: true, persistKey: LOCAL_STORAGE_QUERY_RESULT_DOCK_KEY }`.
+- [x] 4.2 Update `QueryResultSidebar.tsx` header: read `dockPosition` / `dockCollapsed` / `toggleDock` / `toggleDockCollapsed` from `useAppContext().sidebar`; render the dock `DialGhostIconButton` next to the `DialCloseButton` — `IconLayoutBottombar` ("Dock to bottom") when `Right`, `IconLayoutSidebarRight` ("Dock to right") when `Bottom` — and, only when `Bottom`, a collapse/expand button (`IconChevronDown`/`IconChevronUp`, `BasicI18nKey.Collapse`/`Expand`). Body (`StatChip`s + `GridView`) unchanged.
+- [x] 4.3 Update `QueryResultSidebar.spec.tsx`: dock toggle renders and calls `toggleDock`; icon/title reflects `dockPosition`; collapse control shown only when `Bottom` and calls `toggleDockCollapsed`; expand shown when collapsed. Also added `dockable`/`dockPosition`/`dockCollapsed`/`toggleDock`/`toggleDockCollapsed` to the central `AppContext` mock in `test-setup.tsx`.
+
+## 5. Verification
+
+- [x] 5.1 Ran the affected suites from `apps/ai-dial-admin/` — `AppContext` (7), `Common/Sidebar` (4), `QueryResultSidebar` (8). `eslint` on changed source files → 0 errors. Note: full-project `tsc` fails only on stale `.next` project-reference artifacts unrelated to this change; type-aware lint and the vitest transform of all touched files pass.
+- [x] 5.2 Browser verification via Playwright against the running app (`localhost:4200`): ran a query → result opens in the right sidebar with the dock toggle; toggled to bottom → full-width overlay over the content area (does **not** cover the left menu), resizable, query form not reflowed, content (Result heading + row count + grid) intact; collapse → overlay shrinks to its header revealing the full query form; reloaded + re-ran → opened docked to the bottom (position persisted). 0 console errors on fresh load.

--- a/openspec/specs/analytics/spec.md
+++ b/openspec/specs/analytics/spec.md
@@ -369,6 +369,45 @@ The header Run action SHALL execute the current query and open the result in a s
 - **THEN** an error notification is shown
 - **AND** the previous result (if any) is not replaced by a broken grid
 
+### Requirement: Result sidebar can be docked right or bottom
+
+The result panel SHALL open dockable, with a dock toggle in its header that switches its position between the right sidebar (default) and a bottom overlay. The bottom overlay SHALL be positioned within the main content area (to the right of the left navigation menu, not covering it), SHALL be resizable in height by a top drag handle, and SHALL float over the page without reflowing the query form. The result content (row/total meta line and the result grid) SHALL be identical in both positions. The toggle SHALL indicate its target: a dock-to-bottom affordance when docked right, and a dock-to-right affordance when docked bottom.
+
+#### Scenario: Dock the result to the bottom
+
+- **WHEN** the result is shown in the right sidebar and the user activates the dock toggle
+- **THEN** the same result content moves to a bottom overlay spanning the main content area
+- **AND** the overlay does not cover the left navigation menu
+- **AND** the query form above is not reflowed
+
+#### Scenario: Dock the result back to the right
+
+- **WHEN** the result is shown in the bottom overlay and the user activates the dock toggle
+- **THEN** the same result content moves back to the right sidebar
+
+### Requirement: Bottom result overlay can be collapsed
+
+When the result is docked to the bottom, its header SHALL provide a collapse/expand control. Collapsing SHALL shrink the overlay to its header row (keeping the meta line and controls reachable) so the query form behind it is visible; expanding SHALL restore the previous height. The collapsed state SHALL reset to expanded when the result is reopened or its dock position changes.
+
+#### Scenario: Collapse reveals the query form
+
+- **WHEN** the result is docked to the bottom and the user activates the collapse control
+- **THEN** the overlay shrinks to its header and the full query form below becomes visible
+
+#### Scenario: Expand restores the result
+
+- **WHEN** the bottom overlay is collapsed and the user activates the expand control
+- **THEN** the overlay returns to its prior height showing the result grid
+
+### Requirement: Result dock position is remembered
+
+The chosen result dock position (right or bottom) SHALL be persisted in the browser's local storage under a Query-Builder-specific key and restored when the result is next opened, including after a page reload. Persistence SHALL be SSR-safe (the default right position is used until the persisted value is read on the client).
+
+#### Scenario: Bottom position persists across reload
+
+- **WHEN** the user has docked the result to the bottom, then reloads the page and runs a query
+- **THEN** the result opens docked to the bottom
+
 ### Requirement: SQL view shows only the source selector and a SQL editor
 
 In the SQL view the page SHALL render the persistent Source section (entity selector and, for complex entities, the instance-id controls) and a SQL code editor filling the remaining area, and SHALL NOT render the Mode, Filter, Select, Group by, Time bucket, Aggregate, Having, Sort, or Page sections. The editor SHALL provide SQL syntax highlighting (via the Monaco `sql` language). The Copy and Run actions SHALL remain available; Copy SHALL copy the SQL editor text.

--- a/openspec/specs/dockable-sidebar/spec.md
+++ b/openspec/specs/dockable-sidebar/spec.md
@@ -1,0 +1,125 @@
+# Dockable Sidebar — Spec
+
+## Purpose
+
+The shared `Common/Sidebar/Sidebar` is a context-driven singleton that renders whatever `AppContext.showSidebar` last set, as a right-side `<aside>`. This capability adds an opt-in dock mode so a caller's content can be docked to the right (default) or as a bottom overlay, with a caller-rendered toggle, a resizable/collapsible bottom overlay, and per-caller localStorage persistence of the chosen position. The primitive is content-agnostic; the first consumer is the Query Builder result sidebar.
+
+## Requirements
+
+### Requirement: Opt-in dock mode on the shared sidebar
+
+The shared `Common/Sidebar/Sidebar` SHALL support two dock positions, modeled by a `DockPosition` enum: `Right` (the existing right-side `<aside>`) and `Bottom` (a bottom overlay). Dock mode SHALL be **opt-in per caller** and disabled by default. When a caller does not opt in, the sidebar SHALL render exactly as it does today (right-side `<aside>`, honoring the width `className`) with no toggle affordance.
+
+#### Scenario: Default caller is unaffected
+
+- **WHEN** a caller invokes `sidebar.showSidebar(content, className)` with no dock options
+- **THEN** the sidebar renders as a right-side `<aside>` honoring `className`, no dock toggle is shown, and behavior is identical to before this change
+
+#### Scenario: Caller opts into dock mode
+
+- **WHEN** a caller invokes `sidebar.showSidebar(content, className, { dockable: true })`
+- **THEN** the sidebar renders dockable, exposing `dockPosition` and `toggleDock()` via the sidebar context for the caller's header to consume
+
+### Requirement: `showSidebar` accepts optional dock options additively
+
+`AppContext.showSidebar` SHALL accept an optional third argument `options` of shape `{ dockable?: boolean; persistKey?: string }`. The argument SHALL be optional so that every existing `showSidebar(content, className)` call site continues to work unchanged. The sidebar context SHALL expose `dockable: boolean`, `dockPosition: DockPosition`, and `toggleDock: () => void`.
+
+#### Scenario: Existing two-argument calls keep working
+
+- **WHEN** existing code calls `showSidebar(content, className)` without the options argument
+- **THEN** the sidebar opens as a non-dockable right sidebar and no runtime error occurs
+
+#### Scenario: closeSidebar resets dock opt-in
+
+- **WHEN** `closeSidebar()` is called
+- **THEN** `dockable` is reset to `false` so a subsequent non-dockable caller does not inherit the previous caller's toggle
+
+### Requirement: Bottom position renders as an overlay scoped to the content area
+
+When `dockPosition` is `Bottom`, the sidebar content SHALL be rendered inside a resizable container positioned `absolute` to the bottom of the main content region (`bottom: 0; left: 0; right: 0; top: auto`), with a top border and a top resize handle, layered above page content (e.g. `z-[35]`). The overlay SHALL span only the main content area and SHALL NOT cover the left navigation menu. The width `className` SHALL be ignored in this mode. The page content behind the overlay SHALL NOT reflow.
+
+#### Scenario: Bottom overlay floats over the content, not the menu
+
+- **WHEN** a dockable sidebar's `dockPosition` is `Bottom`
+- **THEN** the content appears as a panel docked to the bottom of the main content area (to the right of the left navigation menu), floating over the page, and the page layout (e.g. the query form) does not shift or shrink
+
+#### Scenario: Bottom overlay is resizable in height
+
+- **WHEN** the sidebar is docked to the bottom and the user drags the top resize handle
+- **THEN** the panel height changes between a minimum and a maximum clamp, and the content area adjusts to the new height
+
+### Requirement: Bottom overlay can be collapsed to its header
+
+When docked to the bottom, the overlay SHALL support a collapsed state exposed via the sidebar context (`dockCollapsed` + `toggleDockCollapsed()`). When collapsed, the overlay SHALL shrink to a height that shows only the caller's header row and SHALL disable the resize handle, so the user can see the page content behind it. The collapsed state SHALL reset to expanded when the sidebar is opened, closed, or the dock position changes. A dockable caller SHALL render a collapse/expand control in its header only while docked to the bottom.
+
+#### Scenario: Collapse reveals the page behind the overlay
+
+- **WHEN** the sidebar is docked to the bottom and the user activates the collapse control
+- **THEN** the overlay shrinks to its header row and the previously covered page content (e.g. the full query form) becomes visible
+
+#### Scenario: Expand restores the overlay
+
+- **WHEN** the bottom overlay is collapsed and the user activates the expand control
+- **THEN** the overlay returns to its prior height and the content area is shown again
+
+#### Scenario: Switching dock position clears the collapsed state
+
+- **WHEN** the bottom overlay is collapsed and the user toggles the dock position to `Right`
+- **THEN** the collapsed state is reset so the right sidebar shows its content normally
+
+### Requirement: Dock toggle switches position and is caller-rendered
+
+A dockable caller SHALL render a toggle control in its own header that calls `toggleDock()`. `toggleDock()` SHALL switch `dockPosition` between `Right` and `Bottom`. The toggle SHALL indicate the target position: showing a "dock to bottom" affordance when currently `Right`, and a "dock to right" affordance when currently `Bottom`. The toggle SHALL be keyboard-focusable and activatable via Enter or Space.
+
+#### Scenario: Toggle from right to bottom
+
+- **WHEN** the sidebar is docked `Right` and the user activates the dock toggle
+- **THEN** `dockPosition` becomes `Bottom` and the content re-renders as the bottom overlay
+
+#### Scenario: Toggle from bottom to right
+
+- **WHEN** the sidebar is docked `Bottom` and the user activates the dock toggle
+- **THEN** `dockPosition` becomes `Right` and the content re-renders as the right-side `<aside>`
+
+#### Scenario: Toggle is keyboard operable
+
+- **WHEN** the user focuses the dock toggle and presses Enter or Space
+- **THEN** the dock position toggles, identically to a click
+
+### Requirement: Dock position persists per caller
+
+When a `persistKey` is supplied via the dock options, the sidebar SHALL read the persisted `dockPosition` from `localStorage` under that key on mount and SHALL write the new value on every toggle, reusing the shared `getFromLocalStorage` / `setToLocalStorage` utilities. Reads and writes SHALL be SSR-safe: the initial (server) render SHALL use the `Right` default and the persisted value SHALL be applied on the client after mount, avoiding hydration mismatch. When no `persistKey` is supplied, the position SHALL NOT be persisted and SHALL default to `Right` on each open.
+
+#### Scenario: Persisted bottom position is restored
+
+- **WHEN** a caller with `persistKey` previously toggled to `Bottom`, and the caller opens the sidebar again (including after a page reload)
+- **THEN** the sidebar opens docked to `Bottom`
+
+#### Scenario: No persistKey means no persistence
+
+- **WHEN** a dockable caller supplies no `persistKey` and toggles to `Bottom`, then closes and reopens the sidebar
+- **THEN** the sidebar opens docked to `Right` (the default) and nothing is written to `localStorage`
+
+#### Scenario: Per-caller isolation
+
+- **WHEN** two different dockable callers use different `persistKey` values
+- **THEN** toggling the dock position for one caller does not change the persisted position of the other
+
+### Requirement: Query Builder result is dockable and remembers its position
+
+The Query Builder result sidebar SHALL opt into dock mode with a dedicated `persistKey`, and `QueryResultSidebar` SHALL render the dock toggle in its header alongside the close button. The result content (row/total stat chips and the results grid) SHALL be unchanged and SHALL fill the available area in both dock positions.
+
+#### Scenario: Query result can be docked to the bottom
+
+- **WHEN** the user runs a query and activates the dock toggle in the result sidebar header
+- **THEN** the same result content (stat chips + grid) moves to a bottom overlay spanning the main content area, and the query form above is not reflowed
+
+#### Scenario: Query result remembers the bottom choice
+
+- **WHEN** the user has docked the query result to the bottom, then runs another query (or reloads the page)
+- **THEN** the result opens docked to the bottom again
+
+#### Scenario: Result content is identical across positions
+
+- **WHEN** the query result is shown in either the right or the bottom position
+- **THEN** it renders the same stat chips and the same `GridView` of result rows, with the grid filling the panel


### PR DESCRIPTION
## What

Query Builder improvements for the Analytics page (Issue #3844):

### Dockable result sidebar (main change)
- The result panel can be **docked right (default) or as a bottom overlay** via a toggle in its header — mirroring the layout switch users know from Eval → Run Analytics.
- Bottom mode is an **absolute overlay scoped to the content area** (does not cover the left navigation menu), **resizable** by a top handle, and **collapsible** to its header so the full query form stays reachable.
- The chosen dock position is **persisted per caller in localStorage** (SSR-safe) and restored on reload.
- Built as an **opt-in, content-agnostic capability on the shared `Common/Sidebar`**: `showSidebar` gains an additive optional `options` arg (`{ dockable, persistKey }`); all existing 2-arg callers are unchanged.
- Result content (stat chips + grid) is byte-for-byte identical in both positions.

### Field-list UX (prior commit on this branch)
- Sort field lists alphabetically, searchable field dropdowns, vertical Select layout.

## Why

For wide result sets the right sidebar is cramped; docking the result to the bottom gives the grid the full horizontal width, consistent with the Eval analytics UX.

## How it was verified
- Unit tests: `AppContext` dock state/persistence, `Common/Sidebar` right vs bottom render, `QueryResultSidebar` dock + collapse toggles. Full `ai-dial-admin` suite passes (pre-push gate).
- Browser (Playwright) against the running app: dock right→bottom, menu not covered, resize, collapse reveals the form, and position persisted across reload.

## Specs
- New `openspec/specs/dockable-sidebar/spec.md` (the reusable primitive).
- Query Builder result-docking requirements added to `openspec/specs/analytics/spec.md` (master).

Part of #3844

🤖 Generated with [Claude Code](https://claude.com/claude-code)