### PR TITLE
fix: [Assets-Applications] JSON editor in Parameters tab always renders in dark theme regardless of UI theme (Issue #3965)

### DIFF
--- a/apps/ai-dial-admin/src/components/Common/SchemaUIRenderer/SchemaUIRenderer.tsx
+++ b/apps/ai-dial-admin/src/components/Common/SchemaUIRenderer/SchemaUIRenderer.tsx
@@ -2,9 +2,12 @@
 
 import { FC, useCallback } from 'react';
 
-import { STANDARD_CONTROL_WIDTH } from '@/src/constants/main-layout';
-import { useIsReadOnlyAdmin } from '@/src/hooks/use-is-read-only-admin';
 import { DialSchemaRenderer, JsonSchema } from '@epam/ai-dial-ui-kit';
+import { EditorThemes } from '@epam/ai-dial-ui-kit/dist/src/types/editor';
+
+import { STANDARD_CONTROL_WIDTH } from '@/src/constants/main-layout';
+import { useTheme } from '@/src/context/ThemeContext';
+import { useIsReadOnlyAdmin } from '@/src/hooks/use-is-read-only-admin';
 
 interface Props {
   schema: JsonSchema;
@@ -25,6 +28,7 @@ const SchemaUiRenderer: FC<Props> = ({
   acceptableResourceTypes,
 }) => {
   const isReadOnlyAdmin = useIsReadOnlyAdmin();
+  const { currentTheme } = useTheme();
   const isReadonly = disabled || isReadOnlyAdmin;
   const onChange = useCallback(
     (value: Record<string, unknown>) => {
@@ -43,6 +47,7 @@ const SchemaUiRenderer: FC<Props> = ({
       inputClassName={STANDARD_CONTROL_WIDTH}
       defaultExpanded={defaultExpanded}
       acceptableResourceTypes={acceptableResourceTypes}
+      jsonEditorTheme={currentTheme as EditorThemes}
     />
   );
 };


### PR DESCRIPTION
**Description:**

added theme support in schema renderer

Issues:

- Issue #3965


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
