### PR TITLE
feat(analytics/Tables): collect display name and description when creating columns (Issue #3847)

### DIFF
--- a/apps/ai-dial-admin/src/components/Analytics/Tables/ColumnRowsEditor.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/ColumnRowsEditor.tsx
@@ -42,7 +42,14 @@ const ColumnRowsEditor: FC<Props> = ({ rows, onChange, errors }) => {
         // A validation error makes that field's column taller (label + input + error text). With
         // items-end (the normal bottom-aligned layout) that drags the erroring column's label out of
         // line with its error-free siblings, so switch to top alignment whenever this row has any error.
-        const rowHasError = Boolean(rowError?.source_name || rowError?.name || rowError?.tag || rowError?.element_type);
+        const rowHasError = Boolean(
+          rowError?.source_name ||
+          rowError?.name ||
+          rowError?.tag ||
+          rowError?.display_name ||
+          rowError?.description ||
+          rowError?.element_type,
+        );
         return (
           <div key={row.id} className={classNames('flex gap-2', rowHasError ? 'items-start' : 'items-end')}>
             <DialInput
@@ -56,6 +63,24 @@ const ColumnRowsEditor: FC<Props> = ({ rows, onChange, errors }) => {
               // diverge from its source name via a later rename, done in the grid on an active table —
               // see TableDetailView's onRenameCell) — so one control fills both DTO fields.
               onChange={(v) => update(row.id, { source_name: v ?? '', name: v ?? '' })}
+            />
+            <DialInput
+              id={`col-display-name-${row.id}`}
+              containerClassName="flex-[2] min-w-[140px]"
+              labelProps={first ? { label: t(AnalyticsTablesI18nKey.DisplayName) } : undefined}
+              value={row.display_name}
+              error={rowError?.display_name}
+              invalid={Boolean(rowError?.display_name)}
+              onChange={(v) => update(row.id, { display_name: v ?? '' })}
+            />
+            <DialInput
+              id={`col-description-${row.id}`}
+              containerClassName="flex-[3] min-w-[160px]"
+              labelProps={first ? { label: t(AnalyticsTablesI18nKey.Description) } : undefined}
+              value={row.description}
+              error={rowError?.description}
+              invalid={Boolean(rowError?.description)}
+              onChange={(v) => update(row.id, { description: v ?? '' })}
             />
             <DialSelectField
               id={`col-type-${row.id}`}

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/tests/ColumnRowsEditor.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/tests/ColumnRowsEditor.spec.tsx
@@ -4,7 +4,7 @@ import { describe, expect, test, vi } from 'vitest';
 
 import ColumnRowsEditor from '@/src/components/Analytics/Tables/ColumnRowsEditor';
 import { createColumnRow } from '@/src/components/Analytics/Tables/utils';
-import { AnalyticsTablesI18nKey } from '@/src/constants/i18n';
+import { AnalyticsTablesI18nKey, ErrorI18nKey } from '@/src/constants/i18n';
 import { AnalyticsFieldType } from '@/src/models/analytics/entity';
 import { ColumnRow } from '@/src/models/analytics/tables-ui';
 
@@ -117,5 +117,74 @@ describe('ColumnRowsEditor', () => {
       />,
     );
     expect(screen.getByRole('alert')).toHaveTextContent('Required');
+  });
+
+  test('renders a Display name and a Description field on a row', () => {
+    render(<ColumnRowsEditor rows={[row()]} onChange={vi.fn()} />);
+
+    expect(screen.getByLabelText(AnalyticsTablesI18nKey.DisplayName, { exact: false })).toBeInTheDocument();
+    expect(screen.getByLabelText(AnalyticsTablesI18nKey.Description, { exact: false })).toBeInTheDocument();
+  });
+
+  test('renders the two field labels on the first row only', () => {
+    const rows = [row(), row()];
+    const { container } = render(<ColumnRowsEditor rows={rows} onChange={vi.fn()} />);
+
+    expect(screen.getAllByLabelText(AnalyticsTablesI18nKey.DisplayName, { exact: false })).toHaveLength(1);
+    expect(screen.getAllByLabelText(AnalyticsTablesI18nKey.Description, { exact: false })).toHaveLength(1);
+    // The second row still has both controls; only its labels are omitted, as for every other field here.
+    expect(container.querySelector(`#col-display-name-${rows[1].id}`)).toBeTruthy();
+    expect(container.querySelector(`#col-description-${rows[1].id}`)).toBeTruthy();
+  });
+
+  test('typing a display name patches only that field on the row', () => {
+    const onChange = vi.fn();
+    render(<ColumnRowsEditor rows={[row()]} onChange={onChange} />);
+
+    fireEvent.change(screen.getByLabelText(AnalyticsTablesI18nKey.DisplayName, { exact: false }), {
+      target: { value: 'Total tokens' },
+    });
+
+    expect(onChange).toHaveBeenCalledWith([expect.objectContaining({ display_name: 'Total tokens', description: '' })]);
+  });
+
+  test('typing a description patches only that field on the row', () => {
+    const onChange = vi.fn();
+    render(<ColumnRowsEditor rows={[row()]} onChange={onChange} />);
+
+    fireEvent.change(screen.getByLabelText(AnalyticsTablesI18nKey.Description, { exact: false }), {
+      target: { value: 'Prompt plus completion tokens' },
+    });
+
+    expect(onChange).toHaveBeenCalledWith([
+      expect.objectContaining({ description: 'Prompt plus completion tokens', display_name: '' }),
+    ]);
+  });
+
+  test('shows a length validation error on the display name and on the description', () => {
+    render(
+      <ColumnRowsEditor
+        rows={[row(), row()]}
+        errors={[{ display_name: ErrorI18nKey.Length }, { description: ErrorI18nKey.Length }]}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(screen.getAllByText(ErrorI18nKey.Length)).toHaveLength(2);
+  });
+
+  // rowHasError drives the row's top-aligned layout; a row erroring only on one of the two new fields
+  // must trigger it too, or its labels fall out of line with its error-free siblings.
+  test('a row erroring only on the description still gets the top-aligned layout', () => {
+    const { container } = render(
+      <ColumnRowsEditor rows={[row()]} errors={[{ description: ErrorI18nKey.Length }]} onChange={vi.fn()} />,
+    );
+    expect(container.querySelector('.items-start')).toBeTruthy();
+    expect(container.querySelector('.items-end')).toBeNull();
+  });
+
+  test('a row with no errors keeps the bottom-aligned layout', () => {
+    const { container } = render(<ColumnRowsEditor rows={[row()]} onChange={vi.fn()} />);
+    expect(container.querySelector('.items-end')).toBeTruthy();
+    expect(container.querySelector('.items-start')).toBeNull();
   });
 });

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/tests/DraftSchemaEditor.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/tests/DraftSchemaEditor.spec.tsx
@@ -143,6 +143,49 @@ describe('DraftSchemaEditor source', () => {
     expect(draft.update).toHaveBeenCalledWith('columns', expect.any(Array));
   });
 
+  test('the column rows offer a Display name and a Description field', () => {
+    render(<DraftSchemaEditor table={source} draft={fixtureDraft()} />);
+    expect(screen.getByLabelText(AnalyticsTablesI18nKey.DisplayName, { exact: false })).toBeInTheDocument();
+    expect(screen.getByLabelText(AnalyticsTablesI18nKey.Description, { exact: false })).toBeInTheDocument();
+  });
+
+  test('editing a column display name and description calls the draft update with the new rows', () => {
+    const draft = fixtureDraft();
+    render(<DraftSchemaEditor table={source} draft={draft} />);
+
+    fireEvent.change(screen.getByLabelText(AnalyticsTablesI18nKey.DisplayName, { exact: false }), {
+      target: { value: 'Total tokens' },
+    });
+    expect(draft.update).toHaveBeenCalledWith('columns', [expect.objectContaining({ display_name: 'Total tokens' })]);
+
+    fireEvent.change(screen.getByLabelText(AnalyticsTablesI18nKey.Description, { exact: false }), {
+      target: { value: 'Prompt plus completion tokens' },
+    });
+    expect(draft.update).toHaveBeenCalledWith('columns', [
+      expect.objectContaining({ description: 'Prompt plus completion tokens' }),
+    ]);
+  });
+
+  test('seeds the column rows with the display name and description a FAILED table already stores', () => {
+    const seeded = fixtureDraft({
+      columns: [
+        {
+          ...createColumnRow(),
+          source_name: 'total_tokens',
+          name: 'total_tokens',
+          display_name: 'Total tokens',
+          description: 'Prompt plus completion tokens',
+        },
+      ],
+    });
+    render(<DraftSchemaEditor table={{ ...source, status: TableStatus.Failed }} draft={seeded} />);
+
+    expect(screen.getByLabelText(AnalyticsTablesI18nKey.DisplayName, { exact: false })).toHaveValue('Total tokens');
+    expect(screen.getByLabelText(AnalyticsTablesI18nKey.Description, { exact: false })).toHaveValue(
+      'Prompt plus completion tokens',
+    );
+  });
+
   test('renders no Save submit button — that trigger lives in the detail view header', () => {
     render(<DraftSchemaEditor table={source} draft={fixtureDraft()} />);
     expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/tests/TableDetailView.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/tests/TableDetailView.spec.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { getTable, getTableAccess } from '@/src/app/[lang]/tables/actions';
+import { getTable, getTableAccess, updateTableSchema } from '@/src/app/[lang]/tables/actions';
 import TableDetailView from '@/src/components/Analytics/Tables/TableDetailView';
 import { ActionMenuOperationI18nKey, AnalyticsTablesI18nKey, ButtonsI18nKey } from '@/src/constants/i18n';
 import { AnalyticsFieldType } from '@/src/models/analytics/entity';
@@ -509,6 +509,92 @@ describe('TableDetailView write rows', () => {
 
     fireEvent.change(editor, { target: { value: '[]' } });
     expect(insertButton).toBeEnabled();
+  });
+});
+
+describe('TableDetailView add columns :: display name and description', () => {
+  // The header trigger and the popup's submit share the "Add columns" label, so every query below is
+  // scoped to the popup itself.
+  const openPopup = async () => {
+    const user = userEvent.setup();
+    render(<TableDetailView name="dial_usage_log" initialTable={table()} apiBaseUrl="" flightUri="" />);
+    await user.click(screen.getByRole('button', { name: AnalyticsTablesI18nKey.AddColumns }));
+    return { user, popup: within(screen.getByRole('dialog')) };
+  };
+
+  test('the popup offers a Display name and a Description field on its column row', async () => {
+    const { popup } = await openPopup();
+
+    expect(popup.getByLabelText(AnalyticsTablesI18nKey.DisplayName, { exact: false })).toBeInTheDocument();
+    expect(popup.getByLabelText(AnalyticsTablesI18nKey.Description, { exact: false })).toBeInTheDocument();
+  });
+
+  // The point of the change: metadata authored here reaches the backend in the same request that creates
+  // the column, so no follow-up trip through the edit modal is needed.
+  test('a column added with metadata sends display_name and description in the add patch', async () => {
+    vi.mocked(updateTableSchema).mockResolvedValue({ success: true });
+    const { user, popup } = await openPopup();
+
+    fireEvent.change(popup.getByLabelText(AnalyticsTablesI18nKey.ColumnName, { exact: false }), {
+      target: { value: 'total_tokens' },
+    });
+    fireEvent.change(popup.getByLabelText(AnalyticsTablesI18nKey.DisplayName, { exact: false }), {
+      target: { value: 'Total tokens' },
+    });
+    fireEvent.change(popup.getByLabelText(AnalyticsTablesI18nKey.Description, { exact: false }), {
+      target: { value: 'Prompt plus completion tokens' },
+    });
+    await user.click(popup.getByRole('button', { name: AnalyticsTablesI18nKey.AddColumns }));
+
+    expect(updateTableSchema).toHaveBeenCalledWith('dial_usage_log', {
+      add: [
+        expect.objectContaining({
+          source_name: 'total_tokens',
+          name: 'total_tokens',
+          display_name: 'Total tokens',
+          description: 'Prompt plus completion tokens',
+        }),
+      ],
+    });
+  });
+
+  test('a column added without metadata sends neither key', async () => {
+    vi.mocked(updateTableSchema).mockResolvedValue({ success: true });
+    const { user, popup } = await openPopup();
+
+    fireEvent.change(popup.getByLabelText(AnalyticsTablesI18nKey.ColumnName, { exact: false }), {
+      target: { value: 'total_tokens' },
+    });
+    await user.click(popup.getByRole('button', { name: AnalyticsTablesI18nKey.AddColumns }));
+
+    const patch = vi.mocked(updateTableSchema).mock.lastCall?.[1];
+    expect(patch?.add?.[0]).not.toHaveProperty('display_name');
+    expect(patch?.add?.[0]).not.toHaveProperty('description');
+  });
+
+  test('an over-cap display name or description disables submit', async () => {
+    const { popup } = await openPopup();
+    const submit = popup.getByRole('button', { name: AnalyticsTablesI18nKey.AddColumns });
+
+    fireEvent.change(popup.getByLabelText(AnalyticsTablesI18nKey.ColumnName, { exact: false }), {
+      target: { value: 'total_tokens' },
+    });
+    expect(submit).toBeEnabled();
+
+    fireEvent.change(popup.getByLabelText(AnalyticsTablesI18nKey.DisplayName, { exact: false }), {
+      target: { value: 'a'.repeat(129) },
+    });
+    expect(submit).toBeDisabled();
+
+    fireEvent.change(popup.getByLabelText(AnalyticsTablesI18nKey.DisplayName, { exact: false }), {
+      target: { value: 'Total tokens' },
+    });
+    expect(submit).toBeEnabled();
+
+    fireEvent.change(popup.getByLabelText(AnalyticsTablesI18nKey.Description, { exact: false }), {
+      target: { value: 'b'.repeat(1025) },
+    });
+    expect(submit).toBeDisabled();
   });
 });
 

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/tests/use-draft-schema-form.spec.ts
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/tests/use-draft-schema-form.spec.ts
@@ -47,6 +47,72 @@ describe('useDraftSchemaForm source', () => {
     });
   });
 
