### PR TITLE
fix(Analytics/QueryBuilder): resolve source_name_8 stale-schema issue (Issue #3844)

### DIFF
--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/QueryBuilder.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/QueryBuilder.tsx
@@ -174,11 +174,26 @@ const QueryBuilder: FC<Props> = ({ initialEntities, initialEntityName, initialFi
   // Generated (unedited) SQL is the builder's own query in another notation — never guarded.
   const sqlEdited = !!sqlText.trim() && sqlText !== lastGeneratedSql.current;
 
+  // The AI, JSON, and SQL paths can each adopt a different entity than the one whose schema is loaded.
+  // Fields must follow the query's entity: running with a stale schema makes the toolbar time bound
+  // resolve its timestamp column against the wrong entity (e.g. "source_name_8"), which the backend
+  // then rejects as an unknown field. Re-fetch the schema whenever the entity changes.
+  const resolveFieldsForEntity = async (entityName: string): Promise<AnalyticsEntityField[]> => {
+    if (!entityName || entityName === state.entityName) return state.fields;
+    if (!entities.some((e) => e.name === entityName)) return state.fields;
+    const schema = await getEntitySchema(entityName);
+    if (schema) return schema.fields || [];
+    showNotification(getErrorNotification(t(QueryBuilderI18nKey.SchemaLoadFailed)));
+    return [];
+  };
+
   // A ge/le pair on the timestamp field belongs to the toolbar control, not the visual filter tree.
-  const hydrateBuilderFromQuery = (parsed: StructuredQuery) => {
-    const lifted = timestampField ? liftTimeRange(parsed.filter, timestampField) : null;
+  const hydrateBuilderFromQuery = async (parsed: StructuredQuery) => {
+    const fields = await resolveFieldsForEntity(parsed.entity ?? state.entityName);
+    const timestamp = findTimestampField(fields);
+    const lifted = timestamp ? liftTimeRange(parsed.filter, timestamp) : null;
     const forState = lifted ? { ...parsed, filter: lifted.rest } : parsed;
-    setState(parseQuery(forState, state.fields, state.functions));
+    setState(parseQuery(forState, fields, state.functions));
     if (lifted && !sameRange(lifted.range, timeBound?.range)) {
       timeFilter.onTimeRangeChange(lifted.range, true);
     }
@@ -218,7 +233,7 @@ const QueryBuilder: FC<Props> = ({ initialEntities, initialEntityName, initialFi
       if (isSqlView && sqlEdited) {
         const res = await translateSqlToQuery(sqlText);
         if (res.success && res.response?.query && isBuilderRepresentable(res.response.query)) {
-          hydrateBuilderFromQuery(res.response.query);
+          await hydrateBuilderFromQuery(res.response.query);
           setSqlText('');
           setSqlError(null);
           lastGeneratedSql.current = '';
@@ -273,7 +288,7 @@ const QueryBuilder: FC<Props> = ({ initialEntities, initialEntityName, initialFi
         return;
       }
       setJsonDiverged(false);
-      hydrateBuilderFromQuery(parsed);
+      void hydrateBuilderFromQuery(parsed);
     } catch {
       setJsonInvalid(true);
     }
@@ -294,7 +309,7 @@ const QueryBuilder: FC<Props> = ({ initialEntities, initialEntityName, initialFi
     setAiLoading(true);
     const res = await translateSqlToQuery(sql);
     if (res.success && res.response?.query && isBuilderRepresentable(res.response.query)) {
-      hydrateBuilderFromQuery(res.response.query);
+      await hydrateBuilderFromQuery(res.response.query);
       setSqlText('');
       setJsonText('');
       setJsonDiverged(false);

--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/tests/QueryBuilder.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/tests/QueryBuilder.spec.tsx
@@ -7,6 +7,7 @@ import {
   executeQuery,
   executeSqlQuery,
   generateQuery,
+  getEntitySchema,
   translateQuery,
   translateSqlToQuery,
 } from '@/src/app/[lang]/query-builder/actions';
@@ -451,6 +452,42 @@ describe('QueryBuilder AI view', () => {
     await user.click(runButton);
     expect(executeQuery).toHaveBeenCalled();
     expect(executeSqlQuery).not.toHaveBeenCalled();
+  });
+
+  test('a generated query targeting another entity refreshes the schema so the time bound uses the right timestamp field', async () => {
+    // Repro for the `unknown field 'source_name_8'` error: the page loads a first entity whose
+    // timestamp column is named differently, then the AI generates a query for a *different* entity.
+    // Without re-fetching the schema, the toolbar time bound resolves against the stale entity's
+    // timestamp column (source_name_8) — a field the queried entity doesn't have.
+    const user = userEvent.setup();
+    setQueryAssistantEnabled(true);
+    vi.mocked(getEntitySchema).mockResolvedValue({
+      fields: [{ name: 'request_time', type: AnalyticsFieldType.Timestamp, source: 'request_time' }],
+    });
+    vi.mocked(translateSqlToQuery).mockResolvedValue({
+      success: true,
+      response: { query: { entity: 'dial_usage_log', mode: QueryMode.Row } },
+    } as never);
+    vi.mocked(executeQuery).mockResolvedValue({ success: true, response: { rows: [] } } as never);
+
+    renderBuilder({
+      initialEntities: [{ name: 'custom_source' }, { name: 'dial_usage_log' }],
+      initialEntityName: 'custom_source',
+      initialFields: [{ name: 'source_name_8', type: AnalyticsFieldType.Timestamp, source: 'source_name_8' }],
+    });
+    await generate(user, '```sql\nSELECT 1\n```');
+    const runButton = await screen.findByRole('button', { name: /QueryBuilder.Run/ });
+    await vi.waitFor(() => expect(runButton).toBeEnabled());
+
+    await user.click(runButton);
+
+    expect(getEntitySchema).toHaveBeenCalledWith('dial_usage_log');
+    const sent = vi.mocked(executeQuery).mock.calls[0][0] as StructuredQuery;
+    expect(sent.entity).toBe('dial_usage_log');
+    const args = (sent.filter as { args: { op: string; args: { name?: string }[] }[] }).args;
+    expect(args.map((a) => a.op)).toEqual(['ge', 'le']);
+    expect(args[0].args[0].name).toBe('request_time');
+    expect(JSON.stringify(sent)).not.toContain('source_name_8');
   });
 
   test('a follow-up reply without SQL clears the armed query and disables Run', async () => {


### PR DESCRIPTION
**Description:**

The toolbar time bound can resolve the timestamp column against the wrong entity when a query targets a different entity than the one whose schema is currently loaded. This causes the backend to reject the field as unknown (e.g., "source_name_8"). The fix re-fetches the entity schema whenever hydrating a query that targets a different entity, ensuring fields are resolved correctly.

Issues:

- Issue #3844

**Key Changes:**

- [apps/ai-dial-admin/src/components/Analytics/QueryBuilder/QueryBuilder.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/fix/querybuilder-stale-schema/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/QueryBuilder.tsx) — add `resolveFieldsForEntity` helper and update `hydrateBuilderFromQuery` to re-fetch schema when entity differs
- [apps/ai-dial-admin/src/components/Analytics/QueryBuilder/tests/QueryBuilder.spec.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/fix/querybuilder-stale-schema/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/tests/QueryBuilder.spec.tsx) — add test case for cross-entity schema refresh

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with \`(Issue #3844)\`