### PR TITLE
fix(Analytics/Tables): validate name and required sections, column identifiers, renames and metadata (Issue #3847)

### DIFF
--- a/apps/ai-dial-admin/src/components/Analytics/Tables/ColumnRowsEditor.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/ColumnRowsEditor.tsx
@@ -7,14 +7,16 @@ import { AnalyticsTablesI18nKey } from '@/src/constants/i18n';
 import { useI18n } from '@/src/locales/client';
 import { createColumnRow } from '@/src/components/Analytics/Tables/utils';
 import { AnalyticsFieldType } from '@/src/models/analytics/entity';
-import { ColumnRow } from '@/src/models/analytics/tables-ui';
+import { ColumnRow, ColumnRowError } from '@/src/models/analytics/tables-ui';
 
 interface Props {
   rows: ColumnRow[];
   onChange: (rows: ColumnRow[]) => void;
+  // Per-row validation messages, aligned by index with `rows`.
+  errors?: ColumnRowError[];
 }
 
-const ColumnRowsEditor: FC<Props> = ({ rows, onChange }) => {
+const ColumnRowsEditor: FC<Props> = ({ rows, onChange, errors }) => {
   const t = useI18n();
 
   const update = (id: string, patch: Partial<ColumnRow>) =>
@@ -24,6 +26,7 @@ const ColumnRowsEditor: FC<Props> = ({ rows, onChange }) => {
     <div className="flex flex-col gap-2">
       {rows.map((row, index) => {
         const first = index === 0;
+        const rowError = errors?.[index];
         return (
           <div key={row.id} className="flex items-end gap-2">
             <DialInput
@@ -31,6 +34,7 @@ const ColumnRowsEditor: FC<Props> = ({ rows, onChange }) => {
               containerClassName="flex-1 min-w-[120px]"
               labelProps={first ? { label: t(AnalyticsTablesI18nKey.SourceName) } : undefined}
               value={row.source_name}
+              error={rowError?.source_name}
               onChange={(v) => update(row.id, { source_name: v ?? '' })}
             />
             <DialInput
@@ -38,6 +42,7 @@ const ColumnRowsEditor: FC<Props> = ({ rows, onChange }) => {
               containerClassName="flex-1 min-w-[120px]"
               labelProps={first ? { label: t(AnalyticsTablesI18nKey.ColumnName) } : undefined}
               value={row.name}
+              error={rowError?.name}
               onChange={(v) => update(row.id, { name: v ?? '' })}
             />
             <DialSelectField
@@ -53,6 +58,7 @@ const ColumnRowsEditor: FC<Props> = ({ rows, onChange }) => {
               containerClassName="w-[120px] shrink-0"
               labelProps={first ? { label: t(AnalyticsTablesI18nKey.Tag) } : undefined}
               value={row.tag}
+              error={rowError?.tag}
               onChange={(v) => update(row.id, { tag: v ?? '' })}
             />
             <div className="flex h-[38px] items-center gap-2">

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/CreateTablePopup.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/CreateTablePopup.tsx
@@ -6,7 +6,12 @@ import { DialFormPopup, DialInput, DialSelectField, PopupSize } from '@epam/ai-d
 
 import { createTable } from '@/src/app/[lang]/tables/actions';
 import ColumnRowsEditor from '@/src/components/Analytics/Tables/ColumnRowsEditor';
-import { createTableForm, getTableNameError, toTableColumns } from '@/src/components/Analytics/Tables/utils';
+import {
+  createTableForm,
+  getColumnRowErrors,
+  hasColumnRowErrors,
+  toTableColumns,
+} from '@/src/components/Analytics/Tables/utils';
 import { PARTITION_GRANULARITY_OPTIONS } from '@/src/constants/analytics/tables';
 import { AnalyticsTablesI18nKey } from '@/src/constants/i18n';
 import { useNotification } from '@/src/context/NotificationContext';
@@ -14,6 +19,7 @@ import { useI18n } from '@/src/locales/client';
 import { AnalyticsFieldType } from '@/src/models/analytics/entity';
 import { AnalyticsTable, AnalyticsTableType, CreateTableDto, PartitionGranularity } from '@/src/models/analytics/table';
 import { TableForm } from '@/src/models/analytics/tables-ui';
+import { getAnalyticsIdentifierError } from '@/src/utils/validation/analytics-table-error';
 import { getErrorNotification, getSuccessNotification } from '@/src/utils/notification';
 
 interface Props {
@@ -69,13 +75,15 @@ const CreateTablePopup: FC<Props> = ({ tableType, tables, onClose, onCreated }) 
   const columnOptions = sourceNames.map((s) => ({ value: s, label: s }));
 
   const existingNames = tables.map((tbl) => tbl.name);
-  const nameError = getTableNameError(form.name, existingNames, t);
+  const nameError = getAnalyticsIdentifierError(form.name, existingNames, t);
 
   // Source tables require at least one fully-declared column and a non-empty ordering key (both are
-  // enforced by the backend); mirror that here so submit is blocked before the request is sent.
+  // enforced by the backend); mirror that here so submit is blocked before the request is sent. Column
+  // rows are validated for identifier grammar and uniqueness against each other (no pre-existing columns).
+  const columnErrors = getColumnRowErrors(form.columns, { sourceNames: [], names: [] }, t);
   const validColumns = toTableColumns(form.columns);
   const validOrdering = form.orderingKey.filter((k) => sourceNames.includes(k));
-  const sourceComplete = validColumns.length > 0 && validOrdering.length > 0;
+  const sourceComplete = validColumns.length > 0 && validOrdering.length > 0 && !hasColumnRowErrors(columnErrors);
   const canSubmit = Boolean(form.name.trim()) && !nameError && (isSource ? sourceComplete : true);
 
   const onSubmit = async () => {
@@ -133,7 +141,7 @@ const CreateTablePopup: FC<Props> = ({ tableType, tables, onClose, onCreated }) 
           id="table-name"
           labelProps={{ label: t(AnalyticsTablesI18nKey.Name), required: true }}
           value={form.name}
-          error={nameError ?? undefined}
+          error={nameError?.text}
           onChange={(v) => update('name', v ?? '')}
         />
         <DialInput
@@ -150,7 +158,11 @@ const CreateTablePopup: FC<Props> = ({ tableType, tables, onClose, onCreated }) 
                 {t(AnalyticsTablesI18nKey.Columns)}
                 <span className="text-error"> *</span>
               </span>
-              <ColumnRowsEditor rows={form.columns} onChange={(rows) => update('columns', rows)} />
+              <ColumnRowsEditor
+                rows={form.columns}
+                errors={columnErrors}
+                onChange={(rows) => update('columns', rows)}
+              />
             </div>
             <DialSelectField
               id="table-ordering-key"

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/CreateTablePopup.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/CreateTablePopup.tsx
@@ -6,7 +6,7 @@ import { DialFormPopup, DialInput, DialSelectField, PopupSize } from '@epam/ai-d
 
 import { createTable } from '@/src/app/[lang]/tables/actions';
 import ColumnRowsEditor from '@/src/components/Analytics/Tables/ColumnRowsEditor';
-import { createTableForm, toTableColumns } from '@/src/components/Analytics/Tables/utils';
+import { createTableForm, getTableNameError, toTableColumns } from '@/src/components/Analytics/Tables/utils';
 import { PARTITION_GRANULARITY_OPTIONS } from '@/src/constants/analytics/tables';
 import { AnalyticsTablesI18nKey } from '@/src/constants/i18n';
 import { useNotification } from '@/src/context/NotificationContext';
@@ -68,17 +68,26 @@ const CreateTablePopup: FC<Props> = ({ tableType, tables, onClose, onCreated }) 
   }, [form.columns]);
   const columnOptions = sourceNames.map((s) => ({ value: s, label: s }));
 
+  const existingNames = tables.map((tbl) => tbl.name);
+  const nameError = getTableNameError(form.name, existingNames, t);
+
+  // Source tables require at least one fully-declared column and a non-empty ordering key (both are
+  // enforced by the backend); mirror that here so submit is blocked before the request is sent.
+  const validColumns = toTableColumns(form.columns);
+  const validOrdering = form.orderingKey.filter((k) => sourceNames.includes(k));
+  const sourceComplete = validColumns.length > 0 && validOrdering.length > 0;
+  const canSubmit = Boolean(form.name.trim()) && !nameError && (isSource ? sourceComplete : true);
+
   const onSubmit = async () => {
     const trimmed = form.name.trim();
-    if (!trimmed) return;
+    if (!canSubmit) return;
 
-    const validOrdering = form.orderingKey.filter((k) => sourceNames.includes(k));
     const dto: CreateTableDto = isSource
       ? {
           name: trimmed,
           type: AnalyticsTableType.Source,
-          columns: toTableColumns(form.columns),
-          ...(validOrdering.length ? { ordering_key: validOrdering } : {}),
+          columns: validColumns,
+          ordering_key: validOrdering,
           ...(form.description.trim() ? { description: form.description.trim() } : {}),
           ...(form.partitionColumn && form.granularity && temporalNames.includes(form.partitionColumn)
             ? { partition_by: { column: form.partitionColumn, granularity: form.granularity } }
@@ -116,7 +125,7 @@ const CreateTablePopup: FC<Props> = ({ tableType, tables, onClose, onCreated }) 
       size={PopupSize.Lg}
       header={t(isSource ? AnalyticsTablesI18nKey.CreateSourceTitle : AnalyticsTablesI18nKey.CreateEnrichmentTitle)}
       submitLabel={t(isSource ? AnalyticsTablesI18nKey.CreateSource : AnalyticsTablesI18nKey.CreateEnrichment)}
-      disableSubmitButton={!form.name.trim()}
+      disableSubmitButton={!canSubmit}
       onSubmit={onSubmit}
     >
       <div className="flex max-h-[70vh] flex-col gap-4 overflow-auto p-6">
@@ -124,6 +133,7 @@ const CreateTablePopup: FC<Props> = ({ tableType, tables, onClose, onCreated }) 
           id="table-name"
           labelProps={{ label: t(AnalyticsTablesI18nKey.Name), required: true }}
           value={form.name}
+          error={nameError ?? undefined}
           onChange={(v) => update('name', v ?? '')}
         />
         <DialInput
@@ -136,12 +146,16 @@ const CreateTablePopup: FC<Props> = ({ tableType, tables, onClose, onCreated }) 
         {isSource ? (
           <>
             <div className="flex flex-col gap-2">
-              <span className="dial-small-semi text-primary">{t(AnalyticsTablesI18nKey.Columns)}</span>
+              <span className="dial-small-semi text-primary">
+                {t(AnalyticsTablesI18nKey.Columns)}
+                <span className="text-error"> *</span>
+              </span>
               <ColumnRowsEditor rows={form.columns} onChange={(rows) => update('columns', rows)} />
             </div>
             <DialSelectField
               id="table-ordering-key"
               multiple
+              required
               label={t(AnalyticsTablesI18nKey.OrderingKey)}
               options={columnOptions}
               value={form.orderingKey}

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/EditColumnPopup.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/EditColumnPopup.tsx
@@ -5,19 +5,27 @@ import { FC, useState } from 'react';
 import { DialFormPopup, DialInput, DialSwitch, PopupSize } from '@epam/ai-dial-ui-kit';
 
 import { buildColumnEditPatch } from '@/src/components/Analytics/Tables/utils';
+import {
+  ANALYTICS_DESCRIPTION_MAX_LENGTH,
+  ANALYTICS_DISPLAY_NAME_MAX_LENGTH,
+  ANALYTICS_TAG_MAX_LENGTH,
+} from '@/src/constants/analytics/tables';
 import { AnalyticsTablesI18nKey, ButtonsI18nKey } from '@/src/constants/i18n';
 import { useI18n } from '@/src/locales/client';
 import { AnalyticsSchemaPatch, AnalyticsTableColumn } from '@/src/models/analytics/table';
 import { ColumnEditValues } from '@/src/models/analytics/tables-ui';
+import { getAnalyticsIdentifierError, getAnalyticsLengthError } from '@/src/utils/validation/analytics-table-error';
 
 interface Props {
   column: AnalyticsTableColumn;
   renameDisabled?: boolean;
+  // Exposed names of the table's other columns; a rename must not collide with them.
+  existingNames?: string[];
   onClose: () => void;
   onSubmit: (patch: AnalyticsSchemaPatch) => void;
 }
 
-const EditColumnPopup: FC<Props> = ({ column, renameDisabled, onClose, onSubmit }) => {
+const EditColumnPopup: FC<Props> = ({ column, renameDisabled, existingNames = [], onClose, onSubmit }) => {
   const t = useI18n();
 
   const [values, setValues] = useState<ColumnEditValues>({
@@ -33,7 +41,16 @@ const EditColumnPopup: FC<Props> = ({ column, renameDisabled, onClose, onSubmit 
 
   const setSensitive = (value: boolean) => setValues((prev) => ({ ...prev, sensitive: value }));
 
-  const patch = values.name.trim() ? buildColumnEditPatch(column, values) : null;
+  // A rename is only validated when the name actually changes; renaming is disabled for
+  // system/grain/ordering-key columns, so an unchanged name never errors.
+  const nameChanged = values.name.trim() !== column.name;
+  const nameError = nameChanged ? getAnalyticsIdentifierError(values.name, existingNames, t) : null;
+  const tagError = getAnalyticsLengthError(values.tag, ANALYTICS_TAG_MAX_LENGTH, t);
+  const displayNameError = getAnalyticsLengthError(values.display_name, ANALYTICS_DISPLAY_NAME_MAX_LENGTH, t);
+  const descriptionError = getAnalyticsLengthError(values.description, ANALYTICS_DESCRIPTION_MAX_LENGTH, t);
+  const hasError = Boolean(nameError || tagError || displayNameError || descriptionError);
+
+  const patch = !hasError && values.name.trim() ? buildColumnEditPatch(column, values) : null;
 
   return (
     <DialFormPopup
@@ -52,24 +69,28 @@ const EditColumnPopup: FC<Props> = ({ column, renameDisabled, onClose, onSubmit 
           labelProps={{ label: t(AnalyticsTablesI18nKey.ColumnName) }}
           value={values.name}
           disabled={renameDisabled}
+          error={nameError?.text}
           onChange={setValue('name')}
         />
         <DialInput
           id="column-edit-display-name"
           labelProps={{ label: t(AnalyticsTablesI18nKey.DisplayName) }}
           value={values.display_name}
+          error={displayNameError?.text}
           onChange={setValue('display_name')}
         />
         <DialInput
           id="column-edit-tag"
           labelProps={{ label: t(AnalyticsTablesI18nKey.Tag) }}
           value={values.tag}
+          error={tagError?.text}
           onChange={setValue('tag')}
         />
         <DialInput
           id="column-edit-description"
           labelProps={{ label: t(AnalyticsTablesI18nKey.Description) }}
           value={values.description}
+          error={descriptionError?.text}
           onChange={setValue('description')}
         />
         <DialSwitch

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/TableDetailView.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/TableDetailView.tsx
@@ -17,7 +17,13 @@ import {
 import { addRows, deleteTable, getTable, updateTableSchema } from '@/src/app/[lang]/tables/actions';
 import ColumnRowsEditor from '@/src/components/Analytics/Tables/ColumnRowsEditor';
 import EditColumnPopup from '@/src/components/Analytics/Tables/EditColumnPopup';
-import { createColumnRow, isRenameRestricted, toTableColumns } from '@/src/components/Analytics/Tables/utils';
+import {
+  createColumnRow,
+  getColumnRowErrors,
+  hasColumnRowErrors,
+  isRenameRestricted,
+  toTableColumns,
+} from '@/src/components/Analytics/Tables/utils';
 import { TypeCellRenderer } from '@/src/components/Analytics/Common/TypeBadge';
 import SensitiveIndicator from '@/src/components/Common/SensitiveIndicator/SensitiveIndicator';
 import GridView from '@/src/components/Grid/GridView/GridView';
@@ -32,6 +38,7 @@ import { AnalyticsSchemaPatch, AnalyticsTable, AnalyticsTableColumn } from '@/sr
 import { ColumnRow } from '@/src/models/analytics/tables-ui';
 import { ServerActionResponse } from '@/src/models/server-action';
 import { ApplicationRoute } from '@/src/types/routes';
+import { getAnalyticsIdentifierError } from '@/src/utils/validation/analytics-table-error';
 import { getErrorNotification, getSuccessNotification } from '@/src/utils/notification';
 
 interface Props {
@@ -63,6 +70,15 @@ const TableDetailView: FC<Props> = ({ name, initialTable }) => {
   const [editColumn, setEditColumn] = useState<AnalyticsTableColumn | null>(null);
 
   const isSystem = Boolean(table.system);
+  const columns = useMemo(() => table.columns ?? [], [table.columns]);
+
+  // New columns must not collide with the table's existing source/exposed names (the backend rejects
+  // duplicates); validate the add-columns rows against them plus each other.
+  const addColumnErrors = getColumnRowErrors(
+    addColumns,
+    { sourceNames: columns.map((c) => c.source_name), names: columns.map((c) => c.name) },
+    t,
+  );
 
   const reload = useCallback(async () => {
     const tbl = await getTable(name);
@@ -105,9 +121,19 @@ const TableDetailView: FC<Props> = ({ name, initialTable }) => {
   const onRenameCell = useCallback(
     (from: string, to: string) => {
       const target = to.trim();
-      if (target && target !== from) void applyPatch({ rename: [{ from, to: target }] });
+      if (!target || target === from) return;
+      // Validate the new name against the grammar and the other columns' names; on failure notify and
+      // reload so the inline-edited grid cell reverts to its previous value.
+      const others = columns.filter((c) => c.name !== from).map((c) => c.name);
+      const error = getAnalyticsIdentifierError(target, others, t);
+      if (error) {
+        showNotification(getErrorNotification(error.text));
+        void reload();
+        return;
+      }
+      void applyPatch({ rename: [{ from, to: target }] });
     },
-    [applyPatch],
+    [applyPatch, columns, reload, showNotification, t],
   );
 
   const onSubmitEditColumn = async (patch: AnalyticsSchemaPatch) => {
@@ -218,7 +244,7 @@ const TableDetailView: FC<Props> = ({ name, initialTable }) => {
       <div className="flex min-h-0 flex-1 flex-col">
         <GridView
           columnDefs={columnDefs}
-          rowData={table.columns ?? []}
+          rowData={columns}
           getRowId={(params) => params.data.name}
           additionalGridOptions={{
             onCellValueChanged: (e) => {
@@ -248,12 +274,12 @@ const TableDetailView: FC<Props> = ({ name, initialTable }) => {
           size={PopupSize.Lg}
           header={t(AnalyticsTablesI18nKey.AddColumns)}
           submitLabel={t(AnalyticsTablesI18nKey.AddColumns)}
-          disableSubmitButton={toTableColumns(addColumns).length === 0}
+          disableSubmitButton={toTableColumns(addColumns).length === 0 || hasColumnRowErrors(addColumnErrors)}
           onClose={() => setAddOpen(false)}
           onSubmit={() => void onSubmitAddColumns()}
         >
           <div className="max-h-[70vh] overflow-auto p-6">
-            <ColumnRowsEditor rows={addColumns} onChange={setAddColumns} />
+            <ColumnRowsEditor rows={addColumns} errors={addColumnErrors} onChange={setAddColumns} />
           </div>
         </DialFormPopup>
       )}
@@ -280,6 +306,7 @@ const TableDetailView: FC<Props> = ({ name, initialTable }) => {
         <EditColumnPopup
           column={editColumn}
           renameDisabled={isRenameRestricted(table, editColumn)}
+          existingNames={columns.filter((c) => c.name !== editColumn.name).map((c) => c.name)}
           onClose={() => setEditColumn(null)}
           onSubmit={(patch) => void onSubmitEditColumn(patch)}
         />

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/tests/CreateTablePopup.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/tests/CreateTablePopup.spec.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import CreateTablePopup from '@/src/components/Analytics/Tables/CreateTablePopup';
-import { AnalyticsTablesI18nKey } from '@/src/constants/i18n';
+import { AnalyticsTablesI18nKey, ErrorI18nKey } from '@/src/constants/i18n';
 import { AnalyticsTable, AnalyticsTableType } from '@/src/models/analytics/table';
 
 vi.mock('@/src/app/[lang]/tables/actions');
@@ -43,21 +43,21 @@ describe('CreateTablePopup source', () => {
   test('an invalid name shows the format error and keeps submit disabled', () => {
     setup();
     typeName('Bad Name');
-    expect(screen.getByText(AnalyticsTablesI18nKey.NameFormatError)).toBeInTheDocument();
+    expect(screen.getByText(ErrorI18nKey.SnakeCaseIdentifier)).toBeInTheDocument();
     expect(submitButton(AnalyticsTablesI18nKey.CreateSource)).toBeDisabled();
   });
 
   test('a name that collides with an existing table shows the exists error', () => {
     setup();
     typeName('events');
-    expect(screen.getByText(AnalyticsTablesI18nKey.NameExistsError)).toBeInTheDocument();
+    expect(screen.getByText(ErrorI18nKey.KeyValueExists)).toBeInTheDocument();
   });
 
   test('a valid, unique name clears the inline error (submit still gated on columns/ordering key)', () => {
     setup();
     typeName('orders');
-    expect(screen.queryByText(AnalyticsTablesI18nKey.NameFormatError)).not.toBeInTheDocument();
-    expect(screen.queryByText(AnalyticsTablesI18nKey.NameExistsError)).not.toBeInTheDocument();
+    expect(screen.queryByText(ErrorI18nKey.SnakeCaseIdentifier)).not.toBeInTheDocument();
+    expect(screen.queryByText(ErrorI18nKey.KeyValueExists)).not.toBeInTheDocument();
   });
 });
 

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/tests/CreateTablePopup.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/tests/CreateTablePopup.spec.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import CreateTablePopup from '@/src/components/Analytics/Tables/CreateTablePopup';
+import { AnalyticsTablesI18nKey } from '@/src/constants/i18n';
+import { AnalyticsTable, AnalyticsTableType } from '@/src/models/analytics/table';
+
+vi.mock('@/src/app/[lang]/tables/actions');
+
+// The rows editor is exercised in its own spec; stub it so these tests stay focused on the popup's
+// name validation, required markers, and submit gating.
+vi.mock('@/src/components/Analytics/Tables/ColumnRowsEditor', () => ({
+  default: () => <div>column-rows-editor</div>,
+}));
+
+const tables: AnalyticsTable[] = [{ name: 'events', type: AnalyticsTableType.Source }];
+
+const setup = (tableType: AnalyticsTableType = AnalyticsTableType.Source) =>
+  render(<CreateTablePopup tableType={tableType} tables={tables} onClose={vi.fn()} onCreated={vi.fn()} />);
+
+const nameField = () => screen.getByLabelText(AnalyticsTablesI18nKey.Name, { exact: false });
+// DialInput remounts on re-render, so per-keystroke typing detaches; set the value in one change event.
+const typeName = (value: string) => fireEvent.change(nameField(), { target: { value } });
+const submitButton = (key: AnalyticsTablesI18nKey) => screen.getByRole('button', { name: key });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('CreateTablePopup source', () => {
+  test('renders the name field and the required Columns / Ordering key sections', () => {
+    setup();
+    expect(nameField()).toBeInTheDocument();
+    expect(screen.getByText(AnalyticsTablesI18nKey.Columns)).toBeInTheDocument();
+    expect(screen.getByText(AnalyticsTablesI18nKey.OrderingKey)).toBeInTheDocument();
+  });
+
+  test('submit is disabled while the form is incomplete (no name, columns, or ordering key)', () => {
+    setup();
+    expect(submitButton(AnalyticsTablesI18nKey.CreateSource)).toBeDisabled();
+  });
+
+  test('an invalid name shows the format error and keeps submit disabled', () => {
+    setup();
+    typeName('Bad Name');
+    expect(screen.getByText(AnalyticsTablesI18nKey.NameFormatError)).toBeInTheDocument();
+    expect(submitButton(AnalyticsTablesI18nKey.CreateSource)).toBeDisabled();
+  });
+
+  test('a name that collides with an existing table shows the exists error', () => {
+    setup();
+    typeName('events');
+    expect(screen.getByText(AnalyticsTablesI18nKey.NameExistsError)).toBeInTheDocument();
+  });
+
+  test('a valid, unique name clears the inline error (submit still gated on columns/ordering key)', () => {
+    setup();
+    typeName('orders');
+    expect(screen.queryByText(AnalyticsTablesI18nKey.NameFormatError)).not.toBeInTheDocument();
+    expect(screen.queryByText(AnalyticsTablesI18nKey.NameExistsError)).not.toBeInTheDocument();
+  });
+});
+
+describe('CreateTablePopup enrichment', () => {
+  test('renders source table / grain key selects instead of the columns section', () => {
+    setup(AnalyticsTableType.Enrichment);
+    expect(nameField()).toBeInTheDocument();
+    expect(screen.getByText(AnalyticsTablesI18nKey.SourceTable)).toBeInTheDocument();
+    expect(screen.getByText(AnalyticsTablesI18nKey.GrainKey)).toBeInTheDocument();
+    expect(screen.queryByText(AnalyticsTablesI18nKey.Columns)).not.toBeInTheDocument();
+  });
+});

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/tests/EditColumnPopup.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/tests/EditColumnPopup.spec.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { describe, expect, test, vi } from 'vitest';
 
 import EditColumnPopup from '@/src/components/Analytics/Tables/EditColumnPopup';
-import { AnalyticsTablesI18nKey, ButtonsI18nKey } from '@/src/constants/i18n';
+import { AnalyticsTablesI18nKey, ButtonsI18nKey, ErrorI18nKey } from '@/src/constants/i18n';
 import { AnalyticsFieldType } from '@/src/models/analytics/entity';
 import { AnalyticsTableColumn } from '@/src/models/analytics/table';
 
@@ -65,6 +65,33 @@ describe('EditColumnPopup', () => {
 
     setInput(AnalyticsTablesI18nKey.ColumnName, '');
 
+    expect(screen.getByRole('button', { name: ButtonsI18nKey.Save })).toBeDisabled();
+  });
+
+  test('a rename to an invalid identifier shows the format error and disables submit', () => {
+    renderPopup();
+
+    setInput(AnalyticsTablesI18nKey.ColumnName, 'Total-Cost');
+
+    expect(screen.getByText(ErrorI18nKey.SnakeCaseIdentifier)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: ButtonsI18nKey.Save })).toBeDisabled();
+  });
+
+  test('a rename that collides with another column shows the exists error and disables submit', () => {
+    renderPopup({ existingNames: ['total_cost'] });
+
+    setInput(AnalyticsTablesI18nKey.ColumnName, 'total_cost');
+
+    expect(screen.getByText(ErrorI18nKey.KeyValueExists)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: ButtonsI18nKey.Save })).toBeDisabled();
+  });
+
+  test('a tag longer than the length cap shows the length error and disables submit', () => {
+    renderPopup();
+
+    setInput(AnalyticsTablesI18nKey.Tag, 'a'.repeat(65));
+
+    expect(screen.getByText(ErrorI18nKey.Length)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: ButtonsI18nKey.Save })).toBeDisabled();
   });
 

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/tests/utils.spec.ts
@@ -3,14 +3,15 @@ import { describe, expect, test } from 'vitest';
 import {
   buildColumnEditPatch,
   createColumnRow,
-  getTableNameError,
+  getColumnRowErrors,
+  hasColumnRowErrors,
   isRenameRestricted,
   toTableColumns,
 } from '@/src/components/Analytics/Tables/utils';
-import { AnalyticsTablesI18nKey } from '@/src/constants/i18n';
+import { ErrorI18nKey } from '@/src/constants/i18n';
 import { AnalyticsFieldType } from '@/src/models/analytics/entity';
 import { AnalyticsTable, AnalyticsTableColumn, AnalyticsTableType } from '@/src/models/analytics/table';
-import { ColumnEditValues } from '@/src/models/analytics/tables-ui';
+import { ColumnEditValues, ColumnRow } from '@/src/models/analytics/tables-ui';
 
 describe('createColumnRow', () => {
   test('creates a blank row with a unique id and string default type', () => {
@@ -179,38 +180,50 @@ describe('buildColumnEditPatch', () => {
   });
 });
 
-describe('getTableNameError', () => {
+describe('getColumnRowErrors / hasColumnRowErrors', () => {
   // Stub t() returns the key so assertions target the i18n key, not translated text.
   const t = (key: string) => key;
+  const noExisting = { sourceNames: [], names: [] };
+  const row = (overrides: Partial<ColumnRow>): ColumnRow => ({ ...createColumnRow(), ...overrides });
 
-  test('returns null for an empty or whitespace-only name (emptiness is signalled elsewhere)', () => {
-    expect(getTableNameError('', [], t)).toBeNull();
-    expect(getTableNameError('   ', [], t)).toBeNull();
+  test('a blank or partial row (missing source_name or name) produces no identifier errors', () => {
+    const rows = [row({}), row({ source_name: 'only_source' }), row({ name: 'only_name' })];
+    const errors = getColumnRowErrors(rows, noExisting, t);
+    expect(errors).toEqual([{}, {}, {}]);
+    expect(hasColumnRowErrors(errors)).toBe(false);
   });
 
-  test('accepts valid lowercase snake_case identifiers (trimming first)', () => {
-    expect(getTableNameError('events', [], t)).toBeNull();
-    expect(getTableNameError('user_events_2', [], t)).toBeNull();
-    expect(getTableNameError('  events  ', [], t)).toBeNull();
+  test('fully-declared rows with valid, unique identifiers produce no errors', () => {
+    const rows = [row({ source_name: 'event_id', name: 'event' }), row({ source_name: 'total', name: 'total_cost' })];
+    expect(hasColumnRowErrors(getColumnRowErrors(rows, noExisting, t))).toBe(false);
   });
 
-  test('rejects names that violate the identifier grammar', () => {
-    expect(getTableNameError('Events', [], t)).toBe(AnalyticsTablesI18nKey.NameFormatError);
-    expect(getTableNameError('_events', [], t)).toBe(AnalyticsTablesI18nKey.NameFormatError);
-    expect(getTableNameError('2events', [], t)).toBe(AnalyticsTablesI18nKey.NameFormatError);
-    expect(getTableNameError('my-table', [], t)).toBe(AnalyticsTablesI18nKey.NameFormatError);
-    expect(getTableNameError('my table', [], t)).toBe(AnalyticsTablesI18nKey.NameFormatError);
+  test('flags source_name and name that violate the identifier grammar', () => {
+    const errors = getColumnRowErrors([row({ source_name: 'Bad Source', name: 'Bad-Name' })], noExisting, t);
+    expect(errors[0].source_name).toBe(ErrorI18nKey.SnakeCaseIdentifier);
+    expect(errors[0].name).toBe(ErrorI18nKey.SnakeCaseIdentifier);
   });
 
-  test('rejects names longer than the identifier max length', () => {
-    expect(getTableNameError('a'.repeat(65), [], t)).toBe(AnalyticsTablesI18nKey.NameLengthError);
-    expect(getTableNameError('a'.repeat(64), [], t)).toBeNull();
+  test('flags duplicate names among sibling rows', () => {
+    const rows = [row({ source_name: 'a', name: 'dup' }), row({ source_name: 'b', name: 'dup' })];
+    const errors = getColumnRowErrors(rows, noExisting, t);
+    expect(errors[0].name).toBe(ErrorI18nKey.KeyValueExists);
+    expect(errors[1].name).toBe(ErrorI18nKey.KeyValueExists);
   });
 
-  test('rejects a name that collides with an existing table (compared after trimming)', () => {
-    expect(getTableNameError('events', ['events', 'orders'], t)).toBe(AnalyticsTablesI18nKey.NameExistsError);
-    expect(getTableNameError('  events  ', ['events'], t)).toBe(AnalyticsTablesI18nKey.NameExistsError);
-    expect(getTableNameError('events', ['orders'], t)).toBeNull();
+  test('flags a row that collides with a pre-existing table column', () => {
+    const errors = getColumnRowErrors(
+      [row({ source_name: 'new_source', name: 'existing_name' })],
+      { sourceNames: [], names: ['existing_name'] },
+      t,
+    );
+    expect(errors[0].name).toBe(ErrorI18nKey.KeyValueExists);
+  });
+
+  test('flags a tag longer than the length cap even on an otherwise blank row', () => {
+    const errors = getColumnRowErrors([row({ tag: 'a'.repeat(65) })], noExisting, t);
+    expect(errors[0].tag).toBe(ErrorI18nKey.Length);
+    expect(hasColumnRowErrors(errors)).toBe(true);
   });
 });
 

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/tests/utils.spec.ts
@@ -3,9 +3,11 @@ import { describe, expect, test } from 'vitest';
 import {
   buildColumnEditPatch,
   createColumnRow,
+  getTableNameError,
   isRenameRestricted,
   toTableColumns,
 } from '@/src/components/Analytics/Tables/utils';
+import { AnalyticsTablesI18nKey } from '@/src/constants/i18n';
 import { AnalyticsFieldType } from '@/src/models/analytics/entity';
 import { AnalyticsTable, AnalyticsTableColumn, AnalyticsTableType } from '@/src/models/analytics/table';
 import { ColumnEditValues } from '@/src/models/analytics/tables-ui';
@@ -174,6 +176,41 @@ describe('buildColumnEditPatch', () => {
 
   test('a blank name never produces a rename op', () => {
     expect(buildColumnEditPatch(COLUMN, values({ name: '  ' }))).toBeNull();
+  });
+});
+
+describe('getTableNameError', () => {
+  // Stub t() returns the key so assertions target the i18n key, not translated text.
+  const t = (key: string) => key;
+
+  test('returns null for an empty or whitespace-only name (emptiness is signalled elsewhere)', () => {
+    expect(getTableNameError('', [], t)).toBeNull();
+    expect(getTableNameError('   ', [], t)).toBeNull();
+  });
+
+  test('accepts valid lowercase snake_case identifiers (trimming first)', () => {
+    expect(getTableNameError('events', [], t)).toBeNull();
+    expect(getTableNameError('user_events_2', [], t)).toBeNull();
+    expect(getTableNameError('  events  ', [], t)).toBeNull();
+  });
+
+  test('rejects names that violate the identifier grammar', () => {
+    expect(getTableNameError('Events', [], t)).toBe(AnalyticsTablesI18nKey.NameFormatError);
+    expect(getTableNameError('_events', [], t)).toBe(AnalyticsTablesI18nKey.NameFormatError);
+    expect(getTableNameError('2events', [], t)).toBe(AnalyticsTablesI18nKey.NameFormatError);
+    expect(getTableNameError('my-table', [], t)).toBe(AnalyticsTablesI18nKey.NameFormatError);
+    expect(getTableNameError('my table', [], t)).toBe(AnalyticsTablesI18nKey.NameFormatError);
+  });
+
+  test('rejects names longer than the identifier max length', () => {
+    expect(getTableNameError('a'.repeat(65), [], t)).toBe(AnalyticsTablesI18nKey.NameLengthError);
+    expect(getTableNameError('a'.repeat(64), [], t)).toBeNull();
+  });
+
+  test('rejects a name that collides with an existing table (compared after trimming)', () => {
+    expect(getTableNameError('events', ['events', 'orders'], t)).toBe(AnalyticsTablesI18nKey.NameExistsError);
+    expect(getTableNameError('  events  ', ['events'], t)).toBe(AnalyticsTablesI18nKey.NameExistsError);
+    expect(getTableNameError('events', ['orders'], t)).toBeNull();
   });
 });
 

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/utils.ts
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/utils.ts
@@ -1,4 +1,9 @@
-import { PARTITION_NONE } from '@/src/constants/analytics/tables';
+import {
+  ANALYTICS_IDENTIFIER_MAX_LENGTH,
+  ANALYTICS_IDENTIFIER_PATTERN,
+  PARTITION_NONE,
+} from '@/src/constants/analytics/tables';
+import { AnalyticsTablesI18nKey } from '@/src/constants/i18n';
 import { AnalyticsFieldType } from '@/src/models/analytics/entity';
 import {
   AnalyticsColumnMetadataUpdate,
@@ -34,6 +39,24 @@ export const createTableForm = (tables: AnalyticsTable[]): TableForm => {
     sourceTable: firstSource?.name ?? '',
     grainKey: firstSource?.ordering_key?.[0] ?? '',
   };
+};
+
+// Validates a table name against the backend identifier grammar and uniqueness, returning a localized
+// error message or null when valid. An empty value returns null — emptiness is signalled by the
+// required marker and a disabled submit, not an inline error, so the field stays quiet until typed.
+export const getTableNameError = (
+  name: string,
+  existingNames: string[],
+  t: (key: string, args?: Record<string, string | number>) => string,
+): string | null => {
+  const trimmed = name.trim();
+  if (!trimmed) return null;
+  if (trimmed.length > ANALYTICS_IDENTIFIER_MAX_LENGTH) {
+    return t(AnalyticsTablesI18nKey.NameLengthError, { max: ANALYTICS_IDENTIFIER_MAX_LENGTH });
+  }
+  if (!ANALYTICS_IDENTIFIER_PATTERN.test(trimmed)) return t(AnalyticsTablesI18nKey.NameFormatError);
+  if (existingNames.includes(trimmed)) return t(AnalyticsTablesI18nKey.NameExistsError);
+  return null;
 };
 
 const normalized = (value?: string): string => (value ?? '').trim();

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/utils.ts
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/utils.ts
@@ -1,9 +1,4 @@
-import {
-  ANALYTICS_IDENTIFIER_MAX_LENGTH,
-  ANALYTICS_IDENTIFIER_PATTERN,
-  PARTITION_NONE,
-} from '@/src/constants/analytics/tables';
-import { AnalyticsTablesI18nKey } from '@/src/constants/i18n';
+import { ANALYTICS_TAG_MAX_LENGTH, PARTITION_NONE } from '@/src/constants/analytics/tables';
 import { AnalyticsFieldType } from '@/src/models/analytics/entity';
 import {
   AnalyticsColumnMetadataUpdate,
@@ -12,7 +7,16 @@ import {
   AnalyticsTableColumn,
   AnalyticsTableType,
 } from '@/src/models/analytics/table';
-import { ColumnEditValues, ColumnRow, TableForm } from '@/src/models/analytics/tables-ui';
+import {
+  ColumnEditValues,
+  ColumnRow,
+  ColumnRowError,
+  ExistingColumnNames,
+  TableForm,
+} from '@/src/models/analytics/tables-ui';
+import { getAnalyticsIdentifierError, getAnalyticsLengthError } from '@/src/utils/validation/analytics-table-error';
+
+type Translate = (key: string, args?: Record<string, string | number>) => string;
 
 let counter = 0;
 export const nextColumnId = (): string => `col-${++counter}`;
@@ -41,23 +45,40 @@ export const createTableForm = (tables: AnalyticsTable[]): TableForm => {
   };
 };
 
-// Validates a table name against the backend identifier grammar and uniqueness, returning a localized
-// error message or null when valid. An empty value returns null — emptiness is signalled by the
-// required marker and a disabled submit, not an inline error, so the field stays quiet until typed.
-export const getTableNameError = (
-  name: string,
-  existingNames: string[],
-  t: (key: string, args?: Record<string, string | number>) => string,
-): string | null => {
-  const trimmed = name.trim();
-  if (!trimmed) return null;
-  if (trimmed.length > ANALYTICS_IDENTIFIER_MAX_LENGTH) {
-    return t(AnalyticsTablesI18nKey.NameLengthError, { max: ANALYTICS_IDENTIFIER_MAX_LENGTH });
-  }
-  if (!ANALYTICS_IDENTIFIER_PATTERN.test(trimmed)) return t(AnalyticsTablesI18nKey.NameFormatError);
-  if (existingNames.includes(trimmed)) return t(AnalyticsTablesI18nKey.NameExistsError);
-  return null;
+// Validates the column rows of a create/add-columns form against the backend rules: each row that will
+// actually be sent (both source_name and name filled — partial rows are dropped by toTableColumns) must
+// have snake_case identifiers unique within the table (against sibling rows and any pre-existing columns),
+// and a tag within its length cap. Returns one entry per row, aligned by index; empty entries are valid.
+export const getColumnRowErrors = (
+  rows: ColumnRow[],
+  existing: ExistingColumnNames,
+  t: Translate,
+): ColumnRowError[] => {
+  const trimmedRows = rows.map((r) => ({ source: r.source_name.trim(), name: r.name.trim() }));
+
+  return rows.map((row, index) => {
+    const error: ColumnRowError = {};
+    const source = trimmedRows[index].source;
+    const name = trimmedRows[index].name;
+
+    if (source && name) {
+      const siblingSources = trimmedRows.filter((_, i) => i !== index).map((r) => r.source);
+      const siblingNames = trimmedRows.filter((_, i) => i !== index).map((r) => r.name);
+      const sourceError = getAnalyticsIdentifierError(source, [...existing.sourceNames, ...siblingSources], t);
+      if (sourceError) error.source_name = sourceError.text;
+      const nameError = getAnalyticsIdentifierError(name, [...existing.names, ...siblingNames], t);
+      if (nameError) error.name = nameError.text;
+    }
+
+    const tagError = getAnalyticsLengthError(row.tag, ANALYTICS_TAG_MAX_LENGTH, t);
+    if (tagError) error.tag = tagError.text;
+
+    return error;
+  });
 };
+
+export const hasColumnRowErrors = (errors: ColumnRowError[]): boolean =>
+  errors.some((e) => e.source_name || e.name || e.tag);
 
 const normalized = (value?: string): string => (value ?? '').trim();
 

--- a/apps/ai-dial-admin/src/constants/analytics/tables.ts
+++ b/apps/ai-dial-admin/src/constants/analytics/tables.ts
@@ -10,6 +10,11 @@ export const COLUMN_TYPE_OPTIONS: SelectOption[] = Object.values(AnalyticsFieldT
   label: capitalize(value),
 }));
 
+// Backend grammar for user-declared table/column identifiers (ADAS `Identifiers.requireUserIdentifier`):
+// snake_case, must start with a lowercase letter, and must not start with `_` (reserved for system columns).
+export const ANALYTICS_IDENTIFIER_PATTERN = /^[a-z][a-z0-9_]*$/;
+export const ANALYTICS_IDENTIFIER_MAX_LENGTH = 64;
+
 export const PARTITION_NONE = '';
 export const PARTITION_GRANULARITY_OPTIONS: SelectOption[] = [
   { value: PARTITION_NONE, label: 'None' },

--- a/apps/ai-dial-admin/src/constants/analytics/tables.ts
+++ b/apps/ai-dial-admin/src/constants/analytics/tables.ts
@@ -15,6 +15,11 @@ export const COLUMN_TYPE_OPTIONS: SelectOption[] = Object.values(AnalyticsFieldT
 export const ANALYTICS_IDENTIFIER_PATTERN = /^[a-z][a-z0-9_]*$/;
 export const ANALYTICS_IDENTIFIER_MAX_LENGTH = 64;
 
+// Backend length caps for a column's free-form catalog metadata (ADAS `TableColumnRules`).
+export const ANALYTICS_TAG_MAX_LENGTH = 64;
+export const ANALYTICS_DISPLAY_NAME_MAX_LENGTH = 128;
+export const ANALYTICS_DESCRIPTION_MAX_LENGTH = 1024;
+
 export const PARTITION_NONE = '';
 export const PARTITION_GRANULARITY_OPTIONS: SelectOption[] = [
   { value: PARTITION_NONE, label: 'None' },

--- a/apps/ai-dial-admin/src/constants/i18n.ts
+++ b/apps/ai-dial-admin/src/constants/i18n.ts
@@ -1039,6 +1039,7 @@ export enum ErrorI18nKey {
   KeyValueExists = 'Error.KeyValueExists',
   ForbiddenChars = 'Error.ForbiddenChars',
   AlphanumericUnderscore = 'Error.AlphanumericUnderscore',
+  SnakeCaseIdentifier = 'Error.SnakeCaseIdentifier',
   RequiredProperty = 'Error.RequiredProperty',
   InvalidPath = 'Error.InvalidPath',
   InvalidStatus = 'Error.InvalidStatus',
@@ -2276,7 +2277,4 @@ export enum AnalyticsTablesI18nKey {
   RowsInserted = 'AnalyticsTables.RowsInserted',
   ActionFailed = 'AnalyticsTables.ActionFailed',
   InvalidRowsJson = 'AnalyticsTables.InvalidRowsJson',
-  NameFormatError = 'AnalyticsTables.NameFormatError',
-  NameLengthError = 'AnalyticsTables.NameLengthError',
-  NameExistsError = 'AnalyticsTables.NameExistsError',
 }

--- a/apps/ai-dial-admin/src/constants/i18n.ts
+++ b/apps/ai-dial-admin/src/constants/i18n.ts
@@ -2276,4 +2276,7 @@ export enum AnalyticsTablesI18nKey {
   RowsInserted = 'AnalyticsTables.RowsInserted',
   ActionFailed = 'AnalyticsTables.ActionFailed',
   InvalidRowsJson = 'AnalyticsTables.InvalidRowsJson',
+  NameFormatError = 'AnalyticsTables.NameFormatError',
+  NameLengthError = 'AnalyticsTables.NameLengthError',
+  NameExistsError = 'AnalyticsTables.NameExistsError',
 }

--- a/apps/ai-dial-admin/src/locales/en.ts
+++ b/apps/ai-dial-admin/src/locales/en.ts
@@ -2327,5 +2327,9 @@ export default {
     RowsInserted: 'Rows inserted.',
     ActionFailed: 'The operation failed.',
     InvalidRowsJson: 'Rows must be a valid JSON array of objects.',
+    NameFormatError:
+      "Name must be lowercase snake_case: start with a letter, then letters, digits or underscores (must not start with '_').",
+    NameLengthError: 'Name must be at most {max} characters.',
+    NameExistsError: 'A table with this name already exists.',
   },
 } as const;

--- a/apps/ai-dial-admin/src/locales/en.ts
+++ b/apps/ai-dial-admin/src/locales/en.ts
@@ -1391,6 +1391,8 @@ export default {
     ForbiddenChars: 'Field must not contain forbidden characters: {list}',
     AlphanumericUnderscore:
       'Field must not contain forbidden characters. Only alphanumeric characters and underscore are allowed.',
+    SnakeCaseIdentifier:
+      "Must be lowercase snake_case: start with a letter, then letters, digits or underscores (must not start with '_').",
     KeyValueExists: 'This value already exists.',
     DisplayNameErrorVersion:
       'This name is used by versionless entity. Specify version for entity with this display name to group entities.',
@@ -2327,9 +2329,5 @@ export default {
     RowsInserted: 'Rows inserted.',
     ActionFailed: 'The operation failed.',
     InvalidRowsJson: 'Rows must be a valid JSON array of objects.',
-    NameFormatError:
-      "Name must be lowercase snake_case: start with a letter, then letters, digits or underscores (must not start with '_').",
-    NameLengthError: 'Name must be at most {max} characters.',
-    NameExistsError: 'A table with this name already exists.',
   },
 } as const;

--- a/apps/ai-dial-admin/src/models/analytics/tables-ui.ts
+++ b/apps/ai-dial-admin/src/models/analytics/tables-ui.ts
@@ -11,6 +11,20 @@ export interface ColumnRow {
   sensitive: boolean;
 }
 
+// Per-row validation messages for a ColumnRow; an absent key means that field is valid.
+export interface ColumnRowError {
+  source_name?: string;
+  name?: string;
+  tag?: string;
+}
+
+// Names already declared on the table an "Add columns" patch targets; new rows must not collide with
+// them. Empty for the create-table flow, where no columns exist yet.
+export interface ExistingColumnNames {
+  sourceNames: string[];
+  names: string[];
+}
+
 export interface ColumnEditValues {
   name: string;
   display_name: string;

--- a/apps/ai-dial-admin/src/utils/validation/analytics-table-error.ts
+++ b/apps/ai-dial-admin/src/utils/validation/analytics-table-error.ts
@@ -1,0 +1,43 @@
+import { ANALYTICS_IDENTIFIER_MAX_LENGTH, ANALYTICS_IDENTIFIER_PATTERN } from '@/src/constants/analytics/tables';
+import { ErrorI18nKey } from '@/src/constants/i18n';
+import { FieldError } from '@/src/models/error';
+import { ErrorType } from '@/src/types/error-type';
+
+type Translate = (key: string, args?: Record<string, string | number>) => string;
+
+/**
+ * Validates a user-declared analytics identifier (a table or column name) against the backend grammar
+ * (ADAS `Identifiers.requireUserIdentifier`): lowercase snake_case, at most
+ * {@link ANALYTICS_IDENTIFIER_MAX_LENGTH} characters, no leading underscore — plus optional uniqueness
+ * against `existingNames`. Returns a {@link FieldError} or null when valid. A blank value returns null:
+ * emptiness is signalled by the required marker and a disabled submit, not an inline error.
+ */
+export const getAnalyticsIdentifierError = (
+  value: string,
+  existingNames: string[],
+  t: Translate,
+): FieldError | null => {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (trimmed.length > ANALYTICS_IDENTIFIER_MAX_LENGTH) {
+    return { type: ErrorType.LENGTH, text: t(ErrorI18nKey.Length, { number: ANALYTICS_IDENTIFIER_MAX_LENGTH }) };
+  }
+  if (!ANALYTICS_IDENTIFIER_PATTERN.test(trimmed)) {
+    return { type: ErrorType.FORBIDDEN_CHARS, text: t(ErrorI18nKey.SnakeCaseIdentifier) };
+  }
+  if (existingNames.includes(trimmed)) {
+    return { type: ErrorType.EXISTING, text: t(ErrorI18nKey.KeyValueExists) };
+  }
+  return null;
+};
+
+/**
+ * Validates an optional free-form catalog metadata field (tag / display name / description) against its
+ * backend length cap. Blank is allowed (clears the attribute); returns a {@link FieldError} or null.
+ */
+export const getAnalyticsLengthError = (value: string, max: number, t: Translate): FieldError | null => {
+  if (value.trim().length > max) {
+    return { type: ErrorType.LENGTH, text: t(ErrorI18nKey.Length, { number: max }) };
+  }
+  return null;
+};

--- a/apps/ai-dial-admin/src/utils/validation/tests/analytics-table-error.spec.ts
+++ b/apps/ai-dial-admin/src/utils/validation/tests/analytics-table-error.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'vitest';
+
+import { ErrorI18nKey } from '@/src/constants/i18n';
+import { ErrorType } from '@/src/types/error-type';
+import { getAnalyticsIdentifierError, getAnalyticsLengthError } from '@/src/utils/validation/analytics-table-error';
+
+// Stub t() returns the key so assertions target the i18n key, not translated text.
+const t = (key: string) => key;
+
+describe('getAnalyticsIdentifierError', () => {
+  test('returns null for a blank value (emptiness is signalled elsewhere)', () => {
+    expect(getAnalyticsIdentifierError('', [], t)).toBeNull();
+    expect(getAnalyticsIdentifierError('   ', [], t)).toBeNull();
+  });
+
+  test('accepts valid lowercase snake_case identifiers, trimming first', () => {
+    expect(getAnalyticsIdentifierError('events', [], t)).toBeNull();
+    expect(getAnalyticsIdentifierError('user_events_2', [], t)).toBeNull();
+    expect(getAnalyticsIdentifierError('  events  ', [], t)).toBeNull();
+  });
+
+  test('rejects grammar violations with a forbidden-chars error', () => {
+    for (const bad of ['Events', '_events', '2events', 'my-table', 'my table']) {
+      expect(getAnalyticsIdentifierError(bad, [], t)).toEqual({
+        type: ErrorType.FORBIDDEN_CHARS,
+        text: ErrorI18nKey.SnakeCaseIdentifier,
+      });
+    }
+  });
+
+  test('rejects values longer than the identifier max length', () => {
+    expect(getAnalyticsIdentifierError('a'.repeat(65), [], t)).toEqual({
+      type: ErrorType.LENGTH,
+      text: ErrorI18nKey.Length,
+    });
+    expect(getAnalyticsIdentifierError('a'.repeat(64), [], t)).toBeNull();
+  });
+
+  test('rejects a value that collides with an existing name (compared after trimming)', () => {
+    expect(getAnalyticsIdentifierError('events', ['events', 'orders'], t)).toEqual({
+      type: ErrorType.EXISTING,
+      text: ErrorI18nKey.KeyValueExists,
+    });
+    expect(getAnalyticsIdentifierError('  events  ', ['events'], t)?.type).toBe(ErrorType.EXISTING);
+    expect(getAnalyticsIdentifierError('events', ['orders'], t)).toBeNull();
+  });
+});
+
+describe('getAnalyticsLengthError', () => {
+  test('returns null when within the cap (blank allowed)', () => {
+    expect(getAnalyticsLengthError('', 64, t)).toBeNull();
+    expect(getAnalyticsLengthError('short', 64, t)).toBeNull();
+    expect(getAnalyticsLengthError('a'.repeat(64), 64, t)).toBeNull();
+  });
+
+  test('returns a length error when over the cap (measured after trimming)', () => {
+    expect(getAnalyticsLengthError('a'.repeat(65), 64, t)).toEqual({
+      type: ErrorType.LENGTH,
+      text: ErrorI18nKey.Length,
+    });
+    expect(getAnalyticsLengthError(`  ${'a'.repeat(64)}  `, 64, t)).toBeNull();
+  });
+});


### PR DESCRIPTION
**Description:**

Adds front-end validation across the Analytics **Tables** page so user-declared values are caught before they reach the backend (matching the ADAS grammar in `Identifiers.requireUserIdentifier` and `TableColumnRules`), and marks required sections on the create-source form. Addresses review comments 1–3 on the issue (comment 3 Nullable and comment 4 decimal were confirmed out of scope; comment 5 array type needs backend support).

What changed:

- **Create table — Name** (source & enrichment): validate against the identifier grammar (lowercase snake_case, ≤64 chars, no leading `_`) plus uniqueness; inline error and submit gating instead of a backend error.
- **Required sections** on Create source table: `*` markers on **Columns** and **Ordering key**, and submit is gated until both are provided (backend requires ≥1 column and a non-empty ordering key). `ordering_key` is now always sent.
- **ColumnRowsEditor** (create + add columns): per-row `source_name`/`name` grammar + uniqueness (vs sibling rows and pre-existing columns) and tag length; inline errors + submit gating.
- **EditColumnPopup**: rename-target grammar + uniqueness against other columns, and tag/display_name/description length caps; submit gating.
- **Inline grid rename**: validate the new name and revert with a notification on failure.
- Validation reuses the app's shared framework: new `utils/validation/analytics-table-error.ts` helpers returning `FieldError`, reusing `ErrorType` and shared `Error` i18n messages (`Length`, `KeyValueExists`) plus a new `SnakeCaseIdentifier` message.

Tests: new `analytics-table-error.spec.ts`, extended `Tables` utils/CreateTablePopup/EditColumnPopup specs (48 passing in the Tables suite). Lint, prettier, and typecheck of touched files clean.

Issues:

- Issue #3847


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)