### PR TITLE
feat(Assets): add duplicate and open-in-new-tab actions for platform assets (Issue #4110)

### DIFF
--- a/apps/ai-dial-admin/src/components/Assets/AppRunners/tests/List.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/AppRunners/tests/List.spec.tsx
@@ -30,10 +30,14 @@ describe('AppRunnersList :: list affordances', () => {
     expect(getToolbarOptionLabels(ApplicationRoute.AssetsAppRunners, true)).toEqual([]);
   });
 
-  test('Should offer only delete as a row action — no duplicate, move, or export', () => {
+  test('Should offer duplicate, delete and open-in-new-tab as row actions — but no move or export', () => {
     const actions = getGridActionLabels(ApplicationRoute.AssetsAppRunners, false);
 
-    expect(actions.map((action) => action.key)).toEqual(['delete']);
+    expect(actions.map((action) => action.key)).toEqual(['duplicate', 'delete', 'openInNewTab']);
+  });
+
+  test('Should offer no row actions to a read-only admin', () => {
+    expect(getGridActionLabels(ApplicationRoute.AssetsAppRunners, true)).toEqual([]);
   });
 });
 

--- a/apps/ai-dial-admin/src/components/Assets/AppRunners/tests/folder-actions.spec.ts
+++ b/apps/ai-dial-admin/src/components/Assets/AppRunners/tests/folder-actions.spec.ts
@@ -27,9 +27,16 @@ describe('App runner asset :: folder operations', () => {
     expect(getToolbarOptionLabels(VIEW, false).map((item) => item.key)).toEqual(['newItem']);
   });
 
-  test('Should offer only delete in the grid context menu', () => {
-    expect(getGridActionLabels(VIEW, false).map((item) => item.key)).toEqual(['delete']);
+  test('Should offer duplicate, delete and open-in-new-tab in the grid context menu', () => {
+    expect(getGridActionLabels(VIEW, false).map((item) => item.key)).toEqual(['duplicate', 'delete', 'openInNewTab']);
   });
+
+  test.each(['addSibling', 'addChild', 'move', 'rename', 'managePermissions'])(
+    'Should not offer the folder-bound %s in the grid context menu',
+    (action) => {
+      expect(getGridActionLabels(VIEW, false).map((item) => item.key)).not.toContain(action);
+    },
+  );
 
   test('Should confirm the empty asset a folder create would send carries no id', () => {
     expect(getEmptyAsset(VIEW, 'platform/')).not.toHaveProperty('$id');

--- a/apps/ai-dial-admin/src/components/Assets/BaseAssetList/BaseAssetList.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/BaseAssetList/BaseAssetList.tsx
@@ -27,6 +27,7 @@ import { useNotification } from '@/src/context/NotificationContext';
 import { useI18n } from '@/src/locales/client';
 import { DialApplicationScheme } from '@/src/models/dial/application';
 import { AssetApp, AssetWithVersion } from '@/src/models/dial/deployment-asset';
+import { DialAppRunnerResource, PlatformAsset } from '@/src/models/dial/resource';
 import { ImportData } from '@/src/models/import-asset';
 import { ServerActionResponse } from '@/src/models/server-action';
 import { ConflictResolutionPolicy, ImportFileType } from '@/src/types/import';
@@ -35,7 +36,7 @@ import { downloadFile, downloadJson } from '@/src/utils/download';
 import { getCreateNotificationDescription, getCreateNotificationTitle } from '@/src/utils/entities/create-entity';
 import { filterNames } from '@/src/utils/entities/filter-names';
 import { getJsonFileName } from '@/src/utils/import/get-json-name';
-import { getRootFolder } from '@/src/utils/files/root-folder';
+import { getRootFolder, isFlatPlatformView } from '@/src/utils/files/root-folder';
 import { getErrorNotification, getSuccessNotification } from '@/src/utils/notification';
 import { getUrnForEntity, onOpenInNewTab } from '@/src/utils/open-in-new-tab';
 import { useRouter } from 'next/navigation';
@@ -52,6 +53,7 @@ import {
   getEmptyStateContent,
   getFileManagerLabel,
   getGridColumns,
+  getPlatformAssetDuplicate,
   getResourceTypeByRoute,
   ImportAssetActionMap,
   MoveAssetActionMap,
@@ -256,13 +258,22 @@ const BaseAssetList: FC<Props> = ({ view, runners }) => {
         if (res.success) {
           fetchFiles?.(folderPath);
           if (isCreateDuplicate) {
+            const isFlatAsset = isFlatPlatformView(view);
+            const entityLabel = isFlatAsset
+              ? asset.name || (asset as DialAppRunnerResource).$id
+              : `${asset.name}__${asset.version}`;
             showNotification(
               getSuccessNotification(
                 getCreateNotificationTitle(view, t),
-                getCreateNotificationDescription(view, `${asset.name}__${asset.version}`, t),
+                getCreateNotificationDescription(view, entityLabel, t),
               ),
             );
-            router.push(getUrnForEntity(view, { name: asset.name, version: asset.version, folderId: folderPath }));
+            router.push(
+              getUrnForEntity(
+                view,
+                isFlatAsset ? asset : { name: asset.name, version: asset.version, folderId: folderPath },
+              ),
+            );
           }
         } else {
           showNotification(getErrorNotification(res.errorHeader, res.errorMessage, res.requestId));
@@ -278,6 +289,13 @@ const BaseAssetList: FC<Props> = ({ view, runners }) => {
 
   const handleDuplicate = useCallback(
     (asset: AssetWithVersion) => {
+      if (isFlatPlatformView(view)) {
+        const duplicate = getPlatformAssetDuplicate(view, asset as unknown as PlatformAsset);
+        handleCreateAsset(duplicate as unknown as AssetWithVersion, void 0, true);
+        handleModalClose();
+        return;
+      }
+
       const newAsset = {
         ...asset,
         path: `${asset.folderId}${asset.name}__${asset.version}`,
@@ -286,7 +304,7 @@ const BaseAssetList: FC<Props> = ({ view, runners }) => {
       handleCreateAsset(newAsset as AssetApp, asset.folderId, true);
       handleModalClose();
     },
-    [handleCreateAsset, handleModalClose],
+    [handleCreateAsset, handleModalClose, view],
   );
 
   const handleMoveItems = useCallback(

--- a/apps/ai-dial-admin/src/components/Assets/BaseAssetList/Modals.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/BaseAssetList/Modals.tsx
@@ -5,6 +5,9 @@ import ExportModal from '@/src/components/EntityListView/Export/ExportModal';
 import ImportModal from '@/src/components/EntityListView/Import/ImportModal';
 import CreateEntity from '@/src/components/EntityListView/CreateEntity/CreateEntity';
 import DuplicateAsset from '@/src/components/Assets/Deployments/DuplicateAsset';
+import DuplicatePlatformAsset from '@/src/components/Assets/Modals/DuplicatePlatformAsset';
+import { PlatformAsset } from '@/src/models/dial/resource';
+import { isFlatPlatformView } from '@/src/utils/files/root-folder';
 import { ApplicationRoute } from '@/src/types/routes';
 import { ModalType } from './types';
 import { AssetsFolderContext } from '@/src/context/assets/AssetsFolderContext';
@@ -90,18 +93,29 @@ const Modals: FC<Props> = ({
           isModal
         />
       )}
-      {isModalOpen && modalType === ModalType.duplicate && (
-        <DuplicateAsset
-          context={getContext}
-          view={view}
-          isModalOpen={isModalOpen}
-          onClose={onClose}
-          entity={duplicateItem as AssetWithVersion}
-          versionsMap={versionsMap}
-          onDuplicate={onDuplicate}
-          onCreateFolder={onCreateFolder}
-        />
-      )}
+      {isModalOpen &&
+        modalType === ModalType.duplicate &&
+        (isFlatPlatformView(view) ? (
+          <DuplicatePlatformAsset
+            view={view}
+            isModalOpen={isModalOpen}
+            onClose={onClose}
+            names={names || []}
+            entity={duplicateItem as unknown as PlatformAsset}
+            onDuplicate={(asset) => onDuplicate?.(asset as unknown as AssetWithVersion)}
+          />
+        ) : (
+          <DuplicateAsset
+            context={getContext}
+            view={view}
+            isModalOpen={isModalOpen}
+            onClose={onClose}
+            entity={duplicateItem as AssetWithVersion}
+            versionsMap={versionsMap}
+            onDuplicate={onDuplicate}
+            onCreateFolder={onCreateFolder}
+          />
+        ))}
       {isModalOpen && modalType === ModalType.delete && deletedItems && (
         <DeleteAssetsModal
           context={getContext}

--- a/apps/ai-dial-admin/src/components/Assets/BaseAssetList/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/Assets/BaseAssetList/tests/utils.spec.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test, vi } from 'vitest';
-import { getAllSelectedItemsPaths } from '../utils';
+import { getAllSelectedItemsPaths, getPlatformAssetDuplicate } from '../utils';
+import { DialAppRunnerResource, DialModelResource, PlatformAsset } from '@/src/models/dial/resource';
+import { ApplicationRoute } from '@/src/types/routes';
 
 describe('BaseAssetList', () => {
   describe('getAllSelectedItemsPaths', () => {
@@ -21,6 +23,70 @@ describe('BaseAssetList', () => {
 
       expect(result).toHaveLength(1);
       expect(result).to.have.members(['public/test__3']);
+    });
+  });
+
+  describe('getPlatformAssetDuplicate', () => {
+    const model = {
+      name: 'gpt-4-copy',
+      displayName: 'GPT-4 copy',
+      endpoint: 'http://model/chat',
+      path: 'platform/gpt-4',
+      folderId: 'platform/',
+      author: 'someone',
+      createdAt: '1',
+      updatedAt: '2',
+      status: 'valid',
+      validationWarnings: [{ field: 'endpoint' }],
+      reference: 'abc123',
+    } as unknown as DialModelResource;
+
+    const runner = {
+      $id: 'http://runner/schema-copy',
+      'dial:applicationTypeDisplayName': 'Runner copy',
+      name: 'http%3A%2F%2Frunner%2Fschema',
+      path: 'platform/http%3A%2F%2Frunner%2Fschema',
+      folderId: 'platform/',
+      author: 'someone',
+      createdAt: '1',
+      updatedAt: '2',
+    } as unknown as DialAppRunnerResource;
+
+    test('should keep the model name, since it is the identity the user just edited', () => {
+      const duplicate = getPlatformAssetDuplicate(ApplicationRoute.AssetsModels, model) as DialModelResource;
+
+      expect(duplicate.name).toBe('gpt-4-copy');
+      expect(duplicate.displayName).toBe('GPT-4 copy');
+      expect(duplicate.endpoint).toBe('http://model/chat');
+    });
+
+    test('should drop the fields Core owns from a model duplicate', () => {
+      const duplicate = getPlatformAssetDuplicate(ApplicationRoute.AssetsModels, model);
+
+      expect(duplicate).not.toHaveProperty('path');
+      expect(duplicate).not.toHaveProperty('folderId');
+      expect(duplicate).not.toHaveProperty('author');
+      expect(duplicate).not.toHaveProperty('createdAt');
+      expect(duplicate).not.toHaveProperty('updatedAt');
+      expect(duplicate).not.toHaveProperty('status');
+      expect(duplicate).not.toHaveProperty('validationWarnings');
+      expect(duplicate).not.toHaveProperty('reference');
+    });
+
+    test('should drop the runner name, since keeping it navigates back to the original', () => {
+      const duplicate = getPlatformAssetDuplicate(ApplicationRoute.AssetsAppRunners, runner) as DialAppRunnerResource;
+
+      expect(duplicate).not.toHaveProperty('name');
+      expect(duplicate).not.toHaveProperty('path');
+      expect(duplicate.$id).toBe('http://runner/schema-copy');
+      expect(duplicate['dial:applicationTypeDisplayName']).toBe('Runner copy');
+    });
+
+    test('should not mutate the asset it was given', () => {
+      const source = { ...model } as PlatformAsset;
+      getPlatformAssetDuplicate(ApplicationRoute.AssetsModels, source);
+
+      expect(source).toEqual(model);
     });
   });
 });

--- a/apps/ai-dial-admin/src/components/Assets/BaseAssetList/utils.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/BaseAssetList/utils.tsx
@@ -35,6 +35,7 @@ import { useModelsFolder } from '@/src/context/assets/ModelsFolderContext';
 import { usePromptFolder } from '@/src/context/assets/PromptFolderContext';
 import { useToolsetFolder } from '@/src/context/assets/ToolsetsFolderContext';
 import { AssetWithVersion } from '@/src/models/dial/deployment-asset';
+import { DialAppRunnerResource, DialModelResource, PlatformAsset } from '@/src/models/dial/resource';
 import { ServerActionResponse } from '@/src/models/server-action';
 import { ImportFileType } from '@/src/types/import';
 import { ResourceType } from '@/src/types/resource-type';
@@ -231,6 +232,25 @@ export const getEmptyStateContent = (
     default:
       return { title: '', description: '' };
   }
+};
+
+export const getPlatformAssetDuplicate = (view: ApplicationRoute, asset: PlatformAsset): PlatformAsset => {
+  const {
+    path: __path,
+    folderId: __folderId,
+    author: __author,
+    createdAt: __createdAt,
+    updatedAt: __updatedAt,
+    status: __status,
+    validationWarnings: __validationWarnings,
+    reference: __reference,
+    name,
+    ...duplicate
+  } = asset as DialModelResource & DialAppRunnerResource;
+
+  return view === ApplicationRoute.AssetsAppRunners
+    ? (duplicate as PlatformAsset)
+    : ({ ...duplicate, name } as PlatformAsset);
 };
 
 export const getResourceTypeByRoute = (view: ApplicationRoute) => {

--- a/apps/ai-dial-admin/src/components/Assets/Modals/DuplicatePlatformAsset.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Modals/DuplicatePlatformAsset.tsx
@@ -1,0 +1,81 @@
+import { DialFormPopup } from '@epam/ai-dial-ui-kit';
+import { FC, useCallback, useState } from 'react';
+
+import DisplayNameControl from '@/src/components/BaseControls/DisplayName';
+import IdControl from '@/src/components/BaseControls/Id/Id';
+import { ButtonsI18nKey } from '@/src/constants/i18n';
+import { useSaveValidationContext } from '@/src/context/SaveValidationContext';
+import { useI18n } from '@/src/locales/client';
+import { DialAppRunnerResource, DialModelResource, PlatformAsset } from '@/src/models/dial/resource';
+import { ApplicationRoute } from '@/src/types/routes';
+import { CORE_UNENCODABLE_ID_CHARS } from '@/src/utils/app-runners/constants';
+import { getClonedEntityName, getCloneTitle } from '@/src/utils/entities/duplicate-entity';
+
+interface Props {
+  view: ApplicationRoute;
+  isModalOpen: boolean;
+  names: string[];
+  entity: PlatformAsset;
+  onClose: () => void;
+  onDuplicate: (entity: PlatformAsset) => void;
+}
+
+const DuplicatePlatformAsset: FC<Props> = ({ view, isModalOpen, names, entity, onClose, onDuplicate }) => {
+  const t = useI18n();
+  const { isValid } = useSaveValidationContext();
+  const isRunner = view === ApplicationRoute.AssetsAppRunners;
+
+  const [clonedAsset, setClonedAsset] = useState<PlatformAsset>(() =>
+    isRunner
+      ? ({ ...entity, $id: getClonedEntityName((entity as DialAppRunnerResource).$id, true) } as DialAppRunnerResource)
+      : ({ ...entity, name: getClonedEntityName(entity.name, true) } as DialModelResource),
+  );
+
+  const onChangeId = useCallback(
+    ({ name }: { name?: string }) => {
+      setClonedAsset((asset) => (isRunner ? { ...asset, $id: name } : { ...asset, name: name as string }));
+    },
+    [isRunner],
+  );
+
+  const onChangeDisplayName = useCallback(
+    (displayName?: string) => {
+      setClonedAsset((asset) =>
+        isRunner ? { ...asset, 'dial:applicationTypeDisplayName': displayName } : { ...asset, displayName },
+      );
+    },
+    [isRunner],
+  );
+
+  const id = isRunner ? (clonedAsset as DialAppRunnerResource).$id : clonedAsset.name;
+  const displayName = isRunner
+    ? (clonedAsset as DialAppRunnerResource)['dial:applicationTypeDisplayName']
+    : (clonedAsset as DialModelResource).displayName;
+
+  return (
+    <DialFormPopup
+      onClose={onClose}
+      header={getCloneTitle(view, t)}
+      portalId="DuplicatePlatformAsset"
+      open={isModalOpen}
+      onSubmit={() => onDuplicate(clonedAsset)}
+      onCancel={onClose}
+      disableSubmitButton={!isValid}
+      cancelLabel={t(ButtonsI18nKey.Cancel)}
+      submitLabel={t(ButtonsI18nKey.Duplicate)}
+    >
+      <div className="flex flex-col px-6 py-4 gap-y-8">
+        <IdControl
+          entity={{ name: id }}
+          names={names}
+          isUrlId={isRunner}
+          forbiddenChars={isRunner ? CORE_UNENCODABLE_ID_CHARS : void 0}
+          onChangeEntity={onChangeId}
+        />
+        <DisplayNameControl displayName={displayName} onChange={onChangeDisplayName} required />
+      </div>
+    </DialFormPopup>
+  );
+};
+
+export default DuplicatePlatformAsset;

--- a/apps/ai-dial-admin/src/components/Assets/Modals/tests/DuplicatePlatformAsset.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Modals/tests/DuplicatePlatformAsset.spec.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test, vi } from 'vitest';
+
+import { ButtonsI18nKey } from '@/src/constants/i18n';
+import { PlatformAsset } from '@/src/models/dial/resource';
+import { ApplicationRoute } from '@/src/types/routes';
+import DuplicatePlatformAsset from '../DuplicatePlatformAsset';
+
+const model = { name: 'gpt-4', displayName: 'GPT-4', endpoint: 'http://model/chat' } as PlatformAsset;
+const runner = {
+  $id: 'http://runner/schema',
+  'dial:applicationTypeDisplayName': 'Runner',
+} as unknown as PlatformAsset;
+
+const renderModal = (view: ApplicationRoute, entity: PlatformAsset, onDuplicate = vi.fn(), onClose = vi.fn()) => {
+  render(
+    <DuplicatePlatformAsset
+      view={view}
+      isModalOpen
+      names={[]}
+      entity={entity}
+      onClose={onClose}
+      onDuplicate={onDuplicate}
+    />,
+  );
+
+  return { onDuplicate, onClose };
+};
+
+describe('DuplicatePlatformAsset', () => {
+  test('Should offer only an id and a display name, these assets having no version or folder', () => {
+    renderModal(ApplicationRoute.AssetsModels, model);
+
+    expect(screen.getAllByRole('textbox')).toHaveLength(2);
+  });
+
+  test('Should suffix the model id without brackets, which Core rejects in a resource name', () => {
+    renderModal(ApplicationRoute.AssetsModels, model);
+
+    expect(screen.getAllByRole('textbox')[0]).toHaveValue('gpt-4-copy');
+  });
+
+  test('Should duplicate a model under the edited name', async () => {
+    const user = userEvent.setup();
+    const { onDuplicate } = renderModal(ApplicationRoute.AssetsModels, model);
+
+    await user.click(screen.getByRole('button', { name: ButtonsI18nKey.Duplicate }));
+
+    expect(onDuplicate).toHaveBeenCalledWith({ ...model, name: 'gpt-4-copy' });
+  });
+
+  test('Should edit an app runner through its $id, not its name', async () => {
+    const user = userEvent.setup();
+    const { onDuplicate } = renderModal(ApplicationRoute.AssetsAppRunners, runner);
+    const idInput = screen.getAllByRole('textbox')[0];
+
+    expect(idInput).toHaveValue('http://runner/schema-copy');
+
+    fireEvent.change(idInput, { target: { value: 'http://runner/other' } });
+    await user.click(screen.getByRole('button', { name: ButtonsI18nKey.Duplicate }));
+
+    expect(onDuplicate).toHaveBeenCalledWith({ ...runner, $id: 'http://runner/other' });
+  });
+
+  test('Should close without duplicating on cancel', async () => {
+    const user = userEvent.setup();
+    const { onDuplicate, onClose } = renderModal(ApplicationRoute.AssetsModels, model);
+
+    await user.click(screen.getByRole('button', { name: ButtonsI18nKey.Cancel }));
+
+    expect(onClose).toHaveBeenCalled();
+    expect(onDuplicate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ai-dial-admin/src/components/Assets/Models/tests/folder-actions.spec.ts
+++ b/apps/ai-dial-admin/src/components/Assets/Models/tests/folder-actions.spec.ts
@@ -27,9 +27,16 @@ describe('Model asset :: folder operations', () => {
     expect(getToolbarOptionLabels(VIEW, false).map((item) => item.key)).toEqual(['newItem']);
   });
 
-  test('Should offer only delete in the grid context menu', () => {
-    expect(getGridActionLabels(VIEW, false).map((item) => item.key)).toEqual(['delete']);
+  test('Should offer duplicate, delete and open-in-new-tab in the grid context menu', () => {
+    expect(getGridActionLabels(VIEW, false).map((item) => item.key)).toEqual(['duplicate', 'delete', 'openInNewTab']);
   });
+
+  test.each(['addSibling', 'addChild', 'move', 'rename', 'managePermissions'])(
+    'Should not offer the folder-bound %s in the grid context menu',
+    (action) => {
+      expect(getGridActionLabels(VIEW, false).map((item) => item.key)).not.toContain(action);
+    },
+  );
 
   test('Should confirm the placeholder a folder create would send is not a usable model', () => {
     expect(getEmptyAsset(VIEW, 'platform/')).not.toHaveProperty('endpoint');

--- a/apps/ai-dial-admin/src/components/Assets/utils.ts
+++ b/apps/ai-dial-admin/src/components/Assets/utils.ts
@@ -90,7 +90,11 @@ export const getGridActionLabels = (view: ApplicationRoute, isReadOnlyAdmin: boo
         : allActionLabels.filter((item) => item.key !== 'duplicate' && item.key !== 'openInNewTab');
     case ApplicationRoute.AssetsModels:
     case ApplicationRoute.AssetsAppRunners:
-      return isReadOnlyAdmin ? [] : allActionLabels.filter((item) => item.key === 'delete');
+      return isReadOnlyAdmin
+        ? []
+        : allActionLabels.filter(
+            (item) => item.key === 'duplicate' || item.key === 'delete' || item.key === 'openInNewTab',
+          );
     case ApplicationRoute.AssetsApplications:
     case ApplicationRoute.AssetsToolsets:
     case ApplicationRoute.Prompts:

--- a/apps/ai-dial-admin/src/models/dial/resource.ts
+++ b/apps/ai-dial-admin/src/models/dial/resource.ts
@@ -143,6 +143,9 @@ export interface DialAppRunnerResource extends Omit<
   ['dial:applicationTypeRoutes']?: DialAppRoute[];
 }
 
+/** The resource types DIAL Core keeps in its flat `platform` bucket — see `isFlatPlatformView`. */
+export type PlatformAsset = DialModelResource | DialAppRunnerResource;
+
 export enum DialModelResourceType {
   Chat = 'CHAT',
   Completion = 'COMPLETION',

--- a/apps/ai-dial-admin/src/utils/entities/duplicate-entity.ts
+++ b/apps/ai-dial-admin/src/utils/entities/duplicate-entity.ts
@@ -3,6 +3,8 @@ import { ApplicationRoute } from '@/src/types/routes';
 
 export const duplicateEntityMap: Record<string, DuplicateI18nKey> = {
   [ApplicationRoute.Models]: DuplicateI18nKey.Model,
+  [ApplicationRoute.AssetsModels]: DuplicateI18nKey.Model,
+  [ApplicationRoute.AssetsAppRunners]: DuplicateI18nKey.ApplicationRunner,
   [ApplicationRoute.Applications]: DuplicateI18nKey.Application,
   [ApplicationRoute.AssetsApplications]: DuplicateI18nKey.Application,
   [ApplicationRoute.AssetsToolsets]: DuplicateI18nKey.Toolset,


### PR DESCRIPTION
**Description:**

Add duplicate and open-in-new-tab row actions to the context menu for Models and AppRunners in the Assets section. This resolves the missing actions in the grid context menu for these platform assets.

The implementation includes:
- New `DuplicatePlatformAsset` modal component for handling duplication of flat platform resources
- Logic to preserve editable fields while dropping Core-owned metadata during duplication
- Updated grid action labels to include duplicate and openInNewTab for Models and AppRunners
- Comprehensive test coverage for the new functionality

Issues:

- Issue #4110

**Key Changes:**

- [apps/ai-dial-admin/src/components/Assets/BaseAssetList/BaseAssetList.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/development/apps/ai-dial-admin/src/components/Assets/BaseAssetList/BaseAssetList.tsx) — add duplicate action handler for platform assets
- [apps/ai-dial-admin/src/components/Assets/BaseAssetList/Modals.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/development/apps/ai-dial-admin/src/components/Assets/BaseAssetList/Modals.tsx) — conditionally render DuplicatePlatformAsset modal for flat views
- [apps/ai-dial-admin/src/components/Assets/BaseAssetList/utils.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/development/apps/ai-dial-admin/src/components/Assets/BaseAssetList/utils.tsx) — add getPlatformAssetDuplicate utility function
- [apps/ai-dial-admin/src/components/Assets/utils.ts](https://github.com/epam/ai-dial-admin-frontend/blob/development/apps/ai-dial-admin/src/components/Assets/utils.ts) — update getGridActionLabels to include duplicate and openInNewTab for Models and AppRunners
- [apps/ai-dial-admin/src/models/dial/resource.ts](https://github.com/epam/ai-dial-admin-frontend/blob/development/apps/ai-dial-admin/src/models/dial/resource.ts) — add PlatformAsset type alias

**New Components:**

- [apps/ai-dial-admin/src/components/Assets/Modals/DuplicatePlatformAsset.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/development/apps/ai-dial-admin/src/components/Assets/Modals/DuplicatePlatformAsset.tsx) — modal component for duplicating platform assets (Models and AppRunners)

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #4110)` (comma-separated list of issues)