### PR TITLE
ci(sdlc): enable the code-review agent

### DIFF
--- a/agents/code-review/agent.yml
+++ b/agents/code-review/agent.yml
@@ -1,14 +1,10 @@
-# DISABLED. The leading `_` on the directory name is how the dispatcher skips a
-# manifest — match-agents.py globs `agents/*/agent.yml` and ignores underscore-
-# prefixed directories, so this agent is discovered by nobody until it is renamed.
+# Enabled: the dispatcher discovers `agents/*/agent.yml` and skips only
+# underscore-prefixed directories. To disable without reverting, set the repo
+# variable STAGE_CODE_REVIEW_ENABLED=false.
 #
-# To activate: `git mv agents/_code-review agents/code-review`.
-#
-# Prerequisites before that rename:
-#   1. the `code-review-and-quality` skill exists (it ships separately) — the
-#      dispatcher would otherwise start an agent whose `skill:` resolves to nothing
-#   2. `DIAL_API_KEY` secret and `DIAL_CORE_URL` / `DIAL_ROUTE_PATH` vars are set
-#   3. this file is on the default branch, or no trigger is registered
+# Requires the `code-review-and-quality` skill (the `skill:` below is invoked as
+# `/code-review-and-quality`) plus either DIAL_CORE_URL + DIAL_API_KEY, or
+# ANTHROPIC_API_KEY.
 contract_version: '0.1'
 name: code-review
 skill: code-review-and-quality


### PR DESCRIPTION
**Description:**

Flips the harness on. One file, a rename: `agents/_code-review` → `agents/code-review`. That underscore
is the dispatcher's on-switch — `match-agents.py` globs `agents/*/agent.yml` and skips only
underscore-prefixed directories.

Deliberately separate from #4163 so merge order can't produce a broken state. The agent invokes
`/code-review-and-quality`, so this must land **after** #4166; until it does, #4163 stays inert on its
own.

Issues:

- No tracking issue — infra work.

---

**Base is `feat/port-agent-tooling`**, not `development` — the rename only makes sense on top of #4163,
and this keeps the diff to the one file it changes. GitHub retargets it to `development` automatically
when #4163 merges.

**Merge order:** #4163 (harness) and #4166 (skills) first, in either order, then this.

**Verified locally:**

- with this tree the dispatcher discovers `code-review`
- `STAGE_CODE_REVIEW_ENABLED=false` still suppresses it, so it can be turned off without a revert

**Still required, and not repo state — set these before or after merging:**

| | |
| --- | --- |
| DIAL route | var `DIAL_CORE_URL` + secret `DIAL_API_KEY` (optionally `DIAL_ROUTE_PATH`, `DIAL_MODEL`) |
| or direct | secret `ANTHROPIC_API_KEY` |

`run-agent.yml` picks the route automatically from whether `DIAL_CORE_URL` is set. Neither is
configured today — the repo currently has only `ACTIONS_BOT_TOKEN` and the DockerHub secrets, and no
repo variables at all. Without credentials the agent job fails fast rather than silently passing.

**Two things to expect on the first run:**

- **Test it on an ordinary code PR.** The trust gate rejects any PR touching `.claude/**`,
  `.github/workflows/**`, `agents/**`, or adding a symlink — including this one. That's by design; a
  normal feature PR is what exercises the agent.
- **Check the model pin.** `model: claude-sonnet-4-6` resolves as `anthropic.claude-sonnet-4-6` on the
  DIAL route, matching what `claude-security-review.yml` already uses. If that deployment isn't
  available, set `DIAL_MODEL` or bump the pin — an unavailable deployment fails the run.

**Breaking Changes:** none, but this is the point where AI review starts commenting on PRs. `STAGE_CODE_REVIEW_ENABLED=false` is the kill switch.

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` — no tracking issue for this work
