### PR TITLE
fix(analytics): add 403 forbidden check for analytics pages (Issue #3847)

### DIFF
--- a/apps/ai-dial-admin/src/app/[lang]/query-builder/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/query-builder/page.tsx
@@ -1,12 +1,18 @@
 import QueryBuilder from '@/src/components/Analytics/QueryBuilder/QueryBuilder';
+import Page403 from '@/src/components/Page403/Page403';
 import { AnalyticsEntity, AnalyticsEntityField } from '@/src/models/analytics/entity';
 import { QueryFunction } from '@/src/models/analytics/query-function';
+import { isAnalyticsForbidden } from '@/src/server/analytics/analytics-access';
 import { errorObjLog } from '@/src/server/logger';
 import { getEntities, getEntitySchema, getFunctions } from './actions';
 
 export const dynamic = 'force-dynamic';
 
 export default async function Page() {
+  if (await isAnalyticsForbidden()) {
+    return <Page403 />;
+  }
+
   let entities: AnalyticsEntity[] = [];
   let entityName = '';
   let fields: AnalyticsEntityField[] = [];

--- a/apps/ai-dial-admin/src/app/[lang]/tables/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/tables/page.tsx
@@ -1,13 +1,19 @@
 import { notFound } from 'next/navigation';
 
 import TablesView from '@/src/components/Analytics/Tables/TablesView';
+import Page403 from '@/src/components/Page403/Page403';
 import { AnalyticsTable } from '@/src/models/analytics/table';
+import { isAnalyticsForbidden } from '@/src/server/analytics/analytics-access';
 import { errorObjLog } from '@/src/server/logger';
 import { getTables } from './actions';
 
 export const dynamic = 'force-dynamic';
 
 export default async function Page() {
+  if (await isAnalyticsForbidden()) {
+    return <Page403 />;
+  }
+
   let tables: AnalyticsTable[] | null = null;
 
   try {

--- a/apps/ai-dial-admin/src/server/analytics/analytics-access.ts
+++ b/apps/ai-dial-admin/src/server/analytics/analytics-access.ts
@@ -1,0 +1,12 @@
+import { cookies, headers } from 'next/headers';
+
+import { analyticsDataApi } from '@/src/app/api/api';
+import { getUserToken } from '@/src/utils/auth/auth-request';
+import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
+
+export async function isAnalyticsForbidden(): Promise<boolean> {
+  const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
+  const access = await analyticsDataApi.checkAccess(token);
+
+  return !access.success && access.status === 403;
+}

--- a/apps/ai-dial-admin/src/server/analytics/analytics-data-api.ts
+++ b/apps/ai-dial-admin/src/server/analytics/analytics-data-api.ts
@@ -28,6 +28,10 @@ export const TABLE_SCHEMA_URL = (name: string): string => `${TABLE_URL(name)}/sc
 export const TABLE_ROWS_URL = (name: string): string => `${TABLE_URL(name)}/rows`;
 
 export class AnalyticsDataApi extends BaseApi {
+  checkAccess(token: Token): Promise<ServerActionResponse> {
+    return this.getAction(QUERIES_ENTITIES_URL, token);
+  }
+
   getEntities(token: Token): Promise<AnalyticsEntity[] | null> {
     return this.get<AnalyticsEntity[]>(QUERIES_ENTITIES_URL, token);
   }


### PR DESCRIPTION
**Description:**

Add access control checks for analytics pages (Query Builder and Tables) to return a 403 Forbidden page when users do not have permission to access analytics data. Implements a new `isAnalyticsForbidden` function that checks access via the analytics API and prevents unauthorized access to analytics features.

Issues:

- Issue #3847

**Key Changes:**

- [apps/ai-dial-admin/src/server/analytics/analytics-access.ts](https://github.com/epam/ai-dial-admin-frontend/blob/fix/add-403-forbidden-check-analytics/apps/ai-dial-admin/src/server/analytics/analytics-access.ts) — new access control module with `isAnalyticsForbidden` function
- [apps/ai-dial-admin/src/app/[lang]/query-builder/page.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/fix/add-403-forbidden-check-analytics/apps/ai-dial-admin/src/app/%5Blang%5D/query-builder/page.tsx) — add forbidden access check
- [apps/ai-dial-admin/src/app/[lang]/tables/page.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/fix/add-403-forbidden-check-analytics/apps/ai-dial-admin/src/app/%5Blang%5D/tables/page.tsx) — add forbidden access check
- [apps/ai-dial-admin/src/server/analytics/analytics-data-api.ts](https://github.com/epam/ai-dial-admin-frontend/blob/fix/add-403-forbidden-check-analytics/apps/ai-dial-admin/src/server/analytics/analytics-data-api.ts) — add `checkAccess` method to API class

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with \`(Issue #3847)\`