### PR TITLE
fix(assets): normalize Core PUT response so create-asset redirect resolves (Issue #3932)

### DIFF
--- a/apps/ai-dial-admin/src/components/Assets/Deployments/tests/CreateAsset.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Deployments/tests/CreateAsset.spec.tsx
@@ -1,7 +1,10 @@
 import { AssetsFolderContext } from '@/src/context/assets/AssetsFolderContext';
+import { ServerActionResponse } from '@/src/models/server-action';
 import { ApplicationRoute } from '@/src/types/routes';
-import { render, screen } from '@testing-library/react';
-import { describe, expect, test, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useRouter } from 'next/navigation';
+import { Mock, describe, expect, test, vi } from 'vitest';
 import CreateAsset from '../CreateAsset';
 
 vi.mock('@/src/components/EntityMainProperties/Properties/AssetProperties', () => ({
@@ -54,5 +57,43 @@ describe('CreateAsset', () => {
     renderWithData([{ name: 'existing', version: '1.0.0' }] as AssetsFolderContext['data']);
 
     expect(screen.getByText('AssetPropertiesStub')).toBeInTheDocument();
+  });
+
+  test('redirects to the created resource using admin-format path fields from the write response', async () => {
+    // Mirrors the MCP-container "Create Asset Toolset" flow: initialValues present (leading slash),
+    // and onCreate resolves the way the fixed AssetApi.put does — response carrying path/folderId/name/version.
+    const push = vi.fn();
+    (useRouter as Mock).mockReturnValue({ push, refresh: vi.fn() });
+
+    const onCreate = vi.fn(
+      (): Promise<ServerActionResponse> =>
+        Promise.resolve({
+          success: true,
+          response: {
+            name: 't',
+            path: 'public/t__1.0',
+            folderId: 'public/',
+            version: '1.0',
+            url: 'toolsets/public/t__1.0',
+          },
+        }),
+    );
+
+    const ctx = { ...baseContext, data: [] } as AssetsFolderContext;
+    render(
+      <CreateAsset
+        view={ApplicationRoute.AssetsToolsets}
+        isModalOpen={true}
+        initialValues={{ name: 't' }}
+        context={() => ctx}
+        onCreate={onCreate}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Buttons.Create' }));
+
+    await waitFor(() => expect(push).toHaveBeenCalledTimes(1));
+    expect(push).toHaveBeenCalledWith('/assets-toolsets/t?path=public%2Ft__1.0');
   });
 });

--- a/apps/ai-dial-admin/src/server/core/asset-api.ts
+++ b/apps/ai-dial-admin/src/server/core/asset-api.ts
@@ -9,7 +9,7 @@ import {
 import { RESOURCE_TYPE_PREFIX } from '@/src/constants/publications-core';
 import { Token } from '@/src/models/auth';
 import { ServerActionResponse } from '@/src/models/server-action';
-import { encodeCorePath } from '@/src/server/publications/path';
+import { encodeCorePath, parseVersionedPath, VersionedPathParts } from '@/src/server/publications/path';
 import { ResourceType } from '@/src/types/resource-type';
 import { CoreApi } from './core-api';
 import { createHeadersForCreate, createIfMatchHeaders, createIfNoneMatchHeaders } from './asset-headers';
@@ -132,8 +132,16 @@ export class AssetApi extends CoreApi {
     return { success: true, response: merged, etag: contentResult.etag };
   }
 
-  /** Creates (rejects if already present, unless `allowOverride`) or updates a resource (`PUT /v1/{type}/{path}`). */
-  put<T extends object>(
+  /**
+   * Creates (rejects if already present, unless `allowOverride`) or updates a resource (`PUT /v1/{type}/{path}`).
+   *
+   * Core's PUT reply is a metadata node in Core format (`name`/`url`/`bucket`/…), but post-write consumers
+   * (e.g. the create-asset redirect via `getEntityPath`) expect the admin-format identity split
+   * (`path`/`folderId`/`name`/`version`) the BE proxy used to return. On success we derive those from the
+   * written `path` — authoritative for where the resource now lives — and merge them onto the response,
+   * keeping writes consistent with the merge readers (`getMerged*`).
+   */
+  async put<T extends object>(
     token: Token,
     type: ResourceType,
     path: string,
@@ -142,7 +150,27 @@ export class AssetApi extends CoreApi {
   ): Promise<ServerActionResponse> {
     const url = `${CORE_RESOURCE_URL[type]}${encodeCorePath(path)}`;
     const headers = createHeadersForCreate(Boolean(options.allowOverride || options.etag), options.etag);
-    return this.putAction(url, this.withContentId(type, path, body), token, headers);
+    const result = await this.putAction(url, this.withContentId(type, path, body), token, headers);
+    if (!result.success) {
+      return result;
+    }
+    const base = result.response && typeof result.response === 'object' ? result.response : {};
+    return { ...result, response: { ...base, ...this.parsePathFields(path) } };
+  }
+
+  /**
+   * Splits the written path into the admin-format identity fields. Guarded: a path with no `/`
+   * separator (e.g. an empty `folderId` falling back to the bare `ROOT_FOLDER` = `'public'`) makes
+   * `parseVersionedPath` throw — in that case we skip enrichment rather than fail an otherwise-
+   * successful write.
+   */
+  private parsePathFields(path: string): Partial<VersionedPathParts> {
+    try {
+      const { path: parsedPath, folderId, name, version } = parseVersionedPath(path);
+      return { path: parsedPath, folderId, name, version };
+    } catch {
+      return {};
+    }
   }
 
   /**

--- a/apps/ai-dial-admin/src/server/core/tests/asset-api.spec.ts
+++ b/apps/ai-dial-admin/src/server/core/tests/asset-api.spec.ts
@@ -174,6 +174,61 @@ describe('Server :: Core :: AssetApi', () => {
     expect(body).toEqual({ name: 't' });
   });
 
+  test('put merges admin-format path fields (path/folderId/name/version) onto a successful response', async () => {
+    fetch.mockResponseOnce(
+      JSON.stringify({ name: 't__1.0', url: 'toolsets/folder/t__1.0', bucket: 'b', nodeType: 'ITEM' }),
+      {
+        headers: { 'content-type': 'application/json' },
+      },
+    );
+
+    const result = await instance.put(TOKEN_MOCK, ResourceType.TOOLSET, 'folder/t__1.0', { name: 't' });
+
+    expect(result.success).toBe(true);
+    expect(result.response).toMatchObject({
+      // Core-format fields preserved
+      url: 'toolsets/folder/t__1.0',
+      bucket: 'b',
+      // admin-format identity fields added, derived from the written path
+      path: 'folder/t__1.0',
+      folderId: 'folder/',
+      name: 't',
+      version: '1.0',
+    });
+  });
+
+  test('put leaves version undefined for an unversioned path', async () => {
+    fetch.mockResponseOnce(JSON.stringify({ url: 'toolsets/folder/t' }), {
+      headers: { 'content-type': 'application/json' },
+    });
+
+    const result = await instance.put(TOKEN_MOCK, ResourceType.TOOLSET, 'folder/t', { name: 't' });
+
+    expect(result.response).toMatchObject({ path: 'folder/t', folderId: 'folder/', name: 't' });
+    expect((result.response as { version?: string }).version).toBeUndefined();
+  });
+
+  test('put does not throw on a slashless path and returns the response unchanged', async () => {
+    fetch.mockResponseOnce(JSON.stringify({ url: 'toolsets/publict' }), {
+      headers: { 'content-type': 'application/json' },
+    });
+
+    const result = await instance.put(TOKEN_MOCK, ResourceType.TOOLSET, 'publict', { name: 't' });
+
+    expect(result.success).toBe(true);
+    expect(result.response).toEqual({ url: 'toolsets/publict' });
+    expect(result.response).not.toHaveProperty('folderId');
+  });
+
+  test('put returns a failed response unchanged, with no path fields added', async () => {
+    fetch.mockResponseOnce('conflict', { status: 412 });
+
+    const result = await instance.put(TOKEN_MOCK, ResourceType.TOOLSET, 'folder/t__1.0', { name: 't' });
+
+    expect(result.success).toBe(false);
+    expect(result.response).toBeUndefined();
+  });
+
   test('delete sends If-Match when an etag is supplied, no header otherwise', async () => {
     fetch.mockResponseOnce('');
     await instance.delete(TOKEN_MOCK, ResourceType.CONVERSATION, 'folder/c', 'etag-2');

--- a/openspec/changes/archive/2026-07-17-fix-asset-create-redirect-404/design.md
+++ b/openspec/changes/archive/2026-07-17-fix-asset-create-redirect-404/design.md
@@ -1,0 +1,39 @@
+## Context
+
+Direct-to-Core writes (`AssetApi.put`) return Core's metadata node verbatim. Core format carries the resource identity inside a single encoded `url` string; the frontend everywhere else consumes the admin-format split (`path`, `folderId`, `name`, `version`). Reads were migrated to bridge this (`getMerged*` runs the response through `parseEncodedVersionedPath`), but writes were not — so `put`'s response is the one place a Core-format object leaks into admin-format consumers.
+
+## Decision: normalize at `put()`, derive from the `path` argument
+
+Fix the mismatch once, at the boundary where the Core response enters the app, rather than at each consumer.
+
+**Where:** `AssetApi.put`. On a successful `putAction`, merge `{ path, folderId, name, version }` onto `response` before returning.
+
+**Source of the fields:** the `path` argument `put` already receives (e.g. `my-folder/mytoolset__1.0`), parsed with the existing `parseVersionedPath(path)` helper. This is preferred over parsing `response.url` because:
+- It does not depend on the Core PUT response body carrying a `url` (defensive against empty/204-style bodies).
+- The path we wrote to is authoritative for identity; the response body is not needed to know where the resource now lives.
+
+```
+put(token, type, path, body)
+  └─ putAction(...) → { success, response, etag }
+       if success:
+         const { path, folderId, name, version } = parseVersionedPath(path)
+         return { ...result, response: { ...result.response, path, folderId, name, version } }
+```
+
+Existing `response` fields (Core `name`/`url`/etc.) are preserved; admin fields are added on top, so nothing that reads the Core shape regresses.
+
+### Alternatives considered
+
+- **Fix `CreateAsset.onSubmit` only** (drop `res.response`, redirect from `currentEntity`): `onSubmit` already does `res.response || currentEntity`, and `currentEntity` carries `name`/`version`/`folderId` from the modal form, so dropping `res.response` would fix the observable 404 with a one-line change. Since verification showed `CreateAsset.onSubmit` is the *only* consumer that trusts `res.response`, this is a legitimately smaller fix. Not chosen because it leaves `put`'s response Core-shaped — a latent trap for the next consumer that reads it — but it is the fallback if the `put`-level change proves risky.
+- **Teach `getEntityPath` to derive from `url`**: pushes Core-encoding knowledge into a presentation util and only covers the redirect. Rejected as leaky.
+
+## Edge cases
+
+- **Slashless path must not throw (confirmed risk):** `parseVersionedPath` throws `"The path does not contain a '/'"` when the path has no `/`. `ROOT_FOLDER` is the bare string `'public'` (no trailing slash), and `createToolset` falls back to `folderId = toolset.folderId || ROOT_FOLDER` — so an empty `folderId` yields a slashless path like `publicName__1.0`. In practice the modal gates submit until a real folder path (`public/…`) is selected, but normalization MUST be defensive: guard the parse (skip enrichment / try-catch) so a slashless path returns the original response unchanged rather than throwing and breaking an otherwise-successful write. Covered by a test.
+- **Update path (`etag` supplied):** `updateToolset`/`updateAsset` also go through `put`; they gain the same normalized fields — harmless and consistent.
+- **Unversioned resources:** `version` comes back `undefined` from `parseVersionedPath`, matching `getEntityPath`'s existing `data.path` branch (which uses `path` directly), so the redirect stays correct.
+- **Failed writes:** leave the error `ServerActionResponse` untouched — only merge on `success`.
+
+## Verification
+
+Browser-observable acceptance for the gate: MCP container → Create Asset Toolset → Create → lands on the new toolset's detail page (no 404), URL contains a valid `?path=`.

--- a/openspec/changes/archive/2026-07-17-fix-asset-create-redirect-404/proposal.md
+++ b/openspec/changes/archive/2026-07-17-fix-asset-create-redirect-404/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+Issue #3932: creating an Asset Toolset from an MCP container page returns a **404 "Page not found"** instead of opening the new toolset. The toolset *is* created in Core — only the post-create redirect breaks.
+
+Root cause is a regression from the direct-to-Core migration. `AssetApi.put` now writes straight to DIAL Core and returns Core's response verbatim — a metadata node in **Core format** (`name`, `url`, `parentPath`, `bucket`, `nodeType`). The redirect in `CreateAsset.onSubmit` feeds that response to `getEntityPath`, which expects the **admin-format** fields the admin BE used to return (`path`, `folderId`, `version`). None of those exist on the Core response, so the helper builds a garbage path:
+
+```
+data.path || `${data.folderId}${data.name}__${data.version}`
+  →  "undefined" + name + "__undefined"
+```
+
+The redirect lands on `/assets-toolsets/<name>?path=undefined<name>__undefined`; the `[id]` page's `getToolset(path)` then fails, hits `notFound()`, and the user sees a 404.
+
+**Scope of the leak (verified):** `CreateAsset.onSubmit` (the deployment "Create Asset" modal, used from MCP/model-serving container pages) is the only consumer that trusts `res.response` to carry admin-format fields. The assets-toolsets / assets-applications **list** create flows (`BaseAssetList.handleCreateAsset`) build their redirect from local form data (`getUrnForEntity(view, { name, version, folderId })`) and never read `res.response`, so they do **not** reproduce the 404. The fix still belongs at the write boundary so `res.response` is trustworthy for any consumer, but the observable bug is confined to the container "Create Asset" flow.
+
+## What Changes
+
+- **Normalize `AssetApi.put`'s return value** so a successful write resolves with the admin-format fields (`path`, `folderId`, `name`, `version`) merged onto the response — derived from the `path` argument `put` already receives, via the existing `parseVersionedPath` helper. Reads (`getMerged*`) already return these fields; this makes writes consistent with reads.
+- No change to `getEntityPath`, `CreateAsset`, or any calling screen — they keep consuming admin-format fields exactly as before the Core migration.
+- **Test coverage** for the normalized write response and for the MCP-container → Asset Toolset redirect building a valid URL.
+
+## Non-goals
+
+- No change to the Core wire contract or request path — only the shape `put` resolves with.
+- No redesign of `getEntityPath` or the redirect logic in `CreateAsset`.
+- No BE changes.
+
+## Capabilities
+
+### Modified Capabilities
+- `core-asset-client`: `put` resolves with normalized admin-format path fields on success, so post-write consumers (redirects, list refresh) receive the same `path`/`folderId`/`version`/`name` shape as reads.
+
+## Impact
+
+- **API layer**: `src/server/core/asset-api.ts` — `put()` merges parsed path fields onto a successful `ServerActionResponse`.
+- **Consumer (behavior restored, no code change)**: `CreateAsset.onSubmit` redirect via `getEntityPath` (`utils/open-in-new-tab.ts`) — the deployment "Create Asset" modal used from MCP/model-serving container pages. List create flows already sidestep `res.response` and are unaffected.
+- **Tests**: `src/server/core/tests/asset-api.spec.ts` (or equivalent), plus the create-asset redirect spec.

--- a/openspec/changes/archive/2026-07-17-fix-asset-create-redirect-404/specs/core-asset-client/spec.md
+++ b/openspec/changes/archive/2026-07-17-fix-asset-create-redirect-404/specs/core-asset-client/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Write operations resolve with normalized admin-format path fields
+
+On a successful `put` (create or update) of a versioned asset resource, the client SHALL resolve with a response that includes the admin-format identity fields `path`, `folderId`, `name`, and `version`, derived from the resource path written to (via the shared version-path helper). This matches the field shape the merge readers already return, so post-write consumers (redirects, list refresh) receive a consistent object regardless of Core's raw response shape.
+
+Existing Core-format fields on the response SHALL be preserved; the admin-format fields SHALL be added alongside them.
+
+#### Scenario: Successful versioned write returns parsed path fields
+- **WHEN** `put` succeeds for a resource written to `folder/Name__1.0`
+- **THEN** the resolved response SHALL include `path`, `folderId=folder/`, `name=Name`, and `version=1.0`
+
+#### Scenario: Unversioned write omits version
+- **WHEN** `put` succeeds for a resource written to a path with no `__version` suffix
+- **THEN** the resolved response SHALL include `path`, `folderId`, and `name`, with `version` undefined
+
+#### Scenario: Failed write is unchanged
+- **WHEN** `put` fails (non-success `ServerActionResponse`)
+- **THEN** the response SHALL be returned unchanged, with no path fields added
+
+#### Scenario: Unparseable path does not break the write
+- **WHEN** `put` succeeds but the written path cannot be parsed into folder + name (e.g. a path with no `/` separator)
+- **THEN** the successful response SHALL be returned unchanged rather than raising an error
+
+### Requirement: Post-create redirect resolves to the created resource
+
+After creating an asset resource through the create-asset flow, the application SHALL redirect to the created resource's detail route using the normalized `path` from the write response, without producing an invalid path containing `undefined` segments.
+
+#### Scenario: Create Asset Toolset from an MCP container
+- **WHEN** a user creates an Asset Toolset from an MCP container page and the write succeeds
+- **THEN** the app SHALL navigate to `/assets-toolsets/<name>?path=<encoded resource path>`
+- **AND** the target page SHALL load the created toolset instead of a 404

--- a/openspec/changes/archive/2026-07-17-fix-asset-create-redirect-404/tasks.md
+++ b/openspec/changes/archive/2026-07-17-fix-asset-create-redirect-404/tasks.md
@@ -1,0 +1,17 @@
+## 1. Normalize the write response
+
+- [x] 1.1 In `AssetApi.put` (`src/server/core/asset-api.ts`), on a successful `putAction` result, parse the `path` argument with `parseVersionedPath` and merge `{ path, folderId, name, version }` onto `response`; leave failure results untouched.
+- [x] 1.2 Keep existing Core-format response fields (`name`, `url`, etc.) intact — admin fields are added, not replaced.
+- [x] 1.3 Guard the parse against a slashless path (`ROOT_FOLDER` = `'public'` with no trailing slash): if `parseVersionedPath` cannot parse, return the successful response unchanged rather than throwing.
+
+## 2. Tests
+
+- [x] 2.1 Unit test `AssetApi.put`: successful write resolves with `path`/`folderId`/`name`/`version` derived from the written path (versioned and unversioned cases).
+- [x] 2.2 Unit test: a slashless path (e.g. `publicName`) does not throw — resolves with the response unchanged.
+- [x] 2.3 Unit test: a failed `put` returns the error response unchanged (no path fields added).
+- [x] 2.4 Component/redirect test: `CreateAsset.onSubmit` for the MCP-container → Asset Toolset flow pushes a valid `/assets-toolsets/<name>?path=<encoded path>` URL (no `undefined` segments).
+
+## 3. Verification
+
+- [x] 3.1 Manual/gate: MCP containers → open running container → Create → Asset Toolset → fill required fields → Create → redirected to the new toolset detail page, no 404. **Verified — works.**
+- [x] 3.2 Regression check (no behavior change expected): assets-toolsets list create/duplicate and assets-applications create still redirect correctly — these build the redirect from local form data, so confirm the `put` change doesn't disturb them. **Verified — works.**

--- a/openspec/specs/core-asset-client/spec.md
+++ b/openspec/specs/core-asset-client/spec.md
@@ -77,3 +77,34 @@ The system SHALL default the list path to `"public/"` and the page-size limit to
 #### Scenario: Application-resource list without a path is not defaulted
 - **WHEN** an application-resource metadata read omits `path`
 - **THEN** no default path is substituted
+
+### Requirement: Write operations resolve with normalized admin-format path fields
+
+On a successful `put` (create or update) of a versioned asset resource, the client SHALL resolve with a response that includes the admin-format identity fields `path`, `folderId`, `name`, and `version`, derived from the resource path written to (via the shared version-path helper). This matches the field shape the merge readers already return, so post-write consumers (redirects, list refresh) receive a consistent object regardless of Core's raw response shape.
+
+Existing Core-format fields on the response SHALL be preserved; the admin-format fields SHALL be added alongside them.
+
+#### Scenario: Successful versioned write returns parsed path fields
+- **WHEN** `put` succeeds for a resource written to `folder/Name__1.0`
+- **THEN** the resolved response SHALL include `path`, `folderId=folder/`, `name=Name`, and `version=1.0`
+
+#### Scenario: Unversioned write omits version
+- **WHEN** `put` succeeds for a resource written to a path with no `__version` suffix
+- **THEN** the resolved response SHALL include `path`, `folderId`, and `name`, with `version` undefined
+
+#### Scenario: Failed write is unchanged
+- **WHEN** `put` fails (non-success `ServerActionResponse`)
+- **THEN** the response SHALL be returned unchanged, with no path fields added
+
+#### Scenario: Unparseable path does not break the write
+- **WHEN** `put` succeeds but the written path cannot be parsed into folder + name (e.g. a path with no `/` separator)
+- **THEN** the successful response SHALL be returned unchanged rather than raising an error
+
+### Requirement: Post-create redirect resolves to the created resource
+
+After creating an asset resource through the create-asset flow, the application SHALL redirect to the created resource's detail route using the normalized `path` from the write response, without producing an invalid path containing `undefined` segments.
+
+#### Scenario: Create Asset Toolset from an MCP container
+- **WHEN** a user creates an Asset Toolset from an MCP container page and the write succeeds
+- **THEN** the app SHALL navigate to `/assets-toolsets/<name>?path=<encoded resource path>`
+- **AND** the target page SHALL load the created toolset instead of a 404


### PR DESCRIPTION
**Description:**

Creating an Asset Toolset from an MCP container page returned a **404 "Page not found"** instead of opening the newly created toolset. The toolset was created in DIAL Core successfully — only the post-create redirect broke.

Root cause: `AssetApi.put` writes directly to Core and returned Core's response verbatim — a metadata node in **Core format** (`name`/`url`/`bucket`/`nodeType`). The create-asset redirect (`CreateAsset.onSubmit` → `getEntityPath`) expects the **admin-format** identity fields the admin BE used to return (`path`/`folderId`/`name`/`version`). None exist on the Core response, so the helper built a garbage path (`undefined<name>__undefined`), the target page's `getToolset` failed, and `notFound()` fired.

Fix: on a successful write, `put` now merges the admin-format fields — derived from the written `path` via the existing `parseVersionedPath` helper — onto the response, keeping writes consistent with the merge readers (`getMerged*`). Core-format fields are preserved. The parse is guarded so a slashless path (empty `folderId` falling back to bare `ROOT_FOLDER`) can never throw and break an otherwise-successful write.

Scope note: `CreateAsset.onSubmit` (the deployment "Create Asset" modal) is the only consumer that trusted `res.response` for the redirect; the assets-toolsets / assets-applications list flows build their redirect from local form data and were never affected — verified as a regression check.

**Changes:**

- `AssetApi.put`: normalize successful response with `path`/`folderId`/`name`/`version`; `parsePathFields` guard for unparseable paths.
- Unit tests: versioned / unversioned / slashless / failed-write cases.
- Component test: `CreateAsset` redirect regression asserting a valid `/assets-toolsets/<name>?path=<path>` URL.
- OpenSpec: archived change `fix-asset-create-redirect-404`; folded delta into `specs/core-asset-client`.

Issues:

- Issue #3932

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