+  test('buildDto carries a column display name and description, and omits them when blank', () => {
+    const { result } = renderHook(() => useDraftSchemaForm(source, null, t));
+
+    act(() =>
+      result.current.update('columns', [
+        {
+          ...result.current.form.columns[0],
+          source_name: 'total_tokens',
+          name: 'total_tokens',
+          type: AnalyticsFieldType.Long,
+          display_name: 'Total tokens',
+          description: 'Prompt plus completion tokens',
+        },
+        {
+          ...result.current.form.columns[0],
+          id: 'c2',
+          source_name: 'ts',
+          name: 'ts',
+          type: AnalyticsFieldType.Timestamp,
+        },
+      ]),
+    );
+    act(() => result.current.update('orderingKey', ['ts']));
+
+    expect(result.current.canMaterialize).toBe(true);
+    expect(result.current.buildDto()).toEqual({
+      columns: [
+        {
+          source_name: 'total_tokens',
+          name: 'total_tokens',
+          type: AnalyticsFieldType.Long,
+          nullable: false,
+          display_name: 'Total tokens',
+          description: 'Prompt plus completion tokens',
+        },
+        { source_name: 'ts', name: 'ts', type: AnalyticsFieldType.Timestamp, nullable: false },
+      ],
+      ordering_key: ['ts'],
+    });
+  });
+
+  test('an over-cap display name or description blocks Materialize on an otherwise complete schema', () => {
+    const { result } = renderHook(() => useDraftSchemaForm(source, null, t));
+
+    act(() =>
+      result.current.update('columns', [
+        { ...result.current.form.columns[0], source_name: 'ts', name: 'ts', type: AnalyticsFieldType.Timestamp },
+      ]),
+    );
+    act(() => result.current.update('orderingKey', ['ts']));
+    expect(result.current.canMaterialize).toBe(true);
+
+    act(() => result.current.update('columns', [{ ...result.current.form.columns[0], display_name: 'a'.repeat(129) }]));
+    expect(result.current.canMaterialize).toBe(false);
+
+    act(() =>
+      result.current.update('columns', [
+        { ...result.current.form.columns[0], display_name: '', description: 'b'.repeat(1025) },
+      ]),
+    );
+    expect(result.current.canMaterialize).toBe(false);
+
+    act(() => result.current.update('columns', [{ ...result.current.form.columns[0], description: '' }]));
+    expect(result.current.canMaterialize).toBe(true);
+  });
+
   test('retyping the selected partition column away from Date/Timestamp clears both it and the granularity', () => {
     const { result } = renderHook(() => useDraftSchemaForm(source, null, t));
 

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/tests/utils.spec.ts
@@ -66,6 +66,37 @@ describe('createDraftSchemaForm', () => {
     expect(form.grainKey).toBe('order_id');
   });
 
+  // A FAILED table is resubmitted from this seed, so metadata the user already authored must survive the
+  // round-trip rather than being silently dropped on retry.
+  test('seeds a column display name and description from an already-drafted table', () => {
+    const form = createDraftSchemaForm({
+      name: 'orders',
+      type: AnalyticsTableType.Source,
+      columns: [
+        {
+          source_name: 'total_tokens',
+          name: 'total_tokens',
+          type: AnalyticsFieldType.Long,
+          display_name: 'Total tokens',
+          description: 'Prompt plus completion tokens',
+        },
+      ],
+    });
+    expect(form.columns[0]).toMatchObject({
+      display_name: 'Total tokens',
+      description: 'Prompt plus completion tokens',
+    });
+  });
+
+  test('seeds a column with no stored display name or description as blank strings', () => {
+    const form = createDraftSchemaForm({
+      name: 'orders',
+      type: AnalyticsTableType.Source,
+      columns: [{ source_name: 'ts', name: 'ts', type: AnalyticsFieldType.Timestamp }],
+    });
+    expect(form.columns[0]).toMatchObject({ display_name: '', description: '' });
+  });
+
   test('seeds the scan-metadata pair, which a re-post cannot clear', () => {
     const form = createDraftSchemaForm({
       name: 'orders',
@@ -169,6 +200,8 @@ describe('createColumnRow', () => {
       type: AnalyticsFieldType.String,
       element_type: '',
       tag: '',
+      display_name: '',
+      description: '',
       nullable: false,
       sensitive: false,
     });
@@ -178,36 +211,15 @@ describe('createColumnRow', () => {
 describe('toTableColumns', () => {
   test('keeps only rows with both source_name and name, trims, and omits empty tag', () => {
     const rows = [
-      {
-        id: '1',
+      row({
         source_name: ' event_id ',
         name: ' event ',
         type: AnalyticsFieldType.Uuid,
-        element_type: '' as const,
         tag: ' identity ',
         nullable: true,
-        sensitive: false,
-      },
-      {
-        id: '2',
-        source_name: '',
-        name: 'skip',
-        type: AnalyticsFieldType.String,
-        element_type: '' as const,
-        tag: '',
-        nullable: false,
-        sensitive: false,
-      },
-      {
-        id: '3',
-        source_name: 'x',
-        name: 'x',
-        type: AnalyticsFieldType.Long,
-        element_type: '' as const,
-        tag: '',
-        nullable: false,
-        sensitive: false,
-      },
+      }),
+      row({ source_name: '', name: 'skip' }),
+      row({ source_name: 'x', name: 'x', type: AnalyticsFieldType.Long }),
     ];
     expect(toTableColumns(rows)).toEqual([
       { source_name: 'event_id', name: 'event', type: AnalyticsFieldType.Uuid, nullable: true, tag: 'identity' },
@@ -217,26 +229,8 @@ describe('toTableColumns', () => {
 
   test('sensitive rows carry sensitive: true; non-sensitive rows omit the field', () => {
     const rows = [
-      {
-        id: '1',
-        source_name: 'email',
-        name: 'email',
-        type: AnalyticsFieldType.String,
-        element_type: '' as const,
-        tag: '',
-        nullable: false,
-        sensitive: true,
-      },
-      {
-        id: '2',
-        source_name: 'total',
-        name: 'total',
-        type: AnalyticsFieldType.Decimal,
-        element_type: '' as const,
-        tag: '',
-        nullable: false,
-        sensitive: false,
-      },
+      row({ source_name: 'email', name: 'email', sensitive: true }),
+      row({ source_name: 'total', name: 'total', type: AnalyticsFieldType.Decimal }),
     ];
     expect(toTableColumns(rows)).toEqual([
       { source_name: 'email', name: 'email', type: AnalyticsFieldType.String, nullable: false, sensitive: true },
@@ -246,16 +240,13 @@ describe('toTableColumns', () => {
 
   test('an Array row carries its element_type and is forced non-nullable', () => {
     const rows = [
-      {
-        id: '1',
+      row({
         source_name: 'tags',
         name: 'tags',
         type: AnalyticsFieldType.Array,
         element_type: AnalyticsFieldType.String,
-        tag: '',
         nullable: true,
-        sensitive: false,
-      },
+      }),
     ];
     expect(toTableColumns(rows)).toEqual([
       {
@@ -269,20 +260,51 @@ describe('toTableColumns', () => {
   });
 
   test('an Array row with no element_type chosen yet omits the field rather than sending an empty value', () => {
-    const rows = [
-      {
-        id: '1',
-        source_name: 'tags',
-        name: 'tags',
-        type: AnalyticsFieldType.Array,
-        element_type: '' as const,
-        tag: '',
-        nullable: false,
-        sensitive: false,
-      },
-    ];
+    const rows = [row({ source_name: 'tags', name: 'tags', type: AnalyticsFieldType.Array, element_type: '' })];
     expect(toTableColumns(rows)).toEqual([
       { source_name: 'tags', name: 'tags', type: AnalyticsFieldType.Array, nullable: false },
+    ]);
+  });
+
+  test('carries a filled display name and description, trimmed', () => {
+    const rows = [
+      row({
+        source_name: 'total_tokens',
+        name: 'total_tokens',
+        type: AnalyticsFieldType.Long,
+        display_name: '  Total tokens  ',
+        description: '  Prompt plus completion tokens  ',
+      }),
+    ];
+    expect(toTableColumns(rows)).toEqual([
+      {
+        source_name: 'total_tokens',
+        name: 'total_tokens',
+        type: AnalyticsFieldType.Long,
+        nullable: false,
+        display_name: 'Total tokens',
+        description: 'Prompt plus completion tokens',
+      },
+    ]);
+  });
+
+  // Blank means "not set" at creation time, so the key is omitted rather than sent as an empty string —
+  // unlike the edit modal, where a blank value is the signal that clears a stored one.
+  test('omits a blank or whitespace-only display name and description', () => {
+    const rows = [
+      row({ source_name: 'a', name: 'a', display_name: '', description: '' }),
+      row({ source_name: 'b', name: 'b', display_name: '   ', description: '  ' }),
+    ];
+    expect(toTableColumns(rows)).toEqual([
+      { source_name: 'a', name: 'a', type: AnalyticsFieldType.String, nullable: false },
+      { source_name: 'b', name: 'b', type: AnalyticsFieldType.String, nullable: false },
+    ]);
+  });
+
+  test('carries one of the pair when only the other is blank', () => {
+    const rows = [row({ source_name: 'a', name: 'a', display_name: 'A value', description: '' })];
+    expect(toTableColumns(rows)).toEqual([
+      { source_name: 'a', name: 'a', type: AnalyticsFieldType.String, nullable: false, display_name: 'A value' },
     ]);
   });
 });
@@ -417,6 +439,35 @@ describe('getColumnRowErrors / hasColumnRowErrors', () => {
     const errors = getColumnRowErrors([row({ tag: 'a'.repeat(65) })], noExisting, t);
     expect(errors[0].tag).toBe(ErrorI18nKey.Length);
     expect(hasColumnRowErrors(errors)).toBe(true);
+  });
+
+  test('flags a display name over its 128-char cap and a description over its 1024-char cap', () => {
+    const errors = getColumnRowErrors(
+      [row({ display_name: 'a'.repeat(129) }), row({ description: 'b'.repeat(1025) })],
+      noExisting,
+      t,
+    );
+    expect(errors[0].display_name).toBe(ErrorI18nKey.Length);
+    expect(errors[1].description).toBe(ErrorI18nKey.Length);
+    expect(hasColumnRowErrors(errors)).toBe(true);
+  });
+
+  test('accepts a display name and description exactly at their caps', () => {
+    const errors = getColumnRowErrors(
+      [row({ source_name: 'a', name: 'a', display_name: 'a'.repeat(128), description: 'b'.repeat(1024) })],
+      noExisting,
+      t,
+    );
+    expect(errors[0].display_name).toBeUndefined();
+    expect(errors[0].description).toBeUndefined();
+    expect(hasColumnRowErrors(errors)).toBe(false);
+  });
+
+  // These two keys are the ones a boolean-OR gate silently forgets: an unlisted key reads as undefined,
+  // so the error is computed and then ignored, letting an over-cap value reach the backend as a 422.
+  test('reports an error carrying only a display name or only a description', () => {
+    expect(hasColumnRowErrors([{ display_name: ErrorI18nKey.Length }])).toBe(true);
+    expect(hasColumnRowErrors([{ description: ErrorI18nKey.Length }])).toBe(true);
   });
 
   test('flags an Array row with no element_type chosen', () => {

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/utils.ts
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/utils.ts
@@ -1,4 +1,9 @@
-import { ANALYTICS_TAG_MAX_LENGTH, PARTITION_NONE } from '@/src/constants/analytics/tables';
+import {
+  ANALYTICS_DESCRIPTION_MAX_LENGTH,
+  ANALYTICS_DISPLAY_NAME_MAX_LENGTH,
+  ANALYTICS_TAG_MAX_LENGTH,
+  PARTITION_NONE,
+} from '@/src/constants/analytics/tables';
 import { ErrorI18nKey } from '@/src/constants/i18n';
 import { AnalyticsFieldType } from '@/src/models/analytics/entity';
 import { ApplicationRoute } from '@/src/types/routes';
@@ -34,6 +39,8 @@ export const createColumnRow = (): ColumnRow => ({
   type: AnalyticsFieldType.String,
   element_type: '',
   tag: '',
+  display_name: '',
+  description: '',
   nullable: false,
   sensitive: false,
 });
@@ -82,6 +89,8 @@ const toColumnRows = (columns: AnalyticsTableColumn[]): ColumnRow[] =>
     type: c.type,
     element_type: c.element_type ?? '',
     tag: c.tag ?? '',
+    display_name: c.display_name ?? '',
+    description: c.description ?? '',
     nullable: Boolean(c.nullable),
     sensitive: Boolean(c.sensitive),
   }));
@@ -98,10 +107,6 @@ export const createDraftSchemaForm = (table: AnalyticsTable): DraftSchemaForm =>
   versionColumn: table.version_column ?? '',
 });
 
-// Validates the column rows of a create/add-columns form against the backend rules: each row that will
-// actually be sent (both source_name and name filled — partial rows are dropped by toTableColumns) must
-// have snake_case identifiers unique within the table (against sibling rows and any pre-existing columns),
-// and a tag within its length cap. Returns one entry per row, aligned by index; empty entries are valid.
 export const getColumnRowErrors = (
   rows: ColumnRow[],
   existing: ExistingColumnNames,
@@ -126,6 +131,12 @@ export const getColumnRowErrors = (
     const tagError = getAnalyticsLengthError(row.tag, ANALYTICS_TAG_MAX_LENGTH, t);
     if (tagError) error.tag = tagError.text;
 
+    const displayNameError = getAnalyticsLengthError(row.display_name, ANALYTICS_DISPLAY_NAME_MAX_LENGTH, t);
+    if (displayNameError) error.display_name = displayNameError.text;
+
+    const descriptionError = getAnalyticsLengthError(row.description, ANALYTICS_DESCRIPTION_MAX_LENGTH, t);
+    if (descriptionError) error.description = descriptionError.text;
+
     if (row.type === AnalyticsFieldType.Array && !row.element_type) {
       error.element_type = t(ErrorI18nKey.RequiredField);
     }
@@ -135,7 +146,7 @@ export const getColumnRowErrors = (
 };
 
 export const hasColumnRowErrors = (errors: ColumnRowError[]): boolean =>
-  errors.some((e) => e.source_name || e.name || e.tag || e.element_type);
+  errors.some((e) => e.source_name || e.name || e.tag || e.display_name || e.description || e.element_type);
 
 const normalized = (value?: string): string => (value ?? '').trim();
 
@@ -182,10 +193,11 @@ export const toTableColumns = (rows: ColumnRow[]): AnalyticsTableColumn[] =>
         source_name: r.source_name.trim(),
         name: r.name.trim(),
         type: r.type,
-        // The backend rejects a nullable array column, so an Array row is always sent as non-nullable.
         nullable: isArray ? false : r.nullable,
         ...(isArray && r.element_type ? { element_type: r.element_type } : {}),
         ...(r.tag.trim() ? { tag: r.tag.trim() } : {}),
+        ...(r.display_name.trim() ? { display_name: r.display_name.trim() } : {}),
+        ...(r.description.trim() ? { description: r.description.trim() } : {}),
         ...(r.sensitive ? { sensitive: true } : {}),
       };
     });

--- a/apps/ai-dial-admin/src/models/analytics/tables-ui.ts
+++ b/apps/ai-dial-admin/src/models/analytics/tables-ui.ts
@@ -6,18 +6,20 @@ export interface ColumnRow {
   source_name: string;
   name: string;
   type: AnalyticsFieldType;
-  // Required when `type` is Array; '' means not yet chosen (matches the `granularity: … | ''` pattern).
   element_type: AnalyticsFieldType | '';
   tag: string;
+  display_name: string;
+  description: string;
   nullable: boolean;
   sensitive: boolean;
 }
 
-// Per-row validation messages for a ColumnRow; an absent key means that field is valid.
 export interface ColumnRowError {
   source_name?: string;
   name?: string;
   tag?: string;
+  display_name?: string;
+  description?: string;
   element_type?: string;
 }
 

--- a/openspec/changes/archive/2026-08-17-add-column-creation-display-name-description/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-17-add-column-creation-display-name-description/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-17

--- a/openspec/changes/archive/2026-08-17-add-column-creation-display-name-description/design.md
+++ b/openspec/changes/archive/2026-08-17-add-column-creation-display-name-description/design.md
@@ -1,0 +1,125 @@
+## Context
+
+See `proposal.md` — Why. The behavior contract is in `specs/analytics/spec.md`.
+
+Three facts shape the approach:
+
+1. **One editor, two surfaces.** `ColumnRowsEditor` is rendered by `DraftSchemaEditor` (the
+   `PENDING`/`FAILED` schema-definition surface) and by the **Add columns** popup inside
+   `TableDetailView`. Adding the fields to the editor covers both with no conditional prop; hiding
+   them on one surface would *require* adding one. Both were requested, so no prop is needed.
+2. **Nothing new is needed below the editor.** `AnalyticsTableColumn` already carries
+   `display_name?` / `description?`; the caps (`ANALYTICS_DISPLAY_NAME_MAX_LENGTH` 128,
+   `ANALYTICS_DESCRIPTION_MAX_LENGTH` 1024), the validator (`getAnalyticsLengthError`), and the i18n
+   keys (`AnalyticsTablesI18nKey.DisplayName` / `.Description`) all exist and are already used by
+   `EditColumnPopup`. The gap is the UI row model (`ColumnRow`), the inputs, and the DTO mapper.
+3. **The row already carries a layout workaround.** `ColumnRowsEditor` switches from `items-end` to
+   `items-start` whenever a row has any validation error, and offsets the trailing label-less
+   switch/remove group on the first row by `LABEL_ROW_OFFSET_CLASS` to compensate. Both behaviors are
+   keyed off a `rowHasError` boolean that enumerates the error keys explicitly — so two new
+   error-capable fields are not a no-op for layout.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep the existing row-editor shape: one `ColumnRow` per column, per-row error objects aligned by
+  index, blank-means-absent at DTO build time.
+- Reuse the caps, validator, and i18n keys the edit modal already uses, so the creation form and the
+  edit modal can never disagree about what is valid.
+
+**Non-Goals:**
+
+- Any refactor of `ColumnRowsEditor` beyond adding the two fields. In particular, the two-line row
+  layout considered below is explicitly not being built.
+- Extracting the row into a per-row sub-component. It stays a single mapped block, as today.
+
+## Decisions
+
+### D1 — Both fields render inline on the existing single row
+
+The row becomes: Name · Type · (Element type) · Tag · Display name · Description · [Nullable]
+[Sensitive] [remove]. Labels stay on the first row only, matching every existing field.
+
+Chosen because it keeps the diff to two `DialInput` blocks and preserves the editor's one-row-per-column
+reading, which is what makes a twelve-column schema scannable at all.
+
+*Alternative considered — a two-line row* (identifier/type fields on line 1, the two metadata fields
+on line 2). It gives the two new fields, especially Description, far more usable width and degrades
+better on a narrow viewport. Rejected: it doubles each row's height, so the scannability argument
+above cuts the other way for a long schema, and it requires reworking the first-row label placement
+and the `LABEL_ROW_OFFSET_CLASS` offset rather than extending them.
+
+Consequence to handle rather than discover: six text/select controls plus two switches on one flex
+row is tight. Give Display name and Description explicit `flex` weights and `min-w-[…]` floors in the
+same style as the existing fields (Name is `flex-[2] min-w-[160px]`, Tag is `flex-1 min-w-[120px]`),
+weighting Description the widest of the new pair since it holds the longest values. The row is
+already horizontally constrained by its container; do not introduce a horizontal scroll container
+just for this row — the min-widths plus the existing flex behavior are what the other fields rely on.
+
+### D2 — `ColumnRow` gains two plain `string` fields, not an optional pair
+
+`display_name: string` and `description: string`, defaulted to `''` by `createColumnRow` and
+`toColumnRows`. This matches how `tag` is already modeled: the row model is a form model where every
+text field is a controlled non-optional string, and optionality is expressed at the DTO boundary.
+Making them `string | undefined` would push `?? ''` into the JSX for no gain.
+
+### D3 — Blank-means-absent is enforced in `toTableColumns`, not in the editor
+
+`toTableColumns` already spreads `...(r.tag.trim() ? { tag: r.tag.trim() } : {})`. The two new fields
+follow that exact shape. This keeps one place that decides what reaches the wire and keeps the trim
+consistent with the service's own `normalizeDisplayName` / `normalizeDescription` (which trim and map
+blank to null).
+
+Note the asymmetry with `EditColumnPopup`, which sends a blank string *deliberately* — there a blank
+means "clear the stored value" under merge-patch semantics. At creation there is nothing to clear, so
+omission is correct. This is a real difference in meaning, not an inconsistency, and it is why the
+two paths do not share a mapper.
+
+### D4 — Validation extends `ColumnRowError` and both of its consumers
+
+`ColumnRowError` gains `display_name?` and `description?`. `getColumnRowErrors` runs
+`getAnalyticsLengthError` against each cap. Two consumers then have to be updated or the errors are
+computed and silently ignored:
+
+- `hasColumnRowErrors` — gates Save / submit. Missing the new keys means an over-cap value reaches the
+  backend as a 422.
+- `rowHasError` inside `ColumnRowsEditor` — drives the `items-start` switch and the first-row offset.
+  Missing the new keys means a row erroring *only* on display name or description renders misaligned.
+
+Unlike the identifier checks, the length checks apply to **every** row, not only rows that will be
+sent — a length error on a row with a blank name is unreachable in practice (the row is dropped by
+`toTableColumns`), but scoping the check would be extra logic for no benefit, and `tag` is already
+validated unconditionally the same way.
+
+### D5 — No new i18n keys, no new constants
+
+`AnalyticsTablesI18nKey.DisplayName` and `.Description` already exist with the strings "Display name"
+and "Description" in `locales/en.ts`, and are the same labels the edit modal shows for the same two
+fields — which is exactly the consistency wanted. Per `components.md` §10, reuse rather than add.
+
+### D6 — Accessibility
+
+Each new input gets a stable per-row `id` in the established pattern
+(`col-display-name-${row.id}`, `col-description-${row.id}`) so its `labelProps` label — rendered on
+the first row only — associates with the first row's control, matching how Name, Type, and Tag
+already behave in this editor. Rows after the first carry no visible label, which is the editor's
+existing (and pre-existing) accessibility characteristic for all of its fields; this change neither
+improves nor worsens it, and changing it is out of scope. `DialInput`'s `error` + `invalid` props
+supply the validation message and state, as they already do for Tag.
+
+## Risks / Trade-offs
+
+- **Row crowding on a narrow viewport** → mitigated by explicit `flex` weights and `min-w` floors
+  (D1). This is the accepted cost of the chosen layout; the two-line alternative is recorded above if
+  it needs revisiting.
+- **Silently ignored validation** → the two consumers named in D4 are the failure mode, and both are
+  easy to miss because neither shows up as a type error: `hasColumnRowErrors` and `rowHasError`
+  enumerate error keys as boolean ORs, so an unlisted key just reads as `undefined`. Both need a test.
+- **`FAILED`-table round-trip** → `toColumnRows` seeds the row model from a stored definition. Missing
+  the two fields there would silently drop authored metadata on resubmit, turning a retry into data
+  loss. Covered by a spec scenario and a test.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-08-17-add-column-creation-display-name-description/proposal.md
+++ b/openspec/changes/archive/2026-08-17-add-column-creation-display-name-description/proposal.md
@@ -1,0 +1,80 @@
+## Why
+
+A column's **display name** and **description** are the two fields that make an analytics table
+readable to anyone who did not author it — the display name is what the Query Builder's field
+dropdowns and the Connect panel snippets show, and the description is the only place a column's
+meaning is recorded. Today both are collectable only *after* a column exists, one column at a time,
+through the per-column edit modal (`EditColumnPopup`). Someone declaring a twelve-column source table
+therefore has to save the schema, then reopen twelve modals to name and describe what they just
+typed — and in practice they don't, so tables ship with columns that read as bare `snake_case`
+identifiers.
+
+The gap is purely in the admin UI. `AnalyticsTableColumn` already models both fields, the columns
+grid already renders them, and the data-access service already accepts `display_name` (≤128 chars)
+and `description` (≤1024 chars) on the `ColumnRequest` DTO used by *both*
+`POST /v1/tables/{name}/schema` and the `add` member of `PATCH /v1/tables/{name}/schema`. The
+frontend simply never sends them at creation time.
+
+## What Changes
+
+- The shared column-row editor (`ColumnRowsEditor`) gains two optional text inputs per row —
+  **Display name** and **Description** — rendered inline on the same horizontal row as the existing
+  Name / Type / Tag fields, with labels on the first row only, matching how every other field in that
+  editor already behaves.
+- Both fields are optional. A blank value is valid and is simply omitted from the submitted column,
+  exactly as a blank Tag is today.
+- Both fields are length-validated per row against the caps the backend enforces —
+  `ANALYTICS_DISPLAY_NAME_MAX_LENGTH` (128) and `ANALYTICS_DESCRIPTION_MAX_LENGTH` (1024), the same
+  constants and the same `getAnalyticsLengthError` validator the edit modal already uses. An
+  over-cap value blocks Save/Submit rather than reaching the backend as a 422.
+- Because the editor is shared, both column-creation surfaces gain the fields with no per-surface
+  conditional: the schema-definition surface for a `PENDING`/`FAILED` table (`DraftSchemaEditor`) and
+  the **Add columns** popup for an `ACTIVE` table (`TableDetailView`).
+- The values authored at creation round-trip: a `FAILED` table's schema-definition surface, which
+  seeds itself from the last-submitted definition, seeds the two new fields too.
+- No new i18n keys. `AnalyticsTablesI18nKey.DisplayName` and `AnalyticsTablesI18nKey.Description`
+  already exist and are already used by the edit modal.
+
+## Non-goals
+
+- No change to the per-column edit modal. It already collects both fields and its patch-diffing
+  behavior is untouched.
+- No change to the `heavy` column flag, which the frontend does not model at all.
+- No change to the create-table popup (`CreateTablePopup`), which is identity-only by contract and
+  carries no columns.
+- No inline editing of display name or description in the columns grid — the grid stays read-only for
+  those two fields, with editing reached through the row's edit action as today.
+- No change to the backend, its DTOs, or its validation.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `analytics`: The **Define and materialize a table schema** requirement's enumeration of a column
+  row's fields gains optional display name and description, with their validation caps; the **Table
+  detail column schema management** requirement's add-columns paragraph gains the same fields, since
+  it reuses the same row editor.
+
+## Impact
+
+Affected code, all under `apps/ai-dial-admin/src`:
+
+- `models/analytics/tables-ui.ts` — `ColumnRow` gains `display_name` and `description`;
+  `ColumnRowError` gains the matching optional error keys.
+- `components/Analytics/Tables/ColumnRowsEditor.tsx` — two new `DialInput` controls; the
+  `rowHasError` computation must account for the two new error keys so the row's top-alignment
+  fix still triggers.
+- `components/Analytics/Tables/utils.ts` — `createColumnRow` and `toColumnRows` seed the new fields,
+  `toTableColumns` emits them when non-blank, `getColumnRowErrors` length-validates them, and
+  `hasColumnRowErrors` accounts for them.
+- Tests: `ColumnRowsEditor.spec.tsx`, `utils.spec.ts`, `use-draft-schema-form.spec.ts`,
+  `DraftSchemaEditor.spec.tsx`, `TableDetailView.spec.tsx`.
+- `openspec/specs/analytics/spec.md` — the two requirements named above.
+
+No API, server-action, dependency, or contract changes. The one shared surface touched
+(`ColumnRowsEditor`) is used only by the two analytics table column-creation flows, so the blast
+radius is confined to `Analytics > Tables`.

--- a/openspec/changes/archive/2026-08-17-add-column-creation-display-name-description/specs/analytics/spec.md
+++ b/openspec/changes/archive/2026-08-17-add-column-creation-display-name-description/specs/analytics/spec.md
@@ -1,0 +1,272 @@
+## MODIFIED Requirements
+
+### Requirement: Define and materialize a table schema
+
+For a not-yet-materialized table (`status` `PENDING` or `FAILED`), the table detail view SHALL present a schema-definition surface in place of the live column surface. The surface SHALL let the user define the whole physical schema: for a **source**, a repeatable set of columns (a single **Name** field, used as both the column's exposed name and its physical source name since the two are always equal at definition time, type, nullable, optional tag, optional display name, optional description, optional sensitive flag, and — for a column typed Array — a required element type), an ordering key chosen from the declared column names, an optional partition (a temporal column + a day/month/year granularity), and an optional scan-metadata pair (`identity_column` and `version_column`); for an **enrichment**, its columns plus a grain key chosen from its source table's columns. Cardinality SHALL NOT be user-selectable — the enrichment submission SHALL send the single supported value (`zero_or_one`). Column rows SHALL be validated for identifier grammar, uniqueness, tag length, display-name length, and description length exactly as the create/add-columns editor validates today, against both the exposed-name and source-name uniqueness constraints (which the merged Name field satisfies identically).
+
+The **display name** and **description** fields SHALL be optional and SHALL be presented inline on the column row alongside its other fields, with field labels rendered on the first row only, as the row's existing fields already are. A blank value SHALL be valid and SHALL be omitted from the submitted column, exactly as a blank tag is — the service treats an absent metadata field as "not set". A display name longer than 128 characters or a description longer than 1024 characters SHALL be rejected client-side with a per-row validation message and SHALL disable Save, because the service answers 422 for either (the same caps and the same message the per-column edit modal already applies).
+
+An Array-typed column row SHALL offer an additional element-type selector, restricted to the non-array, non-object column types (no nested arrays or objects). Submitting a row typed Array without an element type SHALL be rejected client-side (the backend also rejects it, 422). An Array-typed row's Nullable control SHALL be disabled and forced off — the backend rejects a nullable array column.
+
+For a **source** table, the Partition column field's label SHALL carry an info affordance (an icon with a hover tooltip) explaining that only Date/Timestamp-typed columns are selectable, since that restriction is not otherwise visually obvious. The Granularity field SHALL be rendered only once a partition column is selected; deselecting the partition column (including indirectly, by retyping the selected column away from Date/Timestamp) SHALL also clear any chosen granularity.
+
+For a **source** table only, the surface SHALL offer two additional optional selects — **Identity column** and **Version column** — the pair the governed incremental scan pages a source by. An **enrichment** SHALL offer neither (the backend rejects either member for an enrichment with 422). The Identity column options SHALL be the declared columns that are non-nullable and not sensitive; the Version column options SHALL be that same set narrowed to `Timestamp`-typed columns (`Date` SHALL NOT be offered — the backend requires `timestamp`). Both labels SHALL carry an info affordance, following the Partition column pattern, stating that the values are the caller's own promise the service cannot verify (the version is assigned at ingest, monotonic, and never backdated; the identity is unique per row) and that the choice cannot be changed once the table is materialized.
+
+Because the scan requires **both** members and the backend accepts one alone — producing a table that is permanently unscannable, since `POST /v1/tables/{name}/schema` answers 409 once the table is `ACTIVE` and no `PATCH` member sets the pair — the surface SHALL treat the pair as all-or-nothing: while exactly one of the two is chosen, Save SHALL be disabled and the empty field SHALL show a validation message naming the other as required alongside it. Choosing neither SHALL be valid and SHALL leave the table unscannable, which is the correct declaration for a source whose row identity is its whole ordering key.
+
+A selection SHALL be cleared when the column it references stops qualifying — renamed, removed, retyped, or flipped to nullable or sensitive in the column rows — so the submission can never carry a stale or now-invalid column name. For a `FAILED` table, both selects SHALL be seeded from the values the definition already stores, because an omitted member leaves any stored value unchanged rather than clearing it; when the definition stores either member, both selects SHALL be required (the pair cannot be cleared by re-posting).
+
+Submitting the schema (a header **Save** action) SHALL send the whole document via `defineTableSchema` (`POST /v1/tables/{name}/schema`), which defines the schema **and** materializes the table in the same call — there is no separate save-draft step, and no way to persist an incomplete schema. Each submitted column SHALL carry `display_name` and `description` only when the corresponding field is non-blank, and SHALL omit either key otherwise. The submitted payload SHALL carry `identity_column`/`version_column` only when chosen, and SHALL omit either key when unset. Save SHALL be disabled until the schema is complete for its kind (a source needs at least one valid column, a non-empty ordering key, and a complete-or-absent scan-metadata pair; an enrichment needs a grain key), since the backend rejects an incomplete submission (422) without persisting it. On success the view SHALL refresh showing the table `ACTIVE` with its live column surface. On a backend (ClickHouse) failure the table becomes `FAILED`; the detail view SHALL present the same schema-definition surface with an indication that activation failed, allowing the user to adjust the schema and resubmit. While the table is not `ACTIVE`, the write-rows action SHALL NOT be offered.
+
+#### Scenario: Save is gated on a complete schema
+
+- **WHEN** a source table's schema has no ordering key (or no columns), or an enrichment's schema has no grain key
+- **THEN** the Save action is disabled
+- **AND** once the schema is complete the Save action is enabled
+
+#### Scenario: Save defines and activates the table
+
+- **WHEN** the user submits a `PENDING` table's complete schema and the request succeeds
+- **THEN** `defineTableSchema` is sent and the view refreshes showing the table as `ACTIVE` with its live column surface
+
+#### Scenario: Failed activation can be retried
+
+- **WHEN** a table is `FAILED`
+- **THEN** the detail view shows the schema-definition surface with a failure indication
+- **AND** the user can adjust the schema and submit again
+
+#### Scenario: Enrichment schema hardcodes cardinality
+
+- **WHEN** an enrichment schema is submitted
+- **THEN** the payload carries cardinality `zero_or_one` and no cardinality control is rendered
+
+#### Scenario: Array column requires an element type
+
+- **WHEN** the user sets a column row's type to Array and leaves its element type unset
+- **THEN** the row shows a validation error and Save is disabled
+- **AND** choosing an element type (a non-array, non-object type) clears the error
+
+#### Scenario: Array column cannot be nullable
+
+- **WHEN** a column row's type is Array
+- **THEN** its Nullable control is disabled and shows off
+- **AND** the built column payload does not send `nullable: true` for that row
+
+#### Scenario: A column row offers display name and description
+
+- **WHEN** a `PENDING` table's schema-definition surface renders its column rows
+- **THEN** each row offers an optional Display name field and an optional Description field alongside its other fields
+- **AND** only the first row shows the two field labels
+
+#### Scenario: Authored display name and description are submitted
+
+- **WHEN** the user fills a column's Display name with "Total tokens" and its Description with "Prompt plus completion tokens" and saves a complete schema
+- **THEN** that column in the submitted payload carries `display_name` "Total tokens" and `description` "Prompt plus completion tokens"
+
+#### Scenario: Blank display name and description are omitted
+
+- **WHEN** the user leaves a column's Display name and Description empty (or types only whitespace) and saves
+- **THEN** that column in the submitted payload carries neither a `display_name` nor a `description` key
+
+#### Scenario: Over-cap display name or description blocks Save
+
+- **WHEN** a column row's Display name exceeds 128 characters, or its Description exceeds 1024 characters
+- **THEN** that field shows a length validation message and Save is disabled
+- **AND** shortening the value within its cap clears the message and re-enables Save
+
+#### Scenario: A FAILED table seeds the authored display name and description
+
+- **WHEN** the schema-definition surface renders a `FAILED` table whose stored definition has columns carrying `display_name` and `description`
+- **THEN** each column row is seeded with those values, so resubmitting does not silently drop them
+
+#### Scenario: Partition column restriction is explained via a tooltip
+
+- **WHEN** a source table's schema-definition surface renders
+- **THEN** the Partition column field's label shows an info icon
+- **AND** hovering it shows a tooltip explaining that only Date/Timestamp columns are selectable
+
+#### Scenario: Granularity is hidden until a partition column is chosen
+
+- **WHEN** no partition column is selected
+- **THEN** the Granularity field is not rendered
+- **AND** selecting a partition column reveals it
+
+#### Scenario: Retyping the selected partition column clears granularity too
+
+- **WHEN** the column currently selected as the partition column is retyped away from Date/Timestamp
+- **THEN** the partition column selection is cleared
+- **AND** the previously chosen granularity is cleared, and the Granularity field is hidden again
+
+#### Scenario: Scan-metadata selects are offered for a source only
+
+- **WHEN** a `PENDING` **source** table's schema-definition surface renders
+- **THEN** an Identity column and a Version column select are shown, each optional and each with an info affordance on its label
+- **AND** a `PENDING` **enrichment** table's surface shows neither
+
+#### Scenario: Scan-metadata options are restricted to columns the scan can page by
+
+- **WHEN** the declared column rows include a non-nullable `timestamp`, a nullable `timestamp`, a sensitive `timestamp`, a non-nullable `date`, and a non-nullable `string`
+- **THEN** the Identity column options are the non-nullable, non-sensitive columns (the `timestamp`, the `date`, and the `string`)
+- **AND** the Version column options are only the non-nullable, non-sensitive `timestamp` column
+
+#### Scenario: Declaring both members submits both
+
+- **WHEN** the user chooses an Identity column and a Version column and submits
+- **THEN** Save is enabled and the payload carries both `identity_column` and `version_column`
+
+#### Scenario: Declaring neither member is valid
+
+- **WHEN** the user leaves both scan-metadata selects empty and the rest of the source schema is complete
+- **THEN** Save is enabled and the payload carries neither `identity_column` nor `version_column`
+
+#### Scenario: Declaring exactly one member blocks Save
+
+- **WHEN** the user chooses an Identity column and leaves the Version column empty (or the reverse)
+- **THEN** Save is disabled and the empty field shows a validation message naming the other member as required alongside it
+- **AND** clearing the chosen one, or choosing the missing one, re-enables Save
+
+#### Scenario: A scan-metadata selection is cleared when its column stops qualifying
+
+- **WHEN** the column currently chosen as the Version column is retyped away from `Timestamp`, renamed, removed, or flipped to nullable or sensitive
+- **THEN** the Version column selection is cleared, so the submission cannot carry a stale or invalid column name
+
+#### Scenario: A FAILED table's stored pair is seeded and cannot be cleared
+
+- **WHEN** the schema-definition surface renders a `FAILED` source whose definition already stores `identity_column` and `version_column`
+- **THEN** both selects are seeded with those stored values
+- **AND** both are required, because omitting a member on re-post leaves the stored value unchanged rather than clearing it
+
+### Requirement: Table detail column schema management
+
+The Table detail page SHALL branch on the table's lifecycle `status`. The **live** column-management surface described here SHALL be offered only when the table is `ACTIVE`; for a `PENDING`/`FAILED` table the detail view SHALL instead offer the schema-definition surface (see "Define and materialize a table schema"). The detail header SHALL show the table's name and status badge regardless of status, and, when the table has a `description`, the description SHALL be shown beneath them regardless of status too (truncated with the full value reachable via an ellipsis tooltip, as elsewhere long text is truncated).
+
+While the table is `ACTIVE`, the header SHALL also show a read-only schema-metadata summary: for a **source** table, its ordering key when set, its partition column and granularity together when a partition is set, and its `identity_column` and `version_column` each when the definition declares it; for an **enrichment** table, its grain key when set. A scan-metadata value the definition does not declare SHALL simply be omitted, with no substitute message. A `_`-prefixed scan-metadata value (e.g. `_ingested_at`) is a system column and legitimately matches no row in the columns grid; this SHALL NOT be treated as an error. This summary SHALL NOT be shown for a `PENDING`/`FAILED` table, which instead exposes the same fields as editable inputs in the schema-definition surface.
+
+For an `ACTIVE` table, the detail page SHALL show the table's columns in a grid (name, type, tag, display name, description, nullable rendered as a true/false value); the physical source name SHALL NOT be shown as its own grid column — it is an internal identifier surfaced only where an operation requires it (see "Table detail row writes", whose insert template must key by source name). Long display name/description values SHALL be truncated with the full value reachable via an ellipsis tooltip. A column whose `sensitive` flag is true SHALL show a marker (a colored dot with a "Sensitive" tooltip) rendered inline in the name cell, after the name; non-sensitive columns SHALL show no marker. Each column row SHALL offer a per-column action menu with **edit** and **delete (drop)** actions; the delete action SHALL NOT be offered for a column the table's `identity_column` or `version_column` names, since the backend rejects dropping one (422, nothing repoints the pair). Scan-metadata membership SHALL be matched on the column's physical source name, which a rename may have made different from its exposed name. The column name SHALL also be editable inline in the grid — this SHALL rename the column's exposed name only; the immutable physical source name is unaffected. Renaming a scan-metadata column SHALL remain allowed: the backend repoints the stored pair in the same transaction, and the post-change refresh SHALL therefore show the summary carrying the new name.
+
+For an **enrichment** table, the columns grid SHALL additionally show the table's grain key as a pinned, non-editable row at the top of the grid — it carries no action menu and its name is not inline-editable. Because the grain key is never included in the table's declared `columns` (the backend derives its physical type from the matching column on the enrichment's source table and never exposes it as an ordinary column), the pinned row's type/tag/display-name metadata SHALL be backfilled by looking up the source table's column of the same name; when no matching source column is found, the row SHALL still render (name only, blank type/tag/display name) rather than being omitted.
+
+The edit action SHALL open a unified edit modal seeded with the column's current name, display name, tag, description, and sensitive flag. The name field SHALL be required (submit disabled while blank) and SHALL be disabled for columns the backend does not allow to rename (grain-key, ordering-key, and `_`-prefixed system columns) while the metadata fields remain editable; a scan-metadata column SHALL NOT be added to that set, since renaming one is allowed. Blank display name, tag, or description values SHALL be valid input meaning "clear the value"; the sensitive flag SHALL be toggled with a switch, which SHALL be disabled for a column the `identity_column` or `version_column` names — the backend rejects setting `sensitive: true` on one (422) — while that column's name and other metadata fields stay editable. On submit the modal SHALL diff the form against the original column and send a **single** schema patch: a structural `rename` op when the name changed, plus a **single `update` merge-patch entry** carrying the target column name and only the metadata fields (tag, display name, description, sensitive) that changed. Within the `update` entry an omitted field leaves that attribute unchanged, a blank string value clears it, a non-blank string value sets it, and the boolean `sensitive` is sent as `true`/`false` when toggled. When a rename is included, the `update` entry SHALL reference the new (post-rename) column name. Submit SHALL be disabled when no field changed.
+
+Adding columns SHALL be available from the header via a form popup reusing the column-row editor, including its optional display name and description fields, its element-type control, and its disabled-Nullable behavior for Array-typed rows (see "Define and materialize a table schema"). A column added here SHALL therefore be able to carry its display name and description in the same request that creates it, with no follow-up edit needed; the same optionality, blank-omission, and length rules stated there apply. Every live schema change SHALL be sent as a schema patch to `updateTableSchema` (`PATCH /v1/tables/{name}/schema`), and on success the detail view SHALL refresh from the server. Deleting the whole table SHALL be offered from this view's header (behind a confirmation identifying the table by name) as well as from the catalog list's row action menu; editing its catalog metadata (description/tag order) SHALL NOT be offered here and lives only in that row action menu (see "Tables catalog page").
+
+#### Scenario: Live column surface only for materialized tables
+
+- **WHEN** the detail view renders a `PENDING` or `FAILED` table
+- **THEN** the live add/drop/rename/edit column surface and the write-rows action are not offered (the schema-definition surface is shown instead)
+- **AND** when the table is `ACTIVE` the live column surface is offered
+
+#### Scenario: Inline rename patches the schema
+
+- **WHEN** the user edits an `ACTIVE` table column's name in the grid to a new non-empty value
+- **THEN** a rename schema patch is sent and the grid refreshes with the server state
+
+#### Scenario: Combined edit sends one patch with post-rename names
+
+- **WHEN** the user renames `total_money` to `total_cost` and sets its display name to "Total money spend" in the edit modal and submits
+- **THEN** a single schema patch is sent containing a rename from `total_money` to `total_cost` and an `update` entry whose `name` is `total_cost` and `display_name` is "Total money spend"
+- **AND** the grid refreshes with the server state
+
+#### Scenario: Only changed fields become update fields
+
+- **WHEN** the user changes only the display name and leaves name, tag, and description untouched
+- **THEN** the patch contains a single `update` entry carrying only `name` and `display_name`, with no `tag` or `description` field
+
+#### Scenario: Blank metadata clears the value
+
+- **WHEN** the user clears the display name field and submits
+- **THEN** the `update` entry sends `display_name` as an empty string, clearing the stored display name
+
+#### Scenario: Sensitive columns are marked in the grid
+
+- **WHEN** the columns grid renders a column whose `sensitive` flag is true
+- **THEN** the name cell shows a marker with a "Sensitive" tooltip after the name
+- **AND** a column whose flag is false shows no marker
+
+#### Scenario: Drop a column
+
+- **WHEN** the user chooses delete from a column's action menu
+- **THEN** a drop schema patch is sent and the column is removed after refresh
+
+#### Scenario: Add columns
+
+- **WHEN** the user adds one or more valid columns in the add-columns popup and submits
+- **THEN** an add schema patch is sent and the new columns appear after refresh
+
+#### Scenario: Add-columns popup offers display name and description
+
+- **WHEN** the add-columns popup renders for an `ACTIVE` table
+- **THEN** each column row offers an optional Display name field and an optional Description field
+
+#### Scenario: A column added with metadata needs no follow-up edit
+
+- **WHEN** the user adds a column in the add-columns popup with a Display name and a Description filled in and submits
+- **THEN** the `add` entry of the schema patch carries that column's `display_name` and `description`
+- **AND** after the refresh the grid shows those values without the edit modal having been opened
+
+#### Scenario: Over-cap metadata blocks the add-columns submit
+
+- **WHEN** a column row in the add-columns popup has a Display name over 128 characters or a Description over 1024 characters
+- **THEN** that field shows a length validation message and submit is disabled
+
+#### Scenario: Adding an array column requires an element type
+
+- **WHEN** the user adds a column typed Array in the add-columns popup without choosing an element type
+- **THEN** submit is disabled until an element type is chosen
+
+#### Scenario: Table description shown under the header
+
+- **WHEN** a table (of any status) has a non-empty `description`
+- **THEN** the description is shown under the name and status badge
+- **AND** a table with no description shows nothing in its place
+
+#### Scenario: Source table shows its schema metadata summary
+
+- **WHEN** an `ACTIVE` **source** table with an ordering key and a partition set renders
+- **THEN** its ordering key, partition column, and granularity are all shown
+- **AND** an `ACTIVE` source table with no partition shows only its ordering key
+
+#### Scenario: Source table shows its declared scan-metadata pair
+
+- **WHEN** an `ACTIVE` **source** table whose definition declares `identity_column` and `version_column` renders
+- **THEN** both values are shown in the header summary alongside the ordering key
+- **AND** a source declaring neither shows neither label and no substitute message
+- **AND** a source declaring only one shows that one and omits the other
+
+#### Scenario: A system scan-metadata column is not an error
+
+- **WHEN** an `ACTIVE` source's `version_column` is a `_`-prefixed system column such as `_ingested_at`, which the columns grid therefore does not list
+- **THEN** the summary shows that value and the view renders normally, with no error state
+
+#### Scenario: Enrichment table shows its grain key summary
+
+- **WHEN** an `ACTIVE` **enrichment** table renders
+- **THEN** its grain key is shown in the header summary
+
+#### Scenario: Enrichment grid pins the grain key with backfilled metadata
+
+- **WHEN** an `ACTIVE` enrichment table's columns grid renders and its source table has a column matching the grain key's name
+- **THEN** the grid shows the grain key as a pinned row at the top, with that source column's type, tag, and display name
+- **AND** the pinned row offers no action menu and its name is not inline-editable
+
+#### Scenario: Enrichment grid pins the grain key even without a source-column match
+
+- **WHEN** the enrichment's source table has no column matching the grain key's name
+- **THEN** the pinned row still renders, showing the grain key name with blank type, tag, and display name
+
+#### Scenario: A scan-metadata column cannot be dropped
+
+- **WHEN** the columns grid renders a column whose physical source name is the table's `identity_column` or `version_column`
+- **THEN** that row's action menu offers no delete action
+- **AND** every other column's delete action is unaffected
+
+#### Scenario: A scan-metadata column cannot be marked sensitive
+
+- **WHEN** the user opens the edit modal for a column the table's `identity_column` or `version_column` names
+- **THEN** the Sensitive switch is disabled
+- **AND** the name, tag, display name, and description fields remain editable and a change to any of them still submits a patch
+
+#### Scenario: Renaming a scan-metadata column repoints the summary
+
+- **WHEN** the user renames a column named by the table's `version_column`
+- **THEN** the rename is submitted (it is not blocked) and, after the refresh, the header summary shows the new name

--- a/openspec/changes/archive/2026-08-17-add-column-creation-display-name-description/tasks.md
+++ b/openspec/changes/archive/2026-08-17-add-column-creation-display-name-description/tasks.md
@@ -1,0 +1,35 @@
+## 1. Row model and DTO mapping
+
+- [x] 1.1 In `apps/ai-dial-admin/src/models/analytics/tables-ui.ts`, add `display_name: string` and `description: string` to `ColumnRow` (plain non-optional strings, per design D2), and add optional `display_name?` / `description?` keys to `ColumnRowError`.
+- [x] 1.2 In `apps/ai-dial-admin/src/components/Analytics/Tables/utils.ts`, seed both fields to `''` in `createColumnRow`, and seed them from `c.display_name ?? ''` / `c.description ?? ''` in `toColumnRows` so a `FAILED` table's stored metadata round-trips.
+- [x] 1.3 In the same file, extend `toTableColumns` to emit `display_name` and `description` only when the trimmed value is non-blank, following the existing `...(r.tag.trim() ? { tag: r.tag.trim() } : {})` shape (design D3).
+
+## 2. Validation
+
+- [x] 2.1 In `getColumnRowErrors` (`components/Analytics/Tables/utils.ts`), length-validate both fields with `getAnalyticsLengthError` against `ANALYTICS_DISPLAY_NAME_MAX_LENGTH` and `ANALYTICS_DESCRIPTION_MAX_LENGTH` from `constants/analytics/tables.ts`, unconditionally per row as `tag` already is.
+- [x] 2.2 Add both new keys to the boolean OR in `hasColumnRowErrors`, so an over-cap value disables Save / submit instead of reaching the backend as a 422 (design D4).
+
+## 3. Row editor UI
+
+- [x] 3.1 In `apps/ai-dial-admin/src/components/Analytics/Tables/ColumnRowsEditor.tsx`, add a Display name `DialInput` and a Description `DialInput` to the row, inline directly after Name and before Type (final order: Name, Display name, Description, Type, Element type, Tag), using `AnalyticsTablesI18nKey.DisplayName` and `AnalyticsTablesI18nKey.Description` with `labelProps` on the first row only, ids `col-display-name-${row.id}` / `col-description-${row.id}`, and `error` + `invalid` wired from the row's `ColumnRowError` — matching how the existing Tag field is built.
+- [x] 3.2 Give the two new inputs `flex` weights and `min-w-[…]` floors consistent with the existing fields (Name `flex-[2] min-w-[160px]`, Tag `flex-1 min-w-[120px]`), weighting Description the wider of the pair. Do not add a horizontal scroll container (design D1).
+- [x] 3.3 Add `display_name` and `description` to the `rowHasError` computation, so a row erroring only on one of the new fields still gets the `items-start` alignment and the first-row `LABEL_ROW_OFFSET_CLASS` offset (design D4).
+
+## 4. Tests
+
+- [x] 4.1 Extend `components/Analytics/Tables/tests/utils.spec.ts`: `createColumnRow` defaults both fields to `''`; `toColumnRows` seeds them from a stored column and from an absent value; `toTableColumns` emits both when filled, omits both when blank or whitespace-only, and trims; `getColumnRowErrors` reports a length error at 129 chars of display name and at 1025 chars of description and none at the caps; `hasColumnRowErrors` returns true for an error carrying only `display_name` and only `description`.
+- [x] 4.2 Extend `components/Analytics/Tables/tests/ColumnRowsEditor.spec.tsx`: both fields render per row; labels appear on the first row only; typing updates the row; an over-cap value renders its error message; a row erroring only on `description` still renders with the top-aligned layout.
+- [x] 4.3 Extend `components/Analytics/Tables/tests/DraftSchemaEditor.spec.tsx` and `tests/use-draft-schema-form.spec.ts`: a complete source schema whose column carries a display name and description submits them via `defineTableSchema`; a `FAILED` table seeds both from its stored definition; an over-cap value disables Save.
+- [x] 4.4 Extend `components/Analytics/Tables/tests/TableDetailView.spec.tsx`: the add-columns popup renders both fields, submitting carries them in the patch's `add` entry, and an over-cap value disables the popup's submit.
+
+## 5. Spec sync
+
+- [x] 5.1 Fold the delta at `openspec/changes/add-column-creation-display-name-description/specs/analytics/spec.md` into `openspec/specs/analytics/spec.md`, replacing the **Define and materialize a table schema** and **Table detail column schema management** requirements with their modified versions (analytics is one master spec — no new spec file).
+
+## 6. Browser verification
+
+- [x] 6.1 Run the `spec-browser-verify` skill for this change against the running local app (stack up, auth disabled, `ANALYTICS_ENABLED` on), covering the browser-observable scenarios: both fields present per row on the schema-definition surface and in the add-columns popup, labels on the first row only, an over-cap value disabling Save / submit, and a `FAILED` table's stored display name and description seeded into its rows. Result: 5 of 6 scenarios pass; the FAILED-table seeding scenario is blocked on data availability (no FAILED table exists in the environment) — no `fail` verdicts.
+
+## 7. Quality checks
+
+- [x] 7.1 Run `npm run lint`, `npm run format`, and `npm run test` from the repo root and fix everything they report.

--- a/openspec/specs/analytics/spec.md
+++ b/openspec/specs/analytics/spec.md
@@ -1404,6 +1404,7 @@ Creating a table SHALL open a form popup that is mounted only while open, so clo
 
 ### Requirement: Table detail column schema management
 
+
 The Table detail page SHALL branch on the table's lifecycle `status`. The **live** column-management surface described here SHALL be offered only when the table is `ACTIVE`; for a `PENDING`/`FAILED` table the detail view SHALL instead offer the schema-definition surface (see "Define and materialize a table schema"). The detail header SHALL show the table's name and status badge regardless of status, and, when the table has a `description`, the description SHALL be shown beneath them regardless of status too (truncated with the full value reachable via an ellipsis tooltip, as elsewhere long text is truncated).
 
 While the table is `ACTIVE`, the header SHALL also show a read-only schema-metadata summary: for a **source** table, its ordering key when set, its partition column and granularity together when a partition is set, and its `identity_column` and `version_column` each when the definition declares it; for an **enrichment** table, its grain key when set. A scan-metadata value the definition does not declare SHALL simply be omitted, with no substitute message. A `_`-prefixed scan-metadata value (e.g. `_ingested_at`) is a system column and legitimately matches no row in the columns grid; this SHALL NOT be treated as an error. This summary SHALL NOT be shown for a `PENDING`/`FAILED` table, which instead exposes the same fields as editable inputs in the schema-definition surface.
@@ -1414,7 +1415,7 @@ For an **enrichment** table, the columns grid SHALL additionally show the table'
 
 The edit action SHALL open a unified edit modal seeded with the column's current name, display name, tag, description, and sensitive flag. The name field SHALL be required (submit disabled while blank) and SHALL be disabled for columns the backend does not allow to rename (grain-key, ordering-key, and `_`-prefixed system columns) while the metadata fields remain editable; a scan-metadata column SHALL NOT be added to that set, since renaming one is allowed. Blank display name, tag, or description values SHALL be valid input meaning "clear the value"; the sensitive flag SHALL be toggled with a switch, which SHALL be disabled for a column the `identity_column` or `version_column` names — the backend rejects setting `sensitive: true` on one (422) — while that column's name and other metadata fields stay editable. On submit the modal SHALL diff the form against the original column and send a **single** schema patch: a structural `rename` op when the name changed, plus a **single `update` merge-patch entry** carrying the target column name and only the metadata fields (tag, display name, description, sensitive) that changed. Within the `update` entry an omitted field leaves that attribute unchanged, a blank string value clears it, a non-blank string value sets it, and the boolean `sensitive` is sent as `true`/`false` when toggled. When a rename is included, the `update` entry SHALL reference the new (post-rename) column name. Submit SHALL be disabled when no field changed.
 
-Adding columns SHALL be available from the header via a form popup reusing the column-row editor, including its element-type control and disabled-Nullable behavior for Array-typed rows (see "Define and materialize a table schema"). Every live schema change SHALL be sent as a schema patch to `updateTableSchema` (`PATCH /v1/tables/{name}/schema`), and on success the detail view SHALL refresh from the server. Deleting the whole table SHALL be offered from this view's header (behind a confirmation identifying the table by name) as well as from the catalog list's row action menu; editing its catalog metadata (description/tag order) SHALL NOT be offered here and lives only in that row action menu (see "Tables catalog page").
+Adding columns SHALL be available from the header via a form popup reusing the column-row editor, including its optional display name and description fields, its element-type control, and its disabled-Nullable behavior for Array-typed rows (see "Define and materialize a table schema"). A column added here SHALL therefore be able to carry its display name and description in the same request that creates it, with no follow-up edit needed; the same optionality, blank-omission, and length rules stated there apply. Every live schema change SHALL be sent as a schema patch to `updateTableSchema` (`PATCH /v1/tables/{name}/schema`), and on success the detail view SHALL refresh from the server. Deleting the whole table SHALL be offered from this view's header (behind a confirmation identifying the table by name) as well as from the catalog list's row action menu; editing its catalog metadata (description/tag order) SHALL NOT be offered here and lives only in that row action menu (see "Tables catalog page").
 
 #### Scenario: Live column surface only for materialized tables
 
@@ -1458,6 +1459,22 @@ Adding columns SHALL be available from the header via a form popup reusing the c
 
 - **WHEN** the user adds one or more valid columns in the add-columns popup and submits
 - **THEN** an add schema patch is sent and the new columns appear after refresh
+
+#### Scenario: Add-columns popup offers display name and description
+
+- **WHEN** the add-columns popup renders for an `ACTIVE` table
+- **THEN** each column row offers an optional Display name field and an optional Description field
+
+#### Scenario: A column added with metadata needs no follow-up edit
+
+- **WHEN** the user adds a column in the add-columns popup with a Display name and a Description filled in and submits
+- **THEN** the `add` entry of the schema patch carries that column's `display_name` and `description`
+- **AND** after the refresh the grid shows those values without the edit modal having been opened
+
+#### Scenario: Over-cap metadata blocks the add-columns submit
+
+- **WHEN** a column row in the add-columns popup has a Display name over 128 characters or a Description over 1024 characters
+- **THEN** that field shows a length validation message and submit is disabled
 
 #### Scenario: Adding an array column requires an element type
 
@@ -1763,7 +1780,10 @@ The UI SHALL surface a table's lifecycle `status` (`PENDING`, `ACTIVE`, `FAILED`
 
 ### Requirement: Define and materialize a table schema
 
-For a not-yet-materialized table (`status` `PENDING` or `FAILED`), the table detail view SHALL present a schema-definition surface in place of the live column surface. The surface SHALL let the user define the whole physical schema: for a **source**, a repeatable set of columns (a single **Name** field, used as both the column's exposed name and its physical source name since the two are always equal at definition time, type, nullable, optional tag, optional sensitive flag, and — for a column typed Array — a required element type), an ordering key chosen from the declared column names, an optional partition (a temporal column + a day/month/year granularity), and an optional scan-metadata pair (`identity_column` and `version_column`); for an **enrichment**, its columns plus a grain key chosen from its source table's columns. Cardinality SHALL NOT be user-selectable — the enrichment submission SHALL send the single supported value (`zero_or_one`). Column rows SHALL be validated for identifier grammar, uniqueness, and tag length exactly as the create/add-columns editor validates today, against both the exposed-name and source-name uniqueness constraints (which the merged Name field satisfies identically).
+
+For a not-yet-materialized table (`status` `PENDING` or `FAILED`), the table detail view SHALL present a schema-definition surface in place of the live column surface. The surface SHALL let the user define the whole physical schema: for a **source**, a repeatable set of columns (a single **Name** field, used as both the column's exposed name and its physical source name since the two are always equal at definition time, type, nullable, optional tag, optional display name, optional description, optional sensitive flag, and — for a column typed Array — a required element type), an ordering key chosen from the declared column names, an optional partition (a temporal column + a day/month/year granularity), and an optional scan-metadata pair (`identity_column` and `version_column`); for an **enrichment**, its columns plus a grain key chosen from its source table's columns. Cardinality SHALL NOT be user-selectable — the enrichment submission SHALL send the single supported value (`zero_or_one`). Column rows SHALL be validated for identifier grammar, uniqueness, tag length, display-name length, and description length exactly as the create/add-columns editor validates today, against both the exposed-name and source-name uniqueness constraints (which the merged Name field satisfies identically).
+
+The **display name** and **description** fields SHALL be optional and SHALL be presented inline on the column row alongside its other fields, with field labels rendered on the first row only, as the row's existing fields already are. A blank value SHALL be valid and SHALL be omitted from the submitted column, exactly as a blank tag is — the service treats an absent metadata field as "not set". A display name longer than 128 characters or a description longer than 1024 characters SHALL be rejected client-side with a per-row validation message and SHALL disable Save, because the service answers 422 for either (the same caps and the same message the per-column edit modal already applies).
 
 An Array-typed column row SHALL offer an additional element-type selector, restricted to the non-array, non-object column types (no nested arrays or objects). Submitting a row typed Array without an element type SHALL be rejected client-side (the backend also rejects it, 422). An Array-typed row's Nullable control SHALL be disabled and forced off — the backend rejects a nullable array column.
 
@@ -1775,7 +1795,7 @@ Because the scan requires **both** members and the backend accepts one alone —
 
 A selection SHALL be cleared when the column it references stops qualifying — renamed, removed, retyped, or flipped to nullable or sensitive in the column rows — so the submission can never carry a stale or now-invalid column name. For a `FAILED` table, both selects SHALL be seeded from the values the definition already stores, because an omitted member leaves any stored value unchanged rather than clearing it; when the definition stores either member, both selects SHALL be required (the pair cannot be cleared by re-posting).
 
-Submitting the schema (a header **Save** action) SHALL send the whole document via `defineTableSchema` (`POST /v1/tables/{name}/schema`), which defines the schema **and** materializes the table in the same call — there is no separate save-draft step, and no way to persist an incomplete schema. The submitted payload SHALL carry `identity_column`/`version_column` only when chosen, and SHALL omit either key when unset. Save SHALL be disabled until the schema is complete for its kind (a source needs at least one valid column, a non-empty ordering key, and a complete-or-absent scan-metadata pair; an enrichment needs a grain key), since the backend rejects an incomplete submission (422) without persisting it. On success the view SHALL refresh showing the table `ACTIVE` with its live column surface. On a backend (ClickHouse) failure the table becomes `FAILED`; the detail view SHALL present the same schema-definition surface with an indication that activation failed, allowing the user to adjust the schema and resubmit. While the table is not `ACTIVE`, the write-rows action SHALL NOT be offered.
+Submitting the schema (a header **Save** action) SHALL send the whole document via `defineTableSchema` (`POST /v1/tables/{name}/schema`), which defines the schema **and** materializes the table in the same call — there is no separate save-draft step, and no way to persist an incomplete schema. Each submitted column SHALL carry `display_name` and `description` only when the corresponding field is non-blank, and SHALL omit either key otherwise. The submitted payload SHALL carry `identity_column`/`version_column` only when chosen, and SHALL omit either key when unset. Save SHALL be disabled until the schema is complete for its kind (a source needs at least one valid column, a non-empty ordering key, and a complete-or-absent scan-metadata pair; an enrichment needs a grain key), since the backend rejects an incomplete submission (422) without persisting it. On success the view SHALL refresh showing the table `ACTIVE` with its live column surface. On a backend (ClickHouse) failure the table becomes `FAILED`; the detail view SHALL present the same schema-definition surface with an indication that activation failed, allowing the user to adjust the schema and resubmit. While the table is not `ACTIVE`, the write-rows action SHALL NOT be offered.
 
 #### Scenario: Save is gated on a complete schema
 
@@ -1810,6 +1830,33 @@ Submitting the schema (a header **Save** action) SHALL send the whole document v
 - **WHEN** a column row's type is Array
 - **THEN** its Nullable control is disabled and shows off
 - **AND** the built column payload does not send `nullable: true` for that row
+
+#### Scenario: A column row offers display name and description
+
+- **WHEN** a `PENDING` table's schema-definition surface renders its column rows
+- **THEN** each row offers an optional Display name field and an optional Description field alongside its other fields
+- **AND** only the first row shows the two field labels
+
+#### Scenario: Authored display name and description are submitted
+
+- **WHEN** the user fills a column's Display name with "Total tokens" and its Description with "Prompt plus completion tokens" and saves a complete schema
+- **THEN** that column in the submitted payload carries `display_name` "Total tokens" and `description` "Prompt plus completion tokens"
+
+#### Scenario: Blank display name and description are omitted
+
+- **WHEN** the user leaves a column's Display name and Description empty (or types only whitespace) and saves
+- **THEN** that column in the submitted payload carries neither a `display_name` nor a `description` key
+
+#### Scenario: Over-cap display name or description blocks Save
+
+- **WHEN** a column row's Display name exceeds 128 characters, or its Description exceeds 1024 characters
+- **THEN** that field shows a length validation message and Save is disabled
+- **AND** shortening the value within its cap clears the message and re-enables Save
+
+#### Scenario: A FAILED table seeds the authored display name and description
+
+- **WHEN** the schema-definition surface renders a `FAILED` table whose stored definition has columns carrying `display_name` and `description`
+- **THEN** each column row is seeded with those values, so resubmitting does not silently drop them
 
 #### Scenario: Partition column restriction is explained via a tooltip
 


### PR DESCRIPTION
**Description:**

The column-row editor shared by the schema-definition surface (`PENDING`/`FAILED` table) and the **Add columns** popup (`ACTIVE` table) now collects each column's optional **display name** and **description**. Previously both were reachable only *after* a column existed, one column at a time through the per-column edit modal — so a twelve-column table meant twelve follow-up modals, and in practice tables shipped with columns reading as bare `snake_case`.

Nothing below the editor needed changing: `AnalyticsTableColumn` already modelled both fields, the columns grid already rendered them, and the data-access service already accepted `display_name` (≤128) and `description` (≤1024) on the `ColumnRequest` DTO used by **both** `POST /v1/tables/{name}/schema` and the `add` member of `PATCH /v1/tables/{name}/schema`. The frontend simply never sent them at creation time.

Because the editor is shared, both creation surfaces gain the fields with no per-surface conditional.

**Behaviour notes**

- Both fields are optional. Blank means "not set", so the key is **omitted** rather than sent empty — deliberately unlike the edit modal, where a blank value *clears* a stored one under merge-patch semantics. The two paths therefore don't share a mapper.
- Length-validated at 128 / 1024 against the caps the service enforces, reusing the same constants and validator the edit modal already applies, so an over-cap value disables Save/submit instead of returning a 422.
- A `FAILED` table's surface seeds both fields from its stored definition, so a retry can't silently drop authored metadata.
- Field order across the row: Name, Display name, Description, Type, Element type, Tag.
- No new i18n keys — `AnalyticsTablesI18nKey.DisplayName` / `.Description` already existed and are the same labels the edit modal shows.

**Testing**

- Full suite green: 799 test files passed, 1 skipped, 0 failed. New/extended unit + component coverage in `utils.spec.ts`, `ColumnRowsEditor.spec.tsx`, `DraftSchemaEditor.spec.tsx`, `use-draft-schema-form.spec.ts`, `TableDetailView.spec.tsx`.
- Browser-verified against a live instance: 5 of 6 acceptance scenarios pass (both fields present on each surface, labels on the first row only, over-cap values disabling Save/submit, and an added column showing its metadata in the grid with no follow-up edit). The sixth — a `FAILED` table seeding stored metadata — is blocked on data availability (no `FAILED` table exists in that environment); its underlying logic is unit-tested.

**Spec**

Planning artifacts are archived under `openspec/changes/archive/2026-08-17-add-column-creation-display-name-description/`; the delta is folded into the master `openspec/specs/analytics/spec.md` (two modified requirements, 8 new scenarios, none dropped).

Issues:

- Issue #3847

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
