### PR TITLE
chore(config): bump @epam/ai-dial-ui-kit to 0.13.0-dev.46 (Issue #4108)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@epam/ai-dial-shared": "^0.44.8",
-        "@epam/ai-dial-ui-kit": "0.13.0-dev.45",
+        "@epam/ai-dial-ui-kit": "0.13.0-dev.46",
         "@epam/ai-dial-visualizer-connector": "^0.44.8",
         "@floating-ui/react": "^0.27.19",
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -2236,9 +2236,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@epam/ai-dial-ui-kit": {
-      "version": "0.13.0-dev.45",
-      "resolved": "https://registry.npmjs.org/@epam/ai-dial-ui-kit/-/ai-dial-ui-kit-0.13.0-dev.45.tgz",
-      "integrity": "sha512-asXAgSVhcjOTTMQFch7gOweW1BrJWXzk/vOurvqZNf2vDt66OJlGET7tkIFsZGpe/l5aChrob1qe3xhWlQ7sFg==",
+      "version": "0.13.0-dev.46",
+      "resolved": "https://registry.npmjs.org/@epam/ai-dial-ui-kit/-/ai-dial-ui-kit-0.13.0-dev.46.tgz",
+      "integrity": "sha512-Yecx6QwQPK9hieo5MTWJbx0mD+8cV1cDOXnDdCh4dlfxjG1E34WYBA/RXvjLqm2qzq+jYD2ewh/5WbceVvHX/g==",
       "license": "Apache-2.0",
       "dependencies": {
         "ag-grid-community": "^35.2.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@epam/ai-dial-shared": "^0.44.8",
-    "@epam/ai-dial-ui-kit": "0.13.0-dev.45",
+    "@epam/ai-dial-ui-kit": "0.13.0-dev.46",
     "@epam/ai-dial-visualizer-connector": "^0.44.8",
     "@floating-ui/react": "^0.27.19",
     "@modelcontextprotocol/sdk": "^1.29.0",


### PR DESCRIPTION
## Summary

Bump @epam/ai-dial-ui-kit to 0.13.0-dev.46 to pick up ui-kit PR epam/ai-dial-ui-kit#807. This completes the fix for Issue #4108 ([Assets] Items list rows have extremely low text contrast). The earlier dev.45 bump (PR #4135) made the text readable; dev.46 updates DialGrid's legacy-token row-background fallback from --bg-layer-0 (#000000) to --bg-layer-3 (#1D2439), so Assets lists now match the Entities grids.

## Key Changes

- [package.json](https://github.com/epam/ai-dial-admin-frontend/blob/fix/bump-ai-dial-ui-kit-dev46/package.json) — bump @epam/ai-dial-ui-kit 0.13.0-dev.45 → 0.13.0-dev.46
- [package-lock.json](https://github.com/epam/ai-dial-admin-frontend/blob/fix/bump-ai-dial-ui-kit-dev46/package-lock.json) — lock file update

Issues:

- Issue #4108

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with \`(Issue #<ticket>)\` (comma-separated list of issues)