### PR TITLE
fix: [Assets-AppRunners] keep interceptor selection in the Add dialog (Issue #4144, Issue #4111)

### DIFF
--- a/apps/ai-dial-admin/src/components/Assets/AppRunners/View.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/AppRunners/View.tsx
@@ -4,8 +4,7 @@ import { useRouter } from 'next/navigation';
 import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
-import { DialNeutralButton } from '@epam/ai-dial-ui-kit';
-import { IconPlus } from '@tabler/icons-react';
+import { ButtonAppearance, ButtonVariant, DialButtonDropdown, DropdownItem } from '@epam/ai-dial-ui-kit';
 import { JSONSchema7 } from 'json-schema';
 
 import { getResolvedRunnerSchema, removeRunner, updateRunner } from '@/src/app/[lang]/assets-app-runners/actions';
@@ -20,7 +19,6 @@ import { useNotification } from '@/src/context/NotificationContext';
 import { useSaveValidationContext, ValidationActionType } from '@/src/context/SaveValidationContext';
 import { useProtectedRequest } from '@/src/hooks/use-protected-request';
 import { ButtonsI18nKey, CreateI18nKey, EntitiesI18nKey } from '@/src/constants/i18n';
-import { BASE_BUTTON_ICON_PROPS } from '@/src/constants/main-layout';
 import { useI18n } from '@/src/locales/client';
 import { DialApplicationScheme } from '@/src/models/dial/application';
 import { DialInterceptor } from '@/src/models/dial/interceptor';
@@ -73,6 +71,14 @@ const AppRunnerAssetView: FC<Props> = ({
   const [discardKey, setDiscardKey] = useState(0);
   const [isCreateAssetAppModalOpen, setIsCreateAssetAppModalOpen] = useState(false);
   const [applicationProperties, setApplicationProperties] = useState<Record<string, unknown>>();
+
+  const createItems: DropdownItem[] = [
+    {
+      key: 'AssetApplication',
+      label: t(CreateI18nKey.AssetApplication),
+      onClick: () => setIsCreateAssetAppModalOpen(true),
+    },
+  ];
 
   const jsonConfiguration = useMemo<JsonConfiguration>(
     () => ({
@@ -175,10 +181,11 @@ const AppRunnerAssetView: FC<Props> = ({
         onRemove={removeRunner}
         getAssetContext={useAppRunnersFolder}
       >
-        <DialNeutralButton
-          label={`${t(ButtonsI18nKey.Create)} ${t(CreateI18nKey.AssetApplication)}`}
-          iconBefore={<IconPlus {...BASE_BUTTON_ICON_PROPS} />}
-          onClick={() => setIsCreateAssetAppModalOpen(true)}
+        <DialButtonDropdown
+          label={t(ButtonsI18nKey.Create)}
+          items={createItems}
+          variant={ButtonVariant.Neutral}
+          appearance={ButtonAppearance.Outlined}
         />
       </SimpleEntityHeader>
 

--- a/apps/ai-dial-admin/src/components/Assets/AppRunners/tests/create-asset-application.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/AppRunners/tests/create-asset-application.spec.tsx
@@ -36,7 +36,26 @@ vi.mock('@/src/components/Assets/Deployments/CreateAsset', () => ({
 vi.mock('../TabsContent', () => ({ default: () => <div>tabs-content</div> }));
 vi.mock('next/navigation', () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
 
-const CREATE_ACTION_NAME = `${ButtonsI18nKey.Create} ${CreateI18nKey.AssetApplication}`;
+// The real dropdown keeps its items behind a floating overlay with no menu roles to query; flattening
+// them to buttons keeps these tests about the action rather than the ui-kit's popover.
+vi.mock('@epam/ai-dial-ui-kit', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@epam/ai-dial-ui-kit')>();
+  return {
+    ...actual,
+    DialButtonDropdown: ({ label, items }: any) => (
+      <div>
+        <span>{label}</span>
+        {items?.map((item: any) => (
+          <button key={item.key} onClick={() => item.onClick?.({ key: item.key })}>
+            {item.label}
+          </button>
+        ))}
+      </div>
+    ),
+  };
+});
+
+const CREATE_ACTION_NAME = CreateI18nKey.AssetApplication;
 
 const runner = (overrides: Partial<DialAppRunnerResource> = {}): DialAppRunnerResource =>
   ({
@@ -73,9 +92,10 @@ describe('App runner asset :: create asset application action', () => {
     vi.mocked(getResolvedRunnerSchema).mockResolvedValue({ success: false } as never);
   });
 
-  test('Should offer the create-asset-application action in the header', () => {
+  test('Should offer the create-asset-application action under the header Create dropdown', () => {
     renderView();
 
+    expect(screen.getByText(ButtonsI18nKey.Create)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: CREATE_ACTION_NAME })).toBeInTheDocument();
   });
 

--- a/apps/ai-dial-admin/src/components/EntityView/AddEntitiesGrid.tsx
+++ b/apps/ai-dial-admin/src/components/EntityView/AddEntitiesGrid.tsx
@@ -1,6 +1,6 @@
 import { DialFormPopup, PopupSize } from '@epam/ai-dial-ui-kit';
 import { ColDef, GridOptions, SelectionChangedEvent } from 'ag-grid-community';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import GridView from '@/src/components/Grid/GridView/GridView';
 import { MULTI_ROW_SELECTION } from '@/src/constants/ag-grid';
@@ -30,7 +30,9 @@ const AddEntitiesGrid = <T extends object>({
 }: Props<T>) => {
   const t = useI18n();
   const [selectedEntities, setSelectedEntities] = useState<T[]>([]);
-  const columns = withSourceColumn(columnDefs, entities);
+  // A fresh column array on a selection-only re-render re-pushes `rowData` through ag-grid's grid
+  // options, which rebuilds every row node and clears the selection that just happened.
+  const columns = useMemo(() => withSourceColumn(columnDefs, entities), [columnDefs, entities]);
 
   const onSelectionChanged = (event: SelectionChangedEvent) => {
     const selectedRows = event.api.getSelectedRows();

--- a/apps/ai-dial-admin/src/components/EntityView/Interceptors/GlobalInterceptors.tsx
+++ b/apps/ai-dial-admin/src/components/EntityView/Interceptors/GlobalInterceptors.tsx
@@ -17,6 +17,8 @@ import GridView from '@/src/components/Grid/GridView/GridView';
 import { getInterceptorsColumnDefs } from './utils';
 import { useIsReadOnlyAdmin } from '@/src/hooks/use-is-read-only-admin';
 
+const ADD_INTERCEPTOR_COLUMNS = [DISPLAY_NAME_COLUMN, DESCRIPTION_COLUMN];
+
 interface Props {
   interceptors: DialInterceptor[];
   currentInterceptors: string[];
@@ -126,7 +128,7 @@ const GlobalInterceptors: FC<Props> = ({ interceptors, currentInterceptors, onCh
             entities={availableInterceptors}
             onClose={() => setIsModalOpen(false)}
             onApply={onAddInterceptors}
-            columnDefs={[DISPLAY_NAME_COLUMN, DESCRIPTION_COLUMN]}
+            columnDefs={ADD_INTERCEPTOR_COLUMNS}
           />,
           document.body,
         )}

--- a/apps/ai-dial-admin/src/components/EntityView/Interceptors/Interceptors.tsx
+++ b/apps/ai-dial-admin/src/components/EntityView/Interceptors/Interceptors.tsx
@@ -24,6 +24,8 @@ import { onOpenInNewTab } from '@/src/utils/open-in-new-tab';
 import CollapsableInterceptors from './CollapsableInterceptors';
 import { getInterceptorsColumnDefs, getInterceptorsGridData } from './utils';
 
+const ADD_INTERCEPTOR_COLUMNS = [DISPLAY_NAME_COLUMN, DESCRIPTION_COLUMN];
+
 interface Props<T> {
   entity: T;
   interceptors: DialInterceptor[];
@@ -253,7 +255,7 @@ const EntityInterceptors = <T extends { interceptors?: string[]; 'dial:applicati
             entities={availableInterceptors}
             onClose={() => setIsModalOpen(false)}
             onApply={onAddInterceptors}
-            columnDefs={[DISPLAY_NAME_COLUMN, DESCRIPTION_COLUMN]}
+            columnDefs={ADD_INTERCEPTOR_COLUMNS}
           />,
           document.body,
         )}

--- a/apps/ai-dial-admin/src/components/EntityView/tests/AddEntitiesGrid.spec.tsx
+++ b/apps/ai-dial-admin/src/components/EntityView/tests/AddEntitiesGrid.spec.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { act } from 'react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import AddEntitiesGrid from '@/src/components/EntityView/AddEntitiesGrid';
+import { DESCRIPTION_COLUMN, DISPLAY_NAME_COLUMN } from '@/src/constants/grid-columns/base-columns';
+import { ButtonsI18nKey } from '@/src/constants/i18n';
+import { ConfigEntityOrigin } from '@/src/types/config-file-entity';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let capturedColumnDefs: any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let capturedGridOptions: any;
+
+vi.mock('@/src/components/Grid/GridView/GridView', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  default: ({ columnDefs, additionalGridOptions }: any) => {
+    capturedColumnDefs = columnDefs;
+    capturedGridOptions = additionalGridOptions;
+    return <section aria-label="grid" />;
+  },
+}));
+
+const COLUMNS = [DISPLAY_NAME_COLUMN, DESCRIPTION_COLUMN];
+
+const CORE_ROWS = [
+  { name: 'interceptors/one', displayName: 'One', origin: ConfigEntityOrigin.Api },
+  { name: 'one', displayName: 'One', origin: ConfigEntityOrigin.ConfigFile },
+];
+
+const ADMIN_ROWS = [{ name: 'one', displayName: 'One' }];
+
+const renderGrid = (entities: object[], onApply = vi.fn()) => {
+  render(
+    <AddEntitiesGrid
+      isModalOpen
+      modalTitle="Add interceptors"
+      emptyTitle="No interceptors"
+      entities={entities}
+      columnDefs={COLUMNS}
+      onClose={vi.fn()}
+      onApply={onApply}
+    />,
+  );
+  return onApply;
+};
+
+const selectRows = (rows: object[]) =>
+  act(() => {
+    capturedGridOptions.onSelectionChanged({ api: { getSelectedRows: () => rows } });
+  });
+
+const getApplyButton = () => screen.getByRole('button', { name: ButtonsI18nKey.Apply });
+
+describe('AddEntitiesGrid', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedColumnDefs = undefined;
+    capturedGridOptions = undefined;
+  });
+
+  test('keeps the column defs referentially stable across a selection change', () => {
+    renderGrid(CORE_ROWS);
+    const initialColumnDefs = capturedColumnDefs;
+
+    selectRows([CORE_ROWS[0]]);
+
+    expect(capturedColumnDefs).toBe(initialColumnDefs);
+    expect(getApplyButton()).toBeEnabled();
+  });
+
+  test('appends the source column only for rows carrying an origin', () => {
+    renderGrid(CORE_ROWS);
+    expect(capturedColumnDefs).toHaveLength(COLUMNS.length + 1);
+    expect(capturedColumnDefs.at(-1)).toMatchObject({ field: 'origin', headerName: 'Source' });
+  });
+
+  test('leaves the passed columns untouched for admin-backend rows', () => {
+    renderGrid(ADMIN_ROWS);
+
+    expect(capturedColumnDefs).toBe(COLUMNS);
+  });
+
+  test('disables Apply until something is selected', () => {
+    renderGrid(CORE_ROWS);
+
+    expect(getApplyButton()).toBeDisabled();
+
+    selectRows([CORE_ROWS[1]]);
+
+    expect(getApplyButton()).toBeEnabled();
+  });
+
+  test('applies the selected rows', async () => {
+    const user = userEvent.setup();
+    const onApply = renderGrid(CORE_ROWS);
+
+    selectRows([CORE_ROWS[0], CORE_ROWS[1]]);
+    await user.click(getApplyButton());
+
+    expect(onApply).toHaveBeenCalledWith([CORE_ROWS[0], CORE_ROWS[1]]);
+  });
+});


### PR DESCRIPTION
**Description:**

Two fixes on the App Runner asset page.

**1. Add Interceptors checkbox flickers and resets (Issue #4144)**

`withSourceColumn` returns a new array whenever the rows carry an `origin` — which only happens for Core-sourced rows, i.e. on the asset pages. Ticking a checkbox re-rendered the picker with a fresh `columnDefs` identity, which cascaded through `GridView` into `gridApi.updateGridOptions({ columnDefs, rowData })`. ag-grid force-treats an object-valued option as changed regardless of reference, and with no `getRowId` it takes the non-immutable path: destroy all row nodes → `selectionSvc.reset()` → `selectionChanged` fires with zero rows, wiping the selection that just happened and leaving Apply permanently disabled.

Memoized the derived columns in `AddEntitiesGrid` and hoisted the inline `columnDefs` literals at the two interceptor call sites, so a selection-only re-render can no longer churn column identity. This also fixes **Add Roles** on the same page's App Routes tab, which was broken identically.

New `AddEntitiesGrid.spec.tsx` (5 tests) guards it — the stability test fails if the memo is reverted.

**2. Create Assets Application button overflows its header row (Issue #4111)**

The concatenated `Create` + `Assets Application` label overflowed the fixed-height header row and wrapped onto three lines. Replaced it with `DialButtonDropdown` carrying a single "Assets Application" item, matching the existing App Runners deployment view.

**Verification**

- Browser (Assets → App Runners → runner): two interceptors stay checked, Apply enables, Local Interceptors goes to 2; Add Roles on App Routes holds its selection; the Create dropdown opens the same create-application modal.
- 180 tests pass across `EntityView`, `Assets/AppRunners`, `AddEntitiesTab`; full suite green on pre-push; lint clean.

Not addressed here: `AgGridWrapper` re-pushing `rowData` on a column-only update is the deeper defect behind this bug class, but it sits under nearly every grid in the app and belongs in its own change.

Issues:

- Issue #4144
- Issue #4111

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)