### PR TITLE
feat(analytics/tables): adopt consolidated column-metadata PATCH and mark sensitive columns (Issue #3847)

### DIFF
--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Common/CategorizedFieldDropdown.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Common/CategorizedFieldDropdown.tsx
@@ -8,10 +8,11 @@ import { IconChevronDown, IconChevronRight, IconMathFunction } from '@tabler/ico
 
 import CompactInput from '@/src/components/Analytics/QueryBuilder/Common/CompactInput';
 import SectionAction from '@/src/components/Analytics/QueryBuilder/Common/SectionAction';
+import SensitiveIndicator from '@/src/components/Common/SensitiveIndicator/SensitiveIndicator';
 import { groupFieldOptions } from '@/src/components/Analytics/QueryBuilder/utils/fields';
 import { UNTAGGED_KEY } from '@/src/constants/analytics/query-builder';
 import { FIELD_GROUP_COLOR_CYCLE, QUERY_BUILDER_PALETTE } from '@/src/constants/analytics/query-builder-palette';
-import { QueryBuilderI18nKey } from '@/src/constants/i18n';
+import { AnalyticsTablesI18nKey, QueryBuilderI18nKey } from '@/src/constants/i18n';
 import { useI18n } from '@/src/locales/client';
 import { FieldOption, FunctionOption, QueryBuilderColor } from '@/src/models/analytics/query-builder';
 
@@ -194,39 +195,49 @@ const CategorizedFieldDropdown: FC<Props> = ({
                   />
                 )}
                 {isExpanded(group.tag) &&
-                  group.options.map((option) => (
-                    // Row-level tooltip: hovering anywhere on the option reveals the full
-                    // description (the visible line is truncated to keep the overlay compact).
-                    <DialTooltip
-                      key={option.name}
-                      hideTooltip={!option.description}
-                      tooltip={option.description}
-                      triggerClassName="w-full"
-                      contentClassName="max-w-[320px]"
-                    >
-                      <button
-                        type="button"
-                        role="option"
-                        aria-selected={option.name === value}
-                        className={classNames(
-                          'flex w-full flex-col gap-0.5 rounded px-2 py-1.5 text-left hover:bg-layer-4',
-                          showHeaders && 'pl-6',
-                          option.name === value && 'bg-accent-primary-alpha',
-                        )}
-                        onClick={() => onPick(option.name)}
+                  group.options.map((option) => {
+                    // One row-level tooltip carries both the sensitive note (when sensitive) and the
+                    // full description; the dot renders without its own tooltip so they don't nest.
+                    const rowTooltip = [option.sensitive && t(AnalyticsTablesI18nKey.Sensitive), option.description]
+                      .filter(Boolean)
+                      .join(' — ');
+                    return (
+                      <DialTooltip
+                        key={option.name}
+                        hideTooltip={!rowTooltip}
+                        tooltip={rowTooltip}
+                        triggerClassName="w-full"
+                        contentClassName="max-w-[320px]"
                       >
-                        <span className="flex w-full items-center justify-between gap-2">
-                          <span className="truncate font-mono dial-tiny-text text-primary">
-                            {option.display_name || option.name}
+                        <button
+                          type="button"
+                          role="option"
+                          aria-selected={option.name === value}
+                          className={classNames(
+                            'flex w-full flex-col gap-0.5 rounded px-2 py-1.5 text-left hover:bg-layer-4',
+                            showHeaders && 'pl-6',
+                            option.name === value && 'bg-accent-primary-alpha',
+                          )}
+                          onClick={() => onPick(option.name)}
+                        >
+                          <span className="flex w-full items-center justify-between gap-2">
+                            <span className="flex min-w-0 items-center gap-1.5">
+                              <span className="truncate font-mono dial-tiny-text text-primary">
+                                {option.display_name || option.name}
+                              </span>
+                              {option.sensitive && <SensitiveIndicator />}
+                            </span>
+                            {option.type && (
+                              <span className="shrink-0 dial-tiny-text text-secondary">{option.type}</span>
+                            )}
                           </span>
-                          {option.type && <span className="shrink-0 dial-tiny-text text-secondary">{option.type}</span>}
-                        </span>
-                        {option.description && (
-                          <span className="w-full truncate dial-tiny-text text-secondary">{option.description}</span>
-                        )}
-                      </button>
-                    </DialTooltip>
-                  ))}
+                          {option.description && (
+                            <span className="w-full truncate dial-tiny-text text-secondary">{option.description}</span>
+                          )}
+                        </button>
+                      </DialTooltip>
+                    );
+                  })}
               </div>
             ))}
             {!groups.length && !visibleFunctions.length && (

--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Common/tests/CategorizedFieldDropdown.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Common/tests/CategorizedFieldDropdown.spec.tsx
@@ -1,8 +1,9 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, test, vi } from 'vitest';
 
 import CategorizedFieldDropdown from '@/src/components/Analytics/QueryBuilder/Common/CategorizedFieldDropdown';
+import { AnalyticsTablesI18nKey } from '@/src/constants/i18n';
 import { QueryScalarFn } from '@/src/models/analytics/query';
 import { FieldOption } from '@/src/models/analytics/query-builder';
 
@@ -253,6 +254,29 @@ describe('QueryBuilder :: CategorizedFieldDropdown', () => {
 
     expect(screen.getByRole('option', { name: /Total money spend/ })).toBeInTheDocument();
     expect(screen.queryByRole('option', { name: /deployment/ })).not.toBeInTheDocument();
+  });
+
+  test('sensitive options render the sensitive indicator, others do not', async () => {
+    const user = userEvent.setup();
+    render(
+      <CategorizedFieldDropdown
+        id="test"
+        options={[
+          { name: 'email', type: 'string', sensitive: true },
+          { name: 'total', type: 'decimal' },
+        ]}
+        onSelect={vi.fn()}
+        addLabel="+ Add"
+        ariaLabel="Add field"
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Add field' }));
+
+    const sensitiveOption = screen.getByRole('option', { name: /email/ });
+    expect(within(sensitiveOption).getByRole('img', { name: AnalyticsTablesI18nKey.Sensitive })).toBeInTheDocument();
+    const plainOption = screen.getByRole('option', { name: /total/ });
+    expect(within(plainOption).queryByRole('img')).not.toBeInTheDocument();
   });
 
   test('picker-mode trigger shows the selected field label', () => {

--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/utils/fields.ts
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/utils/fields.ts
@@ -89,6 +89,7 @@ export const fieldsToOptions = (fields: AnalyticsEntityField[]): FieldOption[] =
     tag: f.tag,
     display_name: f.display_name,
     description: f.description,
+    sensitive: f.sensitive,
   }));
 
 export const bucketFieldOptions = (fields: AnalyticsEntityField[]): AnalyticsEntityField[] => {

--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/utils/tests/fields.spec.ts
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/utils/tests/fields.spec.ts
@@ -37,6 +37,18 @@ const FIELDS: AnalyticsEntityField[] = [
   field('orphan', AnalyticsFieldType.String),
 ];
 
+describe('fieldsToOptions', () => {
+  test('carries the sensitive flag through to the option', () => {
+    const fields: AnalyticsEntityField[] = [
+      { name: 'email', type: AnalyticsFieldType.String, source: 'email', sensitive: true },
+      { name: 'total', type: AnalyticsFieldType.Decimal, source: 'total' },
+    ];
+    const options = fieldsToOptions(fields);
+    expect(options[0]).toMatchObject({ name: 'email', sensitive: true });
+    expect(options[1].sensitive).toBeUndefined();
+  });
+});
+
 describe('family', () => {
   test('returns "column" when no family prefix', () => {
     expect(family('event_id')).toBe('column');

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/ColumnRowsEditor.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/ColumnRowsEditor.tsx
@@ -62,6 +62,12 @@ const ColumnRowsEditor: FC<Props> = ({ rows, onChange }) => {
                 isOn={row.nullable}
                 onChange={(value) => update(row.id, { nullable: value })}
               />
+              <DialSwitch
+                switchId={`col-sensitive-${row.id}`}
+                label={t(AnalyticsTablesI18nKey.Sensitive)}
+                isOn={row.sensitive}
+                onChange={(value) => update(row.id, { sensitive: value })}
+              />
               <DialRemoveButton onClick={() => onChange(rows.filter((r) => r.id !== row.id))} />
             </div>
           </div>

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/EditColumnPopup.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/EditColumnPopup.tsx
@@ -2,7 +2,7 @@
 
 import { FC, useState } from 'react';
 
-import { DialFormPopup, DialInput, PopupSize } from '@epam/ai-dial-ui-kit';
+import { DialFormPopup, DialInput, DialSwitch, PopupSize } from '@epam/ai-dial-ui-kit';
 
 import { buildColumnEditPatch } from '@/src/components/Analytics/Tables/utils';
 import { AnalyticsTablesI18nKey, ButtonsI18nKey } from '@/src/constants/i18n';
@@ -25,10 +25,13 @@ const EditColumnPopup: FC<Props> = ({ column, renameDisabled, onClose, onSubmit 
     display_name: column.display_name ?? '',
     tag: column.tag ?? '',
     description: column.description ?? '',
+    sensitive: column.sensitive ?? false,
   });
 
-  const setValue = (key: keyof ColumnEditValues) => (value?: string) =>
+  const setValue = (key: 'name' | 'display_name' | 'tag' | 'description') => (value?: string) =>
     setValues((prev) => ({ ...prev, [key]: value ?? '' }));
+
+  const setSensitive = (value: boolean) => setValues((prev) => ({ ...prev, sensitive: value }));
 
   const patch = values.name.trim() ? buildColumnEditPatch(column, values) : null;
 
@@ -62,6 +65,18 @@ const EditColumnPopup: FC<Props> = ({ column, renameDisabled, onClose, onSubmit 
           labelProps={{ label: t(AnalyticsTablesI18nKey.Tag) }}
           value={values.tag}
           onChange={setValue('tag')}
+        />
+        <DialInput
+          id="column-edit-description"
+          labelProps={{ label: t(AnalyticsTablesI18nKey.Description) }}
+          value={values.description}
+          onChange={setValue('description')}
+        />
+        <DialSwitch
+          switchId="column-edit-sensitive"
+          label={t(AnalyticsTablesI18nKey.Sensitive)}
+          isOn={values.sensitive}
+          onChange={setSensitive}
         />
       </div>
     </DialFormPopup>

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/TableDetailView.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/TableDetailView.tsx
@@ -4,7 +4,7 @@ import { FC, useCallback, useMemo, useState } from 'react';
 
 import { useRouter } from 'next/navigation';
 
-import { ColDef, ValueGetterParams } from 'ag-grid-community';
+import { ColDef, ICellRendererParams, ITooltipParams, ValueGetterParams } from 'ag-grid-community';
 import {
   ConfirmationPopupVariant,
   DialConfirmationPopup,
@@ -19,6 +19,7 @@ import ColumnRowsEditor from '@/src/components/Analytics/Tables/ColumnRowsEditor
 import EditColumnPopup from '@/src/components/Analytics/Tables/EditColumnPopup';
 import { createColumnRow, isRenameRestricted, toTableColumns } from '@/src/components/Analytics/Tables/utils';
 import { TypeCellRenderer } from '@/src/components/Analytics/Common/TypeBadge';
+import SensitiveIndicator from '@/src/components/Common/SensitiveIndicator/SensitiveIndicator';
 import GridView from '@/src/components/Grid/GridView/GridView';
 import JsonEditorBase from '@/src/components/Common/JsonEditorBase/JsonEditorBase';
 import { ACTION_COLUMN } from '@/src/constants/ag-grid';
@@ -37,6 +38,16 @@ interface Props {
   name: string;
   initialTable: AnalyticsTable;
 }
+
+// Renders the column name with a trailing sensitive marker; editing still swaps in the cell editor.
+// The dot is tooltip-less — the grid's cell tooltip (see the name column's tooltipValueGetter) carries
+// the sensitive note, so the two don't double up.
+const ColumnNameCellRenderer: FC<ICellRendererParams<AnalyticsTableColumn>> = ({ value, data }) => (
+  <span className="flex items-center gap-1.5">
+    <span className="truncate">{value}</span>
+    {data?.sensitive && <SensitiveIndicator />}
+  </span>
+);
 
 const TableDetailView: FC<Props> = ({ name, initialTable }) => {
   const t = useI18n();
@@ -154,7 +165,18 @@ const TableDetailView: FC<Props> = ({ name, initialTable }) => {
 
   const columnDefs = useMemo<ColDef[]>(
     () => [
-      { headerName: t(AnalyticsTablesI18nKey.ColumnName), field: 'name', editable: !isSystem, flex: 2 },
+      {
+        headerName: t(AnalyticsTablesI18nKey.ColumnName),
+        field: 'name',
+        editable: !isSystem,
+        cellRenderer: ColumnNameCellRenderer,
+        // Fold the sensitive note into the single cell tooltip so it doesn't double with the dot.
+        tooltipValueGetter: (params: ITooltipParams<AnalyticsTableColumn>) =>
+          [params.data?.name, params.data?.sensitive ? t(AnalyticsTablesI18nKey.Sensitive) : '']
+            .filter(Boolean)
+            .join(' — '),
+        flex: 2,
+      },
       { headerName: t(AnalyticsTablesI18nKey.SourceName), field: 'source_name', flex: 2 },
       { headerName: t(AnalyticsTablesI18nKey.Type), field: 'type', cellRenderer: TypeCellRenderer, flex: 1 },
       { headerName: t(AnalyticsTablesI18nKey.Tag), field: 'tag', flex: 1 },

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/tests/EditColumnPopup.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/tests/EditColumnPopup.spec.tsx
@@ -46,18 +46,18 @@ describe('EditColumnPopup', () => {
 
     expect(onSubmit).toHaveBeenCalledWith({
       rename: [{ from: 'total_money', to: 'total_cost' }],
-      set_display_name: [{ name: 'total_cost', display_name: 'Total money spend' }],
+      update: [{ name: 'total_cost', display_name: 'Total money spend' }],
     });
   });
 
-  test('clearing the label submits an empty relabel (the clear signal)', async () => {
+  test('clearing the label submits an empty display_name (the clear signal)', async () => {
     const user = userEvent.setup();
     const { onSubmit } = renderPopup();
 
     setInput(AnalyticsTablesI18nKey.DisplayName, '');
     await user.click(screen.getByRole('button', { name: ButtonsI18nKey.Save }));
 
-    expect(onSubmit).toHaveBeenCalledWith({ set_display_name: [{ name: 'total_money', display_name: '' }] });
+    expect(onSubmit).toHaveBeenCalledWith({ update: [{ name: 'total_money', display_name: '' }] });
   });
 
   test('a blank name disables submit', () => {
@@ -79,13 +79,32 @@ describe('EditColumnPopup', () => {
     await user.click(screen.getByRole('button', { name: ButtonsI18nKey.Save }));
 
     expect(onSubmit).toHaveBeenCalledWith({
-      retag: [{ name: 'total_money', tag: 'cost' }],
+      update: [{ name: 'total_money', tag: 'cost' }],
     });
   });
 
-  test('the description field is hidden until the backend supports editing it', () => {
-    renderPopup();
+  test('editing the description submits it in the update entry', async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderPopup();
 
-    expect(screen.queryByLabelText(AnalyticsTablesI18nKey.Description)).not.toBeInTheDocument();
+    expect(screen.getByLabelText(AnalyticsTablesI18nKey.Description)).toHaveValue('Money spent');
+    setInput(AnalyticsTablesI18nKey.Description, 'Money spent on the request');
+    await user.click(screen.getByRole('button', { name: ButtonsI18nKey.Save }));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      update: [{ name: 'total_money', description: 'Money spent on the request' }],
+    });
+  });
+
+  test('toggling sensitive submits it in the update entry', async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderPopup();
+
+    const sensitive = screen.getByRole('checkbox');
+    expect(sensitive).not.toBeChecked();
+    fireEvent.click(sensitive);
+    await user.click(screen.getByRole('button', { name: ButtonsI18nKey.Save }));
+
+    expect(onSubmit).toHaveBeenCalledWith({ update: [{ name: 'total_money', sensitive: true }] });
   });
 });

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/tests/utils.spec.ts
@@ -15,7 +15,14 @@ describe('createColumnRow', () => {
     const a = createColumnRow();
     const b = createColumnRow();
     expect(a.id).not.toBe(b.id);
-    expect(a).toMatchObject({ source_name: '', name: '', type: AnalyticsFieldType.String, tag: '', nullable: false });
+    expect(a).toMatchObject({
+      source_name: '',
+      name: '',
+      type: AnalyticsFieldType.String,
+      tag: '',
+      nullable: false,
+      sensitive: false,
+    });
   });
 });
 
@@ -29,13 +36,57 @@ describe('toTableColumns', () => {
         type: AnalyticsFieldType.Uuid,
         tag: ' identity ',
         nullable: true,
+        sensitive: false,
       },
-      { id: '2', source_name: '', name: 'skip', type: AnalyticsFieldType.String, tag: '', nullable: false },
-      { id: '3', source_name: 'x', name: 'x', type: AnalyticsFieldType.Long, tag: '', nullable: false },
+      {
+        id: '2',
+        source_name: '',
+        name: 'skip',
+        type: AnalyticsFieldType.String,
+        tag: '',
+        nullable: false,
+        sensitive: false,
+      },
+      {
+        id: '3',
+        source_name: 'x',
+        name: 'x',
+        type: AnalyticsFieldType.Long,
+        tag: '',
+        nullable: false,
+        sensitive: false,
+      },
     ];
     expect(toTableColumns(rows)).toEqual([
       { source_name: 'event_id', name: 'event', type: AnalyticsFieldType.Uuid, nullable: true, tag: 'identity' },
       { source_name: 'x', name: 'x', type: AnalyticsFieldType.Long, nullable: false },
+    ]);
+  });
+
+  test('sensitive rows carry sensitive: true; non-sensitive rows omit the field', () => {
+    const rows = [
+      {
+        id: '1',
+        source_name: 'email',
+        name: 'email',
+        type: AnalyticsFieldType.String,
+        tag: '',
+        nullable: false,
+        sensitive: true,
+      },
+      {
+        id: '2',
+        source_name: 'total',
+        name: 'total',
+        type: AnalyticsFieldType.Decimal,
+        tag: '',
+        nullable: false,
+        sensitive: false,
+      },
+    ];
+    expect(toTableColumns(rows)).toEqual([
+      { source_name: 'email', name: 'email', type: AnalyticsFieldType.String, nullable: false, sensitive: true },
+      { source_name: 'total', name: 'total', type: AnalyticsFieldType.Decimal, nullable: false },
     ]);
   });
 });
@@ -54,6 +105,7 @@ const values = (overrides?: Partial<ColumnEditValues>): ColumnEditValues => ({
   display_name: 'Total money',
   tag: 'metric',
   description: 'Money spent',
+  sensitive: false,
   ...overrides,
 });
 
@@ -63,39 +115,60 @@ describe('buildColumnEditPatch', () => {
     expect(buildColumnEditPatch(COLUMN, values({ display_name: ' Total money ', tag: ' metric ' }))).toBeNull();
   });
 
-  test('single-field diffs produce a single op', () => {
+  test('single-field metadata diffs produce one update entry carrying only that field', () => {
     expect(buildColumnEditPatch(COLUMN, values({ display_name: 'Total money spend' }))).toEqual({
-      set_display_name: [{ name: 'total_money', display_name: 'Total money spend' }],
+      update: [{ name: 'total_money', display_name: 'Total money spend' }],
     });
     expect(buildColumnEditPatch(COLUMN, values({ tag: 'cost' }))).toEqual({
-      retag: [{ name: 'total_money', tag: 'cost' }],
+      update: [{ name: 'total_money', tag: 'cost' }],
     });
     expect(buildColumnEditPatch(COLUMN, values({ description: 'Money spent on the request' }))).toEqual({
-      redescribe: [{ name: 'total_money', description: 'Money spent on the request' }],
+      update: [{ name: 'total_money', description: 'Money spent on the request' }],
     });
+  });
+
+  test('a rename-only change produces no update entry', () => {
     expect(buildColumnEditPatch(COLUMN, values({ name: 'total_cost' }))).toEqual({
       rename: [{ from: 'total_money', to: 'total_cost' }],
     });
   });
 
-  test('combined rename + metadata ops reference the post-rename name', () => {
+  test('combined rename + metadata update references the post-rename name', () => {
     expect(buildColumnEditPatch(COLUMN, values({ name: 'total_cost', display_name: 'Total money spend' }))).toEqual({
       rename: [{ from: 'total_money', to: 'total_cost' }],
-      set_display_name: [{ name: 'total_cost', display_name: 'Total money spend' }],
+      update: [{ name: 'total_cost', display_name: 'Total money spend' }],
     });
   });
 
   test('blank metadata values are sent as the clear signal', () => {
     expect(buildColumnEditPatch(COLUMN, values({ display_name: '', description: '  ' }))).toEqual({
-      set_display_name: [{ name: 'total_money', display_name: '' }],
-      redescribe: [{ name: 'total_money', description: '' }],
+      update: [{ name: 'total_money', display_name: '', description: '' }],
     });
   });
 
-  test('setting metadata on a column without any produces the ops', () => {
+  test('setting metadata on a column without any produces one update entry', () => {
     const bare: AnalyticsTableColumn = { source_name: 'x', name: 'x', type: AnalyticsFieldType.String };
-    expect(buildColumnEditPatch(bare, { name: 'x', display_name: 'X value', tag: '', description: '' })).toEqual({
-      set_display_name: [{ name: 'x', display_name: 'X value' }],
+    expect(
+      buildColumnEditPatch(bare, { name: 'x', display_name: 'X value', tag: '', description: '', sensitive: false }),
+    ).toEqual({
+      update: [{ name: 'x', display_name: 'X value' }],
+    });
+  });
+
+  test('toggling sensitive is diffed into the update entry', () => {
+    expect(buildColumnEditPatch(COLUMN, values({ sensitive: true }))).toEqual({
+      update: [{ name: 'total_money', sensitive: true }],
+    });
+    const secret: AnalyticsTableColumn = { ...COLUMN, sensitive: true };
+    expect(buildColumnEditPatch(secret, values({ sensitive: false }))).toEqual({
+      update: [{ name: 'total_money', sensitive: false }],
+    });
+  });
+
+  test('sensitive rides along with other changed metadata and the post-rename name', () => {
+    expect(buildColumnEditPatch(COLUMN, values({ name: 'total_cost', sensitive: true }))).toEqual({
+      rename: [{ from: 'total_money', to: 'total_cost' }],
+      update: [{ name: 'total_cost', sensitive: true }],
     });
   });
 

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/utils.ts
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/utils.ts
@@ -1,6 +1,7 @@
 import { PARTITION_NONE } from '@/src/constants/analytics/tables';
 import { AnalyticsFieldType } from '@/src/models/analytics/entity';
 import {
+  AnalyticsColumnMetadataUpdate,
   AnalyticsSchemaPatch,
   AnalyticsTable,
   AnalyticsTableColumn,
@@ -18,6 +19,7 @@ export const createColumnRow = (): ColumnRow => ({
   type: AnalyticsFieldType.String,
   tag: '',
   nullable: false,
+  sensitive: false,
 });
 
 export const createTableForm = (tables: AnalyticsTable[]): TableForm => {
@@ -44,15 +46,21 @@ export const buildColumnEditPatch = (
   const name = edited.name.trim();
   if (name && name !== original.name) patch.rename = [{ from: original.name, to: name }];
   const target = patch.rename ? name : original.name;
-  if (normalized(edited.tag) !== normalized(original.tag)) {
-    patch.retag = [{ name: target, tag: normalized(edited.tag) }];
-  }
+
+  // Merge-patch: include only the metadata fields that changed (blank clears, non-blank sets); an
+  // omitted field leaves the attribute unchanged.
+  const update: AnalyticsColumnMetadataUpdate = { name: target };
+  if (normalized(edited.tag) !== normalized(original.tag)) update.tag = normalized(edited.tag);
   if (normalized(edited.display_name) !== normalized(original.display_name)) {
-    patch.set_display_name = [{ name: target, display_name: normalized(edited.display_name) }];
+    update.display_name = normalized(edited.display_name);
   }
   if (normalized(edited.description) !== normalized(original.description)) {
-    patch.redescribe = [{ name: target, description: normalized(edited.description) }];
+    update.description = normalized(edited.description);
   }
+  if (edited.sensitive !== Boolean(original.sensitive)) update.sensitive = edited.sensitive;
+  // >1 key means a metadata field changed alongside the always-present `name`.
+  if (Object.keys(update).length > 1) patch.update = [update];
+
   return Object.keys(patch).length ? patch : null;
 };
 
@@ -70,4 +78,5 @@ export const toTableColumns = (rows: ColumnRow[]): AnalyticsTableColumn[] =>
       type: r.type,
       nullable: r.nullable,
       ...(r.tag.trim() ? { tag: r.tag.trim() } : {}),
+      ...(r.sensitive ? { sensitive: true } : {}),
     }));

--- a/apps/ai-dial-admin/src/components/Common/SensitiveIndicator/SensitiveIndicator.tsx
+++ b/apps/ai-dial-admin/src/components/Common/SensitiveIndicator/SensitiveIndicator.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { FC } from 'react';
+
+import { AnalyticsTablesI18nKey } from '@/src/constants/i18n';
+import { useI18n } from '@/src/locales/client';
+
+// A small colored dot marking a column as sensitive (access-restricted). Reused in the table detail
+// name cell and the Query Builder field dropdown. It carries no tooltip of its own — both contexts
+// already own a cell/row tooltip that explains the flag, so this stays a pure marker (the aria-label
+// keeps it accessible) and tooltips never double up.
+const SensitiveIndicator: FC = () => {
+  const t = useI18n();
+
+  return (
+    <span
+      role="img"
+      aria-label={t(AnalyticsTablesI18nKey.Sensitive)}
+      className="size-2 shrink-0 rounded-full bg-yellow-400"
+    />
+  );
+};
+
+export default SensitiveIndicator;

--- a/apps/ai-dial-admin/src/components/Common/SensitiveIndicator/tests/SensitiveIndicator.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Common/SensitiveIndicator/tests/SensitiveIndicator.spec.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+
+import SensitiveIndicator from '@/src/components/Common/SensitiveIndicator/SensitiveIndicator';
+import { AnalyticsTablesI18nKey } from '@/src/constants/i18n';
+
+describe('SensitiveIndicator', () => {
+  test('renders an accessible marker labeled Sensitive', () => {
+    render(<SensitiveIndicator />);
+    expect(screen.getByRole('img', { name: AnalyticsTablesI18nKey.Sensitive })).toBeInTheDocument();
+  });
+});

--- a/apps/ai-dial-admin/src/constants/i18n.ts
+++ b/apps/ai-dial-admin/src/constants/i18n.ts
@@ -2241,6 +2241,7 @@ export enum AnalyticsTablesI18nKey {
   ColumnName = 'AnalyticsTables.ColumnName',
   Tag = 'AnalyticsTables.Tag',
   Nullable = 'AnalyticsTables.Nullable',
+  Sensitive = 'AnalyticsTables.Sensitive',
   AddColumns = 'AnalyticsTables.AddColumns',
   WriteRows = 'AnalyticsTables.WriteRows',
   InsertRows = 'AnalyticsTables.InsertRows',

--- a/apps/ai-dial-admin/src/locales/en.ts
+++ b/apps/ai-dial-admin/src/locales/en.ts
@@ -2292,6 +2292,7 @@ export default {
     ColumnName: 'Name',
     Tag: 'Tag',
     Nullable: 'Nullable',
+    Sensitive: 'Sensitive',
     AddColumns: 'Add columns',
     WriteRows: 'Write rows',
     InsertRows: 'Insert rows',

--- a/apps/ai-dial-admin/src/models/analytics/entity.ts
+++ b/apps/ai-dial-admin/src/models/analytics/entity.ts
@@ -22,6 +22,7 @@ export interface AnalyticsEntityField {
   tag?: string;
   display_name?: string;
   description?: string;
+  sensitive?: boolean;
 }
 
 export interface AnalyticsEntitySchema {

--- a/apps/ai-dial-admin/src/models/analytics/query-builder.ts
+++ b/apps/ai-dial-admin/src/models/analytics/query-builder.ts
@@ -102,6 +102,7 @@ export interface FieldOption {
   tag?: string;
   display_name?: string;
   description?: string;
+  sensitive?: boolean;
 }
 
 export interface FieldOptionGroup {

--- a/apps/ai-dial-admin/src/models/analytics/table.ts
+++ b/apps/ai-dial-admin/src/models/analytics/table.ts
@@ -19,6 +19,7 @@ export interface AnalyticsTableColumn {
   tag?: string;
   display_name?: string;
   description?: string;
+  sensitive?: boolean;
 }
 
 export interface AnalyticsTablePartition {
@@ -67,29 +68,22 @@ export interface AnalyticsColumnRename {
   to: string;
 }
 
-export interface AnalyticsColumnRetag {
+// Per-column metadata merge-patch: an omitted field leaves that attribute unchanged, a blank string
+// clears it, and a non-blank string sets it; `sensitive` (omitted → unchanged, true/false → set) is
+// typed for contract completeness but never populated by the UI.
+export interface AnalyticsColumnMetadataUpdate {
   name: string;
-  tag: string;
-}
-
-// Blank display_name/description means "clear the stored value" (backend normalizes blank to null).
-export interface AnalyticsColumnSetDisplayName {
-  name: string;
-  display_name: string;
-}
-
-export interface AnalyticsColumnRedescribe {
-  name: string;
-  description: string;
+  tag?: string;
+  display_name?: string;
+  description?: string;
+  sensitive?: boolean;
 }
 
 export interface AnalyticsSchemaPatch {
   add?: AnalyticsTableColumn[];
   drop?: string[];
   rename?: AnalyticsColumnRename[];
-  retag?: AnalyticsColumnRetag[];
-  set_display_name?: AnalyticsColumnSetDisplayName[];
-  redescribe?: AnalyticsColumnRedescribe[];
+  update?: AnalyticsColumnMetadataUpdate[];
 }
 
 export interface WriteRowsDto {

--- a/apps/ai-dial-admin/src/models/analytics/tables-ui.ts
+++ b/apps/ai-dial-admin/src/models/analytics/tables-ui.ts
@@ -8,6 +8,7 @@ export interface ColumnRow {
   type: AnalyticsFieldType;
   tag: string;
   nullable: boolean;
+  sensitive: boolean;
 }
 
 export interface ColumnEditValues {
@@ -15,6 +16,7 @@ export interface ColumnEditValues {
   display_name: string;
   tag: string;
   description: string;
+  sensitive: boolean;
 }
 
 export interface TableForm {

--- a/openspec/changes/archive/2026-07-16-adopt-consolidated-column-metadata-patch/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-16-adopt-consolidated-column-metadata-patch/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/archive/2026-07-16-adopt-consolidated-column-metadata-patch/design.md
+++ b/openspec/changes/archive/2026-07-16-adopt-consolidated-column-metadata-patch/design.md
@@ -1,0 +1,110 @@
+# Design — adopt consolidated column-metadata PATCH
+
+## Context
+
+The backend collapsed four column-metadata PATCH ops into one `update` merge-patch list. The FE's
+`AnalyticsSchemaPatch` and `buildColumnEditPatch` still emit the old per-op arrays, one of which
+(`redescribe`) never existed on the backend at all. The unknown keys are silently dropped, so column
+metadata editing quietly no-ops. This change realigns the FE contract and, as a direct consequence of
+`description` now being editable, surfaces it in the modal.
+
+## Wire contract
+
+```
+PATCH /v1/tables/{name}/schema
+{
+  add?:    ColumnRequest[],                 // structural — unchanged
+  drop?:   string[],                        // structural — unchanged
+  rename?: { from, to }[],                  // structural — unchanged
+  update?: {                                // NEW — replaces retag/set_display_name/redescribe
+    name: string,                           // exposed (post-rename) column name
+    tag?: string,                           // merge-patch: omit=leave, ""=clear, value=set
+    display_name?: string,                  // merge-patch
+    description?: string,                   // merge-patch
+    sensitive?: boolean                     // omit=leave, true/false=set   (FE never sends this)
+  }[]
+}
+```
+
+## Decision 1 — one `update` entry, only-changed fields
+
+`buildColumnEditPatch` already diffs each metadata field against the original and only touches changed
+ones. That maps cleanly onto merge-patch: build a single object keyed by `name`, add a property only
+when that field changed, and emit `update: [entry]` only if at least one metadata field changed.
+
+```ts
+// after
+export const buildColumnEditPatch = (
+  original: AnalyticsTableColumn,
+  edited: ColumnEditValues,
+): AnalyticsSchemaPatch | null => {
+  const patch: AnalyticsSchemaPatch = {};
+  const name = edited.name.trim();
+  if (name && name !== original.name) patch.rename = [{ from: original.name, to: name }];
+  const target = patch.rename ? name : original.name;
+
+  const update: AnalyticsColumnMetadataUpdate = { name: target };
+  if (normalized(edited.tag) !== normalized(original.tag)) update.tag = normalized(edited.tag);
+  if (normalized(edited.display_name) !== normalized(original.display_name))
+    update.display_name = normalized(edited.display_name);
+  if (normalized(edited.description) !== normalized(original.description))
+    update.description = normalized(edited.description);
+  if (edited.sensitive !== Boolean(original.sensitive)) update.sensitive = edited.sensitive;
+
+  if (Object.keys(update).length > 1) patch.update = [update];   // >1 → a metadata field changed
+  return Object.keys(patch).length ? patch : null;
+};
+```
+
+- **Unchanged field → omitted** → backend leaves it (merge-patch absent).
+- **Cleared field → `""`** → backend clears it (merge-patch blank). `normalized()` already trims to `""`.
+- **Set field → trimmed value** → backend sets it.
+- The `> 1` guard (the entry always carries `name`) prevents sending a metadata-only `update` when only
+  a rename changed.
+
+## Decision 2 — `sensitive` marked visually and made editable
+
+The backend returns `sensitive` on column responses (`TableDto.ColumnDto`) and query-schema fields
+(`QuerySchemaFieldDto`), and documents it as "exposed on the query path to full admins only" — an
+access-restriction signal, not cosmetic. So the flag is surfaced, not just typed:
+
+- **Read models** gain `sensitive?: boolean`: `AnalyticsTableColumn`, `AnalyticsEntityField`,
+  `FieldOption`. No transform layer exists — backend JSON is cast directly — so the model additions are
+  the whole read-side wiring; `fieldsToOptions` passes `sensitive` through.
+- **Visual = a colored dot, not a lock.** A shared `Common/SensitiveIndicator` renders a small
+  `bg-yellow-400` (bright amber-gold) dot with `role="img"` + `aria-label="Sensitive"`. It carries **no
+  tooltip of its own** — both host contexts already own a cell/row tooltip, so the dot stays a pure
+  marker and tooltips never double up (the earlier nested-`DialTooltip` doubling is why).
+- **Table grid**: the marker is rendered **inline in the name cell, after the name** via a
+  `ColumnNameCellRenderer` (name text + trailing dot when `data.sensitive`). The name column stays
+  editable — ag-grid swaps in the cell editor on edit, so the renderer only affects display. The
+  sensitive note is folded into the name column's `tooltipValueGetter` (`"<name> — Sensitive"`), so the
+  cell has a single tooltip rather than the grid's default value tooltip plus the dot's.
+- **Query Builder dropdown**: the dot sits in the option's primary line, after the field label; the
+  single row-level `DialTooltip` carries the note (`"Sensitive — <description>"`, either part optional).
+- **Tooltip copy is just "Sensitive"** — short, not the verbose "exposed on the query path…" sentence.
+- **Editable (post-creation)**: `ColumnEditValues` gains `sensitive: boolean`; the modal seeds it from
+  `column.sensitive ?? false` and renders a `DialSwitch`. `buildColumnEditPatch` diffs
+  `edited.sensitive !== Boolean(original.sensitive)` and, when changed, sets `update.sensitive` (a
+  boolean, so it rides the same single `update` entry as the string metadata fields). Because
+  `sensitive` is a real boolean rather than a string, it is compared directly (not through
+  `normalized()`), and `false` is a legitimate value (turning the flag off), distinct from "unchanged".
+- **Editable (at creation)**: `ColumnRow` and `createColumnRow` gain `sensitive: boolean` (default
+  `false`); `ColumnRowsEditor` renders a per-row `DialSwitch` beside Nullable, so both the Add columns
+  popup and the Create table form can set it. `toTableColumns` includes `sensitive: true` only when the
+  row's flag is on (mirroring how it already omits an empty `tag`) — the backend
+  `CreateTableRequest.ColumnRequest` accepts `sensitive`, and omitting it defaults to non-sensitive.
+
+## Decision 3 — description joins the modal now
+
+`ColumnEditValues.description` and `EditColumnPopup`'s seed (`description: column.description ?? ''`)
+already exist; only the input row is missing. Add a fourth `DialInput` labeled with the existing
+`AnalyticsTablesI18nKey.Description`. No new i18n key, no new state wiring — this flips the dead
+`description` diff branch live. Blank description is valid input meaning "clear", consistent with
+display name and tag.
+
+## Risks
+
+- **Low.** The change is a contract realignment plus one input field. The main correctness surface is
+  the patch-builder shape, covered by unit tests. The description field's save path is exercised the
+  same way display name / tag already are.

--- a/openspec/changes/archive/2026-07-16-adopt-consolidated-column-metadata-patch/proposal.md
+++ b/openspec/changes/archive/2026-07-16-adopt-consolidated-column-metadata-patch/proposal.md
@@ -1,0 +1,102 @@
+# Adopt consolidated column-metadata PATCH, surface description editing, and mark sensitive columns
+
+## Why
+
+The analytics backend shipped `feat/consolidate-column-metadata-patch` (merged to `development`),
+a **breaking** change to `PATCH /v1/tables/{name}/schema`: the separate column-metadata operations
+(`retag`, `set_display_name`, `set_sensitive`, `set_description`) are collapsed into a single
+`update` merge-patch list, each entry carrying a column `name` plus optional `tag`, `display_name`,
+`description`, and `sensitive` fields. Per-field semantics: **absent/null → leave unchanged**,
+**blank `""` → clear**, **non-blank → set** (`sensitive`: `true`/`false` → set).
+
+The frontend still targets the old shape and the backend **silently ignores unknown patch keys**, so:
+
+- The FE sends `retag` and `set_display_name` (`models/analytics/table.ts:90-91`,
+  `components/Analytics/Tables/utils.ts:47-52`). The backend no longer recognizes these, so **tag and
+  display-name editing now silently no-op** on `development` — a success toast over a save that did
+  nothing. Adopting the new shape is **mandatory**, not optional.
+- The FE also emits `redescribe` (`utils.ts:54`), an op the backend **never** had (`git log -S
+  redescribe` on the backend is empty). It was a speculative guess from
+  `add-column-labels-and-descriptions`; the real op landed as `update.description`. The
+  `redescribe` path is dead today because the edit modal never renders a description input.
+
+Because the backend now supports editing `description`, the condition the analytics spec already set —
+"the description field joins the modal **once that operation ships**"
+(`openspec/specs/analytics/spec.md:684`) — is now satisfied. So this change both fixes the regression
+and cashes in that promise.
+
+## What Changes
+
+- **Models** (`src/models/analytics/table.ts`): replace the three metadata op interfaces
+  (`AnalyticsColumnRetag`, `AnalyticsColumnSetDisplayName`, `AnalyticsColumnRedescribe`) and the three
+  `AnalyticsSchemaPatch` fields (`retag`, `set_display_name`, `redescribe`) with a single
+  `update?: AnalyticsColumnMetadataUpdate[]`, where `AnalyticsColumnMetadataUpdate` is
+  `{ name: string; tag?: string; display_name?: string; description?: string; sensitive?: boolean }`.
+  Structural ops (`add`, `drop`, `rename`) are unchanged.
+- **Patch builder** (`components/Analytics/Tables/utils.ts`): rewrite `buildColumnEditPatch` to emit at
+  most one `update` entry `{ name: target, ...changedMetadataFields }` containing **only** the metadata
+  fields that changed (merge-patch: unchanged fields omitted, blank sends `""` to clear). `rename` stays
+  a separate structural op; when a rename is present, the `update` entry references the post-rename
+  name (unchanged `target` logic). Return `null` when nothing changed.
+- **Edit modal** (`components/Analytics/Tables/EditColumnPopup.tsx`): add the **Description** input as a
+  fourth field (seeded from `column.description`, `ColumnEditValues.description` already exists),
+  reusing `AnalyticsTablesI18nKey.Description`. Now that the backend supports it, description is
+  editable alongside name / display name / tag.
+- **Sensitive marking (visual + editable).** The backend returns `sensitive` on both column responses
+  (`TableDto.ColumnDto`) and query-schema fields (`QuerySchemaFieldDto`), where a sensitive column is
+  "exposed on the query path to full admins only" — so it is an access-restriction signal worth showing.
+  - **Read models**: `AnalyticsTableColumn`, `AnalyticsEntityField`, and `FieldOption` gain
+    `sensitive?: boolean`.
+  - **Shared indicator**: a new `Common/SensitiveIndicator` renders a small colored dot (warning token)
+    with a "Sensitive" tooltip, reused across surfaces (plus a `SensitiveCellRenderer` for ag-grid).
+  - **Table detail grid**: a narrow **Sensitive** column renders the dot for sensitive columns.
+  - **Query Builder field dropdown**: the dot appears in each sensitive option's primary line.
+  - **Editable (post-creation)**: the edit modal gains a **Sensitive** `DialSwitch`;
+    `buildColumnEditPatch` diffs it into `update.sensitive` (the wire field is already there).
+  - **Editable (at creation)**: the column-row editor (`ColumnRowsEditor`, shared by the Add columns
+    popup and the Create table form) gains a per-row **Sensitive** `DialSwitch`; `toTableColumns` carries
+    `sensitive: true` into the create/add payload (backend `CreateTableRequest.ColumnRequest` accepts it).
+- **Spec** (`openspec/specs/analytics/spec.md`): update the "Table detail column schema management"
+  requirement — drop the "description SHALL NOT be offered" clause, list the single `update` op in
+  place of `retag`/`set_display_name`, add the Sensitive grid column + toggle, and reword/add scenarios;
+  extend the categorized-field-dropdown requirement with the sensitive dropdown marker.
+
+## Non-goals
+
+- No changes to structural ops (`add`, `drop`, `rename`), row writes, or query serialization.
+- No value-masking of sensitive data in the query-results grid.
+
+## Capabilities
+
+### Modified Capability
+
+- `analytics` (master spec `openspec/specs/analytics/spec.md`): the "Table detail column schema
+  management" requirement changes its patch contract — the `retag`/`set_display_name`(/`redescribe`)
+  operations collapse into one `update` merge-patch entry, and the description field becomes editable in
+  the modal. Scenario wording follows.
+
+## Dependencies / sequencing
+
+- Backend `feat/consolidate-column-metadata-patch` is **already merged** to the analytics service
+  `development`, so there is no merge-before-release caveat — the FE can ship immediately.
+
+## Impact
+
+- **Models**: `src/models/analytics/table.ts`, `src/models/analytics/entity.ts`,
+  `src/models/analytics/query-builder.ts` (`FieldOption`), `src/models/analytics/tables-ui.ts`
+  (`ColumnEditValues`).
+- **Components**: `src/components/Analytics/Tables/utils.ts` (patch builder + `toTableColumns`/`createColumnRow`),
+  `src/components/Analytics/Tables/EditColumnPopup.tsx` (description field + Sensitive toggle),
+  `src/components/Analytics/Tables/ColumnRowsEditor.tsx` (per-row Sensitive toggle at creation),
+  `src/components/Analytics/Tables/TableDetailView.tsx` (Sensitive grid column),
+  `src/components/Analytics/QueryBuilder/Common/CategorizedFieldDropdown.tsx` (dropdown marker),
+  `src/components/Analytics/QueryBuilder/utils/fields.ts` (`fieldsToOptions` passthrough),
+  new `src/components/Common/SensitiveIndicator/SensitiveIndicator.tsx`.
+- **i18n**: reuse `AnalyticsTablesI18nKey.Description`; add `AnalyticsTablesI18nKey.Sensitive` (used as
+  the switch/column label, the marker's `aria-label`, and the short tooltip note).
+- **Tests**: `Tables/tests/utils.spec.ts` (patch-builder shape + sensitive diff),
+  `Tables/tests/EditColumnPopup.spec.tsx` (description + sensitive toggle),
+  `QueryBuilder/utils/tests/fields.spec.ts` (sensitive passthrough),
+  `QueryBuilder/Common/tests/CategorizedFieldDropdown.spec.tsx` (dropdown marker),
+  new `Common/SensitiveIndicator/tests/SensitiveIndicator.spec.tsx`. (`analytics-data-api.spec.ts` and
+  `utils/tests/schema.spec.ts` needed no change — they never asserted the old op names.)

--- a/openspec/changes/archive/2026-07-16-adopt-consolidated-column-metadata-patch/specs/analytics/spec.md
+++ b/openspec/changes/archive/2026-07-16-adopt-consolidated-column-metadata-patch/specs/analytics/spec.md
@@ -1,0 +1,91 @@
+# Analytics — consolidated column-metadata PATCH (delta)
+
+> Applies on top of the master spec `openspec/specs/analytics/spec.md`.
+
+## MODIFIED Requirements
+
+### Requirement: Table detail column schema management
+
+The Table detail page SHALL show the table's columns in a grid (name, source name, type, tag, display name, description, nullable rendered as a true/false value); long display name/description values SHALL be truncated with the full value reachable via an ellipsis tooltip. A column whose `sensitive` flag is true SHALL show a marker (a colored dot with a "Sensitive" tooltip) rendered inline in the name cell, after the name; non-sensitive columns SHALL show no marker. Each column row SHALL offer a per-column action menu with **edit** and **delete (drop)** actions. The column name SHALL also be editable inline in the grid.
+
+The edit action SHALL open a unified edit modal seeded with the column's current name, display name, tag, description, and sensitive flag. The name field SHALL be required (submit disabled while blank) and SHALL be disabled for columns the backend does not allow to rename (grain-key, ordering-key, and `_`-prefixed system columns) while the metadata fields remain editable. Blank display name, tag, or description values SHALL be valid input meaning "clear the value"; the sensitive flag SHALL be toggled with a switch. On submit the modal SHALL diff the form against the original column and send a **single** schema patch: a structural `rename` op when the name changed, plus a **single `update` merge-patch entry** carrying the target column name and only the metadata fields (tag, display name, description, sensitive) that changed. Within the `update` entry an omitted field leaves that attribute unchanged, a blank string value clears it, a non-blank string value sets it, and the boolean `sensitive` is sent as `true`/`false` when toggled. When a rename is included, the `update` entry SHALL reference the new (post-rename) column name. Submit SHALL be disabled when no field changed.
+
+Adding columns SHALL be available from the header via a form popup reusing the column-row editor. Every schema change SHALL be sent as a schema patch to `updateTableSchema`, and on success the detail view SHALL refresh from the server. The header SHALL also offer deleting the whole table with a danger (red confirm) dialog, returning to the catalog on success.
+
+#### Scenario: Inline rename patches the schema
+
+- **WHEN** the user edits a column's name in the grid to a new non-empty value
+- **THEN** a rename schema patch is sent and the grid refreshes with the server state
+
+#### Scenario: Combined edit sends one patch with post-rename names
+
+- **WHEN** the user renames `total_money` to `total_cost` and sets its display name to "Total money spend" in the edit modal and submits
+- **THEN** a single schema patch is sent containing a rename from `total_money` to `total_cost` and an `update` entry whose `name` is `total_cost` and `display_name` is "Total money spend"
+- **AND** the grid refreshes with the server state
+
+#### Scenario: Only changed fields become update fields
+
+- **WHEN** the user changes only the display name and leaves name, tag, and description untouched
+- **THEN** the patch contains a single `update` entry carrying only `name` and `display_name`, with no `tag` or `description` field
+
+#### Scenario: Blank metadata clears the value
+
+- **WHEN** the user clears the display name field and submits
+- **THEN** the `update` entry sends `display_name` as an empty string, clearing the stored display name
+
+#### Scenario: Description is editable and patched
+
+- **WHEN** the user changes a column's description in the edit modal and submits
+- **THEN** the modal renders a description input
+- **AND** the patch contains a single `update` entry carrying `name` and the new `description`
+
+#### Scenario: Sensitive columns are marked in the grid
+
+- **WHEN** the columns grid renders a column whose `sensitive` flag is true
+- **THEN** the name cell shows a marker with a "Sensitive" tooltip after the name
+- **AND** a column whose flag is false shows no marker
+
+#### Scenario: Toggling sensitive is patched
+
+- **WHEN** the user toggles the Sensitive switch in the edit modal and submits
+- **THEN** the patch contains a single `update` entry carrying `name` and the new boolean `sensitive`
+
+#### Scenario: Restricted columns cannot be renamed but keep metadata editable
+
+- **WHEN** the user opens the edit modal for a grain-key or ordering-key column
+- **THEN** the name input is disabled
+- **AND** display name, tag, description, and sensitive remain editable
+
+#### Scenario: Drop a column
+
+- **WHEN** the user chooses delete from a column's action menu
+- **THEN** a drop schema patch is sent and the column is removed after refresh
+
+#### Scenario: Add columns
+
+- **WHEN** the user adds one or more valid columns in the add-columns popup and submits
+- **THEN** an add schema patch is sent and the new columns appear after refresh
+
+### Requirement: Builder sections use section blocks with categorized field dropdowns and collapsible items
+
+> Only the sensitive-marker addition is new here; the rest of the requirement is unchanged from the master spec.
+
+Field options SHALL display the field's **display name** as primary text, the field type right-aligned, and the schema `description` as a secondary line when present. A field whose schema `sensitive` flag is true SHALL show a sensitive marker (a colored dot with a "Sensitive" tooltip) in its dropdown option, after the display name. All other categorized-field-dropdown behavior (grouping, accordion, search over name/display name, chips/summaries, display-name-only presentation) is unchanged.
+
+#### Scenario: Sensitive field shows a marker in the dropdown
+
+- **WHEN** a schema field whose `sensitive` flag is true is shown in a field dropdown
+- **THEN** its option renders a sensitive marker with a "Sensitive" tooltip
+- **AND** a non-sensitive field's option renders no such marker
+
+### Requirement: Create table (source or enrichment)
+
+> Only the per-column sensitive flag is new here; the rest of the requirement is unchanged from the master spec.
+
+A **source** table's repeatable column set SHALL collect, per column, an optional **sensitive** flag alongside source name, exposed name, type, nullable, and optional tag. The flag SHALL default off and be toggled with a switch; the same per-column control SHALL be available in the Add columns popup (both reuse the column-row editor). Columns whose flag is on SHALL carry `sensitive: true` into the create/add payload; non-sensitive columns SHALL omit the flag.
+
+#### Scenario: Creating a sensitive column carries the flag
+
+- **WHEN** the user adds a column, toggles its Sensitive switch on, and submits the create/add form
+- **THEN** that column is sent with `sensitive: true` in the payload
+- **AND** columns left non-sensitive omit the flag

--- a/openspec/changes/archive/2026-07-16-adopt-consolidated-column-metadata-patch/tasks.md
+++ b/openspec/changes/archive/2026-07-16-adopt-consolidated-column-metadata-patch/tasks.md
@@ -1,0 +1,41 @@
+# Tasks — adopt consolidated column-metadata PATCH
+
+## 1. Models
+
+- [x] 1.1 In `src/models/analytics/table.ts`, remove `AnalyticsColumnRetag`, `AnalyticsColumnSetDisplayName`, and `AnalyticsColumnRedescribe`, and add `AnalyticsColumnMetadataUpdate { name: string; tag?: string; display_name?: string; description?: string; sensitive?: boolean }`.
+- [x] 1.2 Replace the `retag` / `set_display_name` / `redescribe` fields on `AnalyticsSchemaPatch` with `update?: AnalyticsColumnMetadataUpdate[]`; keep `add` / `drop` / `rename` unchanged. Update the blank-clears comment to reference merge-patch semantics.
+
+## 2. Patch builder
+
+- [x] 2.1 In `src/components/Analytics/Tables/utils.ts`, rewrite `buildColumnEditPatch` to emit a single `update` entry `{ name: target, ...changedMetadataFields }` (tag / display_name / description added only when changed, blank sends `""`), guarded so a metadata-only `update` is omitted when only a rename changed; return `null` when nothing changed.
+
+## 3. Edit modal
+
+- [x] 3.1 In `src/components/Analytics/Tables/EditColumnPopup.tsx`, add a fourth `DialInput` for description (id `column-edit-description`, seeded from `values.description`, `onChange={setValue('description')}`) labeled with `AnalyticsTablesI18nKey.Description`.
+
+## 4. Tests
+
+- [x] 4.1 Update `src/components/Analytics/Tables/tests/utils.spec.ts` to assert the new single-`update`-entry shape: only-changed fields, blank-clears, post-rename `name`, and no `update` when only rename changed.
+- [x] 4.2 Update `src/components/Analytics/Tables/tests/EditColumnPopup.spec.tsx` to cover the description field rendering and its inclusion in the submitted patch.
+- [x] 4.3 Update `src/server/analytics/tests/analytics-data-api.spec.ts` and `src/utils/tests/schema.spec.ts` if they assert the old `retag` / `set_display_name` / `redescribe` op names.
+
+## 5. Sensitive marking (visual + editable)
+
+- [x] 5.1 Add `sensitive?: boolean` to the read models: `AnalyticsTableColumn` (`table.ts`), `AnalyticsEntityField` (`entity.ts`), `FieldOption` (`query-builder.ts`); add `sensitive: boolean` to `ColumnEditValues` (`tables-ui.ts`).
+- [x] 5.2 Add the shared `Common/SensitiveIndicator/SensitiveIndicator.tsx` (colored `bg-yellow-400` dot + "Sensitive" `DialTooltip`, `role="img"`).
+- [x] 5.3 Table detail grid (`TableDetailView.tsx`): render the marker inline in the name cell (after the name) via a `ColumnNameCellRenderer`; the name column stays editable.
+- [x] 5.4 Query Builder dropdown (`CategorizedFieldDropdown.tsx`): render the indicator before the field label when `option.sensitive`; carry `sensitive` through `fieldsToOptions` (`utils/fields.ts`).
+- [x] 5.5 Edit modal (`EditColumnPopup.tsx`): add a Sensitive `DialSwitch`; seed from `column.sensitive`; diff into `update.sensitive` in `buildColumnEditPatch` (`Tables/utils.ts`).
+- [x] 5.6 i18n: add `AnalyticsTablesI18nKey.Sensitive` + `SensitiveTooltip` (enum + `en.ts`).
+- [x] 5.7 Create-time: add `sensitive: boolean` to `ColumnRow` (`tables-ui.ts`) + `createColumnRow` default; render a per-row Sensitive `DialSwitch` in `ColumnRowsEditor.tsx` (Add columns + Create table); carry it through `toTableColumns` (`utils.ts`, omit when off).
+- [x] 5.8 Tests: `fields.spec.ts` (sensitive passthrough), `CategorizedFieldDropdown.spec.tsx` (dropdown marker), new `SensitiveIndicator.spec.tsx`; extend `utils.spec.ts` for the sensitive diff + `toTableColumns`/`createColumnRow` passthrough, and `EditColumnPopup.spec.tsx` for the sensitive toggle.
+
+## 6. Spec
+
+- [x] 6.1 Apply the delta from `specs/analytics/spec.md` into the master spec `openspec/specs/analytics/spec.md` (the "Table detail column schema management" requirement + scenarios, and the sensitive marker on the categorized-field-dropdown requirement).
+
+> Browser verification: not added — the user opted to rely on unit/component tests. The browser-observable scenarios (description input renders, sensitive toggle/marker) are covered by the `EditColumnPopup`, `CategorizedFieldDropdown`, and `SensitiveIndicator` component tests.
+
+## 7. Quality checks
+
+- [x] 7.1 Run lint, typecheck, and the analytics tests (`vitest` from `apps/ai-dial-admin/`); ensure no remaining references to the removed op names across the app.

--- a/openspec/specs/analytics/spec.md
+++ b/openspec/specs/analytics/spec.md
@@ -235,7 +235,13 @@ The query builder SHALL render in a fixed-width rail at the right edge of the co
 
 Each Builder-view section (Group by, Aggregates, Select, Filters, Having, Sort, Page) SHALL render as a bordered section block with a labeled header and a header-level add action where applicable. Field pickers SHALL be searchable dropdowns whose options are grouped by the field's schema tag/category (untagged fields under a default group). Category groups SHALL be collapsible headers showing the group's option count, with at most one category expanded at a time (accordion); the group holding the current selection SHALL start expanded, and an active search term SHALL show all matches regardless of collapse state. Category header colors SHALL cycle the full builder palette. The dropdown's search input SHALL use the same compact boxed style as the builder's other controls.
 
-Field options SHALL display the field's **display name** — the schema `display_name` when set, otherwise the field `name` — as primary text, the field type right-aligned, and the schema `description` as a secondary line when present; fields without display name and description SHALL render as a single line. The dropdown overlay width SHALL stay bounded: long descriptions truncate to one line and the full text is reachable via a hover tooltip of reasonable width. The dropdown search SHALL match against both the field name and its display name. Added items SHALL render compactly — chips for plain fields, collapsible rows for parameterized items (group-by functions, aggregates, conditions, having rows, sort keys) that expand into their editor and collapse back to a summary chip tinted with the owning section's palette color — and chips and collapsed summaries SHALL refer to fields by their display name. Display names are presentation-only: structured-query serialization, the JSON view, and the SQL view SHALL always use the raw field `name`. Styling SHALL use the project's palette/theme tokens only.
+Field options SHALL display the field's **display name** — the schema `display_name` when set, otherwise the field `name` — as primary text, the field type right-aligned, and the schema `description` as a secondary line when present; fields without display name and description SHALL render as a single line. The dropdown overlay width SHALL stay bounded: long descriptions truncate to one line and the full text is reachable via a hover tooltip of reasonable width. The dropdown search SHALL match against both the field name and its display name. Added items SHALL render compactly — chips for plain fields, collapsible rows for parameterized items (group-by functions, aggregates, conditions, having rows, sort keys) that expand into their editor and collapse back to a summary chip tinted with the owning section's palette color — and chips and collapsed summaries SHALL refer to fields by their display name. Display names are presentation-only: structured-query serialization, the JSON view, and the SQL view SHALL always use the raw field `name`. Styling SHALL use the project's palette/theme tokens only. A field whose schema `sensitive` flag is true SHALL show a sensitive marker (a colored dot with a "Sensitive" tooltip) in its dropdown option, after the display name.
+
+#### Scenario: Sensitive field shows a marker in the dropdown
+
+- **WHEN** a schema field whose `sensitive` flag is true is shown in a field dropdown
+- **THEN** its option renders a sensitive marker with a "Sensitive" tooltip
+- **AND** a non-sensitive field's option renders no such marker
 
 #### Scenario: Field dropdown groups by category
 
@@ -658,7 +664,7 @@ The Tables page SHALL render the tables the page fetched as a grid with columns 
 
 ### Requirement: Create table (source or enrichment)
 
-Creating a table SHALL open a form popup that is mounted only while open, so closing discards its state without a manual reset; the form SHALL be held as a single object seeded when the popup opens (enrichment defaults derived from the first source table). A **source** table SHALL collect a name, optional description, a repeatable set of columns (source name, exposed name, type, nullable, optional tag), an optional ordering key chosen from the declared column source names, and an optional partition consisting of a column and a granularity. The partition column SHALL be restricted to temporal (date/timestamp) columns and the granularity SHALL be one of a fixed set (day/month/year). An **enrichment** table SHALL collect a name, optional description, a source table, and a grain key chosen from the selected source table's ordering key; changing the source table SHALL reset the grain key. Submit SHALL build the type-discriminated create payload and show a success or error notification.
+Creating a table SHALL open a form popup that is mounted only while open, so closing discards its state without a manual reset; the form SHALL be held as a single object seeded when the popup opens (enrichment defaults derived from the first source table). A **source** table SHALL collect a name, optional description, a repeatable set of columns (source name, exposed name, type, nullable, optional tag, optional sensitive flag), an optional ordering key chosen from the declared column source names, and an optional partition consisting of a column and a granularity. A column's sensitive flag SHALL default off and, when on, SHALL be carried into the create payload (columns left non-sensitive omit the flag). The partition column SHALL be restricted to temporal (date/timestamp) columns and the granularity SHALL be one of a fixed set (day/month/year). An **enrichment** table SHALL collect a name, optional description, a source table, and a grain key chosen from the selected source table's ordering key; changing the source table SHALL reset the grain key. Submit SHALL build the type-discriminated create payload and show a success or error notification.
 
 #### Scenario: Popup state is discarded on close
 
@@ -679,9 +685,9 @@ Creating a table SHALL open a form popup that is mounted only while open, so clo
 
 ### Requirement: Table detail column schema management
 
-The Table detail page SHALL show the table's columns in a grid (name, source name, type, tag, display name, description, nullable rendered as a true/false value); long display name/description values SHALL be truncated with the full value reachable via an ellipsis tooltip. Each column row SHALL offer a per-column action menu with **edit** and **delete (drop)** actions. The column name SHALL also be editable inline in the grid.
+The Table detail page SHALL show the table's columns in a grid (name, source name, type, tag, display name, description, nullable rendered as a true/false value); long display name/description values SHALL be truncated with the full value reachable via an ellipsis tooltip. A column whose `sensitive` flag is true SHALL show a marker (a colored dot with a "Sensitive" tooltip) rendered inline in the name cell, after the name; non-sensitive columns SHALL show no marker. Each column row SHALL offer a per-column action menu with **edit** and **delete (drop)** actions. The column name SHALL also be editable inline in the grid.
 
-The edit action SHALL open a unified edit modal seeded with the column's current name, display name, and tag. The description SHALL NOT be offered for editing while the backend has no description-edit operation (the backend silently ignores unknown patch operations, which would make a save appear to do nothing); the field joins the modal once that operation ships. The name field SHALL be required (submit disabled while blank) and SHALL be disabled for columns the backend does not allow to rename (grain-key, ordering-key, and `_`-prefixed system columns) while the metadata fields remain editable. Blank display name or tag values SHALL be valid input meaning "clear the value". On submit the modal SHALL diff the form against the original column and send a **single** schema patch containing only the changed operations (`rename`, `retag`, `set_display_name`); when a rename is included, the metadata operations SHALL reference the new (post-rename) column name. Submit SHALL be disabled when no field changed.
+The edit action SHALL open a unified edit modal seeded with the column's current name, display name, tag, description, and sensitive flag. The name field SHALL be required (submit disabled while blank) and SHALL be disabled for columns the backend does not allow to rename (grain-key, ordering-key, and `_`-prefixed system columns) while the metadata fields remain editable. Blank display name, tag, or description values SHALL be valid input meaning "clear the value"; the sensitive flag SHALL be toggled with a switch. On submit the modal SHALL diff the form against the original column and send a **single** schema patch: a structural `rename` op when the name changed, plus a **single `update` merge-patch entry** carrying the target column name and only the metadata fields (tag, display name, description, sensitive) that changed. Within the `update` entry an omitted field leaves that attribute unchanged, a blank string value clears it, a non-blank string value sets it, and the boolean `sensitive` is sent as `true`/`false` when toggled. When a rename is included, the `update` entry SHALL reference the new (post-rename) column name. Submit SHALL be disabled when no field changed.
 
 Adding columns SHALL be available from the header via a form popup reusing the column-row editor. Every schema change SHALL be sent as a schema patch to `updateTableSchema`, and on success the detail view SHALL refresh from the server. The header SHALL also offer deleting the whole table with a danger (red confirm) dialog, returning to the catalog on success.
 
@@ -693,24 +699,41 @@ Adding columns SHALL be available from the header via a form popup reusing the c
 #### Scenario: Combined edit sends one patch with post-rename names
 
 - **WHEN** the user renames `total_money` to `total_cost` and sets its display name to "Total money spend" in the edit modal and submits
-- **THEN** a single schema patch is sent containing a rename from `total_money` to `total_cost` and a set_display_name targeting `total_cost`
+- **THEN** a single schema patch is sent containing a rename from `total_money` to `total_cost` and an `update` entry whose `name` is `total_cost` and `display_name` is "Total money spend"
 - **AND** the grid refreshes with the server state
 
-#### Scenario: Only changed fields become operations
+#### Scenario: Only changed fields become update fields
 
-- **WHEN** the user changes only the display name and leaves name and tag untouched
-- **THEN** the patch contains only a set_display_name operation
+- **WHEN** the user changes only the display name and leaves name, tag, and description untouched
+- **THEN** the patch contains a single `update` entry carrying only `name` and `display_name`, with no `tag` or `description` field
 
 #### Scenario: Blank metadata clears the value
 
 - **WHEN** the user clears the display name field and submits
-- **THEN** a set_display_name operation with an empty value is sent, clearing the stored display name
+- **THEN** the `update` entry sends `display_name` as an empty string, clearing the stored display name
+
+#### Scenario: Description is editable and patched
+
+- **WHEN** the user changes a column's description in the edit modal and submits
+- **THEN** the modal renders a description input
+- **AND** the patch contains a single `update` entry carrying `name` and the new `description`
+
+#### Scenario: Sensitive columns are marked in the grid
+
+- **WHEN** the columns grid renders a column whose `sensitive` flag is true
+- **THEN** the name cell shows a marker with a "Sensitive" tooltip after the name
+- **AND** a column whose flag is false shows no marker
+
+#### Scenario: Toggling sensitive is patched
+
+- **WHEN** the user toggles the Sensitive switch in the edit modal and submits
+- **THEN** the patch contains a single `update` entry carrying `name` and the new boolean `sensitive`
 
 #### Scenario: Restricted columns cannot be renamed but keep metadata editable
 
 - **WHEN** the user opens the edit modal for a grain-key or ordering-key column
 - **THEN** the name input is disabled
-- **AND** display name and tag remain editable
+- **AND** display name, tag, description, and sensitive remain editable
 
 #### Scenario: Drop a column
 


### PR DESCRIPTION
**Description:**

The analytics backend consolidated the column-metadata operations on `PATCH /v1/tables/{name}/schema` into a single `update` merge-patch (a **breaking** change), so the frontend's old `retag`/`set_display_name`/`redescribe` ops silently no-op'd — tag and display-name editing appeared to save but did nothing. This aligns the frontend with the new contract, surfaces column **description** editing now that the backend supports it, and adds visibility + editing for the **sensitive** column flag (an access-restriction marker the backend exposes to full admins).

Issues:

- Issue #3847

**Key Changes:**

- [src/models/analytics/table.ts](https://github.com/epam/ai-dial-admin-frontend/blob/feat/consolidate-column-metadata-patch/apps/ai-dial-admin/src/models/analytics/table.ts) — replace the three metadata op interfaces/fields with a single `AnalyticsColumnMetadataUpdate` (`update`); add `sensitive` to `AnalyticsTableColumn`
- [src/components/Analytics/Tables/utils.ts](https://github.com/epam/ai-dial-admin-frontend/blob/feat/consolidate-column-metadata-patch/apps/ai-dial-admin/src/components/Analytics/Tables/utils.ts) — rewrite `buildColumnEditPatch` to emit one merge-patch entry (only-changed fields, blank clears); carry `sensitive` through `toTableColumns`
- [src/components/Analytics/Tables/EditColumnPopup.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/feat/consolidate-column-metadata-patch/apps/ai-dial-admin/src/components/Analytics/Tables/EditColumnPopup.tsx) — add Description input and a Sensitive toggle
- [src/components/Analytics/Tables/TableDetailView.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/feat/consolidate-column-metadata-patch/apps/ai-dial-admin/src/components/Analytics/Tables/TableDetailView.tsx) — render the sensitive dot inline in the name cell; fold the "Sensitive" note into the cell tooltip
- [src/components/Analytics/Tables/ColumnRowsEditor.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/feat/consolidate-column-metadata-patch/apps/ai-dial-admin/src/components/Analytics/Tables/ColumnRowsEditor.tsx) — per-row Sensitive switch (create-time, Add columns + Create table)
- [src/components/Analytics/QueryBuilder/Common/CategorizedFieldDropdown.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/feat/consolidate-column-metadata-patch/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Common/CategorizedFieldDropdown.tsx) — sensitive dot after the field name; single row tooltip carries the note
- [openspec/specs/analytics/spec.md](https://github.com/epam/ai-dial-admin-frontend/blob/feat/consolidate-column-metadata-patch/openspec/specs/analytics/spec.md) — updated requirements/scenarios for the `update` contract, description editing, and sensitive marking

**New Components:**

- `SensitiveIndicator` (`src/components/Common/SensitiveIndicator/`) — a small amber-gold dot marking a column as sensitive; reused in the table grid name cell and the Query Builder field dropdown.

**Breaking Changes:**

- `AnalyticsSchemaPatch` no longer has `retag` / `set_display_name` / `redescribe`; column-metadata edits now go through a single `update: AnalyticsColumnMetadataUpdate[]` list (merge-patch semantics). Any caller of `updateTableSchema` building a metadata patch must use the new shape.

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
