### PR TITLE
fix: [Assets-Applications] show App Runner's App Routes in the application's App Routes tab (Issue #4105)

### DIFF
--- a/apps/ai-dial-admin/src/components/EntityView/AppRoute/ApplicationAppRoutes.tsx
+++ b/apps/ai-dial-admin/src/components/EntityView/AppRoute/ApplicationAppRoutes.tsx
@@ -1,12 +1,17 @@
 import { FC, useCallback, useMemo } from 'react';
 
+import { DialLoader, DialNoDataContent } from '@epam/ai-dial-ui-kit';
+
 import { getAppRunner } from '@/src/components/Applications/ParametersTab/utils';
+import { EntitiesI18nKey } from '@/src/constants/i18n';
 import { useIsReadOnlyAdmin } from '@/src/hooks/use-is-read-only-admin';
+import { useI18n } from '@/src/locales/client';
 import { ApplicationSourceType, DialApplication, DialApplicationScheme } from '@/src/models/dial/application';
 import { DialRole } from '@/src/models/dial/role';
 import { DialAppRoute } from '@/src/models/dial/route';
 import { ApplicationRoute } from '@/src/types/routes';
 import EntityRoutes from './AppRoute';
+import { useAssetRunnerRoutes } from './use-asset-runner-routes';
 import { DialApplicationResource } from '@/src/models/dial/resource';
 
 interface Props {
@@ -18,12 +23,20 @@ interface Props {
 }
 
 const ApplicationAppRoutes: FC<Props> = ({ view, selectedEntity, applicationRunners, onChangeEntity, ...props }) => {
+  const t = useI18n();
   const isReadOnlyAdmin = useIsReadOnlyAdmin();
 
   const isAsset = view === ApplicationRoute.AssetsApplications;
   const hasSchemaSource =
     selectedEntity.source?.$type === ApplicationSourceType.SCHEMA ||
     !!(selectedEntity as DialApplicationResource).application_type_schema_id;
+
+  const appRunner = useMemo(
+    () => (hasSchemaSource ? getAppRunner(selectedEntity, applicationRunners, view) : undefined),
+    [hasSchemaSource, selectedEntity, applicationRunners, view],
+  );
+
+  const { routes: assetRunnerRoutes, isLoading, error } = useAssetRunnerRoutes(appRunner);
 
   const routes = useMemo(() => {
     if (!hasSchemaSource) {
@@ -33,9 +46,8 @@ const ApplicationAppRoutes: FC<Props> = ({ view, selectedEntity, applicationRunn
       }
       return selectedEntity.routes || [];
     }
-    const appRunners = getAppRunner(selectedEntity, applicationRunners, view);
-    return appRunners?.['dial:applicationTypeRoutes'] || [];
-  }, [hasSchemaSource, selectedEntity, applicationRunners, view, isAsset]);
+    return assetRunnerRoutes ?? appRunner?.['dial:applicationTypeRoutes'] ?? [];
+  }, [hasSchemaSource, isAsset, selectedEntity, assetRunnerRoutes, appRunner]);
 
   const onChangeRoutes = useCallback(
     (updatedRoutes: DialAppRoute[]) => {
@@ -53,6 +65,24 @@ const ApplicationAppRoutes: FC<Props> = ({ view, selectedEntity, applicationRunn
     },
     [isAsset, onChangeEntity, selectedEntity],
   );
+
+  // Mounting the route editor before the runner read settles would show its "No App Routes" empty
+  // state, which is the very thing the read is there to answer.
+  if (isLoading) {
+    return (
+      <div className="flex flex-col size-full">
+        <DialLoader size={40} />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col size-full">
+        <DialNoDataContent title={t(EntitiesI18nKey.ResolvedSchemaFailed)} description={error} />
+      </div>
+    );
+  }
 
   return (
     <EntityRoutes

--- a/apps/ai-dial-admin/src/components/EntityView/AppRoute/tests/ApplicationAppRoutes.spec.tsx
+++ b/apps/ai-dial-admin/src/components/EntityView/AppRoute/tests/ApplicationAppRoutes.spec.tsx
@@ -1,0 +1,162 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import ApplicationAppRoutes from '@/src/components/EntityView/AppRoute/ApplicationAppRoutes';
+import { buildAppRunnerOptions } from '@/src/components/SourceField/Application/utils';
+import { DialApplication, DialApplicationScheme } from '@/src/models/dial/application';
+import { DialAppRunnerResource, DialApplicationResource } from '@/src/models/dial/resource';
+import { DialAppRoute } from '@/src/models/dial/route';
+import { ResourceInfo } from '@/src/server/core/asset-metadata';
+import { ApplicationRoute } from '@/src/types/routes';
+
+vi.mock('@/src/app/[lang]/assets-app-runners/actions', () => ({
+  getRunner: vi.fn(),
+}));
+
+vi.mock('@epam/ai-dial-ui-kit', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@epam/ai-dial-ui-kit');
+  return {
+    ...actual,
+    DialLoader: () => <div role="progressbar" />,
+    DialNoDataContent: ({ title, description }: { title?: string; description?: string }) => (
+      <div role="status">
+        {title}
+        {description}
+      </div>
+    ),
+  };
+});
+
+let capturedRoutesProps: { routes?: DialAppRoute[]; disabled?: boolean } | null = null;
+
+vi.mock('@/src/components/EntityView/AppRoute/AppRoute', () => ({
+  default: (props: { routes?: DialAppRoute[]; disabled?: boolean }) => {
+    capturedRoutesProps = props;
+    return (
+      <ul aria-label="routes">
+        {props.routes?.map((route) => (
+          <li key={route.name}>{route.name}</li>
+        ))}
+      </ul>
+    );
+  },
+}));
+
+import { getRunner } from '@/src/app/[lang]/assets-app-runners/actions';
+
+const ASSET_REFERENCE = 'schemas/platform/http%3A%2F%2Fasdqwe';
+const ASSET_PATH = 'http%3A%2F%2Fasdqwe';
+
+const OTHER_ASSET_REFERENCE = 'schemas/platform/http%3A%2F%2Fother';
+const OTHER_ASSET_PATH = 'http%3A%2F%2Fother';
+
+const entityRunner = {
+  $id: 'urn:runner:entity',
+  'dial:applicationTypeRoutes': [{ name: 'entity-route' }],
+} as unknown as DialApplicationScheme;
+
+const assetRunner = { name: 'http://asdqwe', path: ASSET_PATH, folderId: '' } as ResourceInfo;
+const otherAssetRunner = { name: 'http://other', path: OTHER_ASSET_PATH, folderId: '' } as ResourceInfo;
+
+const runners = buildAppRunnerOptions([entityRunner], [assetRunner, otherAssetRunner]);
+
+const appWithRunner = (reference: string) =>
+  ({ name: 'app', application_type_schema_id: reference }) as unknown as DialApplication;
+
+const runnerResponse = (routeName: string) => ({
+  success: true,
+  response: { 'dial:applicationTypeRoutes': [{ name: routeName }] } as DialAppRunnerResource,
+});
+
+const renderRoutes = (entity: DialApplication) =>
+  render(
+    <ApplicationAppRoutes
+      view={ApplicationRoute.AssetsApplications}
+      applicationRunners={runners}
+      selectedEntity={entity}
+      onChangeEntity={vi.fn()}
+    />,
+  );
+
+describe('ApplicationAppRoutes :: routes inherited from an app runner', () => {
+  beforeEach(() => {
+    capturedRoutesProps = null;
+    vi.mocked(getRunner).mockReset();
+  });
+
+  test('reads an asset runner’s content and renders its routes', async () => {
+    vi.mocked(getRunner).mockResolvedValue(runnerResponse('asset-route'));
+
+    renderRoutes(appWithRunner(ASSET_REFERENCE));
+
+    await waitFor(() => expect(screen.getByText('asset-route')).toBeDefined());
+    expect(getRunner).toHaveBeenCalledWith(ASSET_PATH, '*');
+    expect(capturedRoutesProps?.disabled).toBe(true);
+  });
+
+  test('shows a loader instead of the empty state while the runner is being read', async () => {
+    let resolveRunner: (value: unknown) => void = () => void 0;
+    vi.mocked(getRunner).mockReturnValue(new Promise((resolve) => (resolveRunner = resolve)) as never);
+
+    renderRoutes(appWithRunner(ASSET_REFERENCE));
+
+    expect(screen.getByRole('progressbar')).toBeDefined();
+    expect(screen.queryByRole('list', { name: 'routes' })).toBeNull();
+
+    resolveRunner(runnerResponse('asset-route'));
+
+    await waitFor(() => expect(screen.getByText('asset-route')).toBeDefined());
+  });
+
+  test('reports a failed runner read instead of claiming there are no routes', async () => {
+    vi.mocked(getRunner).mockResolvedValue({ success: false, errorMessage: 'boom' });
+
+    renderRoutes(appWithRunner(ASSET_REFERENCE));
+
+    await waitFor(() => expect(screen.getByRole('status')).toBeDefined());
+    expect(screen.getByRole('status').textContent).toContain('Entities.ResolvedSchemaFailed');
+    expect(screen.getByRole('status').textContent).toContain('boom');
+    expect(screen.queryByRole('list', { name: 'routes' })).toBeNull();
+  });
+
+  test('ignores a stale read once the runner has changed', async () => {
+    const deferred: ((value: unknown) => void)[] = [];
+    vi.mocked(getRunner).mockImplementation(() => new Promise((resolve) => deferred.push(resolve)) as never);
+
+    const { rerender } = renderRoutes(appWithRunner(ASSET_REFERENCE));
+    rerender(
+      <ApplicationAppRoutes
+        view={ApplicationRoute.AssetsApplications}
+        applicationRunners={runners}
+        selectedEntity={appWithRunner(OTHER_ASSET_REFERENCE)}
+        onChangeEntity={vi.fn()}
+      />,
+    );
+
+    deferred[1](runnerResponse('other-route'));
+    deferred[0](runnerResponse('asset-route'));
+
+    await waitFor(() => expect(screen.getByText('other-route')).toBeDefined());
+    expect(screen.queryByText('asset-route')).toBeNull();
+  });
+
+  test('uses the embedded routes of an admin-BE runner without reading any resource', async () => {
+    renderRoutes(appWithRunner('urn:runner:entity'));
+
+    await waitFor(() => expect(screen.getByText('entity-route')).toBeDefined());
+    expect(getRunner).not.toHaveBeenCalled();
+  });
+
+  test('keeps rendering an endpoints-based asset app’s own routes', async () => {
+    const app = {
+      name: 'app',
+      routes: { 'own-route': { name: 'own-route' } },
+    } as unknown as DialApplicationResource;
+
+    renderRoutes(app as unknown as DialApplication);
+
+    await waitFor(() => expect(screen.getByText('own-route')).toBeDefined());
+    expect(getRunner).not.toHaveBeenCalled();
+    expect(capturedRoutesProps?.disabled).toBe(false);
+  });
+});

--- a/apps/ai-dial-admin/src/components/EntityView/AppRoute/use-asset-runner-routes.ts
+++ b/apps/ai-dial-admin/src/components/EntityView/AppRoute/use-asset-runner-routes.ts
@@ -1,0 +1,61 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { getRunner } from '@/src/app/[lang]/assets-app-runners/actions';
+import { AppRunnerOption, AppRunnerOrigin } from '@/src/components/SourceField/Application/models';
+import { getRunnerOrigin } from '@/src/components/SourceField/Application/utils';
+import { DEFAULT_ETAG } from '@/src/constants/api-headers';
+import { EntitiesI18nKey } from '@/src/constants/i18n';
+import { useI18n } from '@/src/locales/client';
+import { DialApplicationScheme } from '@/src/models/dial/application';
+import { DialAppRunnerResource } from '@/src/models/dial/resource';
+import { DialAppRoute } from '@/src/models/dial/route';
+
+/**
+ * An asset app runner reaches an application view as a metadata-only option (`buildAppRunnerOptions`
+ * never reads per-runner content), so its routes have to be read from the runner resource itself.
+ * `routes` stays `null` whenever there is nothing to add — no runner, an admin-BE runner, or a read
+ * still in flight — so callers keep falling back to the option's own routes.
+ */
+export const useAssetRunnerRoutes = (runner?: DialApplicationScheme) => {
+  const t = useI18n();
+  const [routes, setRoutes] = useState<DialAppRoute[] | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const path =
+    runner && getRunnerOrigin(runner) === AppRunnerOrigin.Asset ? (runner as AppRunnerOption).path : undefined;
+
+  useEffect(() => {
+    setRoutes(null);
+    setError(null);
+
+    if (!path) {
+      setIsLoading(false);
+      return;
+    }
+
+    let isStale = false;
+    setIsLoading(true);
+
+    getRunner(path, DEFAULT_ETAG).then((res) => {
+      if (isStale) {
+        return;
+      }
+      setIsLoading(false);
+      if (res.success) {
+        setRoutes((res.response as DialAppRunnerResource)?.['dial:applicationTypeRoutes'] || []);
+        return;
+      }
+      // Routes are unknown rather than absent, so the caller must not fall through to "No App Routes".
+      setError(res.errorMessage || res.errorHeader || t(EntitiesI18nKey.ResolvedSchemaFailed));
+    });
+
+    return () => {
+      isStale = true;
+    };
+  }, [path, t]);
+
+  return { routes, isLoading, error };
+};


### PR DESCRIPTION
**Description:**

An application created from an **asset** App Runner showed "No App Routes" instead of the runner's inherited routes.

Asset runners reach the Applications view through `buildAppRunnerOptions`, which builds them from Core metadata only (`$id`, `path`, author, timestamps) — no content, so no `dial:applicationTypeRoutes`. `ApplicationAppRoutes` read the routes straight off that option, so the list was always empty. Entity runners come from `getApplicationSchemesList` with full bodies, which is why only the asset population was affected.

The new `useAssetRunnerRoutes` hook reads the runner resource via the existing `getRunner` server action when the matched runner is asset-origin, and the tab falls back to the option's embedded routes otherwise — the entity path is untouched. `getRunner` is the right source because it goes through `mergeAppRunnerResource` → `fromCoreAppRoutes`, producing the `DialAppRoute[]` the editor expects (`getResolvedRunnerSchema` is not a substitute: Core strips fields from it and returns its own name-keyed wire shape).

Two details worth a reviewer's eye:

- The effect is keyed on the primitive `path`, not the runner object, so unrelated edits elsewhere in the view don't refetch; a stale-guard flag drops responses for a runner the user already switched away from.
- While the read is in flight the tab renders a loader rather than mounting the route editor — otherwise `AppRouteList` flashes "No App Routes", the exact message the read exists to answer. On failure it shows `Entities.ResolvedSchemaFailed` plus the error, so an unreadable runner is never reported as "no routes".

Out of scope: the same metadata-only gap also degrades the Tools tab (never appears), Features (inherited endpoints render editable) and Properties (Responses Defaults hidden) for these apps. Worth a follow-up issue.

**Verification:**

- Browser A/B against the live app on an asset application bound to an asset App Runner: with the fix stashed the tab shows "No App Routes"; with it restored both runner routes render read-only (11/12 inputs disabled, no **Add** button). Test app was deleted afterwards.
- Regression: entity application with an entity runner, and an asset application pointing at an entity runner — both unchanged.
- `vitest`: 6 new cases (asset fetches with the right path, loader instead of empty state, error surfaced, stale response dropped, entity runner does not fetch, endpoints-based app's own routes still editable) plus 169 passing in the surrounding areas. `tsc` and `eslint` clean.

Issues:

- Issue #4105


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
