### PR TITLE
chore(config): bump ui-kit to 0.13.0-dev.51 fixing input focus indicator (Issue #4138)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@epam/ai-dial-shared": "^0.44.8",
-        "@epam/ai-dial-ui-kit": "0.13.0-dev.46",
+        "@epam/ai-dial-ui-kit": "0.13.0-dev.51",
         "@epam/ai-dial-visualizer-connector": "^0.44.8",
         "@floating-ui/react": "^0.27.19",
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -2236,9 +2236,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@epam/ai-dial-ui-kit": {
-      "version": "0.13.0-dev.46",
-      "resolved": "https://registry.npmjs.org/@epam/ai-dial-ui-kit/-/ai-dial-ui-kit-0.13.0-dev.46.tgz",
-      "integrity": "sha512-Yecx6QwQPK9hieo5MTWJbx0mD+8cV1cDOXnDdCh4dlfxjG1E34WYBA/RXvjLqm2qzq+jYD2ewh/5WbceVvHX/g==",
+      "version": "0.13.0-dev.51",
+      "resolved": "https://registry.npmjs.org/@epam/ai-dial-ui-kit/-/ai-dial-ui-kit-0.13.0-dev.51.tgz",
+      "integrity": "sha512-sjVU09TiHKk9YK9WOcmk0wpi7a8zZxep5BR/nRJRVeJ6dpmFXfpX94lRBVnr7V17v5DL3/oM0VnsxyqSouAwRQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "ag-grid-community": "^35.2.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@epam/ai-dial-shared": "^0.44.8",
-    "@epam/ai-dial-ui-kit": "0.13.0-dev.46",
+    "@epam/ai-dial-ui-kit": "0.13.0-dev.51",
     "@epam/ai-dial-visualizer-connector": "^0.44.8",
     "@floating-ui/react": "^0.27.19",
     "@modelcontextprotocol/sdk": "^1.29.0",


### PR DESCRIPTION
## Summary

Bump ui-kit to version 0.13.0-dev.51 which includes a fix for the input focus indicator issue.

Issues:

- Issue #4138

**Key Changes:**

- [package.json](https://github.com/epam/ai-dial-admin-frontend/blob/chore/bump-ui-kit-to-0.13.0-dev.51/package.json) — update ui-kit from 0.13.0-dev.46 to 0.13.0-dev.51
- [package-lock.json](https://github.com/epam/ai-dial-admin-frontend/blob/chore/bump-ui-kit-to-0.13.0-dev.51/package-lock.json) — lock file update

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with \`(Issue #4138)\`