### PR TITLE
fix: [Assets-Models] allow saving an upstream with an empty endpoint (Issue #4121)

### DIFF
--- a/apps/ai-dial-admin/src/components/Assets/Models/View.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Models/View.tsx
@@ -10,7 +10,6 @@ import EntityJsonEditor from '@/src/components/EntityTabs/JsonEditor/JsonEditor'
 import { useModelsFolder } from '@/src/context/assets/ModelsFolderContext';
 import { useNotification } from '@/src/context/NotificationContext';
 import { useProtectedRequest } from '@/src/hooks/use-protected-request';
-import { ModelAssetI18nKey } from '@/src/constants/i18n';
 import { useI18n } from '@/src/locales/client';
 import { AssetModel } from '@/src/models/dial/deployment-asset';
 import { DialInterceptor } from '@/src/models/dial/interceptor';
@@ -19,7 +18,6 @@ import { ApplicationRoute } from '@/src/types/routes';
 import { getUpdateNotificationDescription, getUpdateNotificationTitle } from '@/src/utils/entities/update-entity';
 import { isEqualSkippingUndefined } from '@/src/utils/is-equals-entity';
 import { getErrorNotification, getSuccessNotification } from '@/src/utils/notification';
-import { hasUpstreamsMissingEndpoint } from '@/src/utils/models/upstream-secrets';
 import { EntityViewTab, getTabsForAsset } from '@/src/utils/tabs/utils';
 import TabsContent from './TabsContent';
 
@@ -68,19 +66,6 @@ const ModelView: FC<Props> = ({ etag, originalModel, roles, interceptors }) => {
   }, [originalModel]);
 
   const onSave = useCallback(() => {
-    // Core matches a stored upstream secret to a request entry by endpoint, so an endpoint-less upstream
-    // is unroutable and breaks that pairing. The editor seeds new rows as `{}`, so this is reachable by
-    // adding an upstream and saving without filling it in.
-    if (hasUpstreamsMissingEndpoint(selectedModel.upstreams)) {
-      showNotification(
-        getErrorNotification(
-          t(ModelAssetI18nKey.MissingUpstreamEndpointTitle),
-          t(ModelAssetI18nKey.MissingUpstreamEndpointMessage),
-        ),
-      );
-      return;
-    }
-
     getReqRef.current(updateModel, selectedModel, etag).then((res) => {
       if (res.success) {
         showNotification(

--- a/apps/ai-dial-admin/src/constants/i18n.ts
+++ b/apps/ai-dial-admin/src/constants/i18n.ts
@@ -569,8 +569,6 @@ export enum ModelAssetI18nKey {
   InvalidMessage = 'ModelAsset.InvalidMessage',
   SecretLossTitle = 'ModelAsset.SecretLossTitle',
   SecretLossMessage = 'ModelAsset.SecretLossMessage',
-  MissingUpstreamEndpointTitle = 'ModelAsset.MissingUpstreamEndpointTitle',
-  MissingUpstreamEndpointMessage = 'ModelAsset.MissingUpstreamEndpointMessage',
 }
 
 export enum ForwardTokenI18nKey {

--- a/apps/ai-dial-admin/src/locales/en.ts
+++ b/apps/ai-dial-admin/src/locales/en.ts
@@ -640,9 +640,6 @@ export default {
     SecretLossTitle: 'Stored credentials will be lost',
     SecretLossMessage:
       'Re-enter the key and secret extra data for these upstreams before saving — a changed endpoint cannot keep its stored credentials:',
-    MissingUpstreamEndpointTitle: 'Upstream endpoint required',
-    MissingUpstreamEndpointMessage:
-      'Every upstream needs an endpoint. Fill in or remove the empty upstream before saving.',
   },
   ForwardToken: {
     ForwardTokenModalTitle: 'Forward Auth Token',

--- a/apps/ai-dial-admin/src/utils/models/tests/upstream-secrets.spec.ts
+++ b/apps/ai-dial-admin/src/utils/models/tests/upstream-secrets.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 
-import { getUpstreamsLosingSecret, hasUpstreamsMissingEndpoint, stripEmptyUpstreamSecrets } from '../upstream-secrets';
+import { getUpstreamsLosingSecret, stripEmptyUpstreamSecrets } from '../upstream-secrets';
 
 describe('Models Utils :: stripEmptyUpstreamSecrets', () => {
   test('Should remove an empty key entirely, not send it as an empty string', () => {
@@ -55,24 +55,6 @@ describe('Models Utils :: stripEmptyUpstreamSecrets', () => {
     stripEmptyUpstreamSecrets(input);
 
     expect(input[0]).toHaveProperty('key');
-  });
-});
-
-describe('Models Utils :: hasUpstreamsMissingEndpoint', () => {
-  test('Should flag an upstream with no endpoint, which Core cannot match a secret to', () => {
-    expect(hasUpstreamsMissingEndpoint([{ endpoint: 'http://a' }, { key: 'k' }])).toBe(true);
-  });
-
-  test('Should flag an empty endpoint', () => {
-    expect(hasUpstreamsMissingEndpoint([{ endpoint: '' }])).toBe(true);
-  });
-
-  test('Should accept upstreams that all carry an endpoint', () => {
-    expect(hasUpstreamsMissingEndpoint([{ endpoint: 'http://a' }, { endpoint: 'http://b' }])).toBe(false);
-  });
-
-  test.each([undefined, []])('Should not flag %s', (upstreams) => {
-    expect(hasUpstreamsMissingEndpoint(upstreams)).toBe(false);
   });
 });
 

--- a/apps/ai-dial-admin/src/utils/models/upstream-secrets.ts
+++ b/apps/ai-dial-admin/src/utils/models/upstream-secrets.ts
@@ -54,14 +54,6 @@ export const stripEmptyUpstreamSecrets = (upstreams?: DialModelEndpoint[]): Dial
 };
 
 /**
- * Core pairs each request upstream with its stored counterpart by matching `endpoint`, falling back to
- * positional matching only for entries carrying none — and its own contract warns that mixing the two
- * forms makes preservation unreliable. An upstream with no endpoint cannot route anyway.
- */
-export const hasUpstreamsMissingEndpoint = (upstreams?: DialModelEndpoint[]): boolean =>
-  !!upstreams?.some((upstream) => !upstream.endpoint);
-
-/**
  * Endpoints whose secret cannot survive the write: Core looks the stored secret up by endpoint, so
  * renaming one while leaving its secrets blank silently drops the credential.
  *

--- a/openspec/specs/model-resources-core-api/spec.md
+++ b/openspec/specs/model-resources-core-api/spec.md
@@ -70,12 +70,16 @@ DIAL Core marks an upstream's `key` and `secretExtraData` as encrypted, write-on
 - **WHEN** `updateModel` sends a model with several upstreams, only some of which carry a secret
 - **THEN** each upstream is stripped independently, and the upstreams supplying secrets still carry them
 
-### Requirement: Every written upstream carries its endpoint so Core can match its stored secret
-DIAL Core pairs each upstream in a write request with its stored counterpart by matching the `endpoint` value, falling back to positional matching only for entries that carry no endpoint, and its own contract documents that mixing the two forms makes preservation unreliable. The system SHALL include an `endpoint` on every upstream it writes.
+### Requirement: An upstream with no endpoint is written as the user entered it
+An upstream's `endpoint` is not the address Core dials — Core routes a completion to the model's own resolved endpoint and forwards the upstream's endpoint, key, and extra data to that adapter as headers. An upstream carrying only credentials or extra data is therefore serviceable, which is why the entity surface accepts one. The system SHALL NOT block or alter a save because an upstream carries no endpoint.
 
-#### Scenario: Upstreams are written with endpoints
-- **WHEN** `updateModel` sends a model with upstreams
-- **THEN** every upstream object in the request body carries an `endpoint` property
+#### Scenario: A model with an endpoint-less upstream saves
+- **WHEN** a user adds an upstream, leaves its endpoint empty, and saves
+- **THEN** the write is issued and the upstream is persisted, with no validation error raised by the frontend
+
+#### Scenario: Secret preservation for an endpoint-less upstream rests on its position
+- **WHEN** a model is written with an upstream that carries no endpoint
+- **THEN** Core pairs it with the stored upstream at the same array index — its documented fallback when `endpoint` is absent — so an omitted secret is still preserved
 
 ### Requirement: A written model resource becomes a served deployment under its canonical id
 DIAL Core merges API-written model resources into its runtime configuration alongside file-defined models, keying API entries by their canonical id (`models/platform/{name}`) and setting each deployment's name from that key, while file-defined entries keep their bare-name keys. A model created through this surface is therefore routable without any further reference from another entity. The system SHALL treat the canonical id as the model's served deployment identifier, and SHALL NOT present the bare resource name as the identifier a caller invokes.


### PR DESCRIPTION
**Description:**

Assets → Models refused to save when an upstream had no endpoint, while Entities → Models allows it and the resulting model works in chat.

The guard added with the model-asset surface (`hasUpstreamsMissingEndpoint`) rested on a wrong premise — that an endpoint-less upstream is unroutable. Verified against `epam/ai-dial-core`:

- `BaseDeploymentPostController.sendProxyRequest` dials the **model's own** resolved endpoint and forwards the upstream's `endpoint`/`key`/`extraData` to that adapter as `X-UPSTREAM-*` headers. An upstream supplying only credentials or extra data is serviceable — hence the entity surface accepting one.
- Secret preservation also survives: `SecretFieldProcessor.matchSourceIndex` pairs an endpoint-less request upstream with the stored upstream at the **same index**, so an omitted `key`/`secretExtraData` is still preserved. Unreliability only arises when endpoint-keyed and endpoint-less entries are mixed in one array — Core's own documented caveat, not grounds for blocking a save.

Changes:

- `Assets/Models/View.tsx` — dropped the pre-save validation block from `onSave`
- `utils/models/upstream-secrets.ts` — removed the now-unused `hasUpstreamsMissingEndpoint`; `stripEmptyUpstreamSecrets` and the endpoint-rename credential warning (`getUpstreamsLosingSecret`) are untouched
- `constants/i18n.ts`, `locales/en.ts` — removed the two dead `MissingUpstreamEndpoint*` strings
- `openspec/specs/model-resources-core-api/spec.md` — replaced "every written upstream carries its endpoint" with a requirement stating endpoint-less upstreams are written as entered, plus the positional-preservation scenario

Issues:

- Issue #4121


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
