### PR TITLE
fix(Deployments): sanitize startup probe by omitting probeProperties for invalid probes (Issue #3816)

### DIFF
--- a/apps/ai-dial-admin/src/utils/deployments/containers.ts
+++ b/apps/ai-dial-admin/src/utils/deployments/containers.ts
@@ -273,9 +273,10 @@ export const isProbeSavable = (probeProperties?: ProbeProperties): boolean => {
 
 /**
  * Prepares a container's startup probe for save. When the required probe fields aren't in place
- * (e.g. the probe was enabled then disabled without a port), the invalid probe config is dropped and
- * only `{ enabled: false }` is sent, so the backend doesn't reject an incomplete probe. A container
- * with no probe, or with a valid probe, is returned unchanged.
+ * (e.g. the probe was enabled then disabled without a port), `probeProperties` is omitted entirely —
+ * the backend requires a non-null `probe` whenever `probeProperties` is present, so sending
+ * `{ enabled: false }` alone is rejected. A container with no probe, or with a valid probe, is
+ * returned unchanged.
  */
 export const sanitizeContainerProbe = (container: Container): Container => {
   if (!container.probeProperties) {
@@ -284,7 +285,7 @@ export const sanitizeContainerProbe = (container: Container): Container => {
   if (isProbeSavable(container.probeProperties)) {
     return container;
   }
-  return { ...container, probeProperties: { enabled: false } };
+  return { ...container, probeProperties: undefined };
 };
 
 export const getContainersByView = (

--- a/apps/ai-dial-admin/src/utils/deployments/tests/containers.spec.ts
+++ b/apps/ai-dial-admin/src/utils/deployments/tests/containers.spec.ts
@@ -752,13 +752,13 @@ describe('containers utils', () => {
       expect(sanitizeContainerProbe(baseContainer)).toBe(baseContainer);
     });
 
-    test('drops an invalid probe and sends only enabled=false', () => {
+    test('omits probeProperties entirely when the probe is invalid', () => {
       vi.mocked(getPortError).mockReturnValue({ type: ErrorType.EMPTY, text: '' });
       const container: Container = {
         ...baseContainer,
         probeProperties: { enabled: false, probe: { $type: PROBE_TYPE.TCP } },
       };
-      expect(sanitizeContainerProbe(container).probeProperties).toEqual({ enabled: false });
+      expect(sanitizeContainerProbe(container).probeProperties).toBeUndefined();
     });
 
     test('keeps the container unchanged when the probe is valid', () => {


### PR DESCRIPTION
**Description:**

Fixed the startup probe sanitization logic to correctly handle invalid probes. When a startup probe is disabled without proper configuration (e.g., enabled then disabled without a port), the function now omits `probeProperties` entirely instead of sending `{ enabled: false }`. This prevents backend rejection, as the backend requires a non-null `probe` object whenever `probeProperties` is present.

Issues:

- Issue #3816

**Key Changes:**

- [apps/ai-dial-admin/src/utils/deployments/containers.ts](https://github.com/epam-ai-dial/ai-dial-admin-frontend/blob/development/apps/ai-dial-admin/src/utils/deployments/containers.ts) — Updated `sanitizeContainerProbe` function to return `probeProperties: undefined` for invalid probes; updated JSDoc to clarify backend validation requirements
- [apps/ai-dial-admin/src/utils/deployments/tests/containers.spec.ts](https://github.com/epam-ai-dial/ai-dial-admin-frontend/blob/development/apps/ai-dial-admin/src/utils/deployments/tests/containers.spec.ts) — Updated test case to verify that invalid probes result in undefined probeProperties

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with \`(Issue #3816)\`