### PR TITLE
fix: [Eval][Run Comparison] Metric Scores order (statistic buttons and group cards) changes when toggling Only matching test cases (Issue #4122)

### DIFF
--- a/apps/ai-dial-admin/src/components/Runs/Summary/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/Runs/Summary/tests/utils.spec.ts
@@ -306,6 +306,22 @@ describe('Runs Summary :: metric scores', () => {
     });
   });
 
+  test('parseMetricScores sorts metric groups alphabetically regardless of row order', () => {
+    const parsed = parseMetricScores({
+      rows: [
+        { metric_name: 'ragas.faithfulness.score', metric_score_name: 'AVG', value: 0.5 },
+        { metric_name: 'aidial_rag_eval.generation.context_to_answer', metric_score_name: 'AVG', value: 0.8 },
+        { metric_name: 'deepeval.answer_relevancy.score', metric_score_name: 'AVG', value: 0.7 },
+      ],
+    });
+
+    expect(parsed.byStatistic.AVG.map((group) => group.name)).toEqual([
+      'aidial_rag_eval.generation',
+      'deepeval.answer_relevancy',
+      'ragas.faithfulness',
+    ]);
+  });
+
   test('parseMetricScores orders statistics by Metric Scores segmented-control order', () => {
     const parsed = parseMetricScores({
       rows: [

--- a/apps/ai-dial-admin/src/components/Runs/Summary/utils.ts
+++ b/apps/ai-dial-admin/src/components/Runs/Summary/utils.ts
@@ -201,7 +201,9 @@ export const splitMetricName = (metricName: string): { group: string; bar: strin
  * Folds `metric_score_results` rows into bar groups per statistic. For each statistic
  * (`metric_score_name`, e.g. AVG), metrics are grouped by their name prefix (before the last `.`),
  * and each leaf metric name becomes a bar with its value. Also collects the distinct statistic
- * names (first-seen order) that drive the statistic SegmentedControl.
+ * names (canonical Metric Scores control order) that drive the statistic SegmentedControl.
+ * Metric groups within each statistic are sorted alphabetically so order is stable across
+ * full-run and matched-only data sources.
  */
 export const parseMetricScores = (result: StructuredQueryResult | null): MetricScoresData => {
   const statistics: string[] = [];
@@ -238,7 +240,14 @@ export const parseMetricScores = (result: StructuredQueryResult | null): MetricS
     group.bars[barName] = Math.round(value * 1000) / 1000;
   }
 
-  return { overallScore, statistics: sortMetricStatistics(statistics), byStatistic };
+  const sortedByStatistic: Record<string, MetricScoreGroup[]> = {};
+  for (const [statistic, groups] of Object.entries(byStatistic)) {
+    sortedByStatistic[statistic] = [...groups].sort((a, b) =>
+      a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }),
+    );
+  }
+
+  return { overallScore, statistics: sortMetricStatistics(statistics), byStatistic: sortedByStatistic };
 };
 
 /**


### PR DESCRIPTION
**Description:**

<SHORT_DESCRIPTION>

Issues:

- Issue #<TICKET_ID>


**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
