### PR TITLE
fix: [Assets-AppRunners] add Create Assets Application action on App Runner detail page (Issue #4111)

### DIFF
--- a/apps/ai-dial-admin/src/components/Assets/AppRunners/View.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/AppRunners/View.tsx
@@ -2,24 +2,40 @@
 
 import { useRouter } from 'next/navigation';
 import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 
-import { removeRunner, updateRunner } from '@/src/app/[lang]/assets-app-runners/actions';
+import { DialNeutralButton } from '@epam/ai-dial-ui-kit';
+import { IconPlus } from '@tabler/icons-react';
+import { JSONSchema7 } from 'json-schema';
+
+import { getResolvedRunnerSchema, removeRunner, updateRunner } from '@/src/app/[lang]/assets-app-runners/actions';
+import { createApp } from '@/src/app/[lang]/assets-applications/actions';
+import CreateAsset from '@/src/components/Assets/Deployments/CreateAsset';
 import { JsonConfiguration } from '@/src/components/EntityHeaderControls/models';
 import SimpleEntityHeader from '@/src/components/EntityHeaderControls/SimpleHeader';
 import EntityJsonEditor from '@/src/components/EntityTabs/JsonEditor/JsonEditor';
 import { useAppRunnersFolder } from '@/src/context/assets/AppRunnersFolderContext';
+import { useAppsFolder } from '@/src/context/assets/AppsFolderContext';
 import { useNotification } from '@/src/context/NotificationContext';
+import { useSaveValidationContext, ValidationActionType } from '@/src/context/SaveValidationContext';
 import { useProtectedRequest } from '@/src/hooks/use-protected-request';
-import { EntitiesI18nKey } from '@/src/constants/i18n';
+import { ButtonsI18nKey, CreateI18nKey, EntitiesI18nKey } from '@/src/constants/i18n';
+import { BASE_BUTTON_ICON_PROPS } from '@/src/constants/main-layout';
 import { useI18n } from '@/src/locales/client';
+import { DialApplicationScheme } from '@/src/models/dial/application';
 import { DialInterceptor } from '@/src/models/dial/interceptor';
-import { DialAppRunnerResource } from '@/src/models/dial/resource';
+import { DialAppRunnerResource, DialResource } from '@/src/models/dial/resource';
 import { DialRole } from '@/src/models/dial/role';
+import { ServerActionResponse } from '@/src/models/server-action';
 import { ApplicationRoute } from '@/src/types/routes';
+import { toCoreRunnerName } from '@/src/utils/app-runners/core-runner-name';
+import { toRunnerReference } from '@/src/utils/app-runners/runner-reference';
 import { validateAppRunner } from '@/src/utils/app-runners/validation';
+import { createSchemaSource } from '@/src/utils/entities/application-source';
 import { getUpdateNotificationDescription, getUpdateNotificationTitle } from '@/src/utils/entities/update-entity';
 import { isEqualSkippingUndefined } from '@/src/utils/is-equals-entity';
 import { getErrorNotification, getSuccessNotification } from '@/src/utils/notification';
+import { getSchemaDefaults } from '@/src/utils/schema';
 import { EntityViewTab, getTabsForAsset } from '@/src/utils/tabs/utils';
 import TabsContent from './TabsContent';
 
@@ -46,6 +62,7 @@ const AppRunnerAssetView: FC<Props> = ({
   const router = useRouter();
   const { fetchFiles } = useAppRunnersFolder();
   const { showNotification } = useNotification();
+  const { dispatch } = useSaveValidationContext();
   const getReqRef = useRef(useProtectedRequest());
 
   const [activeTab, setActiveTab] = useState(EntityViewTab.Properties);
@@ -54,6 +71,8 @@ const AppRunnerAssetView: FC<Props> = ({
   const [isEditorEnabled, setIsEditorEnabled] = useState(false);
   const [isSkipRefresh, setIsSkipRefresh] = useState(false);
   const [discardKey, setDiscardKey] = useState(0);
+  const [isCreateAssetAppModalOpen, setIsCreateAssetAppModalOpen] = useState(false);
+  const [applicationProperties, setApplicationProperties] = useState<Record<string, unknown>>();
 
   const jsonConfiguration = useMemo<JsonConfiguration>(
     () => ({
@@ -65,6 +84,22 @@ const AppRunnerAssetView: FC<Props> = ({
 
   useEffect(() => {
     setSelectedRunner(structuredClone(originalRunner));
+  }, [originalRunner]);
+
+  // Resolved against the saved runner, not `selectedRunner`: Core resolves what is stored, so in-flight
+  // edits would derive defaults from a schema Core has not seen. A failed resolve falls back to the
+  // runner's own schema so the create modal still opens with usable defaults.
+  useEffect(() => {
+    const id = originalRunner.$id;
+
+    if (!id) {
+      return;
+    }
+
+    getResolvedRunnerSchema(toCoreRunnerName(id)).then((res) => {
+      const resolved = res.success ? (res.response as DialApplicationScheme | undefined) : undefined;
+      setApplicationProperties(getSchemaDefaults((resolved ?? originalRunner) as JSONSchema7));
+    });
   }, [originalRunner]);
 
   // An option list read from only one of Core's two populations is shown rather than withheld, so the
@@ -86,6 +121,11 @@ const AppRunnerAssetView: FC<Props> = ({
     setSelectedRunner(structuredClone(originalRunner));
     setDiscardKey((prev) => prev + 1);
   }, [originalRunner]);
+
+  const onCloseCreateAssetAppModal = useCallback(() => {
+    setIsCreateAssetAppModalOpen(false);
+    dispatch({ type: ValidationActionType.Reset });
+  }, [dispatch]);
 
   const onChange = useCallback((runner: DialAppRunnerResource, skipRefresh?: boolean) => {
     setSelectedRunner(runner);
@@ -134,7 +174,13 @@ const AppRunnerAssetView: FC<Props> = ({
         onChangeActiveTab={setActiveTab}
         onRemove={removeRunner}
         getAssetContext={useAppRunnersFolder}
-      />
+      >
+        <DialNeutralButton
+          label={`${t(ButtonsI18nKey.Create)} ${t(CreateI18nKey.AssetApplication)}`}
+          iconBefore={<IconPlus {...BASE_BUTTON_ICON_PROPS} />}
+          onClick={() => setIsCreateAssetAppModalOpen(true)}
+        />
+      </SimpleEntityHeader>
 
       <div className="flex-1 overflow-auto min-h-0">
         {isEditorEnabled ? (
@@ -156,6 +202,21 @@ const AppRunnerAssetView: FC<Props> = ({
             onChange={onChange}
           />
         )}
+        {isCreateAssetAppModalOpen &&
+          createPortal(
+            <CreateAsset
+              view={ApplicationRoute.AssetsApplications}
+              isModalOpen={isCreateAssetAppModalOpen}
+              onClose={onCloseCreateAssetAppModal}
+              onCreate={createApp as (entity: DialResource) => Promise<ServerActionResponse>}
+              context={useAppsFolder}
+              initialValues={{
+                source: originalRunner.$id ? createSchemaSource(toRunnerReference(originalRunner.$id)) : undefined,
+                applicationProperties,
+              }}
+            />,
+            document.body,
+          )}
       </div>
     </div>
   );

--- a/apps/ai-dial-admin/src/components/Assets/AppRunners/tests/create-asset-application.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/AppRunners/tests/create-asset-application.spec.tsx
@@ -1,0 +1,136 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { getResolvedRunnerSchema } from '@/src/app/[lang]/assets-app-runners/actions';
+import { SOURCE_TYPE } from '@/src/components/SourceField/types';
+import { ButtonsI18nKey, CreateI18nKey } from '@/src/constants/i18n';
+import { DialAppRunnerResource } from '@/src/models/dial/resource';
+import { ApplicationRoute } from '@/src/types/routes';
+import AppRunnerAssetView from '../View';
+
+vi.mock('@/src/app/[lang]/assets-app-runners/actions', () => ({
+  updateRunner: vi.fn().mockResolvedValue({ success: true }),
+  removeRunner: vi.fn(),
+  getResolvedRunnerSchema: vi.fn().mockResolvedValue({ success: false }),
+}));
+
+vi.mock('@/src/app/[lang]/assets-applications/actions', () => ({
+  createApp: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+// The header's own gating is covered by its wrapper; here it only has to expose the children slot the
+// create action is passed through, which `View.spec.tsx`'s save-only stub deliberately does not.
+vi.mock('@/src/components/EntityHeaderControls/SimpleHeader', () => ({
+  default: ({ children }: any) => <div>{children}</div>,
+}));
+
+const createAssetProps = vi.fn();
+vi.mock('@/src/components/Assets/Deployments/CreateAsset', () => ({
+  default: (props: any) => {
+    createAssetProps(props);
+    return <div>create-asset-modal</div>;
+  },
+}));
+
+vi.mock('../TabsContent', () => ({ default: () => <div>tabs-content</div> }));
+vi.mock('next/navigation', () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
+
+const CREATE_ACTION_NAME = `${ButtonsI18nKey.Create} ${CreateI18nKey.AssetApplication}`;
+
+const runner = (overrides: Partial<DialAppRunnerResource> = {}): DialAppRunnerResource =>
+  ({
+    $id: 'https://host/runner',
+    'dial:applicationTypeDisplayName': 'Runner',
+    name: 'https%3A%2F%2Fhost%2Frunner',
+    path: 'https%3A%2F%2Fhost%2Frunner',
+    folderId: '',
+    ...overrides,
+  }) as DialAppRunnerResource;
+
+const renderView = (entity: DialAppRunnerResource = runner()) =>
+  render(
+    <AppRunnerAssetView etag="etag" originalRunner={entity} roles={[]} interceptors={[]} globalInterceptors={[]} />,
+  );
+
+const openCreateModal = async (entity: DialAppRunnerResource = runner()) => {
+  const user = userEvent.setup();
+  renderView(entity);
+
+  // The seeded defaults are resolved on mount, so let that settle before opening the modal — otherwise
+  // the captured props read a value the user would never see. An id-less runner resolves nothing.
+  if (entity.$id) {
+    await waitFor(() => expect(getResolvedRunnerSchema).toHaveBeenCalled());
+  }
+  await user.click(screen.getByRole('button', { name: CREATE_ACTION_NAME }));
+};
+
+const lastInitialValues = () => createAssetProps.mock.calls.at(-1)?.[0].initialValues;
+
+describe('App runner asset :: create asset application action', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getResolvedRunnerSchema).mockResolvedValue({ success: false } as never);
+  });
+
+  test('Should offer the create-asset-application action in the header', () => {
+    renderView();
+
+    expect(screen.getByRole('button', { name: CREATE_ACTION_NAME })).toBeInTheDocument();
+  });
+
+  test('Should not mount the create modal until the action is used', () => {
+    renderView();
+
+    expect(screen.queryByText('create-asset-modal')).not.toBeInTheDocument();
+  });
+
+  test('Should open the shared create modal against the asset applications view', async () => {
+    await openCreateModal();
+
+    expect(screen.getByText('create-asset-modal')).toBeInTheDocument();
+    expect(createAssetProps).toHaveBeenCalledWith(
+      expect.objectContaining({ view: ApplicationRoute.AssetsApplications, isModalOpen: true }),
+    );
+  });
+
+  test('Should seed the source with the runner Core resource reference, not the bare id', async () => {
+    await openCreateModal();
+
+    expect(lastInitialValues().source).toEqual({
+      $type: SOURCE_TYPE.SCHEMA,
+      applicationTypeSchemaId: 'schemas/platform/https%3A%2F%2Fhost%2Frunner',
+    });
+  });
+
+  test('Should offer no source when the runner has no id to reference', async () => {
+    await openCreateModal(runner({ $id: undefined }));
+
+    expect(lastInitialValues().source).toBeUndefined();
+  });
+
+  test('Should resolve the schema against Core by the encoded resource name', () => {
+    renderView();
+
+    expect(getResolvedRunnerSchema).toHaveBeenCalledWith('https%3A%2F%2Fhost%2Frunner');
+  });
+
+  test('Should seed application properties from the Core-resolved schema', async () => {
+    vi.mocked(getResolvedRunnerSchema).mockResolvedValue({
+      success: true,
+      response: { properties: { region: { type: 'string', default: 'eu-west' } } },
+    } as never);
+
+    await openCreateModal();
+
+    expect(lastInitialValues().applicationProperties).toEqual({ region: 'eu-west' });
+  });
+
+  test('Should fall back to the runner own schema when Core cannot resolve it', async () => {
+    await openCreateModal(
+      runner({ properties: { region: { type: 'string', default: 'from-runner' } } } as Partial<DialAppRunnerResource>),
+    );
+
+    expect(lastInitialValues().applicationProperties).toEqual({ region: 'from-runner' });
+  });
+});

--- a/openspec/changes/archive/2026-08-10-app-runner-create-asset-application/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-10-app-runner-create-asset-application/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-10

--- a/openspec/changes/archive/2026-08-10-app-runner-create-asset-application/design.md
+++ b/openspec/changes/archive/2026-08-10-app-runner-create-asset-application/design.md
@@ -1,0 +1,85 @@
+## Context
+
+Two `App Runner` detail views exist. `Entities > Application Runners`
+(`components/ApplicationRunners/View/View.tsx`) offers a `Create` dropdown with `Application` and `Assets
+Application`; `Assets > App Runners` (`components/Assets/AppRunners/View.tsx`) passes no `children` to
+`SimpleEntityHeader` and so shows `Delete` alone. Issue #4111 reads the second as a regression against the first.
+
+The two runner populations are referenced differently, and that is the whole of the technical content here:
+
+- An **entity** runner is referenced by its bare `$id`, resolved against the admin backend's runner table.
+- An **asset** runner is referenced by its Core resource name, `schemas/platform/{encodeURIComponent($id)}`, built by
+  `toRunnerReference` (`utils/app-runners/runner-reference.ts`) and accepted by the `Assets > Applications` picker
+  since Issue #4078.
+
+So the entity view's `initialValues` — `createSchemaSource(selectedRunner.$id)` plus defaults from the admin BE's
+`getResolvedApplicationScheme` — cannot be copied verbatim; both halves need the asset counterpart. The header slot
+itself needs nothing: `SimpleButtonsWrapper` already renders `children` after `Delete`, and only when the viewer is
+not a read-only admin, the entity is unchanged, and the JSON editor is off.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add one header action, `Create Assets Application`, seeded so the created application reopens with the runner
+  selected.
+- Compose it from existing pieces — no new component, util, i18n key, or server action.
+- Keep every shared component (`SimpleHeader`, `SimpleButtonsWrapper`, `CreateAsset`, `AssetProperties`) untouched,
+  so no other surface can regress.
+
+**Non-Goals:**
+
+- No entity `Create Application` action (see the proposal's non-goals — the reference has no admin-BE row).
+- No dropdown, no `Applications` tab, no change to `Entities > Application Runners`.
+- No change to how the `Assets > Applications` picker resolves or renders runners.
+
+## Decisions
+
+**Seed the source with `createSchemaSource(toRunnerReference($id))`, not the bare `$id`.**
+`createApp` maps `source.applicationTypeSchemaId` onto `application_type_schema_id`
+(`app/[lang]/assets-applications/actions.ts`), and the picker resolves an asset runner only through the
+`schemas/platform/…` form — `fromRunnerReference` is what turns a stored reference back into a runner. Writing the
+bare `$id` would round-trip as unresolvable and the reopened application's App Runner field would be blank. Rejected
+alternative: write the bare `$id` and broaden the picker's resolution — that would relax a contract two other
+surfaces depend on to save one call to an existing helper.
+
+**Derive `applicationProperties` from Core's `getResolvedRunnerSchema`, not the admin BE's resolver.**
+This is the same origin-driven split `SourceField/Application/AppRunners.tsx` already makes when a user picks an
+asset runner in the merged picker: `getResolvedRunnerSchema(toCoreRunnerName($id))` for asset, the admin BE's
+`getResolvedApplicationScheme` for entity. Reusing that branch keeps one behaviour for "defaults for an asset
+runner" rather than two. On failure, fall back to `getSchemaDefaults` over the runner resource as loaded — the same
+fallback-to-self the entity view uses, so a resolver outage degrades the defaults instead of blocking the modal.
+
+**Key the resolution effect on `originalRunner.$id`, not on `selectedRunner`.**
+The entity view re-resolves on every `selectedRunner` change, which refires on each keystroke in the runner's own
+tabs. Core resolves what is *stored*, so the saved resource is the correct input, and `$id` is immutable after
+create — one fetch per runner, and the defaults match what Core would actually produce.
+
+**Pass the action through the header's `children` slot as a single `DialNeutralButton`.**
+`Adapters` (`Create Model`) and `Interceptor Templates` (`Create Interceptor`) already establish the
+single-target shape, and the slot brings the read-only-admin / unsaved-changes / JSON-editor gating for free.
+Label composed as `` `${t(ButtonsI18nKey.Create)} ${t(CreateI18nKey.AssetApplication)}` `` → "Create Assets
+Application", matching the Adapter precedent, so no i18n key is added. Rejected alternative: a
+`DialButtonDropdown` with one item — a menu that never offers a choice.
+
+**Let `CreateAsset` keep owning the modal, including the source field's absence.**
+`AssetProperties` already hides the source field when `initialValues` is present, so the runner cannot be
+overridden inside a modal opened *from* that runner; `CreateAsset` already owns validation gating, the
+success/error notification, folder refresh, and navigation to the new application. Reset the shared
+`SaveValidationContext` on close, as the entity view does, so the modal's field registrations do not leak into the
+runner's own save gating. Nothing new to write on either count.
+
+## Risks / Trade-offs
+
+- **The issue asks for two actions and gets one** → the proposal and the spec delta both record why the entity
+  variant is impossible, and the exclusion moves from a buried non-goal to an asserted scenario, so the next reader
+  of the issue does not re-open it as an oversight. Worth stating on the ticket.
+- **The seeded reference is only correct as long as the picker's resolution rule holds** → the round-trip is asserted
+  by a test on the exact `schemas/platform/…` string, so a change to either side fails loudly rather than silently
+  producing blank App Runner fields.
+- **Sharing `SaveValidationContext` between the runner view and the create modal** → already the pattern on the
+  entity runner view; the `Reset` on close is what keeps it sound, and the runner's own save gating is covered by
+  the existing `View.spec.tsx` validation tests.
+- **`getResolvedRunnerSchema` adds one Core call per runner detail load** → unconditional so the modal opens
+  instantly, matching the entity view's behaviour; it is one request against a resource the page has already read,
+  and a failure is non-fatal.

--- a/openspec/changes/archive/2026-08-10-app-runner-create-asset-application/proposal.md
+++ b/openspec/changes/archive/2026-08-10-app-runner-create-asset-application/proposal.md
@@ -1,0 +1,64 @@
+## Why
+
+`Assets > App Runners > <runner>` offers only `Delete` in its detail header, while `Entities > Application
+Runners` offers a `Create` action that seeds a new application with the runner as its source (Issue #4111).
+Having configured an asset runner, an admin has to navigate away, create an asset application, and hunt the
+runner down in the source picker — the one action the surface exists to enable is the one it does not offer.
+
+The omission was deliberate when the surface shipped: nothing could point at an asset runner yet. Issue #4078
+has since wired asset runners into the `Assets > Applications` source picker, so the deferral's precondition is
+gone and the archived non-goal is now just a gap.
+
+## What Changes
+
+- Add a `Create Assets Application` action to the app-runner asset detail header, beside `Delete`, seeding the
+  new application's source with the runner being viewed.
+- Seed the source as the runner's Core resource reference — `schemas/platform/{encodeURIComponent($id)}` via the
+  existing `toRunnerReference` — and its `applicationProperties` defaults from DIAL Core's resolved-schema read,
+  so the created application reopens with the runner selected.
+- Reuse the header's existing `children` slot (`SimpleButtonsWrapper`) and the shared `CreateAsset` modal, so the
+  action inherits the established gating: hidden for a read-only admin, while the entity has unsaved changes, and
+  while the JSON editor is open.
+
+### Non-goals
+
+- **No entity `Create Application` action**, despite Issue #4111 asking for a dropdown offering both. An entity
+  application's `application_type_schema_id` is a foreign key into the admin backend's own runner table, and
+  `Entities > Applications` deliberately offers admin-BE runners only — an asset runner has no row to point at, so
+  the action could only produce a reference that reopens blank or is rejected on write. This restates the reason
+  the archived `add-app-runner-asset-resource` proposal gave for excluding it; that half of the issue stays
+  excluded, and the exclusion is now recorded as a spec scenario rather than only as a non-goal.
+- **A single button, not a dropdown.** With one valid target, the shape follows `Adapters` (`Create Model`) and
+  `Interceptor Templates` (`Create Interceptor`), not the two-item dropdown on the entity runner view.
+- **No `Applications` tab** on the runner — the reverse association remains an admin-BE concept with no Core
+  counterpart.
+- **No change to `Entities > Application Runners`**, its create dropdown, or any other detail-view header.
+- **No new i18n keys** — `ButtonsI18nKey.Create` and `CreateI18nKey.AssetApplication` already exist.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `assets-app-runners`: the `App-runner asset detail view tab set` requirement currently forbids both outbound
+  create actions (`Scenario: No outbound create-application actions`). That scenario is replaced: an
+  `Assets Application` action is required, with the reference form and defaults source it must seed, and the
+  entity `Application` action is required to stay absent for the foreign-key reason above.
+
+## Impact
+
+- **Changed**: `src/components/Assets/AppRunners/View.tsx` — the only production file. Adds the header action, the
+  Core-resolved `applicationProperties` derivation, and the portalled `CreateAsset` modal.
+- **Reused unchanged**: `toRunnerReference` (`utils/app-runners/runner-reference.ts`), `toCoreRunnerName`,
+  `createSchemaSource` (`utils/entities/application-source.ts`), `getSchemaDefaults` (`utils/schema.ts`),
+  `getResolvedRunnerSchema` (`app/[lang]/assets-app-runners/actions.ts`), `CreateAsset`
+  (`components/Assets/Deployments/CreateAsset.tsx`), `createApp` (`app/[lang]/assets-applications/actions.ts`),
+  and `useAppsFolder`, whose provider is already global in `app/[lang]/layout.tsx`.
+- **Not touched**: `SimpleHeader.tsx` / `SimpleButtonsWrapper.tsx` (the `children` slot already renders after
+  `Delete` under the right gating), every server action, and every other entity view. No new util, no new i18n key,
+  no shared-component change — so no risk to the surfaces sharing `CreateAsset` or the header wrappers.
+- **Tests**: one new spec under `src/components/Assets/AppRunners/tests/`. The existing `View.spec.tsx` stubs
+  `SimpleHeader` down to a save button, so it cannot observe header children and stays as is.

--- a/openspec/changes/archive/2026-08-10-app-runner-create-asset-application/specs/assets-app-runners/spec.md
+++ b/openspec/changes/archive/2026-08-10-app-runner-create-asset-application/specs/assets-app-runners/spec.md
@@ -1,0 +1,78 @@
+## MODIFIED Requirements
+
+### Requirement: App-runner asset detail view tab set
+
+The system SHALL render an app-runner asset's detail view with exactly five tabs — `Properties`, `Features`,
+`Parameters`, `AppRoutes`, and `Interceptors` — and SHALL NOT include an `Applications` tab, an `Audit` tab, or a
+Core-sync status banner.
+
+The detail header SHALL offer one outbound create action, `Create Assets Application`, which opens the shared
+asset-application create modal with the runner being viewed pre-selected as the new application's source. It SHALL
+NOT offer an equivalent action for `Entities > Applications`: that reference is a foreign key into the admin
+backend's own runner table, so an asset runner has no row to point at and the created application could only reopen
+with an unresolvable source. Because a single valid target does not warrant a menu, the action SHALL be a single
+button rather than the two-item dropdown `Entities > Application Runners` offers.
+
+#### Scenario: Detail view renders exactly five tabs
+
+- **WHEN** a user opens an app-runner asset's detail view
+- **THEN** the tab list contains exactly `Properties`, `Features`, `Parameters`, `AppRoutes`, and `Interceptors`
+
+#### Scenario: No Applications tab
+
+- **WHEN** a user opens an app-runner asset's detail view
+- **THEN** there is no `Applications` tab, unlike `Entities > Application Runners`
+
+#### Scenario: No Audit tab or sync banner
+
+- **WHEN** a user opens an app-runner asset's detail view
+- **THEN** no `Audit` tab is present and no Core-sync status banner is rendered in the header
+
+#### Scenario: No outbound create-application actions
+
+Scoped to the entity variant. This scenario once prohibited both outbound create actions; the asset variant became
+valid once asset runners were selectable from `Assets > Applications`, and is required by the scenarios below. The
+heading is retained because a scenario's name is the identity a delta rewrites content under.
+
+- **WHEN** a user opens an app-runner asset's detail view header
+- **THEN** no action creating an entity `Application` is offered, since an asset runner is not addressable as an
+  entity application's `application_type_schema_id`
+- **AND** no `Create` dropdown is present offering an `Application` item, as `Entities > Application Runners` has
+
+#### Scenario: The header offers a create-asset-application action
+
+- **WHEN** a user opens an app-runner asset's detail view header
+- **THEN** a `Create Assets Application` action is offered alongside `Delete`
+- **AND** it is a single button, not a dropdown
+
+#### Scenario: The create modal opens with the runner as a fixed source
+
+- **WHEN** a user activates `Create Assets Application`
+- **THEN** the shared asset-application create modal opens, requesting name, display name, version, and description
+- **AND** no source field is offered, since the source is the runner the action was started from
+
+#### Scenario: The new application references the runner by its Core resource name
+
+- **WHEN** a user creates an asset application from a runner whose `$id` is `http://asdqwe`
+- **THEN** the application's `application_type_schema_id` is `schemas/platform/http%3A%2F%2Fasdqwe`, the same
+  reference form the `Assets > Applications` picker writes for an asset runner
+- **AND** reopening that application shows the runner as its selected App Runner rather than a blank field
+
+#### Scenario: Parameter defaults come from Core's resolved schema
+
+- **WHEN** the create action seeds the new application's `applicationProperties`
+- **THEN** the defaults are derived from DIAL Core's resolved-schema read for that runner, not the admin backend's
+- **AND** if that read fails, the defaults are derived from the runner resource as loaded, so the modal still opens
+
+#### Scenario: Creation reports its outcome and navigates to the new application
+
+- **WHEN** the create request succeeds
+- **THEN** a success notification naming the created asset application is shown and the browser navigates to that
+  application's detail view
+- **AND** when the request fails, an error notification carrying the server's message is shown and the modal stays
+  open
+
+#### Scenario: The action follows the header's existing gating
+
+- **WHEN** the viewer is a read-only admin, or the runner has unsaved changes, or the JSON editor is open
+- **THEN** the create action is not offered, exactly as `Delete` is not, rather than being offered in a disabled state

--- a/openspec/changes/archive/2026-08-10-app-runner-create-asset-application/tasks.md
+++ b/openspec/changes/archive/2026-08-10-app-runner-create-asset-application/tasks.md
@@ -1,0 +1,55 @@
+## 1. Header action on the app-runner asset detail view
+
+All production work lands in `apps/ai-dial-admin/src/components/Assets/AppRunners/View.tsx`. No shared component,
+util, server action, or i18n key changes — see `design.md`.
+
+- [x] 1.1 Derive the seeded `applicationProperties` in `View.tsx`: in a `useEffect` keyed on `originalRunner.$id`,
+      call `getResolvedRunnerSchema(toCoreRunnerName(originalRunner.$id ?? ''))`
+      (`@/src/app/[lang]/assets-app-runners/actions`) and store
+      `getSchemaDefaults(scheme as JSONSchema7) as Record<string, unknown>` in state; when the read fails or returns
+      nothing, fall back to `originalRunner` as the scheme so the modal still opens with usable defaults.
+- [x] 1.2 Add `isCreateAssetAppModalOpen` state and render a `DialNeutralButton` as `children` of
+      `SimpleEntityHeader`, labelled `` `${t(ButtonsI18nKey.Create)} ${t(CreateI18nKey.AssetApplication)}` `` with
+      `iconBefore={<IconPlus {...BASE_BUTTON_ICON_PROPS} />}` — the `Adapter/View/View.tsx` shape. No change to
+      `EntityHeaderControls/SimpleHeader.tsx` or `Wrappers/SimpleButtonsWrapper.tsx`; the `children` slot already
+      renders after `Delete` and already hides for a read-only admin, while `isChanged`, and while the JSON editor
+      is open.
+- [x] 1.3 Portal `CreateAsset` (`@/src/components/Assets/Deployments/CreateAsset`) into `document.body` when the
+      modal is open, with `view={ApplicationRoute.AssetsApplications}`, `onCreate={createApp}`
+      (`@/src/app/[lang]/assets-applications/actions`), `context={useAppsFolder}`, and
+      `initialValues={{ source: createSchemaSource(toRunnerReference(originalRunner.$id)), applicationProperties }}`
+      — guarding on `$id` being present, and using `toRunnerReference`
+      (`@/src/utils/app-runners/runner-reference`), never the bare `$id`.
+- [x] 1.4 On modal close, clear the flag and dispatch `{ type: ValidationActionType.Reset }` from
+      `useSaveValidationContext()` so the modal's field registrations do not leak into the runner's own save
+      gating; the page already provides the context (`app/[lang]/assets-app-runners/[id]/page.tsx`).
+
+## 2. Unit tests
+
+- [x] 2.1 Add `apps/ai-dial-admin/src/components/Assets/AppRunners/tests/create-asset-application.spec.tsx` with
+      its own stubs — `EntityHeaderControls/SimpleHeader` rendering `{children}`,
+      `Assets/Deployments/CreateAsset` capturing its props, `../TabsContent` inert. The existing `View.spec.tsx`
+      stubs `SimpleHeader` down to a save button and must stay untouched, so it cannot observe header children.
+      `useAppsFolder` is already mocked in `apps/ai-dial-admin/test-setup.tsx`.
+- [x] 2.2 Cover: the header offers the `Create Assets Application` action; clicking it mounts `CreateAsset` with
+      `view === ApplicationRoute.AssetsApplications`; `initialValues.source` is exactly
+      `{ $type: SOURCE_TYPE.SCHEMA, applicationTypeSchemaId: 'schemas/platform/https%3A%2F%2Fhost%2Frunner' }`
+      for `$id` `https://host/runner` — the assertion that guards the reference form.
+- [x] 2.3 Cover the defaults source: with `getResolvedRunnerSchema` mocked to resolve a schema carrying a defaulted
+      property, `initialValues.applicationProperties` reflects that schema's defaults; with it mocked to fail, the
+      defaults come from the runner resource instead and the modal still mounts.
+
+## 3. Browser verification
+
+- [x] 3.1 Run the `spec-browser-verify` flow over the scenarios in
+      `openspec/changes/app-runner-create-asset-application/specs/assets-app-runners/spec.md`, against the local app
+      with the local stack running and auth disabled. Cover the browser-observable scenarios: the header offers
+      `Create Assets Application` and no entity `Create Application`; the modal opens with no source field; creating
+      an application navigates to it and its App Runner field shows the originating runner as selected; the action
+      disappears while the runner has unsaved changes and while the JSON editor is open. Resolve every `fail`
+      verdict before treating this change as complete.
+
+## 4. Quality checks
+
+- [x] 4.1 Run `npx vitest run src/components/Assets/AppRunners` from `apps/ai-dial-admin/`, then `npm run lint` and
+      `npm run format` from the repo root; fix everything they report.

--- a/openspec/specs/assets-app-runners/spec.md
+++ b/openspec/specs/assets-app-runners/spec.md
@@ -2,9 +2,7 @@
 
 ## Purpose
 The `Assets > App Runners` surface: menu entry, flat list with create/delete/bulk-delete, and a five-tab detail view (Properties, Features, Parameters, AppRoutes, Interceptors) over DIAL Core's own app-runner config resources — created by archiving change `add-app-runner-asset-resource`. Covers the `$id`-as-resource-name identity and the URI-shaped-name exceptions the shared asset list needs, the client-side meta-schema validation that substitutes for Core's absent write-time checks, and the merged application-source runner picker that lets an asset application reference either population. Every option list the surface offers — interceptors, global interceptors and per-route roles — is read from DIAL Core as the union of its API-written and configuration-file populations, so no admin-backend request is required to view or configure a runner; the topics control offers no catalogue here because Core has no topic registry. Deliberately has no Audit tab, revisions, rollback, Core-sync banner, versioning, publications, sharing, move, or import/export — DIAL Core exposes none of those for config resources.
-
 ## Requirements
-
 ### Requirement: Assets > App Runners menu entry
 
 The system SHALL add an `App Runners` menu item to the Assets section of the admin menu, directly after `Models`, linking to a new `/assets-app-runners` route.
@@ -93,7 +91,16 @@ Because the row name is the runner's `$id`, it contains characters the shared as
 
 ### Requirement: App-runner asset detail view tab set
 
-The system SHALL render an app-runner asset's detail view with exactly five tabs — `Properties`, `Features`, `Parameters`, `AppRoutes`, and `Interceptors` — and SHALL NOT include an `Applications` tab, an `Audit` tab, or a Core-sync status banner.
+The system SHALL render an app-runner asset's detail view with exactly five tabs — `Properties`, `Features`,
+`Parameters`, `AppRoutes`, and `Interceptors` — and SHALL NOT include an `Applications` tab, an `Audit` tab, or a
+Core-sync status banner.
+
+The detail header SHALL offer one outbound create action, `Create Assets Application`, which opens the shared
+asset-application create modal with the runner being viewed pre-selected as the new application's source. It SHALL
+NOT offer an equivalent action for `Entities > Applications`: that reference is a foreign key into the admin
+backend's own runner table, so an asset runner has no row to point at and the created application could only reopen
+with an unresolvable source. Because a single valid target does not warrant a menu, the action SHALL be a single
+button rather than the two-item dropdown `Entities > Application Runners` offers.
 
 #### Scenario: Detail view renders exactly five tabs
 
@@ -112,8 +119,52 @@ The system SHALL render an app-runner asset's detail view with exactly five tabs
 
 #### Scenario: No outbound create-application actions
 
+Scoped to the entity variant. This scenario once prohibited both outbound create actions; the asset variant became
+valid once asset runners were selectable from `Assets > Applications`, and is required by the scenarios below. The
+heading is retained because a scenario's name is the identity a delta rewrites content under.
+
 - **WHEN** a user opens an app-runner asset's detail view header
-- **THEN** no `Create Application` or `Create Asset Application` action is offered
+- **THEN** no action creating an entity `Application` is offered, since an asset runner is not addressable as an
+  entity application's `application_type_schema_id`
+- **AND** no `Create` dropdown is present offering an `Application` item, as `Entities > Application Runners` has
+
+#### Scenario: The header offers a create-asset-application action
+
+- **WHEN** a user opens an app-runner asset's detail view header
+- **THEN** a `Create Assets Application` action is offered alongside `Delete`
+- **AND** it is a single button, not a dropdown
+
+#### Scenario: The create modal opens with the runner as a fixed source
+
+- **WHEN** a user activates `Create Assets Application`
+- **THEN** the shared asset-application create modal opens, requesting name, display name, version, and description
+- **AND** no source field is offered, since the source is the runner the action was started from
+
+#### Scenario: The new application references the runner by its Core resource name
+
+- **WHEN** a user creates an asset application from a runner whose `$id` is `http://asdqwe`
+- **THEN** the application's `application_type_schema_id` is `schemas/platform/http%3A%2F%2Fasdqwe`, the same
+  reference form the `Assets > Applications` picker writes for an asset runner
+- **AND** reopening that application shows the runner as its selected App Runner rather than a blank field
+
+#### Scenario: Parameter defaults come from Core's resolved schema
+
+- **WHEN** the create action seeds the new application's `applicationProperties`
+- **THEN** the defaults are derived from DIAL Core's resolved-schema read for that runner, not the admin backend's
+- **AND** if that read fails, the defaults are derived from the runner resource as loaded, so the modal still opens
+
+#### Scenario: Creation reports its outcome and navigates to the new application
+
+- **WHEN** the create request succeeds
+- **THEN** a success notification naming the created asset application is shown and the browser navigates to that
+  application's detail view
+- **AND** when the request fails, an error notification carrying the server's message is shown and the modal stays
+  open
+
+#### Scenario: The action follows the header's existing gating
+
+- **WHEN** the viewer is a read-only admin, or the runner has unsaved changes, or the JSON editor is open
+- **THEN** the create action is not offered, exactly as `Delete` is not, rather than being offered in a disabled state
 
 ### Requirement: `$id` is displayed as the runner identity and is immutable after creation
 
@@ -397,3 +448,4 @@ Every field this surface reads or writes is owned by DIAL Core. The system SHALL
 #### Scenario: The claim is stated with its scope
 - **WHEN** the capability describes itself as Core-direct
 - **THEN** it states what holds — that the runner resource and every option list it offers are read from Core — rather than implying the surface has no other dependency
+


### PR DESCRIPTION
## Summary

This PR implements the missing Create Assets Application action on the App Runner detail page. When a user views an app runner asset's detail view header, a single button labeled "Create Assets Application" is now offered alongside the Delete action. This follows the pattern established in other surfaces like Adapters' "Create Model" button.

## Design Decision

The issue originally requested a Create dropdown with both "Application" and "Assets Application" options. This PR ships only "Assets Application" as a single button, not a dropdown, because:

- An entity Application's `application_type_schema_id` is a foreign key into the admin backend's own runner table
- An asset runner has no corresponding row in that table, so the entity Application variant is impossible
- A single valid target does not warrant a menu structure
- This design decision was confirmed with the requester and aligns with the archived add-app-runner-asset-resource proposal which recorded this same constraint

## Verification

- Unit test suite: 7823 passed / 4 skipped / 753 files
- Linting: 0 errors (32 pre-existing warnings, none in changed files)
- Code formatting: clean
- Browser verification (spec-browser-verify gate): green, 8/8 scenarios
  - Includes the round-trip: after a hard reload, the created application's App Runner field resolves to the originating runner rather than rendering blank
  - Modal opens with runner pre-selected as source
  - Parameter defaults derived from Core's resolved schema
  - Success/error notifications display correctly
  - Action respects existing header gating (not offered when read-only, unsaved changes, or editor open)

## Key Changes

- [apps/ai-dial-admin/src/components/Assets/AppRunners/View.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/fix/app-runner-create-asset-application/apps/ai-dial-admin/src/components/Assets/AppRunners/View.tsx) — added Create Assets Application button and modal integration; resolves runner schema from Core for parameter defaults
- [apps/ai-dial-admin/src/components/Assets/AppRunners/tests/create-asset-application.spec.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/fix/app-runner-create-asset-application/apps/ai-dial-admin/src/components/Assets/AppRunners/tests/create-asset-application.spec.tsx) — new unit test suite covering all create modal scenarios
- [openspec/specs/assets-app-runners/spec.md](https://github.com/epam/ai-dial-admin-frontend/blob/fix/app-runner-create-asset-application/openspec/specs/assets-app-runners/spec.md) — expanded spec with create-asset-application requirement and 6 new scenarios

## Spec Note

The consolidated spec's existing scenario "No outbound create-application actions" retained its heading but had its body narrowed to the entity-variant-only constraint. OpenSpec MODIFIED blocks may only rewrite a scenario body, never drop one, and REMOVED+ADDED on the same requirement is rejected by its validator. A follow-up change can rename that scenario properly (e.g. to "No outbound entity-application actions").

## Checklist

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #4111)`