### PR TITLE
fix: [Assets-Models] add missing "Display version" field to Create Model modal (Issue #4114)

### DIFF
--- a/apps/ai-dial-admin/src/components/EntityListView/CreateEntity/CreateEntity.tsx
+++ b/apps/ai-dial-admin/src/components/EntityListView/CreateEntity/CreateEntity.tsx
@@ -28,8 +28,9 @@ import { getErrorNotification, getSuccessNotification } from '@/src/utils/notifi
 import { getEntityPath } from '@/src/utils/open-in-new-tab';
 import { RoutesForCheckingUniqueName } from './constants';
 
-interface CreatePromptEntity extends BaseEntity {
+interface CreateEntityBase extends BaseEntity {
   version?: string;
+  displayVersion?: string;
   folderId?: string;
 }
 
@@ -46,7 +47,7 @@ interface Props<T> {
   isModal?: boolean;
 }
 
-const CreateEntity = <T extends CreatePromptEntity>({
+const CreateEntity = <T extends CreateEntityBase>({
   runners,
   route,
   isModalOpen,
@@ -65,11 +66,17 @@ const CreateEntity = <T extends CreatePromptEntity>({
   const getReqRef = useRef(useProtectedRequest());
   const { showNotification } = useNotification();
 
-  const [currentEntity, setEntity] = useState<T>(
-    isAssetWithVersion(route)
-      ? ({ name: '', description: '', version: DEFAULT_NEW_ENTITY_VERSION } as T)
-      : ({ name: '', description: '', ...initialValues } as T),
-  );
+  const [currentEntity, setEntity] = useState<T>(() => {
+    if (isAssetWithVersion(route)) {
+      return { name: '', description: '', version: DEFAULT_NEW_ENTITY_VERSION } as T;
+    }
+
+    if (route === ApplicationRoute.AssetsModels) {
+      return { name: '', description: '', displayVersion: DEFAULT_NEW_ENTITY_VERSION, ...initialValues } as T;
+    }
+
+    return { name: '', description: '', ...initialValues } as T;
+  });
   const [isUniqueNameError, setIsUniqueNameError] = useState<boolean | undefined>(void 0);
 
   const onCreate = useCallback(

--- a/apps/ai-dial-admin/src/components/EntityListView/CreateEntity/tests/CreateEntity.spec.tsx
+++ b/apps/ai-dial-admin/src/components/EntityListView/CreateEntity/tests/CreateEntity.spec.tsx
@@ -57,4 +57,27 @@ describe('CreateEntity', () => {
     await waitFor(() => expect(createApp).toHaveBeenCalled());
     expect(createApp.mock.calls[0][0]).toMatchObject({ version: '1.0.0' });
   });
+
+  test('seeds the default display version for AssetsModels', async () => {
+    (useRouter as Mock).mockReturnValue({ push: vi.fn() });
+
+    const createModel = vi.fn().mockResolvedValue({ success: true, response: { name: 'model1' } });
+    render(
+      <CreateEntity
+        route={ApplicationRoute.AssetsModels}
+        isModalOpen={true}
+        onClose={vi.fn()}
+        names={[]}
+        versionsMap={{}}
+        createEntity={createModel}
+      />,
+    );
+
+    expect(screen.getByDisplayValue('1.0.0')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText(ButtonsI18nKey.Create));
+
+    await waitFor(() => expect(createModel).toHaveBeenCalled());
+    expect(createModel.mock.calls[0][0]).toMatchObject({ displayVersion: '1.0.0' });
+  });
 });

--- a/apps/ai-dial-admin/src/components/EntityMainProperties/Properties/EntityProperties.tsx
+++ b/apps/ai-dial-admin/src/components/EntityMainProperties/Properties/EntityProperties.tsx
@@ -6,6 +6,7 @@ import { getInterceptorContainers } from '@/src/app/actions/deployments';
 import DescriptionControl from '@/src/components/BaseControls/Description';
 import DisplayNameControl from '@/src/components/BaseControls/DisplayName';
 import IdControl from '@/src/components/BaseControls/Id/Id';
+import VersionControl from '@/src/components/BaseControls/Version';
 import { getSourceItems } from '@/src/components/SourceField/constants';
 import SourceField from '@/src/components/SourceField/SourceField';
 import { EntitiesI18nKey, EntityFieldsI18nKey, EntityPlaceholdersI18nKey } from '@/src/constants/i18n';
@@ -13,6 +14,7 @@ import { useAppContext } from '@/src/context/AppContext';
 import { useSaveValidationContext, ValidationActionType } from '@/src/context/SaveValidationContext';
 import { useI18n } from '@/src/locales/client';
 import { BaseEntity } from '@/src/models/dial/base-entity';
+import { DialModelResource } from '@/src/models/dial/resource';
 import { DialRoute } from '@/src/models/dial/route';
 import { ApplicationRoute } from '@/src/types/routes';
 import { getErrorForPath } from '@/src/utils/validation/path-error';
@@ -72,6 +74,17 @@ const EntityProperties: FC<Props> = ({
         isFullWidth={!isEntityImmutable}
         onChange={(name) => onChangeEntity({ ...entity, displayName: name })}
       />
+
+      {view === ApplicationRoute.AssetsModels && (
+        <VersionControl
+          title={t(EntityFieldsI18nKey.displayVersion)}
+          version={(entity as DialModelResource).displayVersion}
+          optional
+          isFullWidth={!isEntityImmutable}
+          enableSemanticValidation={false}
+          onChange={(displayVersion) => onChangeEntity({ ...entity, displayVersion } as DialModelResource)}
+        />
+      )}
 
       <DescriptionControl entity={entity} onChangeEntity={onChangeEntity} isFullWidth={!isEntityImmutable} />
 

--- a/apps/ai-dial-admin/src/components/EntityMainProperties/Properties/tests/EntityProperties.spec.tsx
+++ b/apps/ai-dial-admin/src/components/EntityMainProperties/Properties/tests/EntityProperties.spec.tsx
@@ -1,9 +1,10 @@
 import { describe, expect, test, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import EntityProperties from '../EntityProperties';
 import { ApplicationRoute } from '@/src/types/routes';
 import { EntityFieldsI18nKey } from '@/src/constants/i18n';
+import { DialModelResource } from '@/src/models/dial/resource';
 
 vi.mock('@/src/app/[lang]/interceptor-templates/actions', () => ({
   getInterceptorTemplatesList: vi.fn(),
@@ -39,5 +40,36 @@ describe('EntityProperties', () => {
     );
 
     expect(screen.queryByText(EntityFieldsI18nKey.intro)).not.toBeInTheDocument();
+  });
+
+  test('shows an optional display version field for the model asset view', () => {
+    const onChangeEntity = vi.fn();
+    render(
+      <EntityProperties
+        view={ApplicationRoute.AssetsModels}
+        entity={{ name: 'my-model', displayName: '', description: '', displayVersion: '1.0.0' } as DialModelResource}
+        names={[]}
+        onChangeEntity={onChangeEntity}
+      />,
+    );
+
+    expect(screen.getByText(EntityFieldsI18nKey.displayVersion)).toBeInTheDocument();
+    const input = screen.getByDisplayValue('1.0.0');
+
+    fireEvent.change(input, { target: { value: '2.0' } });
+    expect(onChangeEntity).toHaveBeenCalledWith(expect.objectContaining({ displayVersion: '2.0' }));
+  });
+
+  test('does not show a display version field for Routes', () => {
+    render(
+      <EntityProperties
+        view={ApplicationRoute.Routes}
+        entity={{ name: 'my-route', displayName: '', description: '' }}
+        names={[]}
+        onChangeEntity={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText(EntityFieldsI18nKey.displayVersion)).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Closes #4114

## Problem

The Assets → Models create modal showed only ID, Display Name and Description. `Assets > Models` is classified as a "simple entity" (`is-simple-entity.ts`), so its create modal renders `EntityProperties`, which had no version control — while the model asset **edit** view (`Assets/Models/Properties.tsx`) has had a `Display version` field all along. Create and edit disagreed.

## Change

- `EntityProperties.tsx` — renders `VersionControl` labelled *Display version* between Display Name and Description, gated on `view === ApplicationRoute.AssetsModels`. Optional, with semantic validation off, mirroring the model asset edit view so the two forms agree.
- `CreateEntity.tsx` — seeds `displayVersion: '1.0.0'` (`DEFAULT_NEW_ENTITY_VERSION`) for that route. It could not ride on the existing `isAssetWithVersion` branch, which seeds the **path-based** `version` that model assets deliberately do not carry.
- Renamed the local generic constraint `CreatePromptEntity` → `CreateEntityBase` (it constrains every route the component handles, not just prompts) and added `displayVersion?: string` to it.

## Why not reuse the existing version predicates

- `isAssetWithVersion` means "carries its version inside the resource path" (`name__version`) and also drives export paths, import conflict columns, grid columns and list-view URNs. Model assets are identified by resource name, so widening it would seed the wrong field, make an optional field required, and change path building across those surfaces.
- `isEntitiesWithDisplayVersion` marks display-name + version as the *uniqueness identity* — a rule DIAL Core does not apply to model resources, and one `utils/models/tests/deployment-id.spec.ts:26` explicitly pins as false for this view.

The field is therefore gated by an exact route match, so no other entity is affected. Verified: the only other direct `EntityProperties` consumers pass `Interceptors` and `undefined`; the shared `Properties` dispatcher is used only by `CreateEntity`; the model asset edit view uses its own component, so there is no duplicate control.

## Testing

- New: display version renders and propagates changes for the model asset view; absent for Routes; create body carries `displayVersion: '1.0.0'` for AssetsModels.
- Existing test pinning that no path-based `version` reaches the AssetsModels create body still passes.
- `EntityMainProperties`, `EntityListView` and `Assets` suites green; `tsc` and eslint clean on the touched files.

Not verified in a running browser — unit tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)