### PR TITLE
chore: run prettier automatically on staged files in pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,11 @@
   "private": true,
   "lint-staged": {
     "*.{js,ts,tsx}": [
+      "prettier --write",
       "npm run lint"
+    ],
+    "*.{json,md,css,scss,html,yml,yaml}": [
+      "prettier --write"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
**Description:**

Prettier was configured in the repo but never ran automatically — the `lint-staged` pre-commit config only invoked ESLint, so formatting was easy to forget. This wires `prettier --write` into `lint-staged`: staged `js/ts/tsx` files are formatted before linting, and `json/md/css/scss/html/yml/yaml` files are formatted as well. lint-staged re-stages the formatted output, so every commit goes in formatted with no manual step.

Issues:

- N/A (tooling chore, no ticket)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)