### PR TITLE
chore: bump ai-dial-ui-kit dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@epam/ai-dial-shared": "^0.44.8",
-        "@epam/ai-dial-ui-kit": "0.13.0-dev.11",
+        "@epam/ai-dial-ui-kit": "0.13.0-dev.36",
         "@epam/ai-dial-visualizer-connector": "^0.44.8",
         "@floating-ui/react": "^0.27.19",
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -2235,9 +2235,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@epam/ai-dial-ui-kit": {
-      "version": "0.13.0-dev.11",
-      "resolved": "https://registry.npmjs.org/@epam/ai-dial-ui-kit/-/ai-dial-ui-kit-0.13.0-dev.11.tgz",
-      "integrity": "sha512-FlxkSFn5FeVKGF14EBZkSB2Jhx7KL1i3ldjGxR9FiZd01EJkuPtov1CRkUGH9Y7JlghP2bbJWzcyABKUL6jtuQ==",
+      "version": "0.13.0-dev.36",
+      "resolved": "https://registry.npmjs.org/@epam/ai-dial-ui-kit/-/ai-dial-ui-kit-0.13.0-dev.36.tgz",
+      "integrity": "sha512-AWS+/Pdm/C0xQu4Hff4gyI9c5/3pc0ywmuw3kS/NcbssqNpxhjczBUKkZ+Cw2jTsHJZhIx/GKgNijnDuaNPF3w==",
       "license": "Apache-2.0",
       "dependencies": {
         "ag-grid-community": "^35.2.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@epam/ai-dial-shared": "^0.44.8",
-    "@epam/ai-dial-ui-kit": "0.13.0-dev.11",
+    "@epam/ai-dial-ui-kit": "0.13.0-dev.36",
     "@epam/ai-dial-visualizer-connector": "^0.44.8",
     "@floating-ui/react": "^0.27.19",
     "@modelcontextprotocol/sdk": "^1.29.0",


### PR DESCRIPTION
**Description:**

Bumps `@epam/ai-dial-ui-kit` from `0.13.0-dev.11` to `0.13.0-dev.36`.

Reviewed every commit on ui-kit `development` in this range for breaking changes. Two removals were found (`DialRoundedButton`/`DialRoundedButtonProps` removed; `DialFabButton`/`DialFabButtonProps` renamed to `FabButton`/`FabButtonProps`), but neither is used anywhere in this repo. `FileManager` components were marked deprecated but not removed — no action needed here. No other exported API changes affect current usage.

Verified with a full `build` and `lint` after the bump — both clean (no new errors or warnings).

Issues:

- Issue #<TICKET_ID>


**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
