### PR TITLE
feat(models): add cache read and cache write pricing fields (Issue: #4176)

### DIFF
--- a/apps/ai-dial-admin/src/components/ActivityAudit/Rollback/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/ActivityAudit/Rollback/tests/utils.spec.ts
@@ -33,7 +33,7 @@ describe('getSystemRollbackColumns', () => {
 
   test('returns BASE_COLUMNS for MODEL', () => {
     const cols = getSystemRollbackColumns(ActivityAuditResourceType.MODEL, t);
-    expect(cols.length).toEqual(14);
+    expect(cols.length).toEqual(16);
   });
 
   test('returns BASE_COLUMNS for APPLICATION', () => {

--- a/apps/ai-dial-admin/src/components/ActivityAudit/View/utils/tests/compare-helpers.spec.ts
+++ b/apps/ai-dial-admin/src/components/ActivityAudit/View/utils/tests/compare-helpers.spec.ts
@@ -122,6 +122,20 @@ describe('Activity audit :: convertPricing', () => {
     );
   });
 
+  test('should scale cacheRead and cacheWrite like the other token rates', () => {
+    const pricing = {
+      unit: PricingType.Token,
+      prompt: 0.001,
+      cacheRead: 0.002,
+      cacheWrite: 0.003,
+    };
+
+    const result = convertPricing(pricing, t);
+    expect(result).toBe(
+      `${ModelViewI18nKey.Tokens} ${ModelViewI18nKey.PerMillion}, prompt: 1000, cacheRead: 2000, cacheWrite: 3000`,
+    );
+  });
+
   test('should handle string values gracefully in non-token mode', () => {
     const pricing = {
       unit: PricingType.Character,

--- a/apps/ai-dial-admin/src/components/ModelView/Pricing/Pricing.tsx
+++ b/apps/ai-dial-admin/src/components/ModelView/Pricing/Pricing.tsx
@@ -38,16 +38,17 @@ const Pricing = <T extends { pricing?: DialModelPricing }>({ model, onChangeMode
 
   const activeType = model.pricing?.unit || BasicI18nKey.None;
   const isTokenType = activeType === PricingType.Token;
+  const isPriceDisabled = activeType === BasicI18nKey.None || isReadOnlyAdmin;
+  // DIAL Core drops a model whose cache rates are set under any unit but `token`, so the inputs stay
+  // disabled rather than letting that state be saved.
+  const isCacheRateDisabled = !isTokenType || isReadOnlyAdmin;
 
   const onChangePricingType = useCallback(
     (type: string) => {
-      if (type === PricingType.Token || type === PricingType.CharWithoutWhitespace) {
-        model.pricing = { unit: type };
-      } else {
-        model.pricing = { prompt: '0', completion: '0' };
-      }
-
-      onChangeModel({ ...model, pricing: { ...model.pricing } });
+      // Every rate is meaningful only under its unit, so changing the unit clears all four rather than
+      // carrying a number whose meaning silently changed.
+      const isKnownUnit = type === PricingType.Token || type === PricingType.CharWithoutWhitespace;
+      onChangeModel({ ...model, pricing: isKnownUnit ? { unit: type } : void 0 });
     },
     [onChangeModel, model],
   );
@@ -68,11 +69,27 @@ const Pricing = <T extends { pricing?: DialModelPricing }>({ model, onChangeMode
     [isTokenType, onChangeModel, model],
   );
 
+  const onChangeCacheRead = useCallback(
+    (cacheRead?: number | string) => {
+      const value = getPriceRealValue(cacheRead, isTokenType);
+      onChangeModel({ ...model, pricing: { ...model.pricing, cacheRead: value } });
+    },
+    [isTokenType, onChangeModel, model],
+  );
+
+  const onChangeCacheWrite = useCallback(
+    (cacheWrite?: number | string) => {
+      const value = getPriceRealValue(cacheWrite, isTokenType);
+      onChangeModel({ ...model, pricing: { ...model.pricing, cacheWrite: value } });
+    },
+    [isTokenType, onChangeModel, model],
+  );
+
   return (
     <div
       className={classNames(
         'flex flex-col gap-y-4 justify-center rounded border border-primary p-3 mb-4',
-        'lg:justify-start lg:border-none lg:p-0 lg:flex-row lg:gap-x-2 lg:items-center lg:mb-0',
+        'lg:justify-start lg:border-none lg:p-0 lg:mb-0',
       )}
     >
       <DialSelectField
@@ -86,23 +103,43 @@ const Pricing = <T extends { pricing?: DialModelPricing }>({ model, onChangeMode
         disabled={isReadOnlyAdmin}
       />
 
-      <PriceControl
-        elementId="promptsPrice"
-        label={t(ModelViewI18nKey.PromptPrice)}
-        value={getMultipliedValue(model.pricing?.prompt, isTokenType)}
-        onChange={onChangePrompt}
-        containerClassName="w-[120px]"
-        disabled={activeType === BasicI18nKey.None || isReadOnlyAdmin}
-      />
+      <div className="flex flex-col gap-y-4 lg:flex-row lg:gap-x-2 lg:items-center">
+        <PriceControl
+          elementId="promptsPrice"
+          label={t(ModelViewI18nKey.PromptPrice)}
+          value={getMultipliedValue(model.pricing?.prompt, isTokenType)}
+          onChange={onChangePrompt}
+          containerClassName="w-[120px]"
+          disabled={isPriceDisabled}
+        />
 
-      <PriceControl
-        elementId="completionsPrice"
-        label={t(ModelViewI18nKey.CompletionPrice)}
-        value={getMultipliedValue(model.pricing?.completion, isTokenType)}
-        onChange={onChangeCompletion}
-        containerClassName="w-[120px]"
-        disabled={activeType === BasicI18nKey.None || isReadOnlyAdmin}
-      />
+        <PriceControl
+          elementId="completionsPrice"
+          label={t(ModelViewI18nKey.CompletionPrice)}
+          value={getMultipliedValue(model.pricing?.completion, isTokenType)}
+          onChange={onChangeCompletion}
+          containerClassName="w-[120px]"
+          disabled={isPriceDisabled}
+        />
+
+        <PriceControl
+          elementId="cacheReadPrice"
+          label={t(ModelViewI18nKey.CacheReadPrice)}
+          value={getMultipliedValue(model.pricing?.cacheRead, isTokenType)}
+          onChange={onChangeCacheRead}
+          containerClassName="w-[120px]"
+          disabled={isCacheRateDisabled}
+        />
+
+        <PriceControl
+          elementId="cacheWritePrice"
+          label={t(ModelViewI18nKey.CacheWritePrice)}
+          value={getMultipliedValue(model.pricing?.cacheWrite, isTokenType)}
+          onChange={onChangeCacheWrite}
+          containerClassName="w-[120px]"
+          disabled={isCacheRateDisabled}
+        />
+      </div>
     </div>
   );
 };

--- a/apps/ai-dial-admin/src/components/ModelView/Pricing/tests/Pricing.spec.tsx
+++ b/apps/ai-dial-admin/src/components/ModelView/Pricing/tests/Pricing.spec.tsx
@@ -1,0 +1,158 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { BasicI18nKey, ModelViewI18nKey } from '@/src/constants/i18n';
+import { DialModelPricing, PricingType } from '@/src/models/dial/model';
+import Pricing from '../Pricing';
+
+const isReadOnlyAdminMock = vi.fn(() => false);
+
+vi.mock('@/src/hooks/use-is-read-only-admin', () => ({
+  useIsReadOnlyAdmin: () => isReadOnlyAdminMock(),
+}));
+
+// Only the select is replaced — the real DialNumberInput is kept so the price fields behave as they
+// do in the app (a cleared field emits null, which is what distinguishes "unset" from "0").
+vi.mock('@epam/ai-dial-ui-kit', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@epam/ai-dial-ui-kit')>()),
+  DialSelectField: ({ id, label, value, options, onChange, disabled }: any) => (
+    <div>
+      <label htmlFor={id}>{label}</label>
+      <select id={id} value={value} disabled={disabled} onChange={(event) => onChange(event.target.value)}>
+        {options.map((option: any) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  ),
+}));
+
+interface TestModel {
+  pricing?: DialModelPricing;
+}
+
+describe('Pricing', () => {
+  const renderPricing = (pricing?: DialModelPricing, onChangeModel = vi.fn()) => {
+    render(<Pricing<TestModel> model={{ pricing }} onChangeModel={onChangeModel} />);
+    return onChangeModel;
+  };
+
+  const tokenPricing: DialModelPricing = {
+    unit: PricingType.Token,
+    prompt: '0.0000008',
+    completion: '0.0000009',
+    cacheRead: '0.0000002',
+    cacheWrite: '0.0000003',
+  };
+
+  const cacheReadField = () => screen.getByRole('spinbutton', { name: ModelViewI18nKey.CacheReadPrice });
+  const cacheWriteField = () => screen.getByRole('spinbutton', { name: ModelViewI18nKey.CacheWritePrice });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isReadOnlyAdminMock.mockReturnValue(false);
+  });
+
+  test('renders a cache read and a cache write field alongside the existing rates', () => {
+    renderPricing(tokenPricing);
+
+    expect(screen.getByRole('spinbutton', { name: ModelViewI18nKey.PromptPrice })).toBeTruthy();
+    expect(screen.getByRole('spinbutton', { name: ModelViewI18nKey.CompletionPrice })).toBeTruthy();
+    expect(cacheReadField()).toBeTruthy();
+    expect(cacheWriteField()).toBeTruthy();
+  });
+
+  test('displays stored cache rates scaled per million under the token unit', () => {
+    renderPricing(tokenPricing);
+
+    expect(cacheReadField()).toHaveValue(0.2);
+    expect(cacheWriteField()).toHaveValue(0.3);
+  });
+
+  test('enables the cache rate fields under the token unit', () => {
+    renderPricing(tokenPricing);
+
+    expect(cacheReadField()).toBeEnabled();
+    expect(cacheWriteField()).toBeEnabled();
+  });
+
+  test('disables the cache rate fields under the character unit', () => {
+    renderPricing({ unit: PricingType.CharWithoutWhitespace, prompt: '0.1' });
+
+    expect(cacheReadField()).toBeDisabled();
+    expect(cacheWriteField()).toBeDisabled();
+  });
+
+  test('disables the cache rate fields when no cost unit is set', () => {
+    renderPricing();
+
+    expect(cacheReadField()).toBeDisabled();
+    expect(cacheWriteField()).toBeDisabled();
+  });
+
+  test('disables the cache rate fields for a read-only administrator', () => {
+    isReadOnlyAdminMock.mockReturnValue(true);
+    renderPricing(tokenPricing);
+
+    expect(cacheReadField()).toBeDisabled();
+    expect(cacheWriteField()).toBeDisabled();
+  });
+
+  test('stores an entered cache read rate per token', async () => {
+    const user = userEvent.setup();
+    const onChangeModel = renderPricing({ unit: PricingType.Token });
+
+    await user.type(cacheReadField(), '0.8');
+
+    // The float artifact is what dividing by 1e6 produces, and is shared with the prompt and
+    // completion rates; it scales back to a clean 0.8 for display.
+    expect(onChangeModel).toHaveBeenLastCalledWith({
+      pricing: { unit: PricingType.Token, cacheRead: '8.000000000000001e-7' },
+    });
+  });
+
+  test('omits a cleared cache write rate instead of storing zero', async () => {
+    const user = userEvent.setup();
+    const onChangeModel = renderPricing(tokenPricing);
+
+    await user.clear(cacheWriteField());
+
+    expect(onChangeModel).toHaveBeenLastCalledWith({
+      pricing: { ...tokenPricing, cacheWrite: undefined },
+    });
+  });
+
+  test('stores an explicit zero cache write rate as a zero string', async () => {
+    const user = userEvent.setup();
+    const onChangeModel = renderPricing({ unit: PricingType.Token });
+
+    await user.type(cacheWriteField(), '0');
+
+    expect(onChangeModel).toHaveBeenLastCalledWith({
+      pricing: { unit: PricingType.Token, cacheWrite: '0' },
+    });
+  });
+
+  test('clears every rate when the cost unit changes', async () => {
+    const user = userEvent.setup();
+    const onChangeModel = renderPricing(tokenPricing);
+
+    await user.selectOptions(screen.getByRole('combobox'), PricingType.CharWithoutWhitespace);
+
+    expect(onChangeModel).toHaveBeenCalledWith({
+      pricing: { unit: PricingType.CharWithoutWhitespace },
+    });
+  });
+
+  test('leaves no pricing behind when the cost unit is cleared', async () => {
+    const user = userEvent.setup();
+    const onChangeModel = renderPricing(tokenPricing);
+
+    await user.selectOptions(screen.getByRole('combobox'), BasicI18nKey.None);
+
+    expect(onChangeModel).toHaveBeenCalledWith({ pricing: undefined });
+  });
+});

--- a/apps/ai-dial-admin/src/constants/grid-columns/grid-columns.tsx
+++ b/apps/ai-dial-admin/src/constants/grid-columns/grid-columns.tsx
@@ -153,6 +153,18 @@ export const MODELS_COLUMNS = (t: (str: string) => string): ColDef[] => [
     hide: true,
     tooltipValueGetter: (params) => params.data?.pricing?.completion,
   },
+  {
+    field: 'pricing.cacheRead',
+    headerName: 'Cache read price',
+    hide: true,
+    tooltipValueGetter: (params) => params.data?.pricing?.cacheRead,
+  },
+  {
+    field: 'pricing.cacheWrite',
+    headerName: 'Cache write price',
+    hide: true,
+    tooltipValueGetter: (params) => params.data?.pricing?.cacheWrite,
+  },
 ];
 
 export const APPLICATIONS_COLUMNS = (t: (str: string) => string, codeAppEditorUrl?: string): ColDef[] => [

--- a/apps/ai-dial-admin/src/constants/grid-columns/tests/grid-columns.spec.ts
+++ b/apps/ai-dial-admin/src/constants/grid-columns/tests/grid-columns.spec.ts
@@ -41,6 +41,8 @@ describe('Constants :: grid columns', () => {
     expect(cols.some((c) => c.field === 'source.$type')).toBe(true);
     expect(cols.some((c) => c.field === 'endpoint')).toBe(true);
     expect(cols.some((c) => c.field === 'pricing.prompt')).toBe(true);
+    expect(cols.some((c) => c.field === 'pricing.cacheRead' && c.hide)).toBe(true);
+    expect(cols.some((c) => c.field === 'pricing.cacheWrite' && c.hide)).toBe(true);
   });
 
   test('ADAPTER_COLUMNS returns expected columns', () => {

--- a/apps/ai-dial-admin/src/constants/i18n.ts
+++ b/apps/ai-dial-admin/src/constants/i18n.ts
@@ -499,6 +499,8 @@ export enum ModelViewI18nKey {
   CostUnit = 'ModelView.Pricing.CostUnit',
   PromptPrice = 'ModelView.Pricing.Prompt',
   CompletionPrice = 'ModelView.Pricing.Completion',
+  CacheReadPrice = 'ModelView.Pricing.CacheRead',
+  CacheWritePrice = 'ModelView.Pricing.CacheWrite',
   Tokens = 'ModelView.Pricing.Tokens',
   CharWithoutWhitespace = 'ModelView.Pricing.CharWithoutWhitespace',
   PerMillion = 'ModelView.Pricing.PerMillion',

--- a/apps/ai-dial-admin/src/locales/en.ts
+++ b/apps/ai-dial-admin/src/locales/en.ts
@@ -537,6 +537,8 @@ export default {
       CostUnit: 'Cost unit',
       Prompt: 'Prompt price',
       Completion: 'Completion price',
+      CacheRead: 'Cache read price',
+      CacheWrite: 'Cache write price',
       Tokens: 'Tokens',
       CharWithoutWhitespace: 'Char without whitespace',
       PerMillion: 'per million',

--- a/apps/ai-dial-admin/src/models/dial/model.ts
+++ b/apps/ai-dial-admin/src/models/dial/model.ts
@@ -27,6 +27,10 @@ export interface DialModelPricing {
   unit?: PricingType;
   prompt?: string;
   completion?: string;
+  // An absent cache rate tells DIAL Core to bill cached tokens at the prompt rate; '0' bills them as
+  // free. Never default these to '0' — the two mean different invoices.
+  cacheRead?: string;
+  cacheWrite?: string;
 }
 
 export enum PricingType {

--- a/openspec/changes/archive/2026-08-12-add-model-cache-pricing/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-12-add-model-cache-pricing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-12

--- a/openspec/changes/archive/2026-08-12-add-model-cache-pricing/design.md
+++ b/openspec/changes/archive/2026-08-12-add-model-cache-pricing/design.md
@@ -1,0 +1,132 @@
+## Context
+
+See `proposal.md` — Why. Requirements are in `specs/model-cache-pricing/spec.md`.
+
+The constraints that shape this design come from outside the frontend:
+
+- `ModelCostCalculator` in DIAL Core reads an absent cache rate as "bill cached tokens at the prompt
+  rate" and `"0"` as "bill them as free". The difference is a real invoice, so the frontend's
+  representation of "empty" must survive the round trip untouched.
+- `ConfigPostProcessor.validatePricing()` warns when a cache rate is set under a non-token unit, and a
+  warned model is removed from the merged config. A UI that lets a user reach that state produces an
+  invalid model with no local error.
+- `components/ModelView/Pricing/Pricing.tsx` is already shared by `ModelProperties.tsx` (entity) and
+  `Assets/Models/Properties.tsx` (asset). The two surfaces write to different backends — the admin BE
+  and Core respectively — but neither passes surface-specific props to the pricing block today.
+- Every other control on both properties pages is laid out at `CONTROL_WIDTH`
+  (`large_tablet:640px desktop:640px large_desktop:40%`). The pricing block is the only control that
+  opts out, sizing itself from its own content.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One implementation serving both model surfaces.
+- Make the invalid states Core rejects unreachable from the UI rather than merely discouraged.
+- Keep the four rate inputs at a readable width without breaking alignment with the rest of the form.
+
+**Non-Goals:**
+
+- Surfacing Core's `validationWarnings` for pricing in the UI. The asset surface already renders Core's
+  invalid status and warnings generically; this change prevents the pricing warning from being
+  produced, and does not add pricing-specific warning presentation.
+- Detecting whether the connected admin backend supports the fields. See `proposal.md` — Impact for
+  why this is a deployment-sequencing constraint instead.
+
+## Decisions
+
+### Extend the shared component rather than branch per surface
+
+`Pricing.tsx` stays a single generic component (`<T extends { pricing?: DialModelPricing }>`), and
+`DialModelPricing` gains the two optional fields. Both surfaces then pick up the change with no edit
+of their own.
+
+*Alternative considered:* a surface-specific variant for assets, on the theory that the Core-backed
+path may diverge. Rejected — the two surfaces need identical pricing behavior because they feed the
+same Core config, and a fork would drift on exactly the validation rule that must not drift. The
+project's component rules already call a second implementation of the same field a review failure.
+
+### Cost unit moves out of the rate row
+
+The rates render as one row of four `PriceControl`s at 120px, with the cost-unit select on its own
+line above them.
+
+| Layout | Width at `lg` | Verdict |
+| --- | --- | --- |
+| Select inline with four rates | 220 + 4×120 + 4×8 = **732px** | Overflows the 640px column; flex shrinks the inputs out of alignment |
+| Select inline, rates narrowed | 220 + 4×95 + 4×8 = 632px | Fits, but ~95px is too narrow for a `$` affordance plus a six-decimal value |
+| **Select on its own line, four rates in a row** | **4×120 + 3×8 = 504px** | **Fits with headroom; nothing shrinks** |
+| Select on its own line, rates 2×2 | 248px | Fits, but splits four comparable values across two rows |
+
+The chosen layout also carries meaning the inline version doesn't: the unit governs all four rates, so
+it reads better above them than beside them as a fifth sibling. The sub-`lg` stacked variant already
+handles any number of fields and is unchanged.
+
+### Disable the cache inputs under a non-token unit; don't hide them
+
+Both cache fields are disabled whenever the unit is not Tokens, using the same `disabled` mechanism
+the prompt and completion fields already use for the None unit and for read-only administrators.
+
+*Alternative considered:* hiding them unless the unit is Tokens. Rejected — a hidden input holding a
+stale value is how the invalid state gets saved without anyone seeing it, and a control that vanishes
+gives a screen-reader user no signal that the option exists. A disabled control stays announced, and
+disabled controls are exempt from the contrast minimum, so the existing disable styling applies
+unchanged.
+
+### Any cost-unit change clears all four rates
+
+`onChangePricingType` resets every rate to unset on any unit change, and selecting None leaves the
+model with neither a unit nor rates.
+
+This both fixes an existing defect and prevents a new one. Today the None branch writes
+`{ prompt: '0', completion: '0' }` — under Core's reading that is "prompt and completion are free",
+not "unpriced". Extending that pattern to the cache fields would silently make cached tokens free on
+every model whose unit was ever cleared. Clearing to *unset* is also what the existing Token/Char
+branch already does for prompt and completion, so this makes one rule out of two behaviors rather than
+inventing a third.
+
+*Alternative considered:* preserving entered rates across a unit switch. Rejected — a rate's magnitude
+is only meaningful under its unit (token rates are entered per million, character rates per
+character), so a preserved number silently changes meaning by six orders of magnitude.
+
+### Reuse the scaling helpers unchanged
+
+`getMultipliedValue` / `getPriceRealValue` in `Pricing/utils.ts` already take `(value, isTokenType)`
+and are field-agnostic, and `getPriceRealValue` already returns `undefined` for empty input and `'0'`
+only for an explicit zero — exactly the omitted-vs-zero contract the spec requires. The two new
+handlers call them the same way the prompt and completion handlers do. No new utility is needed, and
+the existing util tests continue to cover the scaling.
+
+### Grid columns follow the existing hidden-price pattern
+
+Two `ColDef` entries appended to `MODELS_COLUMNS`, matching the `pricing.prompt` / `pricing.completion`
+entries exactly — `hide: true` plus a `tooltipValueGetter`. These use literal `headerName` strings
+because the surrounding price columns do; introducing translated headers for two columns in a list
+where the neighbours are hardcoded would be a partial migration, not a fix.
+
+## Risks / Trade-offs
+
+**A user reaches an invalid model by a path that bypasses the pricing block** (raw JSON editor, config
+import, an entity created before this change) → Not addressed here, and not made worse. Core still
+validates on merge, and the asset surface already surfaces the resulting invalid status and warnings.
+The UI guarantee is over what this control can produce, not over the whole config.
+
+**Clearing rates on every unit change loses data the user typed** → Accepted, and already today's
+behavior for prompt and completion. The alternative silently changes what a number means; losing a
+value the user can see is empty is the safer failure.
+
+**The cost unit moving to its own line adds vertical height to two long forms** → Accepted. It is one
+row on pages that already scroll, and it buys alignment with every other control.
+
+**A cache rate entered against an older admin backend is silently dropped** → Deployment sequencing,
+covered in `proposal.md` — Impact. Not detectable from the frontend.
+
+## Migration Plan
+
+No data migration. The fields are additive and optional at every layer; a model with no cache rates
+behaves exactly as it does today, which is also Core's documented fallback. The admin backend's Flyway
+migration (`V1.119`) ships with the backend, not with this change.
+
+Rollback is a plain revert: reverting the frontend leaves any already-saved `cacheRead` /
+`cacheWrite` values intact in storage and in Core, no longer editable from the console but still
+applied when billing.

--- a/openspec/changes/archive/2026-08-12-add-model-cache-pricing/proposal.md
+++ b/openspec/changes/archive/2026-08-12-add-model-cache-pricing/proposal.md
@@ -1,0 +1,95 @@
+## Why
+
+DIAL Core bills prompt-cache traffic at its own rates: `ModelCostCalculator` subtracts cached and
+cache-write tokens from the prompt total and charges them at `pricing.cacheRead` / `pricing.cacheWrite`.
+Both fields now exist end to end — in Core's `Pricing` config class and, as of
+[admin-backend#1125](https://github.com/epam/ai-dial-admin-backend/pull/1125), through the admin BE's
+DTO, domain, and persistence layers (Flyway `V1.119`, including `model_entity_aud`).
+
+The admin console is the missing link: its pricing block still exposes only `prompt` and `completion`,
+so an administrator cannot price cached tokens on either model surface. Until they can, every model
+served through this console bills cache reads at the full prompt rate — Core's fallback when the
+field is absent.
+
+## What Changes
+
+- **Two new price inputs, `Cache read price` and `Cache write price`**, added to
+  `components/ModelView/Pricing/Pricing.tsx`. Because that component is already shared, the fields
+  appear on **both** model surfaces from a single edit: `Entities > Models` (admin-BE-backed) and
+  `Assets > Models` (Core-backed).
+- **Cache rates are gated to the token unit.** Core's `ConfigPostProcessor.validatePricing()` raises a
+  validation warning when either cache rate is set with `unit != "token"`, and in the merged-config
+  rebuild a warned model is *removed from the config and recorded as invalid*. The two inputs are
+  therefore disabled unless `Cost unit` is `Tokens`, and their values are cleared when the unit
+  changes away from it.
+- **An omitted cache rate is preserved as omitted, never coerced to `"0"`.** Core reads a missing rate
+  as "bill cache tokens at the prompt rate" and `"0"` as "free" — materially different bills. This
+  makes the existing `onChangePricingType` reset (which writes `{ prompt: '0', completion: '0' }`
+  when the unit is cleared, and drops both prices when it is set) a correctness problem rather than
+  a cosmetic one, so it is fixed as part of this change.
+- **The pricing block is re-laid out** so four price inputs fit the form column. `Cost unit` moves to
+  its own line above the prices, leaving one row of four 120px inputs (504px) inside the 640px
+  `CONTROL_WIDTH` every other control on the page uses. Keeping the select inline would need 732px and
+  silently shrink the inputs out of alignment. The sub-`lg` stacked variant is unchanged.
+- **Two hidden model-grid columns** (`pricing.cacheRead`, `pricing.cacheWrite`) alongside the existing
+  hidden prompt/completion price columns.
+- **Two i18n labels** in `ModelViewI18nKey` for the new controls. No audit labels are needed:
+  `convertPricing()` renders each pricing sub-field as a raw `key: value` pair, so the cache rates
+  appear in diffs exactly as `prompt` and `completion` already do.
+
+### Non-goals
+
+- No backend work. Core and the admin BE already carry both fields; this change is frontend-only.
+- No frontend cost calculation or analytics change. Cost is computed by Core and surfaced through
+  the analytics pipeline; `analytics-deployment-price` is untouched.
+- No new Activity Audit logic. `convertPricing()` iterates `Object.entries` over the pricing object
+  and applies the ×1,000,000 token scaling per key, so the new fields render in diffs from the label
+  additions alone.
+- No change to how `char_without_whitespace` pricing behaves beyond disabling the new inputs under it.
+
+## Capabilities
+
+### New Capabilities
+
+- `model-cache-pricing`: the cache-read/cache-write rate fields in the model pricing block — their
+  presence on both the entity and asset model surfaces, the token-unit gating Core requires, the
+  omitted-vs-zero persistence contract, and the reset behaviour when the cost unit changes.
+
+### Modified Capabilities
+
+None. `assets-models` already requires the Properties tab to expose "pricing" as a whole and that
+requirement is unchanged; the new fields are covered by the capability above, which applies to both
+surfaces.
+
+## Impact
+
+**Code**
+
+| File | Change |
+| --- | --- |
+| `src/models/dial/model.ts` | `DialModelPricing` gains optional `cacheRead` / `cacheWrite` |
+| `src/components/ModelView/Pricing/Pricing.tsx` | two inputs, two handlers, unit gating, reset fix, layout |
+| `src/constants/i18n.ts`, `src/locales/en.ts` | two control labels under `ModelView.Pricing` |
+| `src/constants/grid-columns/grid-columns.tsx` | two hidden columns on `MODELS_COLUMNS` |
+
+`src/models/dial/resource.ts` needs no edit — `DialModelResource.pricing` already references
+`DialModelPricing`. Both `ModelProperties.tsx` and `Assets/Models/Properties.tsx` pick up the new
+fields through the shared component without modification.
+
+**Backend paths** — the two surfaces do not share a backend, and both are ready:
+
+```
+Entities > Models ──► admin BE /api/v1/models ──► ModelDto.PricingDto   (PR #1125)
+Assets   > Models ──► DIAL Core PUT /v1/models/platform/{name}          (Core Pricing)
+```
+
+Core-version compatibility needs no frontend gate: `VersionAwareFieldFilter` allowlists config fields
+against the target version's schema at export time, so a deployment pinned below 0.47.0 has the cache
+rates stripped on the way to Core.
+
+**Release ordering** — the admin BE's request mapper runs with
+`FAIL_ON_UNKNOWN_PROPERTIES = false`, so an admin backend older than #1125 accepts a cache rate with
+`200 OK` and silently discards it: the user sees a success toast and an empty field after reload. This
+frontend change must not reach an environment ahead of the backend carrying #1125. The frontend has no
+way to detect the difference, so this is a deployment-sequencing constraint, not something to guard at
+runtime.

--- a/openspec/changes/archive/2026-08-12-add-model-cache-pricing/specs/model-cache-pricing/spec.md
+++ b/openspec/changes/archive/2026-08-12-add-model-cache-pricing/specs/model-cache-pricing/spec.md
@@ -1,0 +1,136 @@
+## Purpose
+
+Lets an administrator price prompt-cache traffic on a model — the per-token rates DIAL Core charges
+for cache reads and cache writes — from the same pricing block that already carries the prompt and
+completion rates, on both the entity and asset model surfaces.
+
+## ADDED Requirements
+
+### Requirement: Cache read and cache write rates are editable on both model surfaces
+
+The model pricing block SHALL expose two additional rate fields, cache read price and cache write
+price, alongside the existing prompt and completion prices. Both fields SHALL be available on the
+`Entities > Models` Properties tab and on the `Assets > Models` properties surface, and a value
+entered on either surface SHALL be persisted to that surface's backend as `pricing.cacheRead` and
+`pricing.cacheWrite` respectively.
+
+Both fields SHALL be read-only for a read-only administrator, matching the existing prompt and
+completion price fields.
+
+#### Scenario: Cache rate fields are present on the entity surface
+
+- **WHEN** a user opens a model under `Entities > Models` and views its Properties tab
+- **THEN** the pricing block presents a cache read price field and a cache write price field, each
+  labelled and addressable by its own accessible name
+
+#### Scenario: Cache rate fields are present on the asset surface
+
+- **WHEN** a user opens a model under `Assets > Models`
+- **THEN** the pricing block presents the same cache read price and cache write price fields
+
+#### Scenario: Entered cache rates are persisted
+
+- **WHEN** a user enters a cache read price and a cache write price on a model whose cost unit is
+  Tokens, and saves
+- **THEN** the saved model carries both values under `pricing.cacheRead` and `pricing.cacheWrite`
+
+#### Scenario: Read-only administrator cannot edit cache rates
+
+- **WHEN** a read-only administrator views a model's pricing block
+- **THEN** the cache read and cache write fields are disabled, as the prompt and completion fields are
+
+### Requirement: Cache rates are accepted only for the token cost unit
+
+DIAL Core treats a cache rate set under any cost unit other than `token` as a validation violation
+and excludes the offending model from the merged configuration. The pricing block SHALL therefore
+prevent that state from being produced: the cache read and cache write fields SHALL be enabled only
+while the cost unit is Tokens, and SHALL be disabled for every other cost unit, including when no
+cost unit is selected.
+
+#### Scenario: Cache rates are editable under the token unit
+
+- **WHEN** a model's cost unit is Tokens
+- **THEN** the cache read and cache write fields are enabled
+
+#### Scenario: Cache rates are disabled under the character unit
+
+- **WHEN** a model's cost unit is Char without whitespace
+- **THEN** the cache read and cache write fields are disabled
+
+#### Scenario: Cache rates are disabled when no cost unit is set
+
+- **WHEN** a model's cost unit is None
+- **THEN** the cache read and cache write fields are disabled
+
+### Requirement: Changing the cost unit clears every rate
+
+Changing the cost unit changes the meaning of every rate under it, so selecting a different cost unit
+SHALL clear the prompt, completion, cache read, and cache write rates, leaving each unset rather than
+setting it to zero. Selecting the None cost unit SHALL leave the model with no cost unit and no rates.
+
+#### Scenario: Switching to the character unit clears entered rates
+
+- **WHEN** a model priced in Tokens with all four rates set has its cost unit changed to Char without
+  whitespace
+- **THEN** all four rate fields are empty
+
+#### Scenario: Switching to None leaves no pricing values behind
+
+- **WHEN** a model with a cost unit and rates set has its cost unit changed to None
+- **THEN** the saved model carries neither a cost unit nor any rate value, and in particular no rate
+  is persisted as `"0"`
+
+### Requirement: An unset cache rate is persisted as absent, never as zero
+
+DIAL Core reads an absent cache rate as an instruction to bill cached tokens at the prompt rate, and a
+rate of `"0"` as an instruction to bill them as free. The system SHALL preserve that distinction: an
+empty cache rate field SHALL be omitted from the saved model, and a cache rate the user explicitly
+sets to zero SHALL be persisted as `"0"`.
+
+#### Scenario: Empty cache rate is omitted
+
+- **WHEN** a user saves a token-priced model leaving the cache read field empty
+- **THEN** the saved model contains no `pricing.cacheRead` value
+
+#### Scenario: Explicit zero cache rate is preserved
+
+- **WHEN** a user enters `0` in the cache write field and saves
+- **THEN** the saved model carries `pricing.cacheWrite` as `"0"`
+
+### Requirement: Cache rates use the same per-million display scaling as the other token rates
+
+Under the Tokens cost unit the pricing block displays rates per million tokens while storing them per
+token. The cache read and cache write fields SHALL follow that same scaling in both directions, so all
+four rates on a token-priced model are read and entered on one consistent scale.
+
+#### Scenario: Stored cache rate is displayed per million
+
+- **WHEN** a token-priced model with a stored `pricing.cacheRead` of `0.0000008` is opened
+- **THEN** the cache read field displays `0.8`
+
+#### Scenario: Entered cache rate is stored per token
+
+- **WHEN** a user enters `0.8` in the cache read field of a token-priced model and saves
+- **THEN** the saved model carries `pricing.cacheRead` as `0.0000008`
+
+### Requirement: Cache rates are available as model list columns
+
+The models grid SHALL offer a cache read price column and a cache write price column, hidden by
+default, matching how the prompt price and completion price columns are already offered.
+
+#### Scenario: Cache rate columns can be shown
+
+- **WHEN** a user opens the column chooser on the models grid
+- **THEN** cache read price and cache write price appear as available columns, hidden by default, and
+  selecting one shows that model's stored rate
+
+### Requirement: Cache rate changes appear in the activity audit
+
+A change to either cache rate SHALL appear in a model's activity audit pricing comparison, labelled
+and scaled consistently with the prompt and completion rates in the same comparison.
+
+#### Scenario: Audit shows an added cache rate
+
+- **WHEN** a revision of a token-priced model added a `pricing.cacheRead` value
+- **THEN** the audit comparison for that revision shows the cache read rate as added, displayed per
+  million tokens

--- a/openspec/changes/archive/2026-08-12-add-model-cache-pricing/tasks.md
+++ b/openspec/changes/archive/2026-08-12-add-model-cache-pricing/tasks.md
@@ -1,0 +1,52 @@
+> No browser-verification task: the user declined one for this change. Coverage of the
+> browser-observable scenarios comes from the component tests in section 4.
+
+## 1. Model type and labels
+
+- [x] 1.1 Add optional `cacheRead` and `cacheWrite` (both `string`) to `DialModelPricing` in
+      `src/models/dial/model.ts`. `DialModelResource` in `src/models/dial/resource.ts` already
+      references this interface and needs no edit.
+- [x] 1.2 Add `CacheReadPrice` and `CacheWritePrice` to `ModelViewI18nKey` in `src/constants/i18n.ts`,
+      keyed under `ModelView.Pricing`, with matching entries in the `ModelView.Pricing` block of
+      `src/locales/en.ts`.
+
+## 2. Pricing block
+
+- [x] 2.1 Add `onChangeCacheRead` and `onChangeCacheWrite` handlers to
+      `src/components/ModelView/Pricing/Pricing.tsx`, each calling `getPriceRealValue(value, isTokenType)`
+      exactly as the existing prompt and completion handlers do, so an empty field yields `undefined`
+      and an explicit zero yields `'0'`.
+- [x] 2.2 Render two `PriceControl` inputs for the new rates, valued via
+      `getMultipliedValue(model.pricing?.cacheRead, isTokenType)` (and the cache-write equivalent), and
+      `disabled` unless `isTokenType` — also disabled for `isReadOnlyAdmin`, matching the existing
+      price fields.
+- [x] 2.3 Rework `onChangePricingType` so any unit change clears all four rates: selecting Tokens or
+      Char without whitespace leaves `{ unit }` alone, and selecting None leaves the model with no unit
+      and no rates instead of today's `{ prompt: '0', completion: '0' }`.
+- [x] 2.4 Re-lay out the block per `design.md` — cost-unit select on its own line, the four
+      `PriceControl`s in one row below it — keeping the existing sub-`lg` stacked variant unchanged.
+
+## 3. Model grid columns
+
+- [x] 3.1 Append hidden `pricing.cacheRead` and `pricing.cacheWrite` columns to `MODELS_COLUMNS` in
+      `src/constants/grid-columns/grid-columns.tsx`, mirroring the existing `pricing.prompt` and
+      `pricing.completion` entries (`hide: true` plus a `tooltipValueGetter`).
+
+## 4. Tests
+
+- [x] 4.1 Add component tests for `Pricing.tsx` under
+      `src/components/ModelView/Pricing/tests/` covering: both cache fields render with their labels;
+      they are enabled under the Tokens unit and disabled under Char without whitespace, None, and
+      read-only admin; an empty field is reported as `undefined` while an entered `0` is reported as
+      `'0'`; and changing the unit clears all four rates with no `'0'` left behind.
+- [x] 4.2 Extend `src/constants/grid-columns/tests/grid-columns.spec.ts` to assert the two new
+      columns exist on `MODELS_COLUMNS` and are hidden by default.
+- [x] 4.3 Add a case to
+      `src/components/ActivityAudit/View/utils/tests/compare-helpers.spec.ts` asserting `convertPricing`
+      renders `cacheRead` / `cacheWrite` with the per-million scaling under the token unit — the helper
+      is key-agnostic, so this pins behavior rather than changing it.
+
+## 5. Quality checks
+
+- [x] 5.1 Run `npm run lint`, `npm run format`, and the full `npm run test` suite, resolving anything
+      they surface.

--- a/openspec/specs/model-cache-pricing/spec.md
+++ b/openspec/specs/model-cache-pricing/spec.md
@@ -1,0 +1,136 @@
+## Purpose
+
+Lets an administrator price prompt-cache traffic on a model — the per-token rates DIAL Core charges
+for cache reads and cache writes — from the same pricing block that already carries the prompt and
+completion rates, on both the entity and asset model surfaces.
+
+## Requirements
+
+### Requirement: Cache read and cache write rates are editable on both model surfaces
+
+The model pricing block SHALL expose two additional rate fields, cache read price and cache write
+price, alongside the existing prompt and completion prices. Both fields SHALL be available on the
+`Entities > Models` Properties tab and on the `Assets > Models` properties surface, and a value
+entered on either surface SHALL be persisted to that surface's backend as `pricing.cacheRead` and
+`pricing.cacheWrite` respectively.
+
+Both fields SHALL be read-only for a read-only administrator, matching the existing prompt and
+completion price fields.
+
+#### Scenario: Cache rate fields are present on the entity surface
+
+- **WHEN** a user opens a model under `Entities > Models` and views its Properties tab
+- **THEN** the pricing block presents a cache read price field and a cache write price field, each
+  labelled and addressable by its own accessible name
+
+#### Scenario: Cache rate fields are present on the asset surface
+
+- **WHEN** a user opens a model under `Assets > Models`
+- **THEN** the pricing block presents the same cache read price and cache write price fields
+
+#### Scenario: Entered cache rates are persisted
+
+- **WHEN** a user enters a cache read price and a cache write price on a model whose cost unit is
+  Tokens, and saves
+- **THEN** the saved model carries both values under `pricing.cacheRead` and `pricing.cacheWrite`
+
+#### Scenario: Read-only administrator cannot edit cache rates
+
+- **WHEN** a read-only administrator views a model's pricing block
+- **THEN** the cache read and cache write fields are disabled, as the prompt and completion fields are
+
+### Requirement: Cache rates are accepted only for the token cost unit
+
+DIAL Core treats a cache rate set under any cost unit other than `token` as a validation violation
+and excludes the offending model from the merged configuration. The pricing block SHALL therefore
+prevent that state from being produced: the cache read and cache write fields SHALL be enabled only
+while the cost unit is Tokens, and SHALL be disabled for every other cost unit, including when no
+cost unit is selected.
+
+#### Scenario: Cache rates are editable under the token unit
+
+- **WHEN** a model's cost unit is Tokens
+- **THEN** the cache read and cache write fields are enabled
+
+#### Scenario: Cache rates are disabled under the character unit
+
+- **WHEN** a model's cost unit is Char without whitespace
+- **THEN** the cache read and cache write fields are disabled
+
+#### Scenario: Cache rates are disabled when no cost unit is set
+
+- **WHEN** a model's cost unit is None
+- **THEN** the cache read and cache write fields are disabled
+
+### Requirement: Changing the cost unit clears every rate
+
+Changing the cost unit changes the meaning of every rate under it, so selecting a different cost unit
+SHALL clear the prompt, completion, cache read, and cache write rates, leaving each unset rather than
+setting it to zero. Selecting the None cost unit SHALL leave the model with no cost unit and no rates.
+
+#### Scenario: Switching to the character unit clears entered rates
+
+- **WHEN** a model priced in Tokens with all four rates set has its cost unit changed to Char without
+  whitespace
+- **THEN** all four rate fields are empty
+
+#### Scenario: Switching to None leaves no pricing values behind
+
+- **WHEN** a model with a cost unit and rates set has its cost unit changed to None
+- **THEN** the saved model carries neither a cost unit nor any rate value, and in particular no rate
+  is persisted as `"0"`
+
+### Requirement: An unset cache rate is persisted as absent, never as zero
+
+DIAL Core reads an absent cache rate as an instruction to bill cached tokens at the prompt rate, and a
+rate of `"0"` as an instruction to bill them as free. The system SHALL preserve that distinction: an
+empty cache rate field SHALL be omitted from the saved model, and a cache rate the user explicitly
+sets to zero SHALL be persisted as `"0"`.
+
+#### Scenario: Empty cache rate is omitted
+
+- **WHEN** a user saves a token-priced model leaving the cache read field empty
+- **THEN** the saved model contains no `pricing.cacheRead` value
+
+#### Scenario: Explicit zero cache rate is preserved
+
+- **WHEN** a user enters `0` in the cache write field and saves
+- **THEN** the saved model carries `pricing.cacheWrite` as `"0"`
+
+### Requirement: Cache rates use the same per-million display scaling as the other token rates
+
+Under the Tokens cost unit the pricing block displays rates per million tokens while storing them per
+token. The cache read and cache write fields SHALL follow that same scaling in both directions, so all
+four rates on a token-priced model are read and entered on one consistent scale.
+
+#### Scenario: Stored cache rate is displayed per million
+
+- **WHEN** a token-priced model with a stored `pricing.cacheRead` of `0.0000008` is opened
+- **THEN** the cache read field displays `0.8`
+
+#### Scenario: Entered cache rate is stored per token
+
+- **WHEN** a user enters `0.8` in the cache read field of a token-priced model and saves
+- **THEN** the saved model carries `pricing.cacheRead` as `0.0000008`
+
+### Requirement: Cache rates are available as model list columns
+
+The models grid SHALL offer a cache read price column and a cache write price column, hidden by
+default, matching how the prompt price and completion price columns are already offered.
+
+#### Scenario: Cache rate columns can be shown
+
+- **WHEN** a user opens the column chooser on the models grid
+- **THEN** cache read price and cache write price appear as available columns, hidden by default, and
+  selecting one shows that model's stored rate
+
+### Requirement: Cache rate changes appear in the activity audit
+
+A change to either cache rate SHALL appear in a model's activity audit pricing comparison, labelled
+and scaled consistently with the prompt and completion rates in the same comparison.
+
+#### Scenario: Audit shows an added cache rate
+
+- **WHEN** a revision of a token-priced model added a `pricing.cacheRead` value
+- **THEN** the audit comparison for that revision shows the cache read rate as added, displayed per
+  million tokens


### PR DESCRIPTION
## Description

Adds `cacheRead` / `cacheWrite` to the model pricing block, available on **BOTH model surfaces** (Entities > Models and Assets > Models) via the shared `Pricing` component.

Cache rates are enabled only under the Tokens cost unit — DIAL Core's `ConfigPostProcessor.validatePricing()` drops a model whose cache rates are set under any other unit.

Changing the cost unit now clears all four rates instead of writing `{ prompt: '0', completion: '0' }`. Core reads an absent rate as "bill cached tokens at the prompt rate" and `"0"` as "free", so the old reset was a real billing defect.

## Backend Support & Deployment Constraint

**NOTE: This frontend must not deploy ahead of an admin backend carrying epam/ai-dial-admin-backend#1125** — an older backend accepts the fields with 200 OK and silently discards them (`FAIL_ON_UNKNOWN_PROPERTIES=false`), which produces a silent billing error.

- Admin BE support: [epam/ai-dial-admin-backend#1125](https://github.com/epam/ai-dial-admin-backend/pull/1125)
- DIAL Core support: native `Pricing` config (already available)

## Key Changes

- [apps/ai-dial-admin/src/models/dial/model.ts](/../../blob/feat/add-cache-pricing/apps/ai-dial-admin/src/models/dial/model.ts) — Added optional `cacheRead` / `cacheWrite` fields to `DialModelPricing`
- [apps/ai-dial-admin/src/components/ModelView/Pricing/Pricing.tsx](/../../blob/feat/add-cache-pricing/apps/ai-dial-admin/src/components/ModelView/Pricing/Pricing.tsx) — Added cache read/write inputs; fixed `onChangePricingType` to clear rates instead of coercing to `'0'`
- [apps/ai-dial-admin/src/constants/i18n.ts](/../../blob/feat/add-cache-pricing/apps/ai-dial-admin/src/constants/i18n.ts) — Added i18n keys `CacheReadPrice` / `CacheWritePrice`
- [apps/ai-dial-admin/src/locales/en.ts](/../../blob/feat/add-cache-pricing/apps/ai-dial-admin/src/locales/en.ts) — Added English labels
- [apps/ai-dial-admin/src/constants/grid-columns/grid-columns.tsx](/../../blob/feat/add-cache-pricing/apps/ai-dial-admin/src/constants/grid-columns/grid-columns.tsx) — Added hidden `pricing.cacheRead` / `pricing.cacheWrite` columns to models grid

## New Components

- [apps/ai-dial-admin/src/components/ModelView/Pricing/tests/Pricing.spec.tsx](/../../blob/feat/add-cache-pricing/apps/ai-dial-admin/src/components/ModelView/Pricing/tests/Pricing.spec.tsx) — Component tests for cache pricing fields

## Tests

Updated test suites to cover the new fields:
- Pricing component tests (render, enable/disable under cost units, value handling)
- Grid columns spec assertions
- Activity Audit conversion tests for cache field scaling

Full suite: 7886 passed / 0 failed; lint 0 errors; formatting clean.

## OpenSpec

- Change archived: openspec/changes/archive/2026-08-12-add-model-cache-pricing/
- Capability spec: openspec/specs/model-cache-pricing/

#4176

## Checklist

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with a reference to related issues (none for this spec-driven change)