### PR TITLE
fix: [Assets-Applications] External Service login fails when app folder name contains spaces  (Issue #3976)

### DIFF
--- a/apps/ai-dial-admin/openspec/changes/archive/2026-07-21-fix-external-service-config-issues/.openspec.yaml
+++ b/apps/ai-dial-admin/openspec/changes/archive/2026-07-21-fix-external-service-config-issues/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-21

--- a/apps/ai-dial-admin/openspec/changes/archive/2026-07-21-fix-external-service-config-issues/design.md
+++ b/apps/ai-dial-admin/openspec/changes/archive/2026-07-21-fix-external-service-config-issues/design.md
@@ -1,0 +1,85 @@
+## Context
+
+Three bugs (#3970, #3971, #3976) were reported against the External Services section of
+Applications → Properties, all rooted in the same small cluster of files:
+`ResourceMultiAuth.tsx`, `ResourceAuthentication.tsx`/`ResourceAuthTypeSection.tsx`, and the
+`signInExternalService`/`signOutExternalService` server actions in `actions.ts`.
+`ResourceAuthentication` is shared with the Toolset auth UI (`ResourceAuthTypeSection.tsx` renders
+one card per `AuthConfig` in a fixed `authOptions` array of OAuth/API_KEY/NONE), so changes there
+must not affect Toolset behavior.
+
+While investigating #3971, a discrepancy surfaced between the current consolidated spec and the
+actual code: `openspec/specs/app-external-services-auth/spec.md` states the Service ID field is
+"read-only for existing services" / "not editable" in edit mode, but `ResourceMultiAuth.tsx`
+already renders `serviceId` as a normal controlled `DialInput` with no such restriction, and
+`onSave` already handles the rename case (`if (originalId && originalId !== currentId) delete
+updated[originalId]`). Renaming already works in the shipped app; the spec text was simply stale.
+This change corrects that spec text to match reality as part of fixing the duplicate-ID bug, since
+the duplicate check needs to explicitly cover the rename path.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Remove "Without authentication" from the external-service auth type selector without touching
+  Toolset auth options.
+- Reject duplicate Service IDs on both Add and rename-during-Edit, with a visible field error and
+  a disabled Apply button (consistent with how other required-field validation already blocks
+  Apply in this form).
+- Make external-service sign-in/sign-out work when the app's resource path contains characters
+  that aren't valid unencoded in a URL segment (starting with spaces, per #3976).
+- Bring `app-external-services-auth` spec back in sync with actual Service-ID-editable behavior.
+
+**Non-Goals:**
+- Case-insensitive or whitespace-normalized duplicate ID comparison — the report describes exact
+  duplicates only; broader normalization is out of scope unless it resurfaces later.
+- Any change to Toolset auth type options or Toolset ID handling.
+- Backend changes — the fix for #3976 is entirely on the request-construction side; the backend
+  already handles encoded paths correctly per the issue's own diagnosis.
+
+## Decisions
+
+### 1. New `excludeAuthTypes?: ToolsetAuthType[]` prop on `ResourceAuthentication`
+Filters the `authOptions` array before both the disabled-view and interactive-view render paths in
+`ResourceAuthentication.tsx`. `ResourceMultiAuth` passes `excludeAuthTypes={[ToolsetAuthType.NONE]}`;
+the Toolset caller passes nothing, so it's fully backward compatible.
+
+**Alternative considered:** repurpose `hideWithLoginOption` to also drop NONE from the options
+list. Rejected — that prop currently controls a narrower, unrelated concern (whether the
+"With login" vs "With login and config" radio choice shows inside the OAuth card in
+`ResourceAuthTypeSection.tsx`). Overloading it would make future changes to either concern
+ambiguous about which behavior they're touching.
+
+### 2. Duplicate Service ID check lives in `ResourceMultiAuth`, gates Apply
+`onSave`'s pre-condition already gates Apply on `!editState.currentId || !isValid`. We add a
+derived `isDuplicateId` check (`currentId !== originalId && !!services[currentId]`) computed in
+the component body and combine it into the Apply `disabled` expression, plus render an inline
+error under the Service ID `DialInput` when true. A single check expression covers both Add
+(`originalId === ''`) and rename-during-Edit (`originalId !== '' && originalId !== currentId`)
+because both cases reduce to "does another entry already own this ID."
+
+**Alternative considered:** validate only on Add, per the literal wording of #3971's repro steps.
+Rejected per explicit product decision — the same silent-overwrite bug exists on rename via the
+identical `updated[currentId] = service` line in `onSave`, so leaving it unfixed there would just
+relocate the bug rather than fix it.
+
+### 3. Encode `appPath` with the existing `encodeCorePath` helper
+`encodeCorePath` (`@/src/server/publications/path.ts`) already implements exactly the needed
+per-segment `encodeURIComponent` + rejoin-with-`/` behavior, and is already a cross-feature import
+used elsewhere in `actions.ts` (`getVersionedName` from the same module). Reusing it means no new
+utility, no duplicated logic, and no relocation — apply it at the two `url:` template-literal call
+sites in `signInExternalService` and `signOutExternalService`.
+
+**Alternative considered:** `encodeURIComponent(appPath)` as a single call. Rejected — `appPath`
+contains `/` folder separators; a blind whole-string encode would turn those into `%2F` and break
+the path structure the backend expects.
+
+## Risks / Trade-offs
+
+- [Existing e2e/manual flows that relied on selecting "Without authentication" for an external
+  service] → None expected: per the issue, that option was never valid for external services in
+  the first place; no legitimate saved data depends on it.
+- [Spec correction for Service-ID-editable-on-edit could be read as an unrelated scope-creep change
+  by reviewers] → Called out explicitly in this design doc and scoped to a one-line factual
+  correction, not a behavior change.
+- [Duplicate-ID check does not normalize case or whitespace] → Acceptable per Non-Goals; can be
+  revisited if a future report asks for it.

--- a/apps/ai-dial-admin/openspec/changes/archive/2026-07-21-fix-external-service-config-issues/proposal.md
+++ b/apps/ai-dial-admin/openspec/changes/archive/2026-07-21-fix-external-service-config-issues/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+Three related bugs in the Applications → Properties → External Services flow were reported
+close together (#3970, #3971, #3976): the auth type selector offers an invalid "Without
+authentication" option, duplicate Service IDs silently overwrite each other instead of being
+rejected, and logging in to an external service fails with a Bad Request whenever the app's
+folder path contains a space. All three sit in the same small surface
+(`ResourceMultiAuth`/`ResourceAuthentication` and the external-service sign-in/sign-out server
+actions), so they're fixed together in one change.
+
+## What Changes
+
+- Add an `excludeAuthTypes?: ToolsetAuthType[]` prop to `ResourceAuthentication` and pass
+  `[ToolsetAuthType.NONE]` from `ResourceMultiAuth` so "Without authentication" is no longer
+  selectable for external services (it remains available for Toolsets, which don't pass the prop).
+- Validate Service ID uniqueness in `ResourceMultiAuth` on both Add and Edit(rename): if the
+  entered ID matches another existing entry, show a field-level error and disable the Apply
+  button. The check compares the entered ID against every other key in `external_services`,
+  excluding the entry's own original ID (so re-saving without renaming is unaffected).
+- Fix external-service sign-in/sign-out URL construction to per-segment URL-encode the app path
+  using the existing `encodeCorePath` helper (`@/src/server/publications/path`), so folder names
+  containing spaces (or other reserved characters) no longer produce a malformed `url` and a
+  Bad Request from the backend.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `app-external-services-auth`: the auth type selector no longer offers "Without authentication";
+  adding/renaming a service now validates against duplicate Service IDs; the sign-in/sign-out
+  `url` field is now segment-encoded so paths with spaces work.
+
+## Impact
+
+- `apps/ai-dial-admin/src/components/Assets/Resources/Auth/ResourceAuthentication.tsx`
+- `apps/ai-dial-admin/src/components/Assets/Resources/Auth/ResourceMultiAuth.tsx`
+- `apps/ai-dial-admin/src/app/[lang]/assets-applications/actions.ts`
+- No new i18n key needed — reuses the existing `ErrorI18nKey.NameExists` message
+- No backend changes; no breaking changes to existing Toolset auth usage (Toolsets continue to
+  offer all three auth types, unaffected by the new `excludeAuthTypes` prop).

--- a/apps/ai-dial-admin/openspec/changes/archive/2026-07-21-fix-external-service-config-issues/specs/app-external-services-auth/spec.md
+++ b/apps/ai-dial-admin/openspec/changes/archive/2026-07-21-fix-external-service-config-issues/specs/app-external-services-auth/spec.md
@@ -1,30 +1,5 @@
 ## ADDED Requirements
 
-### Requirement: External services list displayed in App Properties
-The App Properties panel SHALL display a "External Services" section above the `EntityAttachments` component when the app is opened. The section renders each entry in `app.external_services` as a row showing the auth type icon, display name (falling back to the service ID), an Edit button, and Login/Logout buttons (when `authentication_type !== NONE`).
-
-#### Scenario: App has no external services
-- **WHEN** the app's `external_services` map is empty or absent
-- **THEN** the section shows only an "Add Service" button and no rows
-
-#### Scenario: App has external services
-- **WHEN** the app's `external_services` map contains one or more entries
-- **THEN** each entry is rendered as a row with the service's display name (or ID if no display name), the auth type icon, and action buttons
-
-#### Scenario: Service with NONE auth type
-- **WHEN** a service has `authentication_type === NONE`
-- **THEN** no Login or Logout buttons are shown for that row
-
-#### Scenario: Service shows as logged in
-- **WHEN** a service's `auth_settings.app_level_auth_status === SIGNED_IN` OR `auth_settings.user_level_auth_status === SIGNED_IN`
-- **THEN** the row shows a Logout button and no Login button
-
-#### Scenario: Service shows as logged out
-- **WHEN** a service's `app_level_auth_status` and `user_level_auth_status` are both not `SIGNED_IN`
-- **THEN** the row shows a Login button (if `authentication_type !== NONE`)
-
----
-
 ### Requirement: External service auth type selector excludes "Without authentication"
 The `ResourceAuthentication` component used by `ResourceMultiAuth` for external services SHALL NOT
 offer the `NONE` ("Without authentication") auth type as a selectable option, since an external
@@ -60,7 +35,7 @@ or other reserved characters do not produce a malformed request.
   segment URL-encoded (e.g. `public/als%20code%20apps/my-app`)
 - **AND** the sign-in/sign-out request succeeds instead of returning a Bad Request
 
----
+## MODIFIED Requirements
 
 ### Requirement: Add external service
 The App Properties panel SHALL provide an "Add Service" button that opens an inline edit form
@@ -118,54 +93,6 @@ and auth settings via the Edit button in the list row.
 
 ---
 
-### Requirement: Delete external service
-The App Properties edit mode SHALL provide a way to remove an external service from the app's `external_services` map.
-
-#### Scenario: User deletes a service from edit mode
-- **WHEN** the user is in edit mode for an existing service and confirms deletion
-- **THEN** the service is removed from the local `external_services` map
-- **AND** the component returns to list mode
-- **AND** the deletion is persisted when the parent app Save is triggered
-
----
-
-### Requirement: Login to external service
-The App Properties panel SHALL allow the user to sign in to an external service at APPLICATION level, USER level, or both, using the same popup pattern as asset toolsets.
-
-#### Scenario: User opens login popup
-- **WHEN** the user clicks the Login button on a service row
-- **THEN** a login popup opens allowing the user to select APPLICATION level, USER level, or both
-
-#### Scenario: API key login
-- **WHEN** the service uses `authentication_type === API_KEY` and the user confirms login
-- **THEN** `POST /v1/ops/external-service/signin` is called with `url = applications/{appId}/external_services/{serviceId}`, the selected `credentials_level`, `authentication_type: API_KEY`, and the entered `api_key`
-
-#### Scenario: OAuth login
-- **WHEN** the service uses `authentication_type === OAUTH` and the user confirms login
-- **THEN** the browser navigates to the OAuth provider's authorization endpoint
-- **AND** the `redirect_uri` is set to `{origin}/external-service-signin`
-- **AND** the app ID, service ID, and selected credential level are stored in localStorage for the callback
-
-#### Scenario: OAuth callback completes
-- **WHEN** the OAuth provider redirects to `/external-service-signin` with a `code` parameter
-- **THEN** `signInExternalService` is called with the code
-- **AND** on success the browser navigates back to the original app page
-
----
-
-### Requirement: Logout from external service
-The App Properties panel SHALL allow the user to sign out from an external service at a specific credential level.
-
-#### Scenario: User clicks Logout for single-level login
-- **WHEN** the user is signed in at exactly one level and clicks Logout
-- **THEN** `POST /v1/ops/external-service/signout` is called for that level without a confirmation popup
-
-#### Scenario: User clicks Logout for multi-level login
-- **WHEN** the user is signed in at both APPLICATION and USER levels and clicks Logout
-- **THEN** a confirmation popup appears allowing the user to choose which level(s) to sign out from
-
----
-
 ### Requirement: Generalized ResourceAuthentication component
 `ResourceAuthentication` SHALL accept a generic `authSettings` object and `name` string instead of
 a full `DialToolsetResource`, enabling reuse for external services. An optional
@@ -190,12 +117,3 @@ An optional `excludeAuthTypes` prop filters specific auth types out of the selec
   `redirectUrl={EXTERNAL_SERVICE_AUTH_REDIRECT_URL}`, `onChange`, and
   `excludeAuthTypes={[ToolsetAuthType.NONE]}`
 - **AND** `onChangeForwardPerRequestKey` is not passed
-
----
-
-### Requirement: Auth status stripping before app save
-The server action (or client-side mapper) SHALL strip `app_level_auth_status`, `user_level_auth_status`, and `global_auth_status` from every service's `auth_settings` before including `external_services` in the app PUT body.
-
-#### Scenario: App is saved with external services that have auth statuses
-- **WHEN** the app is saved and `external_services` entries contain auth status fields
-- **THEN** those status fields are absent from the PUT request body

--- a/apps/ai-dial-admin/openspec/changes/archive/2026-07-21-fix-external-service-config-issues/tasks.md
+++ b/apps/ai-dial-admin/openspec/changes/archive/2026-07-21-fix-external-service-config-issues/tasks.md
@@ -1,0 +1,54 @@
+## 1. Auth type selector (#3970)
+
+- [x] 1.1 Add `excludeAuthTypes?: ToolsetAuthType[]` to `ResourceAuthentication`'s `Props`
+      (`src/components/Assets/Resources/Auth/ResourceAuthentication.tsx`) and filter `authOptions`
+      by it before both the disabled-view and interactive-view render paths (keeping the
+      currently-selected type visible even if excluded, so pre-existing NONE-saved services don't
+      crash the read-only view)
+- [x] 1.2 Pass `excludeAuthTypes={[ToolsetAuthType.NONE]}` from `ResourceMultiAuth`
+      (`src/components/Assets/Resources/Auth/ResourceMultiAuth.tsx`) when rendering
+      `ResourceAuthentication`
+- [x] 1.3 Confirm the Toolset auth caller (`src/components/Assets/Toolsets/View/Properties.tsx`,
+      which renders `ResourceAuthentication` with `redirectUrl={TOOLSET_AUTH_REDIRECT_URL}`) is
+      unchanged and still offers all three auth types
+
+## 2. Duplicate Service ID validation (#3971)
+
+- [x] 2.1 In `ResourceMultiAuth.tsx`, compute a derived `isDuplicateId` value from `editState`
+      (`editState.currentId !== editState.originalId && !!services[editState.currentId]`)
+- [x] 2.2 Render an inline validation error under the Service ID `DialInput` when
+      `isDuplicateId` is true, reusing the existing generic `ErrorI18nKey.NameExists`
+      ("This ID already exists.") instead of adding a new key
+- [x] 2.3 Extend the Apply button's `disabled` condition to include `isDuplicateId` so the save is
+      blocked for both Add and rename-during-Edit
+- [x] 2.4 Correct the stale "Service ID is read-only when editing" claim by verifying the field
+      remains a normal editable `DialInput` in edit mode (no code change expected here — this is
+      confirming current behavior matches the corrected spec)
+
+## 3. Scope URL encoding for external service login (#3976)
+
+- [x] 3.1 Import `encodeCorePath` from `@/src/server/publications/path` into
+      `src/app/[lang]/assets-applications/actions.ts`
+- [x] 3.2 Wrap `appPath` with `encodeCorePath(...)` in the `url:` template literal in both
+      `signInExternalService` and `signOutExternalService`
+
+## 4. Tests
+
+- [x] 4.1 Add/extend component tests for `ResourceAuthentication`
+      (`src/components/Assets/Resources/Auth/tests/ResourceAuthentication.spec.tsx`) covering:
+      `excludeAuthTypes` hides the given option; omitting the prop preserves all three options; a
+      persisted (not just defaulted) excluded auth type stays visible
+- [x] 4.2 Add/extend component tests for `ResourceMultiAuth`
+      (`src/components/Assets/Resources/Auth/tests/ResourceMultiAuth.spec.tsx`) covering: adding a
+      service with an ID that already exists shows the error and disables Apply; renaming a
+      service to an ID owned by a different entry shows the error and disables Apply; renaming a
+      service to its own original ID (no-op) does not show the error; Add form excludes
+      "Without authentication". Added `aria-label`s to the row Edit/Delete icon buttons
+      (previously unqueryable by role/name) to support this.
+- [x] 4.3 Extend `src/app/[lang]/assets-applications/actions.spec.ts` covering:
+      `signInExternalService`/`signOutExternalService` build a `url` with each path segment of a
+      spaced app path URL-encoded
+
+## 5. Quality checks
+
+- [x] 5.1 Run lint, format check, and full test suite; fix any failures

--- a/apps/ai-dial-admin/src/app/[lang]/assets-applications/actions.spec.ts
+++ b/apps/ai-dial-admin/src/app/[lang]/assets-applications/actions.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { assetApi, assetsApi, toolsetOpsApi } from '@/src/app/api/api';
+import { assetApi, assetsApi, externalServiceOpsApi, toolsetOpsApi } from '@/src/app/api/api';
 import * as eximModule from '@/src/server/applications/exim';
 import * as zipEximModule from '@/src/server/applications/zip-exim';
 import { getUserToken } from '@/src/utils/auth/auth-request';
@@ -17,6 +17,8 @@ import {
   importApps,
   exportApps,
   getAssetTools,
+  signInExternalService,
+  signOutExternalService,
 } from './actions';
 import { DialFileNodeType } from '@/src/models/dial/file';
 import { ResourceType } from '@/src/types/resource-type';
@@ -339,6 +341,43 @@ describe('Assets application :: server actions', () => {
     const result = await getAssetTools('test');
     expect(getUserToken).toHaveBeenCalled();
     expect(toolsetOpsApi.discoveredTools).toHaveBeenCalledWith(TOKEN_MOCK, 'test', ResourceType.APPLICATION);
+    expect(result).toBe(RESPONSE_MOCK);
+  });
+
+  test('signInExternalService URL-encodes each path segment of a spaced app path', async () => {
+    (externalServiceOpsApi.signIn as any).mockResolvedValue(RESPONSE_MOCK);
+
+    const result = await signInExternalService(
+      'public/als code apps/my-app',
+      'test-service',
+      'APPLICATION',
+      'API_KEY',
+      undefined,
+      'api-key-value',
+    );
+
+    expect(getUserToken).toHaveBeenCalled();
+    expect(externalServiceOpsApi.signIn).toHaveBeenCalledWith(TOKEN_MOCK, {
+      url: 'applications/public/als%20code%20apps/my-app/external_services/test-service',
+      credentialsLevel: 'APPLICATION',
+      authenticationType: 'API_KEY',
+      offline_usage_consent: true,
+      apiKey: 'api-key-value',
+    });
+    expect(result).toBe(RESPONSE_MOCK);
+  });
+
+  test('signOutExternalService URL-encodes each path segment of a spaced app path', async () => {
+    (externalServiceOpsApi.signOut as any).mockResolvedValue(RESPONSE_MOCK);
+
+    const result = await signOutExternalService('public/als code apps/my-app', 'test-service', 'USER', 'API_KEY');
+
+    expect(getUserToken).toHaveBeenCalled();
+    expect(externalServiceOpsApi.signOut).toHaveBeenCalledWith(TOKEN_MOCK, {
+      url: 'applications/public/als%20code%20apps/my-app/external_services/test-service',
+      credentialsLevel: 'USER',
+      authenticationType: 'API_KEY',
+    });
     expect(result).toBe(RESPONSE_MOCK);
   });
 });

--- a/apps/ai-dial-admin/src/app/[lang]/assets-applications/actions.ts
+++ b/apps/ai-dial-admin/src/app/[lang]/assets-applications/actions.ts
@@ -13,7 +13,7 @@ import { bulkDeleteAssets } from '@/src/server/assets/bulk-delete';
 import { runAssetExportAction, runAssetImportAction } from '@/src/server/assets/import-export-action';
 import { moveAssets } from '@/src/server/assets/move';
 import { validateApplicationResourceFields } from '@/src/server/core/asset-validation';
-import { getVersionedName } from '@/src/server/publications/path';
+import { encodeCorePath, getVersionedName } from '@/src/server/publications/path';
 import { ImportFileType } from '@/src/types/import';
 import { ResourceType } from '@/src/types/resource-type';
 import { getUserToken } from '@/src/utils/auth/auth-request';
@@ -159,7 +159,7 @@ export async function signInExternalService(
 ) {
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
   const body: Record<string, unknown> = {
-    url: `applications/${appPath}/external_services/${serviceId}`,
+    url: `applications/${encodeCorePath(appPath)}/external_services/${serviceId}`,
     credentialsLevel: level,
     authenticationType: authType,
     offline_usage_consent: true,
@@ -176,7 +176,7 @@ export async function signInExternalService(
 export async function signOutExternalService(appPath: string, serviceId: string, level: string, authType: string) {
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
   return externalServiceOpsApi.signOut(token, {
-    url: `applications/${appPath}/external_services/${serviceId}`,
+    url: `applications/${encodeCorePath(appPath)}/external_services/${serviceId}`,
     credentialsLevel: level,
     authenticationType: authType,
   });

--- a/apps/ai-dial-admin/src/components/Assets/Resources/Auth/ResourceAuthentication.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Resources/Auth/ResourceAuthentication.tsx
@@ -18,6 +18,7 @@ interface Props {
   redirectUrl?: string;
   disabled?: boolean;
   hideWithLoginOption?: boolean;
+  excludeAuthTypes?: ToolsetAuthType[];
   onChange?: (authSettings: DialToolsetResourceAuthSettings, forwardPerRequestKey?: boolean) => void;
 }
 
@@ -33,6 +34,7 @@ const ResourceAuthentication: FC<Props> = ({
   authSettings,
   redirectUrl,
   hideWithLoginOption,
+  excludeAuthTypes,
   onChange,
   ...props
 }) => {
@@ -42,11 +44,23 @@ const ResourceAuthentication: FC<Props> = ({
   const isDisabled = disabled || isReadOnlyAdmin;
   const selectedAuthType = useMemo(() => authSettings?.authentication_type || ToolsetAuthType.NONE, [authSettings]);
 
-  const authOptions: AuthConfig[] = [
-    { id: ToolsetAuthType.OAUTH, title: t(ToolsetI18nKey.OAuth), icon: <IconBrandOauth {...BASE_BUTTON_ICON_PROPS} /> },
-    { id: ToolsetAuthType.API_KEY, title: t(ToolsetI18nKey.ApiKey), icon: <IconKey {...BASE_BUTTON_ICON_PROPS} /> },
-    { id: ToolsetAuthType.NONE, title: t(ToolsetI18nKey.NoneAuth), icon: <IconLockOff {...BASE_BUTTON_ICON_PROPS} /> },
-  ];
+  const authOptions: AuthConfig[] = useMemo(
+    () =>
+      [
+        {
+          id: ToolsetAuthType.OAUTH,
+          title: t(ToolsetI18nKey.OAuth),
+          icon: <IconBrandOauth {...BASE_BUTTON_ICON_PROPS} />,
+        },
+        { id: ToolsetAuthType.API_KEY, title: t(ToolsetI18nKey.ApiKey), icon: <IconKey {...BASE_BUTTON_ICON_PROPS} /> },
+        {
+          id: ToolsetAuthType.NONE,
+          title: t(ToolsetI18nKey.NoneAuth),
+          icon: <IconLockOff {...BASE_BUTTON_ICON_PROPS} />,
+        },
+      ].filter((option) => authSettings?.authentication_type === option.id || !excludeAuthTypes?.includes(option.id)),
+    [t, excludeAuthTypes, authSettings],
+  );
 
   const onChangeAuthType = useCallback(
     (authenticationType: ToolsetAuthType) => {

--- a/apps/ai-dial-admin/src/components/Assets/Resources/Auth/ResourceMultiAuth.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Resources/Auth/ResourceMultiAuth.tsx
@@ -18,6 +18,7 @@ import {
   ButtonsI18nKey,
   EntityFieldsI18nKey,
   EntityPlaceholdersI18nKey,
+  ErrorI18nKey,
   ExternalServiceI18nKey,
 } from '@/src/constants/i18n';
 import { BASE_BUTTON_ICON_PROPS, STANDARD_CONTROL_WIDTH } from '@/src/constants/main-layout';
@@ -48,6 +49,11 @@ const ResourceMultiAuth: FC<Props> = ({ asset, onChange }) => {
   const [loadingServiceId, setLoadingServiceId] = useState<string | null>(null);
 
   const services = useMemo(() => asset.external_services || {}, [asset.external_services]);
+
+  const isDuplicateId = useMemo(
+    () => !!editState && editState.currentId !== editState.originalId && !!services[editState.currentId],
+    [editState, services],
+  );
 
   const onEdit = useCallback(
     (serviceId: string) => {
@@ -120,6 +126,8 @@ const ResourceMultiAuth: FC<Props> = ({ asset, onChange }) => {
           value={editState.currentId}
           onChange={(v) => setEditState((prev) => (prev ? { ...prev, currentId: v || '' } : prev))}
           disabled={isReadOnlyAdmin}
+          error={isDuplicateId ? t(ErrorI18nKey.NameExists) : undefined}
+          invalid={isDuplicateId}
         />
 
         <DialInput
@@ -147,6 +155,7 @@ const ResourceMultiAuth: FC<Props> = ({ asset, onChange }) => {
           onChange={(auth_settings) => onChangeService({ auth_settings })}
           disabled={isReadOnlyAdmin}
           hideWithLoginOption
+          excludeAuthTypes={[ToolsetAuthType.NONE]}
         />
 
         {!isReadOnlyAdmin && (
@@ -155,7 +164,7 @@ const ResourceMultiAuth: FC<Props> = ({ asset, onChange }) => {
             <DialPrimaryButton
               label={t(ButtonsI18nKey.Apply)}
               onClick={onSave}
-              disabled={!editState.currentId || !isValid}
+              disabled={!editState.currentId || !isValid || isDuplicateId}
             />
           </div>
         )}
@@ -207,11 +216,13 @@ const ResourceMultiAuth: FC<Props> = ({ asset, onChange }) => {
                 {!isReadOnlyAdmin && loadingServiceId !== serviceId && (
                   <>
                     <DialGhostIconButton
+                      aria-label={t(ButtonsI18nKey.Edit)}
                       size={ElementSize.Small}
                       icon={<IconEdit {...BASE_BUTTON_ICON_PROPS} />}
                       onClick={() => onEdit(serviceId)}
                     />
                     <DialGhostIconButton
+                      aria-label={t(ButtonsI18nKey.Delete)}
                       size={ElementSize.Small}
                       icon={<IconTrashX {...BASE_BUTTON_ICON_PROPS} className="text-error" />}
                       onClick={() => onDelete(serviceId)}

--- a/apps/ai-dial-admin/src/components/Assets/Resources/Auth/tests/ResourceAuthentication.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Resources/Auth/tests/ResourceAuthentication.spec.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+
+import { ToolsetI18nKey } from '@/src/constants/i18n';
+import { ToolsetAuthType } from '@/src/models/dial/resource';
+import ResourceAuthentication from '../ResourceAuthentication';
+
+describe('ResourceAuthentication', () => {
+  test('renders all three auth type options by default', () => {
+    render(<ResourceAuthentication name="toolset-1" />);
+
+    expect(screen.getByText(ToolsetI18nKey.OAuth)).toBeInTheDocument();
+    expect(screen.getByText(ToolsetI18nKey.ApiKey)).toBeInTheDocument();
+    expect(screen.getByText(ToolsetI18nKey.NoneAuth)).toBeInTheDocument();
+  });
+
+  test('excludeAuthTypes hides the given option', () => {
+    render(<ResourceAuthentication name="service-1" excludeAuthTypes={[ToolsetAuthType.NONE]} />);
+
+    expect(screen.getByText(ToolsetI18nKey.OAuth)).toBeInTheDocument();
+    expect(screen.getByText(ToolsetI18nKey.ApiKey)).toBeInTheDocument();
+    expect(screen.queryByText(ToolsetI18nKey.NoneAuth)).not.toBeInTheDocument();
+  });
+
+  test('keeps the currently selected excluded type visible so existing data stays viewable', () => {
+    render(
+      <ResourceAuthentication
+        name="service-1"
+        authSettings={{ authentication_type: ToolsetAuthType.NONE }}
+        excludeAuthTypes={[ToolsetAuthType.NONE]}
+      />,
+    );
+
+    expect(screen.getByText(ToolsetI18nKey.NoneAuth)).toBeInTheDocument();
+  });
+});

--- a/apps/ai-dial-admin/src/components/Assets/Resources/Auth/tests/ResourceMultiAuth.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Resources/Auth/tests/ResourceMultiAuth.spec.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test, vi } from 'vitest';
+
+import { ButtonsI18nKey, ErrorI18nKey, ExternalServiceI18nKey, ToolsetI18nKey } from '@/src/constants/i18n';
+import { DialApplicationResource } from '@/src/models/dial/resource';
+import ResourceMultiAuth from '../ResourceMultiAuth';
+
+const baseAsset = {
+  path: 'public/my-app',
+  external_services: {
+    'service-a': { display_name: 'Service A' },
+    'service-b': { display_name: 'Service B' },
+  },
+} as DialApplicationResource;
+
+describe('ResourceMultiAuth', () => {
+  const user = userEvent.setup();
+
+  test('adding a service with an ID that already exists shows an error and disables Apply', async () => {
+    render(<ResourceMultiAuth asset={baseAsset} onChange={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: ExternalServiceI18nKey.AddService }));
+    await user.type(screen.getByLabelText(ExternalServiceI18nKey.ServiceId, { exact: false }), 'service-a');
+
+    expect(screen.getByText(ErrorI18nKey.NameExists)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: ButtonsI18nKey.Apply })).toBeDisabled();
+  });
+
+  test('renaming a service to an ID owned by a different entry shows an error and disables Apply', async () => {
+    render(<ResourceMultiAuth asset={baseAsset} onChange={vi.fn()} />);
+
+    // Rows render in insertion order: service-a first, service-b second.
+    const [editServiceA] = screen.getAllByRole('button', { name: ButtonsI18nKey.Edit });
+    await user.click(editServiceA);
+
+    const idInput = screen.getByLabelText(ExternalServiceI18nKey.ServiceId, { exact: false });
+    await user.clear(idInput);
+    await user.type(idInput, 'service-b');
+
+    expect(screen.getByText(ErrorI18nKey.NameExists)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: ButtonsI18nKey.Apply })).toBeDisabled();
+  });
+
+  test('renaming a service to its own original ID does not show the duplicate error', async () => {
+    render(<ResourceMultiAuth asset={baseAsset} onChange={vi.fn()} />);
+
+    const [editServiceA] = screen.getAllByRole('button', { name: ButtonsI18nKey.Edit });
+    await user.click(editServiceA);
+
+    const idInput = screen.getByLabelText(ExternalServiceI18nKey.ServiceId, { exact: false });
+    expect(idInput).toHaveValue('service-a');
+
+    expect(screen.queryByText(ErrorI18nKey.NameExists)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: ButtonsI18nKey.Apply })).not.toBeDisabled();
+  });
+
+  test('adding a service does not offer "Without authentication" as an auth type', async () => {
+    render(<ResourceMultiAuth asset={baseAsset} onChange={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: ExternalServiceI18nKey.AddService }));
+
+    expect(screen.queryByText(ToolsetI18nKey.NoneAuth)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
**Description:**

added external services fixes

Issues:

- Issue #3976 
- Issue #3971
- Issue #3970


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
