### PR TITLE
fix: [Assets-Toolsets] Duplicate dialog does not display API Key authentication section (Issue #3928)

### DIFF
--- a/apps/ai-dial-admin/src/components/Assets/Deployments/DuplicateAsset.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Deployments/DuplicateAsset.tsx
@@ -24,8 +24,7 @@ import {
 import { AssetsFolderContext } from '@/src/context/assets/AssetsFolderContext';
 import { useSaveValidationContext, ValidationActionType } from '@/src/context/SaveValidationContext';
 import { useI18n } from '@/src/locales/client';
-import { AssetToolset, AssetWithVersion, DeploymentAsset } from '@/src/models/dial/deployment-asset';
-import { ToolsetAuthType } from '@/src/models/dial/toolset';
+import { AssetWithVersion, DeploymentAsset } from '@/src/models/dial/deployment-asset';
 import { ServerActionResponse } from '@/src/models/server-action';
 import { DuplicationTypes } from '@/src/types/prompt';
 import { ApplicationRoute } from '@/src/types/routes';
@@ -33,6 +32,7 @@ import { duplicateEntityMap, getClonedEntityName, getCloneTitle } from '@/src/ut
 import { checkNameVersionCombination, getInitialVersion } from '@/src/utils/entities/versions';
 import { isDeploymentAsset } from '@/src/utils/is-view';
 import { addTrailingSlash } from '@/src/utils/url';
+import { DialToolsetResource, ToolsetAuthType } from '@/src/models/dial/resource';
 
 interface Props {
   view: ApplicationRoute;
@@ -75,17 +75,16 @@ const DuplicateAsset: FC<Props> = ({
   const [isInnerValid, setIsInnerValid] = useState(false);
 
   const isToolsetWithAuth = useMemo(() => {
-    const assetToolset = entity as AssetToolset;
+    const assetToolset = entity as DialToolsetResource;
     return (
-      'authSettings' in entity &&
-      assetToolset.authSettings?.authenticationType &&
-      assetToolset.authSettings.authenticationType !== ToolsetAuthType.NONE
+      assetToolset.auth_settings?.authentication_type &&
+      assetToolset.auth_settings.authentication_type !== ToolsetAuthType.NONE
     );
   }, [entity]);
 
   const authType = useMemo(() => {
     if (!isToolsetWithAuth) return null;
-    return (entity as AssetToolset).authSettings?.authenticationType || null;
+    return (entity as DialToolsetResource).auth_settings?.authentication_type || null;
   }, [isToolsetWithAuth, entity]);
 
   useEffect(() => {
@@ -100,15 +99,15 @@ const DuplicateAsset: FC<Props> = ({
   // Initial validation for auth fields
   useEffect(() => {
     if (authType === ToolsetAuthType.OAUTH) {
-      (clonedAsset as AssetToolset).authSettings = {
-        authenticationType: ToolsetAuthType.NONE,
+      (clonedAsset as DialToolsetResource).auth_settings = {
+        authentication_type: ToolsetAuthType.NONE,
       };
     } else if (authType === ToolsetAuthType.API_KEY) {
-      const toolset = entity as AssetToolset;
+      const toolset = entity as DialToolsetResource;
       dispatch({
         type: ValidationActionType.SetField,
         field: 'authSettings.apiKeyHeader',
-        isValid: !!toolset.authSettings?.apiKeyHeader,
+        isValid: !!toolset.auth_settings?.api_key_header,
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -157,12 +156,12 @@ const DuplicateAsset: FC<Props> = ({
   );
 
   const onChangeApiKeyHeader = useCallback(
-    (apiKeyHeader: string) => {
-      const toolset = clonedAsset as AssetToolset;
+    (api_key_header: string) => {
+      const toolset = clonedAsset as DialToolsetResource;
       setClonedAsset({
         ...toolset,
-        authSettings: { ...toolset.authSettings!, apiKeyHeader },
-      });
+        auth_settings: { ...toolset.auth_settings!, api_key_header },
+      } as AssetWithVersion);
     },
     [clonedAsset],
   );
@@ -207,7 +206,7 @@ const DuplicateAsset: FC<Props> = ({
 
         {authType === ToolsetAuthType.API_KEY && (
           <ApiKeyHeaderControl
-            apiKeyHeader={(clonedAsset as AssetToolset).authSettings?.apiKeyHeader}
+            apiKeyHeader={(clonedAsset as DialToolsetResource).auth_settings?.api_key_header}
             onChange={onChangeApiKeyHeader}
           />
         )}


### PR DESCRIPTION
**Description:**

correct duplicate asset modal

Issues:

- Issue #3928
- Issue #3793


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
