### PR TITLE
fix: [Assets-Applications] Apply button not disabled when required fields for Api Key/OAuth authentication are empty in External Services (Issue #3958)

### DIFF
--- a/apps/ai-dial-admin/src/components/Assets/Resources/Auth/ResourceMultiAuth.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Resources/Auth/ResourceMultiAuth.tsx
@@ -21,6 +21,7 @@ import {
   ExternalServiceI18nKey,
 } from '@/src/constants/i18n';
 import { BASE_BUTTON_ICON_PROPS, STANDARD_CONTROL_WIDTH } from '@/src/constants/main-layout';
+import { useSaveValidationContext } from '@/src/context/SaveValidationContext';
 import { useIsReadOnlyAdmin } from '@/src/hooks/use-is-read-only-admin';
 import { useI18n } from '@/src/locales/client';
 import { DialApplicationResource, DialExternalService, ToolsetAuthType } from '@/src/models/dial/resource';
@@ -42,6 +43,7 @@ interface Props {
 const ResourceMultiAuth: FC<Props> = ({ asset, onChange }) => {
   const t = useI18n();
   const isReadOnlyAdmin = useIsReadOnlyAdmin();
+  const { isValid } = useSaveValidationContext();
   const [editState, setEditState] = useState<EditState | null>(null);
   const [loadingServiceId, setLoadingServiceId] = useState<string | null>(null);
 
@@ -150,7 +152,11 @@ const ResourceMultiAuth: FC<Props> = ({ asset, onChange }) => {
         {!isReadOnlyAdmin && (
           <div className="flex justify-end gap-x-2">
             <DialNeutralButton label={t(ButtonsI18nKey.Back)} onClick={onBack} />
-            <DialPrimaryButton label={t(ButtonsI18nKey.Apply)} onClick={onSave} disabled={!editState.currentId} />
+            <DialPrimaryButton
+              label={t(ButtonsI18nKey.Apply)}
+              onClick={onSave}
+              disabled={!editState.currentId || !isValid}
+            />
           </div>
         )}
       </div>


### PR DESCRIPTION
**Description:**

added validation for adding external service

Issues:

- Issue #3958


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
