### PR TITLE
feat(analytics/Evaluators): add evaluators listing page (Issue #4289)

### DIFF
--- a/.claude/reference/areas.md
+++ b/.claude/reference/areas.md
@@ -93,6 +93,7 @@ Use `Parent/Child` for a single leaf, or just `Parent` when several children cha
 | `analytics/Tables` | `tables` | `Analytics` |
 | `analytics/ConversationsTrace` | `conversations-trace` | `Analytics` |
 | `analytics/EnrichmentRules` | `enrichment-rules` | `Analytics/EnrichmentRules` |
+| `analytics/Evaluators` | `evaluators` | `Analytics/Evaluators` |
 
 ---
 

--- a/apps/ai-dial-admin/src/app/[lang]/enrichment-rules/[id]/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/enrichment-rules/[id]/page.tsx
@@ -6,7 +6,8 @@ import { EnrichmentRule } from '@/src/models/analytics/rule';
 import { EvaluatorSummary } from '@/src/models/analytics/evaluator';
 import { isAnalyticsForbidden } from '@/src/server/analytics/analytics-access';
 import { errorObjLog } from '@/src/server/logger';
-import { getEvaluators, getRule, getRules } from '../actions';
+import { getEvaluators } from '@/src/app/[lang]/evaluators/actions';
+import { getRule, getRules } from '../actions';
 
 export const dynamic = 'force-dynamic';
 

--- a/apps/ai-dial-admin/src/app/[lang]/enrichment-rules/actions.ts
+++ b/apps/ai-dial-admin/src/app/[lang]/enrichment-rules/actions.ts
@@ -3,7 +3,6 @@
 import { cookies, headers } from 'next/headers';
 
 import { analyticsDataApi } from '@/src/app/api/api';
-import { Evaluator, EvaluatorSummary } from '@/src/models/analytics/evaluator';
 import { CreateRuleDto, EnrichmentRule, EnrichmentRuleListItem, RulesListFilters } from '@/src/models/analytics/rule';
 import { AnalyticsTable } from '@/src/models/analytics/table';
 import { ServerActionResponse } from '@/src/models/server-action';
@@ -32,18 +31,6 @@ export async function updateRule(id: string, dto: CreateRuleDto): Promise<Server
 
 export async function deleteRule(id: string): Promise<ServerActionResponse> {
   return analyticsDataApi.deleteRule(id, await token());
-}
-
-export async function getEvaluators(): Promise<EvaluatorSummary[] | null> {
-  return analyticsDataApi.getEvaluators(await token());
-}
-
-export async function getEvaluator(name: string): Promise<Evaluator | null> {
-  return analyticsDataApi.getEvaluator(name, await token());
-}
-
-export async function getEvaluatorVersion(name: string, version: number): Promise<Evaluator | null> {
-  return analyticsDataApi.getEvaluatorVersion(name, version, await token());
 }
 
 export async function getTables(): Promise<AnalyticsTable[] | null> {

--- a/apps/ai-dial-admin/src/app/[lang]/evaluators/actions.ts
+++ b/apps/ai-dial-admin/src/app/[lang]/evaluators/actions.ts
@@ -1,0 +1,22 @@
+'use server';
+
+import { cookies, headers } from 'next/headers';
+
+import { analyticsDataApi } from '@/src/app/api/api';
+import { Evaluator, EvaluatorSummary } from '@/src/models/analytics/evaluator';
+import { getUserToken } from '@/src/utils/auth/auth-request';
+import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
+
+const token = () => getUserToken(getIsEnableAuthToggle(), headers(), cookies());
+
+export async function getEvaluators(): Promise<EvaluatorSummary[] | null> {
+  return analyticsDataApi.getEvaluators(await token());
+}
+
+export async function getEvaluator(name: string): Promise<Evaluator | null> {
+  return analyticsDataApi.getEvaluator(name, await token());
+}
+
+export async function getEvaluatorVersion(name: string, version: number): Promise<Evaluator | null> {
+  return analyticsDataApi.getEvaluatorVersion(name, version, await token());
+}

--- a/apps/ai-dial-admin/src/app/[lang]/evaluators/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/evaluators/page.tsx
@@ -1,0 +1,42 @@
+import { getRules } from '@/src/app/[lang]/enrichment-rules/actions';
+import EvaluatorsView from '@/src/components/Analytics/Evaluators/EvaluatorsView';
+import Page403 from '@/src/components/Page403/Page403';
+import { EvaluatorSummary, EvaluatorUsage } from '@/src/models/analytics/evaluator';
+import { isAnalyticsForbidden } from '@/src/server/analytics/analytics-access';
+import { errorObjLog } from '@/src/server/logger';
+import { toEvaluatorRows, toEvaluatorUsage } from '@/src/utils/analytics/evaluator-usage';
+import { getEvaluators } from './actions';
+
+export const dynamic = 'force-dynamic';
+
+export default async function Page() {
+  if (await isAnalyticsForbidden()) {
+    return <Page403 />;
+  }
+
+  let evaluators: EvaluatorSummary[] | null = null;
+  let usage: EvaluatorUsage | null = null;
+
+  try {
+    evaluators = await getEvaluators();
+  } catch (e) {
+    errorObjLog(e, 'Failed to fetch evaluators');
+  }
+
+  // Left null rather than an empty map on failure: an empty one would report every evaluator as used by
+  // no rule, which is the one thing this column must never invent.
+  try {
+    const rules = await getRules();
+    usage = rules ? toEvaluatorUsage(rules) : null;
+  } catch (e) {
+    errorObjLog(e, 'Failed to fetch enrichment rules for evaluator usage');
+  }
+
+  return (
+    <EvaluatorsView
+      rows={toEvaluatorRows(evaluators ?? [], usage)}
+      hasUsageError={usage == null}
+      hasLoadError={evaluators == null}
+    />
+  );
+}

--- a/apps/ai-dial-admin/src/app/[lang]/evaluators/tests/page.spec.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/evaluators/tests/page.spec.tsx
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { getRules } from '@/src/app/[lang]/enrichment-rules/actions';
+import { getEvaluators } from '@/src/app/[lang]/evaluators/actions';
+import Page from '@/src/app/[lang]/evaluators/page';
+import Page403 from '@/src/components/Page403/Page403';
+import { EvaluatorType } from '@/src/models/analytics/evaluator';
+import { EnrichmentRuleListItem, TriggerKind } from '@/src/models/analytics/rule';
+import { isAnalyticsForbidden } from '@/src/server/analytics/analytics-access';
+
+vi.mock('@/src/app/[lang]/enrichment-rules/actions');
+vi.mock('@/src/app/[lang]/evaluators/actions');
+vi.mock('@/src/server/analytics/analytics-access');
+vi.mock('@/src/server/logger', () => ({ errorObjLog: vi.fn(), errorLog: vi.fn() }));
+
+const rule: EnrichmentRuleListItem = {
+  id: 'r_1',
+  name: 'turn-feedback-live',
+  evaluator_name: 'feedback-rollup',
+  evaluator_version: 2,
+  evaluator: { name: 'feedback-rollup', version: 2, type: EvaluatorType.Sql },
+  target_enrichment: 'turn_feedback',
+  grain_key: 'response_id',
+  trigger_kind: TriggerKind.OnIngest,
+  enabled: true,
+  generation: 5,
+  updated_at: '2026-08-21T09:37:29Z',
+};
+
+const evaluators = [{ name: 'feedback-rollup', latest_version: 2, created_at: '2026-08-17T10:00:00Z' }];
+
+const renderPage = async () => (await Page()) as { type: unknown; props: Record<string, unknown> };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(isAnalyticsForbidden).mockResolvedValue(false);
+  vi.mocked(getEvaluators).mockResolvedValue(evaluators);
+  vi.mocked(getRules).mockResolvedValue([rule]);
+});
+
+describe('evaluators page', () => {
+  test('prefetches the evaluators and hands their rows to the view', async () => {
+    const page = await renderPage();
+
+    expect(getEvaluators).toHaveBeenCalledOnce();
+    expect(page.props).toMatchObject({ hasLoadError: false, hasUsageError: false });
+    expect(page.props.rows).toEqual([
+      { name: 'feedback-rollup', latest_version: 2, created_at: '2026-08-17T10:00:00Z', usedBy: 1 },
+    ]);
+  });
+
+  test('joins the usage from a single rules listing', async () => {
+    await renderPage();
+
+    expect(getRules).toHaveBeenCalledOnce();
+  });
+
+  test('renders the console with a stated failure when the evaluators listing fails', async () => {
+    vi.mocked(getEvaluators).mockResolvedValue(null);
+
+    const page = await renderPage();
+
+    expect(page.props).toMatchObject({ rows: [], hasLoadError: true });
+    expect(page.type).not.toBe(Page403);
+  });
+
+  test('reports a thrown evaluators fetch the same way', async () => {
+    vi.mocked(getEvaluators).mockRejectedValue(new Error('boom'));
+
+    const page = await renderPage();
+
+    expect(page.props).toMatchObject({ rows: [], hasLoadError: true });
+  });
+
+  test('reports the usage as unknown, not zero, when the rules listing fails', async () => {
+    vi.mocked(getRules).mockResolvedValue(null);
+
+    const page = await renderPage();
+
+    expect(page.props).toMatchObject({ hasUsageError: true, hasLoadError: false });
+    expect((page.props.rows as { usedBy: number | null }[])[0].usedBy).toBeNull();
+  });
+
+  test('reports the usage as unknown when the rules fetch throws', async () => {
+    vi.mocked(getRules).mockRejectedValue(new Error('boom'));
+
+    const page = await renderPage();
+
+    expect(page.props).toMatchObject({ hasUsageError: true });
+    expect((page.props.rows as { usedBy: number | null }[])[0].usedBy).toBeNull();
+  });
+
+  test('reports zero for an evaluator no rule names', async () => {
+    vi.mocked(getEvaluators).mockResolvedValue([{ name: 'conversation-insights', latest_version: 4 }]);
+
+    const page = await renderPage();
+
+    expect((page.props.rows as { usedBy: number | null }[])[0].usedBy).toBe(0);
+  });
+
+  test('renders Page403 and fetches nothing for a forbidden caller', async () => {
+    vi.mocked(isAnalyticsForbidden).mockResolvedValue(true);
+
+    const page = await renderPage();
+
+    expect(page.type).toBe(Page403);
+    expect(getEvaluators).not.toHaveBeenCalled();
+    expect(getRules).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ai-dial-admin/src/components/Analytics/EnrichmentRules/EnrichmentRulesView.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/EnrichmentRules/EnrichmentRulesView.tsx
@@ -13,7 +13,8 @@ import {
 } from '@epam/ai-dial-ui-kit';
 import { IconPlus } from '@tabler/icons-react';
 
-import { deleteRule, getEvaluators, getRules } from '@/src/app/[lang]/enrichment-rules/actions';
+import { deleteRule, getRules } from '@/src/app/[lang]/enrichment-rules/actions';
+import { getEvaluators } from '@/src/app/[lang]/evaluators/actions';
 import CreateRulePopup from '@/src/components/Analytics/EnrichmentRules/CreateRulePopup';
 import { EvaluatorCellRenderer } from '@/src/components/Analytics/EnrichmentRules/EvaluatorCell';
 import RuleEnabledBadge from '@/src/components/Analytics/EnrichmentRules/RuleEnabledBadge';

--- a/apps/ai-dial-admin/src/components/Analytics/EnrichmentRules/tests/CreateRulePopup.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/EnrichmentRules/tests/CreateRulePopup.spec.tsx
@@ -2,7 +2,8 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { createRule, getEvaluator, getTable, getTables } from '@/src/app/[lang]/enrichment-rules/actions';
+import { createRule, getTable, getTables } from '@/src/app/[lang]/enrichment-rules/actions';
+import { getEvaluator } from '@/src/app/[lang]/evaluators/actions';
 import CreateRulePopup from '@/src/components/Analytics/EnrichmentRules/CreateRulePopup';
 import { AnalyticsEnrichmentRulesI18nKey } from '@/src/constants/i18n';
 import { AnalyticsFieldType } from '@/src/models/analytics/entity';
@@ -11,6 +12,7 @@ import { TriggerKind } from '@/src/models/analytics/rule';
 import { AnalyticsTable, AnalyticsTableType } from '@/src/models/analytics/table';
 
 vi.mock('@/src/app/[lang]/enrichment-rules/actions');
+vi.mock('@/src/app/[lang]/evaluators/actions');
 
 vi.mock('@epam/ai-dial-ui-kit', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@epam/ai-dial-ui-kit')>();

--- a/apps/ai-dial-admin/src/components/Analytics/EnrichmentRules/tests/EnrichmentRulesPermissions.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/EnrichmentRules/tests/EnrichmentRulesPermissions.spec.tsx
@@ -1,7 +1,8 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { getEvaluators, getRules } from '@/src/app/[lang]/enrichment-rules/actions';
+import { getRules } from '@/src/app/[lang]/enrichment-rules/actions';
+import { getEvaluators } from '@/src/app/[lang]/evaluators/actions';
 import EnrichmentRulesView from '@/src/components/Analytics/EnrichmentRules/EnrichmentRulesView';
 import { ACTIONS_COLUMN_CEL_ID } from '@/src/constants/ag-grid';
 import { AnalyticsEnrichmentRulesI18nKey } from '@/src/constants/i18n';
@@ -9,6 +10,7 @@ import { EvaluatorType } from '@/src/models/analytics/evaluator';
 import { EnrichmentRuleListItem, TriggerKind } from '@/src/models/analytics/rule';
 
 vi.mock('@/src/app/[lang]/enrichment-rules/actions');
+vi.mock('@/src/app/[lang]/evaluators/actions');
 vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }));
 
 // test-setup.tsx pins isFullAdmin true for the whole suite, so the non-admin case needs its own file.

--- a/apps/ai-dial-admin/src/components/Analytics/EnrichmentRules/tests/EnrichmentRulesView.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/EnrichmentRules/tests/EnrichmentRulesView.spec.tsx
@@ -2,7 +2,8 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { deleteRule, getEvaluators, getRules } from '@/src/app/[lang]/enrichment-rules/actions';
+import { deleteRule, getRules } from '@/src/app/[lang]/enrichment-rules/actions';
+import { getEvaluators } from '@/src/app/[lang]/evaluators/actions';
 import EnrichmentRulesView from '@/src/components/Analytics/EnrichmentRules/EnrichmentRulesView';
 import { ACTIONS_COLUMN_CEL_ID } from '@/src/constants/ag-grid';
 import { UNAVAILABLE_VALUE } from '@/src/constants/analytics/conversations-trace';
@@ -11,6 +12,7 @@ import { EvaluatorType } from '@/src/models/analytics/evaluator';
 import { EnrichmentRuleListItem, TriggerKind } from '@/src/models/analytics/rule';
 
 vi.mock('@/src/app/[lang]/enrichment-rules/actions');
+vi.mock('@/src/app/[lang]/evaluators/actions');
 vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }));
 
 vi.mock('@epam/ai-dial-ui-kit', async (importOriginal) => {

--- a/apps/ai-dial-admin/src/components/Analytics/EnrichmentRules/tests/RuleDetailPermissions.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/EnrichmentRules/tests/RuleDetailPermissions.spec.tsx
@@ -2,7 +2,8 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { getEvaluator, getTable, getTables, updateRule } from '@/src/app/[lang]/enrichment-rules/actions';
+import { getTable, getTables, updateRule } from '@/src/app/[lang]/enrichment-rules/actions';
+import { getEvaluator } from '@/src/app/[lang]/evaluators/actions';
 import RuleDetailView from '@/src/components/Analytics/EnrichmentRules/RuleDetailView';
 import { AnalyticsEnrichmentRulesI18nKey, ButtonsI18nKey } from '@/src/constants/i18n';
 import { AnalyticsFieldType } from '@/src/models/analytics/entity';
@@ -11,6 +12,7 @@ import { EnrichmentRule, TriggerKind } from '@/src/models/analytics/rule';
 import { AnalyticsTable, AnalyticsTableType } from '@/src/models/analytics/table';
 
 vi.mock('@/src/app/[lang]/enrichment-rules/actions');
+vi.mock('@/src/app/[lang]/evaluators/actions');
 vi.mock('next/navigation', () => ({ useRouter: () => ({ refresh: vi.fn(), push: vi.fn() }) }));
 
 // test-setup.tsx pins isFullAdmin true for the whole suite, so the non-admin case needs its own file.

--- a/apps/ai-dial-admin/src/components/Analytics/EnrichmentRules/tests/RuleDetailView.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/EnrichmentRules/tests/RuleDetailView.spec.tsx
@@ -2,7 +2,8 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { getEvaluator, getTable, getTables, updateRule } from '@/src/app/[lang]/enrichment-rules/actions';
+import { getTable, getTables, updateRule } from '@/src/app/[lang]/enrichment-rules/actions';
+import { getEvaluator } from '@/src/app/[lang]/evaluators/actions';
 import RuleDetailView from '@/src/components/Analytics/EnrichmentRules/RuleDetailView';
 import { AnalyticsEnrichmentRulesI18nKey, ButtonsI18nKey } from '@/src/constants/i18n';
 import { AnalyticsFieldType } from '@/src/models/analytics/entity';
@@ -11,6 +12,7 @@ import { EnrichmentRule, TriggerKind } from '@/src/models/analytics/rule';
 import { AnalyticsTable, AnalyticsTableType } from '@/src/models/analytics/table';
 
 vi.mock('@/src/app/[lang]/enrichment-rules/actions');
+vi.mock('@/src/app/[lang]/evaluators/actions');
 
 const refresh = vi.fn();
 vi.mock('next/navigation', () => ({ useRouter: () => ({ refresh, push: vi.fn() }) }));

--- a/apps/ai-dial-admin/src/components/Analytics/EnrichmentRules/tests/use-rule-form.spec.ts
+++ b/apps/ai-dial-admin/src/components/Analytics/EnrichmentRules/tests/use-rule-form.spec.ts
@@ -1,7 +1,8 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { getEvaluator, getEvaluatorVersion, getTable, getTables } from '@/src/app/[lang]/enrichment-rules/actions';
+import { getTable, getTables } from '@/src/app/[lang]/enrichment-rules/actions';
+import { getEvaluator, getEvaluatorVersion } from '@/src/app/[lang]/evaluators/actions';
 import { useRuleForm } from '@/src/components/Analytics/EnrichmentRules/use-rule-form';
 import { GROUP_FETCH_MAX_ROWS } from '@/src/constants/analytics/enrichment-rules';
 import { AnalyticsFieldType } from '@/src/models/analytics/entity';
@@ -10,6 +11,7 @@ import { EnrichmentRule, RulePriority, TriggerKind } from '@/src/models/analytic
 import { AnalyticsTable, AnalyticsTableType } from '@/src/models/analytics/table';
 
 vi.mock('@/src/app/[lang]/enrichment-rules/actions');
+vi.mock('@/src/app/[lang]/evaluators/actions');
 
 const sqlEvaluator: Evaluator = {
   name: 'feedback-rollup',

--- a/apps/ai-dial-admin/src/components/Analytics/EnrichmentRules/use-rule-resolution.ts
+++ b/apps/ai-dial-admin/src/components/Analytics/EnrichmentRules/use-rule-resolution.ts
@@ -2,7 +2,8 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { getEvaluator, getEvaluatorVersion, getTable, getTables } from '@/src/app/[lang]/enrichment-rules/actions';
+import { getTable, getTables } from '@/src/app/[lang]/enrichment-rules/actions';
+import { getEvaluator, getEvaluatorVersion } from '@/src/app/[lang]/evaluators/actions';
 import { LATEST_VERSION } from '@/src/constants/analytics/enrichment-rules';
 import { Evaluator } from '@/src/models/analytics/evaluator';
 import { AnalyticsTable, AnalyticsTableType } from '@/src/models/analytics/table';

--- a/apps/ai-dial-admin/src/components/Analytics/Evaluators/EvaluatorsView.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/Evaluators/EvaluatorsView.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { FC, useMemo } from 'react';
+
+import { ColDef } from 'ag-grid-community';
+
+import GridView from '@/src/components/Grid/GridView/GridView';
+import { UNAVAILABLE_VALUE } from '@/src/constants/analytics/conversations-trace';
+import { AnalyticsEvaluatorsI18nKey, MenuI18nKey } from '@/src/constants/i18n';
+import { useI18n } from '@/src/locales/client';
+import { EvaluatorListRow } from '@/src/models/analytics/evaluator';
+import { formatDateTimeToLocalString } from '@/src/utils/formatting/date';
+
+interface Props {
+  rows: EvaluatorListRow[];
+  hasUsageError?: boolean;
+  hasLoadError?: boolean;
+}
+
+const EvaluatorsView: FC<Props> = ({ rows, hasUsageError, hasLoadError }) => {
+  const t = useI18n();
+
+  // No type column: the listing endpoint reports no type, and both ways of filling one mislead — a per-row
+  // version read, or a join from the rules listing that leaves every unreferenced evaluator blank, where an
+  // em dash reads as "no type" rather than "no rule". Type is on the detail page.
+  const columns: ColDef[] = useMemo(
+    () => [
+      { headerName: t(AnalyticsEvaluatorsI18nKey.Name), field: 'name', flex: 2 },
+      { headerName: t(AnalyticsEvaluatorsI18nKey.LatestVersion), field: 'latest_version', flex: 1 },
+      {
+        headerName: t(AnalyticsEvaluatorsI18nKey.RegisteredAt),
+        colId: 'registeredAt',
+        flex: 2,
+        valueGetter: (params) =>
+          formatDateTimeToLocalString((params.data as EvaluatorListRow | undefined)?.created_at) || UNAVAILABLE_VALUE,
+      },
+      {
+        headerName: t(AnalyticsEvaluatorsI18nKey.UsedBy),
+        colId: 'usedBy',
+        flex: 1,
+        cellDataType: false,
+        valueGetter: (params) => {
+          const usedBy = (params.data as EvaluatorListRow | undefined)?.usedBy;
+          return usedBy == null ? t(AnalyticsEvaluatorsI18nKey.UsedByUnknown) : usedBy;
+        },
+      },
+    ],
+    [t],
+  );
+
+  return (
+    <div className="relative flex w-full flex-1 flex-col min-h-0 rounded bg-layer-2 p-4">
+      <div className="mb-8 flex h-[40px] flex-row items-center justify-between gap-4">
+        <h1>{t(MenuI18nKey.Evaluators)}</h1>
+      </div>
+
+      {hasLoadError && (
+        <div role="status" className="mb-4 text-error dial-small">
+          {t(AnalyticsEvaluatorsI18nKey.EvaluatorsLoadFailed)}
+        </div>
+      )}
+
+      {hasUsageError && (
+        <div role="status" className="mb-4 text-secondary dial-small">
+          {t(AnalyticsEvaluatorsI18nKey.UsageLoadFailed)}
+        </div>
+      )}
+
+      <div className="flex min-h-0 flex-1 flex-col">
+        <GridView
+          columnDefs={columns}
+          rowData={rows}
+          getRowId={(params) => params.data.name}
+          emptyDataProps={{ title: t(AnalyticsEvaluatorsI18nKey.NoEvaluators) }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default EvaluatorsView;

--- a/apps/ai-dial-admin/src/components/Analytics/Evaluators/tests/EvaluatorsView.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/Evaluators/tests/EvaluatorsView.spec.tsx
@@ -1,0 +1,155 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+import EvaluatorsView from '@/src/components/Analytics/Evaluators/EvaluatorsView';
+import { ACTIONS_COLUMN_CEL_ID } from '@/src/constants/ag-grid';
+import { UNAVAILABLE_VALUE } from '@/src/constants/analytics/conversations-trace';
+import { AnalyticsEvaluatorsI18nKey } from '@/src/constants/i18n';
+import { EvaluatorListRow } from '@/src/models/analytics/evaluator';
+
+interface MockColDef {
+  headerName?: string;
+  field?: string;
+  colId?: string;
+  sortable?: boolean;
+  filter?: boolean;
+  valueGetter?: (params: { data: EvaluatorListRow }) => unknown;
+}
+
+vi.mock('@/src/components/Grid/GridView/GridView', () => ({
+  default: ({
+    columnDefs,
+    rowData,
+    emptyDataProps,
+  }: {
+    columnDefs?: MockColDef[];
+    rowData?: EvaluatorListRow[];
+    emptyDataProps?: { title?: string };
+  }) => {
+    const dataColumns = columnDefs?.filter((col) => col.field !== ACTIONS_COLUMN_CEL_ID) ?? [];
+
+    return (
+      <div>
+        <div>cols: {columnDefs?.map((col) => col.colId ?? col.field).join('|')}</div>
+        <div>actions: {columnDefs?.some((col) => col.field === ACTIONS_COLUMN_CEL_ID) ? 'present' : 'absent'}</div>
+        <div>sortable: {dataColumns.some((col) => col.sortable === false) ? 'disabled' : 'not-disabled'}</div>
+        <div>filterable: {dataColumns.some((col) => col.filter === false) ? 'disabled' : 'not-disabled'}</div>
+        {rowData?.length === 0 && <div>{emptyDataProps?.title}</div>}
+        {rowData?.map((row) => (
+          <div key={row.name}>
+            {columnDefs
+              ?.map((col) => {
+                const value = col.valueGetter
+                  ? col.valueGetter({ data: row })
+                  : row[col.field as keyof EvaluatorListRow];
+                return `${col.colId ?? col.field}=${String(value)}`;
+              })
+              .join(' ')}
+          </div>
+        ))}
+      </div>
+    );
+  },
+}));
+
+const row = (over: Partial<EvaluatorListRow> = {}): EvaluatorListRow => ({
+  name: 'conversation-insights',
+  latest_version: 4,
+  created_at: '2026-08-17T10:00:00Z',
+  usedBy: 3,
+  ...over,
+});
+
+const renderView = (props?: Partial<Parameters<typeof EvaluatorsView>[0]>) =>
+  render(<EvaluatorsView rows={[row()]} {...props} />);
+
+describe('EvaluatorsView', () => {
+  test('renders the four columns', () => {
+    renderView();
+
+    expect(screen.getByText(/^cols:/)).toHaveTextContent('cols: name|latest_version|registeredAt|usedBy');
+  });
+
+  test('carries no type column', () => {
+    renderView();
+
+    expect(screen.getByText(/^cols:/).textContent).not.toMatch(/type/i);
+  });
+
+  test('carries no action column', () => {
+    renderView();
+
+    expect(screen.getByText(/^actions:/)).toHaveTextContent('actions: absent');
+  });
+
+  test('offers no create control', () => {
+    renderView();
+
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  // Narrowing is the grid's job — the listing is unpaged, so a column that opted out would be unreachable.
+  test('leaves every data column sortable and filterable through the grid', () => {
+    renderView();
+
+    expect(screen.getByText(/^sortable:/)).toHaveTextContent('sortable: not-disabled');
+    expect(screen.getByText(/^filterable:/)).toHaveTextContent('filterable: not-disabled');
+  });
+
+  test('renders no filter toolbar of its own', () => {
+    renderView();
+
+    expect(screen.queryByRole('textbox')).toBeNull();
+    expect(screen.queryByRole('combobox')).toBeNull();
+  });
+
+  test('reports the rule count for a referenced evaluator', () => {
+    renderView();
+
+    expect(screen.getByText(/usedBy=3/)).toBeTruthy();
+  });
+
+  test('reports zero as a value for an unreferenced evaluator', () => {
+    renderView({ rows: [row({ usedBy: 0 })] });
+
+    expect(screen.getByText(/usedBy=0/)).toBeTruthy();
+  });
+
+  test('reports the count as unknown rather than zero when the rules listing failed', () => {
+    renderView({ rows: [row({ usedBy: null })], hasUsageError: true });
+
+    expect(screen.queryByText(/usedBy=0/)).toBeNull();
+    expect(screen.getByText(new RegExp(`usedBy=${AnalyticsEvaluatorsI18nKey.UsedByUnknown}`))).toBeTruthy();
+  });
+
+  test('states why the counts are unavailable', () => {
+    renderView({ hasUsageError: true });
+
+    expect(screen.getByText(AnalyticsEvaluatorsI18nKey.UsageLoadFailed)).toBeTruthy();
+  });
+
+  test('says nothing about usage when the rules listing succeeded', () => {
+    renderView();
+
+    expect(screen.queryByText(AnalyticsEvaluatorsI18nKey.UsageLoadFailed)).toBeNull();
+  });
+
+  test('renders an em dash for an evaluator reporting no registration timestamp', () => {
+    renderView({ rows: [row({ created_at: undefined })] });
+
+    expect(screen.getByText(new RegExp(`registeredAt=${UNAVAILABLE_VALUE}`))).toBeTruthy();
+  });
+
+  test('states a failed evaluators listing', () => {
+    renderView({ hasLoadError: true });
+
+    expect(screen.getByText(AnalyticsEvaluatorsI18nKey.EvaluatorsLoadFailed)).toBeTruthy();
+  });
+
+  test('renders an empty registry as an empty grid with no failure', () => {
+    renderView({ rows: [] });
+
+    expect(screen.getByText(AnalyticsEvaluatorsI18nKey.NoEvaluators)).toBeTruthy();
+    expect(screen.queryByText(AnalyticsEvaluatorsI18nKey.EvaluatorsLoadFailed)).toBeNull();
+  });
+});

--- a/apps/ai-dial-admin/src/components/Breadcrumbs/constants.ts
+++ b/apps/ai-dial-admin/src/components/Breadcrumbs/constants.ts
@@ -221,6 +221,15 @@ export const breadcrumbConfig: Partial<Record<ApplicationRoute, BreadcrumbConfig
       { name: 'Id', href: false },
     ],
   },
+  [ApplicationRoute.AnalyticsEvaluators]: {
+    segments: [
+      {
+        name: 'Evaluators',
+        i18nKey: MenuI18nKey.Evaluators,
+      },
+      { name: 'Name', href: false },
+    ],
+  },
   [ApplicationRoute.AnalyticsQueries]: {
     segments: [
       {

--- a/apps/ai-dial-admin/src/components/Menu/menu-configuration.tsx
+++ b/apps/ai-dial-admin/src/components/Menu/menu-configuration.tsx
@@ -240,6 +240,10 @@ export const MENU_CONFIGURATION = (iconSize: number, featureFlags: FeatureFlags)
           href: ApplicationRoute.AnalyticsEnrichmentRules,
         },
         {
+          key: MenuI18nKey.Evaluators,
+          href: ApplicationRoute.AnalyticsEvaluators,
+        },
+        {
           key: MenuI18nKey.Queries,
           href: ApplicationRoute.AnalyticsQueries,
         },

--- a/apps/ai-dial-admin/src/components/Menu/tests/menu-configuration.spec.ts
+++ b/apps/ai-dial-admin/src/components/Menu/tests/menu-configuration.spec.ts
@@ -165,7 +165,7 @@ describe('MENU_CONFIGURATION — Analytics group', () => {
   const findAnalyticsGroup = (flags: FeatureFlags) =>
     MENU_CONFIGURATION(ICON_SIZE, flags).find((group) => group.key === MenuI18nKey.Analytics);
 
-  test('shows the Analytics group with Tables + Enrichment rules + Queries + Conversations when the flag is enabled', () => {
+  test('shows the Analytics group with Tables + Enrichment rules + Evaluators + Queries + Conversations when the flag is enabled', () => {
     const group = findAnalyticsGroup({ ...baseFlags, analyticsEnabled: true });
 
     expect(group).toBeDefined();
@@ -173,15 +173,31 @@ describe('MENU_CONFIGURATION — Analytics group', () => {
     expect(group?.items.map((item) => item.key)).toEqual([
       MenuI18nKey.Tables,
       MenuI18nKey.EnrichmentRules,
+      MenuI18nKey.Evaluators,
       MenuI18nKey.Queries,
       MenuI18nKey.AnalyticsConversations,
     ]);
     expect(group?.items.map((item) => item.href)).toEqual([
       ApplicationRoute.AnalyticsTables,
       ApplicationRoute.AnalyticsEnrichmentRules,
+      ApplicationRoute.AnalyticsEvaluators,
       ApplicationRoute.AnalyticsQueries,
       ApplicationRoute.ConversationsTrace,
     ]);
+  });
+
+  test('orders Evaluators directly after Enrichment rules', () => {
+    const keys = findAnalyticsGroup({ ...baseFlags, analyticsEnabled: true })?.items.map((item) => item.key) ?? [];
+
+    expect(keys.indexOf(MenuI18nKey.Evaluators)).toBe(keys.indexOf(MenuI18nKey.EnrichmentRules) + 1);
+  });
+
+  test('hides the Evaluators sub-item when the flag is disabled', () => {
+    const allItems = MENU_CONFIGURATION(ICON_SIZE, { ...baseFlags, analyticsEnabled: false }).flatMap((group) =>
+      group.items.map((item) => item.href),
+    );
+
+    expect(allItems).not.toContain(ApplicationRoute.AnalyticsEvaluators);
   });
 
   test('the Analytics Conversations item does not reuse the DIAL Core conversations key', () => {

--- a/apps/ai-dial-admin/src/constants/i18n.ts
+++ b/apps/ai-dial-admin/src/constants/i18n.ts
@@ -68,6 +68,7 @@ export enum MenuI18nKey {
   Queries = 'Menu.Queries',
   Tables = 'Menu.Tables',
   EnrichmentRules = 'Menu.EnrichmentRules',
+  Evaluators = 'Menu.Evaluators',
   AnalyticsConversations = 'Menu.AnalyticsConversations',
 }
 
@@ -2704,6 +2705,17 @@ export enum AnalyticsEnrichmentRulesI18nKey {
   DisableConfirmDescription = 'AnalyticsEnrichmentRules.DisableConfirmDescription',
   EnabledChanged = 'AnalyticsEnrichmentRules.EnabledChanged',
   ToggleBlockedByEdits = 'AnalyticsEnrichmentRules.ToggleBlockedByEdits',
+}
+
+export enum AnalyticsEvaluatorsI18nKey {
+  Name = 'AnalyticsEvaluators.Name',
+  LatestVersion = 'AnalyticsEvaluators.LatestVersion',
+  RegisteredAt = 'AnalyticsEvaluators.RegisteredAt',
+  UsedBy = 'AnalyticsEvaluators.UsedBy',
+  UsedByUnknown = 'AnalyticsEvaluators.UsedByUnknown',
+  NoEvaluators = 'AnalyticsEvaluators.NoEvaluators',
+  EvaluatorsLoadFailed = 'AnalyticsEvaluators.EvaluatorsLoadFailed',
+  UsageLoadFailed = 'AnalyticsEvaluators.UsageLoadFailed',
 }
 
 export enum ConversationsTraceI18nKey {

--- a/apps/ai-dial-admin/src/locales/en.ts
+++ b/apps/ai-dial-admin/src/locales/en.ts
@@ -163,6 +163,7 @@ export default {
     Queries: 'Queries',
     Tables: 'Tables',
     EnrichmentRules: 'Enrichment rules',
+    Evaluators: 'Evaluators',
     AnalyticsConversations: 'Conversations',
 
     EntitiesDescription: 'Centralized space to configure and oversee key components of your AI ecosystem.',
@@ -2654,6 +2655,16 @@ export default {
     EvaluatorsLoadFailed: 'Could not load the evaluator list.',
     EvaluatorTypeLlm: 'LLM',
     EvaluatorTypeSql: 'SQL',
+  },
+  AnalyticsEvaluators: {
+    Name: 'Name',
+    LatestVersion: 'Latest version',
+    RegisteredAt: 'Registered at',
+    UsedBy: 'Used by',
+    UsedByUnknown: 'Unknown',
+    NoEvaluators: 'No evaluators',
+    EvaluatorsLoadFailed: 'Could not load evaluators.',
+    UsageLoadFailed: 'Could not load enrichment rules, so usage counts are unavailable.',
   },
   AnalyticsTables: {
     CreateSource: 'Create source',

--- a/apps/ai-dial-admin/src/models/analytics/evaluator.ts
+++ b/apps/ai-dial-admin/src/models/analytics/evaluator.ts
@@ -13,7 +13,31 @@ export interface EvaluatorVar {
 export interface EvaluatorSummary {
   name: string;
   latest_version: number;
+  /**
+   * Dates the name's first registration, not the version now running — `Evaluator.created_at` dates that,
+   * and the two routinely differ.
+   */
   created_at?: string;
+}
+
+// A Map, not a Record: an evaluator name is only `@NotBlank` on the service, so `constructor`,
+// `toString`, and `__proto__` are all registerable and a plain object mishandles every one of them.
+// It stays server-side; the view is handed rows.
+export type EvaluatorUsage = Map<string, number>;
+
+export interface EvaluatorListRow {
+  name: string;
+  latest_version: number;
+  created_at?: string;
+  // Null means the rules listing failed, which is not the same as no rule using this evaluator.
+  usedBy: number | null;
+}
+
+export interface EvaluatorReferencingRule {
+  id: string;
+  name: string;
+  version: number;
+  isTrackingLatest: boolean;
 }
 
 export interface Evaluator {

--- a/apps/ai-dial-admin/src/types/routes.ts
+++ b/apps/ai-dial-admin/src/types/routes.ts
@@ -65,5 +65,6 @@ export enum ApplicationRoute {
   AnalyticsQueries = '/queries',
   AnalyticsTables = '/tables',
   AnalyticsEnrichmentRules = '/enrichment-rules',
+  AnalyticsEvaluators = '/evaluators',
   ConversationsTrace = '/conversations-trace',
 }

--- a/apps/ai-dial-admin/src/utils/analytics/evaluator-usage.ts
+++ b/apps/ai-dial-admin/src/utils/analytics/evaluator-usage.ts
@@ -1,0 +1,39 @@
+import { isPinnedToLatest } from '@/src/components/Analytics/EnrichmentRules/utils';
+import {
+  EvaluatorListRow,
+  EvaluatorReferencingRule,
+  EvaluatorSummary,
+  EvaluatorUsage,
+} from '@/src/models/analytics/evaluator';
+import { EnrichmentRuleListItem } from '@/src/models/analytics/rule';
+
+// Keyed on the rule's declared `evaluator_name`, not the resolved `evaluator.name`: the two hold the same
+// value, so swapping them breaks nothing visibly, but the declared one is the reference an operator wrote.
+export const toEvaluatorUsage = (rules: EnrichmentRuleListItem[]): EvaluatorUsage =>
+  rules.reduce<EvaluatorUsage>(
+    (usage, rule) => usage.set(rule.evaluator_name, (usage.get(rule.evaluator_name) ?? 0) + 1),
+    new Map(),
+  );
+
+// A null usage stays null per row rather than collapsing to zero: zero says an evaluator is dead weight,
+// which is the one thing the console must not claim when it could not find out.
+export const toEvaluatorRows = (evaluators: EvaluatorSummary[], usage: EvaluatorUsage | null): EvaluatorListRow[] =>
+  evaluators.map((evaluator) => ({
+    name: evaluator.name,
+    latest_version: evaluator.latest_version,
+    created_at: evaluator.created_at,
+    usedBy: usage ? (usage.get(evaluator.name) ?? 0) : null,
+  }));
+
+export const getReferencingRules = (
+  rules: EnrichmentRuleListItem[],
+  evaluatorName: string,
+): EvaluatorReferencingRule[] =>
+  rules
+    .filter((rule) => rule.evaluator_name === evaluatorName)
+    .map((rule) => ({
+      id: rule.id,
+      name: rule.name,
+      version: rule.evaluator.version,
+      isTrackingLatest: isPinnedToLatest(rule.evaluator_version),
+    }));

--- a/apps/ai-dial-admin/src/utils/analytics/tests/evaluator-usage.spec.ts
+++ b/apps/ai-dial-admin/src/utils/analytics/tests/evaluator-usage.spec.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from 'vitest';
+
+import { EvaluatorSummary, EvaluatorType } from '@/src/models/analytics/evaluator';
+import { EnrichmentRuleListItem, TriggerKind } from '@/src/models/analytics/rule';
+import { getReferencingRules, toEvaluatorRows, toEvaluatorUsage } from '@/src/utils/analytics/evaluator-usage';
+
+const rule = (over: Partial<EnrichmentRuleListItem>): EnrichmentRuleListItem => ({
+  id: 'r_1',
+  name: 'turn-feedback-live',
+  evaluator_name: 'feedback-rollup',
+  evaluator_version: 2,
+  evaluator: { name: 'feedback-rollup', version: 2, type: EvaluatorType.Sql },
+  target_enrichment: 'turn_feedback',
+  grain_key: 'response_id',
+  trigger_kind: TriggerKind.OnIngest,
+  enabled: true,
+  generation: 5,
+  updated_at: '2026-08-21T09:37:29Z',
+  ...over,
+});
+
+const summary = (name: string, over: Partial<EvaluatorSummary> = {}): EvaluatorSummary => ({
+  name,
+  latest_version: 2,
+  created_at: '2026-08-17T10:00:00Z',
+  ...over,
+});
+
+describe('toEvaluatorUsage', () => {
+  test('counts the rules naming each evaluator', () => {
+    const usage = toEvaluatorUsage([
+      rule({ id: 'r_1' }),
+      rule({ id: 'r_2' }),
+      rule({ id: 'r_3', evaluator_name: 'conversation-insights' }),
+    ]);
+
+    expect([...usage]).toEqual([
+      ['feedback-rollup', 2],
+      ['conversation-insights', 1],
+    ]);
+  });
+
+  test('counts across versions rather than per version', () => {
+    const usage = toEvaluatorUsage([
+      rule({ id: 'r_1', evaluator_version: 2 }),
+      rule({ id: 'r_2', evaluator_version: undefined }),
+      rule({ id: 'r_3', evaluator_version: 4 }),
+    ]);
+
+    expect(usage.get('feedback-rollup')).toBe(3);
+  });
+
+  test('holds no entry for an evaluator no rule names', () => {
+    expect(toEvaluatorUsage([rule({})]).get('conversation-insights')).toBeUndefined();
+  });
+
+  test('is empty for an empty rule list', () => {
+    expect(toEvaluatorUsage([]).size).toBe(0);
+  });
+
+  // A name is only `@NotBlank` on the service, so these are registerable. A plain-object accumulator
+  // resolves every one of them against `Object.prototype` and counts a function instead of a number.
+  test.each(['constructor', 'toString', '__proto__', 'hasOwnProperty'])('counts an evaluator named %s', (name) => {
+    const usage = toEvaluatorUsage([
+      rule({ id: 'r_1', evaluator_name: name }),
+      rule({ id: 'r_2', evaluator_name: name }),
+    ]);
+
+    expect(usage.get(name)).toBe(2);
+  });
+});
+
+describe('toEvaluatorRows', () => {
+  test('attaches the count to each evaluator', () => {
+    const rows = toEvaluatorRows(
+      [summary('feedback-rollup'), summary('conversation-insights')],
+      new Map([['feedback-rollup', 2]]),
+    );
+
+    expect(rows.map((item) => [item.name, item.usedBy])).toEqual([
+      ['feedback-rollup', 2],
+      ['conversation-insights', 0],
+    ]);
+  });
+
+  test('reports zero for an evaluator the usage map does not mention', () => {
+    const [row] = toEvaluatorRows([summary('conversation-insights')], new Map());
+
+    expect(row.usedBy).toBe(0);
+  });
+
+  test('reports null rather than zero when there is no usage map', () => {
+    const [row] = toEvaluatorRows([summary('conversation-insights')], null);
+
+    expect(row.usedBy).toBeNull();
+  });
+
+  test.each(['constructor', 'toString', '__proto__'])('reports zero for an unreferenced evaluator named %s', (name) => {
+    const [row] = toEvaluatorRows([summary(name)], new Map([['feedback-rollup', 1]]));
+
+    expect(row.usedBy).toBe(0);
+  });
+
+  test('carries the members the grid renders', () => {
+    const [row] = toEvaluatorRows([summary('feedback-rollup', { latest_version: 4 })], new Map());
+
+    expect(row).toEqual({
+      name: 'feedback-rollup',
+      latest_version: 4,
+      created_at: '2026-08-17T10:00:00Z',
+      usedBy: 0,
+    });
+  });
+});
+
+describe('getReferencingRules', () => {
+  test('selects only the rules naming that evaluator', () => {
+    const referencing = getReferencingRules(
+      [rule({ id: 'r_1' }), rule({ id: 'r_2', evaluator_name: 'conversation-insights' })],
+      'feedback-rollup',
+    );
+
+    expect(referencing.map((item) => item.id)).toEqual(['r_1']);
+  });
+
+  test('reports a pinned rule with the version it pins', () => {
+    const [referencing] = getReferencingRules([rule({ evaluator_version: 2 })], 'feedback-rollup');
+
+    expect(referencing).toMatchObject({ version: 2, isTrackingLatest: false });
+  });
+
+  test('reports a rule declaring no version as tracking the latest', () => {
+    const [referencing] = getReferencingRules(
+      [
+        rule({
+          evaluator_version: undefined,
+          evaluator: { name: 'feedback-rollup', version: 4, type: EvaluatorType.Sql },
+        }),
+      ],
+      'feedback-rollup',
+    );
+
+    expect(referencing).toMatchObject({ version: 4, isTrackingLatest: true });
+  });
+
+  test('is empty when no rule names the evaluator', () => {
+    expect(getReferencingRules([rule({})], 'conversation-insights')).toEqual([]);
+  });
+});

--- a/openspec/changes/add-evaluators-console/.openspec.yaml
+++ b/openspec/changes/add-evaluators-console/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-25

--- a/openspec/changes/add-evaluators-console/design.md
+++ b/openspec/changes/add-evaluators-console/design.md
@@ -1,0 +1,223 @@
+## Context
+
+See `proposal.md` — Why. The constraints that actually shape the approach:
+
+- **`GET /v1/evaluators` is a name index, not a definition index.** It answers
+  `{name, latest_version, created_at}` and nothing else. Every fact worth showing lives in a version
+  response, which the listing never carries.
+- **A version response does not know the latest version.** `EvaluatorVersionDto.version` is *its own*
+  number. `GET /v1/evaluators/{name}/versions/2` cannot tell you whether 2 is the newest.
+- **The two `created_at` fields are different facts with the same name.** The summary's dates the name's
+  first registration; the version's dates that version. On dev, `conversation-insights` reads 2026-08-17
+  in the listing and 2026-08-19 on v4.
+- **The member set is type-conditional and enforced imperatively.** `EvaluatorService.requireValidShape`
+  rejects a `sql` evaluator that carries `preset`, `model`, `params`, `request_template`, `input_vars`, or
+  `response_schema`. Bean validation would not have caught it, and the DTO is `@JsonInclude(NON_NULL)`, so
+  a `sql` version simply has no such keys on the wire.
+- **Every read is open; only `POST` is `@FullAdminOnly`.** This surface issues no `POST`.
+- **The app has no `useSearchParams` call anywhere.** Search-param state is read on the server, in the
+  page.
+- **Analytics has no shared entity-detail shell.** Tables is bespoke, Queries has no detail page, and the
+  rule detail page just shipped as its own composition. This page is the fourth bespoke one, not a
+  candidate for the `EntityViewTab` shell.
+
+The requirements themselves are in `specs/analytics/spec.md`; this document covers how, and why not
+otherwise.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Two server-rendered pages that read only, with each of the three server reads on the detail page failing
+  independently and visibly.
+- Reuse the version-switcher, read-only-code, and grid pieces that already exist rather than growing new
+  ones, and leave those pieces where the placement rules say they belong.
+- Keep the shape a reviewer expects from the sibling `EnrichmentRules` folder: page fetches, client view
+  owns interaction, one component per file, i18n keys in a feature enum.
+
+**Non-Goals (design level, beyond the proposal's scope)**
+
+- No client-side data layer, cache, or resolution hook. `use-rule-resolution` exists because the create
+  modal resolves entities as the operator types; nothing on these pages is typed.
+- No shared "read-only entity page" abstraction extracted from this and the rule detail page. Two
+  instances is not the rule of three.
+- No range validation of `?version` against `latest_version` before the read. See Decision 3.
+
+## Decisions
+
+### 1. Both pages read the rules listing on the server; the join is a pure function
+
+`used by` and the detail page's referencing-rules panel are the same join from opposite ends. Both pages
+already fetch on the server (spec: "Analytics pages fetch initial data server-side"), so both fetch the
+rules listing there and hand the client view a derived value.
+
+- Listing page → a row per evaluator carrying `usedBy: number | null`, where `null` means the rules
+  listing failed. The count map itself never crosses the boundary.
+- Detail page → the `EnrichmentRuleListItem[]` filtered to this evaluator's name, plus a failure flag.
+
+Both are built by pure helpers under `src/utils/analytics/` (`utils.md`: pure, placed, testable), not
+inside the view. The intermediate count is a `Map<string, number>`, not a `Record`: an evaluator name is
+only `@NotBlank` on the service, so `constructor`, `toString`, and `__proto__` are all registerable, and a
+plain-object accumulator resolves each of them against `Object.prototype` — counting a function, or (for
+`__proto__`) silently discarding the entry through the setter. A `Map` is correct for every key, and
+keeping it server-side means nothing but arrays, numbers, and nulls crosses the RSC boundary.
+
+`usedBy` is a **required** member whose value may be `null`, not an optional `usedBy?: number`. The
+optional form was rejected because an absent optional reads as zero at every call site that forgets to
+check, and rendering `0` for "could not find out" is the one wrong answer the spec forbids.
+
+The join keys on the rule's declared `evaluator_name`, not the resolved `evaluator.name`. They hold the
+same value today, but the declared one is the reference the operator wrote, which is what "used by" means.
+
+Rejected: a client-side effect. The rules listing is not user-triggered, and fetching it in the browser
+would put an empty `used by` column on screen first and fill it in after — the exact ambiguity between
+"unused" and "not yet known" that Decision 1 exists to prevent.
+
+### 2. The version is a search param, and the switcher navigates
+
+`/evaluators/{name}?version=N`. A version is a lens on one entity, not a second entity: the breadcrumb
+trail stays *Evaluators → {name}*, and the page composition is identical whichever version is addressed.
+
+Selecting a version calls `router.push` with the new URL, which re-runs the server component — the same
+navigate-on-change behaviour `ImagesButtonsWrapper` uses for image versions, and the reason this app needs
+no `useSearchParams`. The alternative, refetching in place through a server action, would leave the URL
+naming a version other than the one on screen, which breaks the shareable link the spec requires.
+
+Rejected: a nested `/evaluators/{name}/versions/{n}` segment. It needs a second breadcrumb entry, a second
+page file that renders the same view, and it makes "the latest" a different URL shape from "version 4",
+which are the same page.
+
+### 3. `?version` is parsed permissively and range-checked by the service
+
+A `version` that is not a positive integer is ignored and the latest is read. A well-formed one is passed
+to `GET /v1/evaluators/{name}/versions/{version}`; if it does not exist the service answers nothing and the
+page resolves `notFound()`.
+
+The alternative — read the listing first, compare against `latest_version`, then decide — inverts the fetch
+order so that a listing failure could 404 a version the service would have served. Letting the service be
+the authority on which versions exist keeps a real page reachable whenever the version read succeeds.
+
+### 4. The detail page issues three reads in three separate `try` blocks
+
+Following `enrichment-rules/[id]/page.tsx`, which does the same thing for the same reason: the three
+failures mean different things and must not collapse into one handler.
+
+| Read | On failure |
+| --- | --- |
+| the addressed version | `notFound()` — there is no page without it |
+| the evaluators listing | switcher degrades to the one version; the name's registration timestamp reads unavailable |
+| the rules listing | the referencing-rules panel states it could not load |
+
+They are awaited in sequence rather than through `Promise.allSettled`, matching the sibling page. Three
+sequential server-side calls to one service is the cost; if it ever shows, `allSettled` is a local change
+that does not touch the failure semantics above.
+
+### 5. `CodeViewer`, not `JsonEditorBase`, for the template and the schema
+
+`src/components/Common/CodeViewer/CodeViewer.tsx` already is every clause of the requirement: read-only
+Monaco, `wordWrap: 'on'`, height capped at `Math.min(lineCount * 19 + 24, 400)` with its own scroll, a copy
+button, a fullscreen viewer, and `JSON.stringify(JSON.parse(content))` with a **verbatim fallback** when the
+content is not JSON — which is exactly what an unparseable `request_template` needs.
+
+`JsonEditorBase` is an *editable* editor. Using it would mean supplying a `readOnly` options object, an
+outer height container, a copy affordance, and pretty-print-with-fallback — reimplementing `CodeViewer` in
+the feature folder.
+
+Two small changes to `CodeViewer`, both additive:
+
+- An opt-in `isInitiallyOpen` prop. The spec requires the request template to be readable on arrival, and
+  `CodeViewer` currently mounts collapsed. The prop defaults to today's behaviour, so its four existing
+  consumers are untouched; the request template passes `true`, the response schema does not.
+- Its toggle carries `aria-expanded` with no `aria-controls`. While in the file, pair it with a `useId`-based
+  id on the content region (`a11y.md`: expand/collapse needs both).
+
+### 6. No accordion on the detail page
+
+The rule detail page groups with `Common/Accordion` because it holds ~25 *editable* controls that an
+operator has to navigate. This page holds seven read-only blocks, two of which (`CodeViewer`) already carry
+their own collapse header. Wrapping those in an accordion gives two chevrons for one thing to open. Blocks
+render as plain `<section>`s with headings and an `aria-label`, in the order the spec lists them.
+
+### 7. Layout: ag-grid for the page, CSS grid for the in-page readings
+
+`components.md` §5/§6 split this by kind, not by looks: ag-grid for tabular *data* (sortable, filterable,
+editable), CSS grid or flexbox for tabular *layout* such as key–value displays.
+
+- The evaluators **listing** is tabular data → `GridView`, with `navigateEntityUrl` on `onCellClicked`,
+  mirroring `EnrichmentRulesView`.
+- `params`, `input_vars`, and `output_vars` are static readings of a handful of rows inside a page section →
+  CSS grid. Sorting 13 output variables is not a feature anyone wants, and an ag-grid instance inside a
+  page section brings sizing problems for nothing. This is why the spec says "two-column reading" rather
+  than "grid".
+
+An output variable's expression is rendered monospaced and truncated with `DialEllipsisTooltip`, which is
+keyboard-reachable — `a11y.md` rules out a bare `title` attribute for this.
+
+### 8. `VersionsControl` moves to `Common/`
+
+It is already prop-generic (`versions: string[]`, `version`, `setVersion`) and domain-free, and it has
+exactly one consumer today (`Assets/Modals/CompareVersions.tsx`). A second consumer in a different feature
+is the trigger `components.md` §4 names for pushing a piece down, so it moves to
+`src/components/Common/VersionsControl/` and `CompareVersions` updates its import. Its `setVersion(value as
+CompareView)` cast is dropped in the move — the parameter is already `string`, and the cast only ties a
+generic control to the audit-compare types.
+
+Rejected outright, despite looking like the right neighbourhood: `BaseControls/Version.tsx`,
+`Assets/Modals/AddVersionModal.tsx`, and the semver helpers in `utils/deployments/validation.ts`. Those
+version images and assets, whose versions are author-supplied semver strings. Evaluator versions are
+integers the service assigns; semver validation would reject `4`, and an "add version" affordance would
+offer to name a number the service ignores.
+
+### 9. The type badge becomes a feature component, and its i18n keys follow it
+
+`EvaluatorTypeBadge` is typed on `EvaluatorType`, so §4 places it in the feature tree, not `Common/`:
+`components/Analytics/Evaluators/EvaluatorTypeBadge.tsx`. `EvaluatorCell` imports it and loses its inline
+`TYPE_COLOR` / `TYPE_LABEL` maps.
+
+The two type labels currently live under `AnalyticsEnrichmentRulesI18nKey`. Once the badge is shared by both
+consoles, that enum is the wrong owner, so `EvaluatorTypeLlm` and `EvaluatorTypeSql` move into the new
+`AnalyticsEvaluatorsI18nKey` alongside the new strings. Four files, no string changes: the rendered "LLM"
+and "SQL" stay identical, and `cells.spec.tsx` updates its expected key.
+
+### 10. `EvaluatorPreset` is an enum that nothing branches on
+
+`code-standards.md` calls for an enum over a bare string for a fixed value set, and `preset` has exactly one
+service-defined value, `chat_completion`. It is typed `preset?: EvaluatorPreset` and **rendered by value,
+never switched on** — so a value the enum does not name still reaches the screen verbatim, as the spec
+requires. The enum exists to give change 2's authoring form a single source for the option list; it is not
+a runtime guard, and adding a fallback branch keyed on it would be the bug the spec's "renders as reported"
+scenario is guarding against.
+
+The same reasoning covers an unrecognised `type`: the per-type branching hides the members `sql` forbids and
+otherwise renders what the version carries, so it keys on `type === EvaluatorType.Sql` rather than
+enumerating types. A future third type degrades to a full reading instead of a blank page.
+
+## Risks / Trade-offs
+
+- **A fabricated `used by` of 0 would be worse than no column** → the count is `Record | null`; `null`
+  renders as unavailable, and no code path substitutes a zero. This is the single most consequential
+  behaviour in the change, so it gets its own spec requirement and its own test.
+- **Three server reads per detail page view** → all three go to one service on the server, and only one of
+  them is on the critical path. Parallelising is a local change if latency shows.
+- **Monaco is not mocked globally** — `test-setup.tsx` only patches `queryCommandSupported` for jsdom → any
+  spec rendering `CodeViewer` mocks `@monaco-editor/react` locally, as `CodeViewer.spec.tsx` already does.
+- **Adding a prop to a shared `CodeViewer`** touches a component with four consumers → the prop is opt-in
+  and defaults to current behaviour; the `aria-controls` addition is additive.
+- **Two same-named `created_at` fields invite a silent mix-up in code** → they live on two distinct models
+  (`EvaluatorSummary` vs `Evaluator`) and behind two distinct i18n keys; neither view ever holds both in one
+  variable.
+- **An evaluator name can contain characters needing URL encoding** → links are built through a helper that
+  encodes, and the page decodes, mirroring `ruleDetailHref` and the rule detail page.
+- **Moving the three evaluator server actions crosses three importers** → a missed import is a TypeScript
+  error, not a silent regression; `use-rule-resolution.ts`, `EnrichmentRulesView.tsx`, and
+  `enrichment-rules/[id]/page.tsx` are the complete set.
+- **The registry cannot be cleaned up from here, only measured** → stated on the page (spec: "never mutates
+  the evaluator registry and says why") so the absence of a delete action is read as the service's contract
+  rather than a missing feature.
+
+## Migration Plan
+
+None. Two new routes, one moved server-action module, one moved shared control, and one shared component
+gaining an opt-in prop. No data migration, no API change, no feature flag beyond the existing
+`ANALYTICS_ENABLED` that already gates the whole group. Rollback is reverting the commit; nothing persists
+state.

--- a/openspec/changes/add-evaluators-console/proposal.md
+++ b/openspec/changes/add-evaluators-console/proposal.md
@@ -1,0 +1,98 @@
+## Why
+
+The enrichment rules console names evaluators but never explains them. The listing's evaluator cell renders
+`{evaluator_name}@{version}` with a type badge, the rule detail's read-only facts repeat the same two
+values, and the create-rule modal offers `evaluators.map((item) => ({ value: item.name, label: item.name }))`
+— a list of bare names. An operator choosing which evaluator a rule should call, or reading a rule someone
+else registered, has nowhere in the console to see what that evaluator actually does: which model it calls,
+what its request template says, what variables it declares, what its response is validated against.
+
+The registry also only grows. `POST /v1/evaluators` is the sole mutation; `PUT` and `DELETE` on a version
+return 409 `evaluator_immutable`, and there is no `DELETE /v1/evaluators/{name}` endpoint at all, so an
+evaluator can never be removed once registered. On the dev instance three of six registered evaluators are
+referenced by no rule, and nothing in the console reveals that — which is the one fact an operator needs
+before registering a new version of something, or before concluding an enrichment stopped because its
+evaluator went missing.
+
+## What Changes
+
+- Add the evaluators listing at `/evaluators`: **name**, **latest version**, **registered at**, and a
+  **used by** count of the rules referencing that evaluator, joined from one rules-listing fetch the page
+  makes on the server. Row activation opens the detail page.
+- Add a read-only evaluator detail page at `/evaluators/{name}`, addressing one version through a
+  `?version=N` search param. The page presents the version's facts, `params`, `request_template`,
+  `input_vars`, `response_schema`, `output_vars`, and the rules that reference it — each linking back to
+  `/enrichment-rules/{id}`.
+- Add a version switcher that enumerates `1..latest_version` and navigates rather than re-fetching in
+  place, reusing `VersionsControl` and the navigate-on-change pattern `ImagesButtonsWrapper` already uses
+  for image versions. `latest_version` is not in a version response, so the detail page reads the
+  evaluators listing alongside the version — which is also where the name's own registration timestamp
+  lives.
+- Label the two `created_at` values by what each dates. The listing's dates when the **name** was first
+  registered; a version response's dates **that version**. On dev they differ by two days for
+  `conversation-insights`, and presenting them as one fact would misreport when the running definition
+  was written.
+- Branch the detail page on evaluator `type`: a `sql` evaluator does not render the `preset`, `model`,
+  `params`, `request_template`, `input_vars`, or `response_schema` sections at all, because the service
+  forbids those members for that type. Rendering them as "not set" would imply they could be set.
+- State the registry's immutability on the page. The console offers no edit and no delete affordance for an
+  evaluator or a version, and says why rather than leaving the absence to be read as an unfinished screen.
+- Move `getEvaluators`, `getEvaluator`, and `getEvaluatorVersion` out of `enrichment-rules/actions.ts` into
+  the new `evaluators/actions.ts`, and update the three importers. The rules console keeps calling them;
+  only the module they live in changes.
+- Add an `EvaluatorPreset` enum to `models/analytics/evaluator.ts`, replacing `preset?: string`.
+
+## Capabilities
+
+### New Capabilities
+
+None. Evaluators are part of the analytics enrichment surface the `analytics` capability already covers.
+
+### Modified Capabilities
+
+- `analytics`: adds the evaluators listing route and its columns, the evaluator detail route and its
+  version addressing, the per-type section branching, the used-by derivation, the two-timestamp labelling,
+  and the statement that the console never mutates the registry. Two existing requirements change: the
+  Analytics menu group gains an "Evaluators" sub-item, and the rule detail's read-only facts link their
+  resolved evaluator to that evaluator's page at the version the rule resolved to.
+- The API-surface requirement is **not** touched. Its evaluator endpoints are already specified, and its
+  line reading "read-only from this app — evaluators are registered outside the UI" stays true: this change
+  adds no mutation. It becomes wrong only in the follow-up that registers versions.
+
+## Impact
+
+- **New**: `app/[lang]/evaluators/page.tsx`, `app/[lang]/evaluators/[name]/page.tsx`,
+  `app/[lang]/evaluators/actions.ts`; `EvaluatorsView`, `EvaluatorDetailView`, `EvaluatorTypeBadge`,
+  `EvaluatorVarsGrid`, `EvaluatorVersionSwitcher`, `EvaluatorUsedByPanel` under
+  `components/Analytics/Evaluators/`.
+- **Modified**: `models/analytics/evaluator.ts` (`EvaluatorPreset`, a listing row type);
+  `enrichment-rules/actions.ts` (evaluator readers removed) and its importers —
+  `use-rule-resolution.ts`, `EnrichmentRulesView.tsx`, `enrichment-rules/[id]/page.tsx`;
+  `EvaluatorCell.tsx` (type badge extracted for reuse); `RuleReadOnlyFacts.tsx` (the resolved evaluator
+  becomes a link to its detail page); `types/routes.ts`; `Menu/menu-configuration.tsx`;
+  `Breadcrumbs/constants.ts`; `constants/i18n.ts` and `locales/en.ts`; `Common/CodeViewer/CodeViewer.tsx`
+  gains an opt-in "open on mount" prop so the request template does not arrive collapsed.
+- **Reused unchanged**: `GridView`, `LabelledText`, `CodeViewer`, `VersionsControl`, `Accordion`,
+  `DialEllipsisTooltip`, `navigateEntityUrl`, `isAnalyticsForbidden`, `Page403`.
+- **Access**: the guard is `isAnalyticsForbidden()` alone. `GET /v1/evaluators*` carries no `@FullAdminOnly`
+  on the service, so unlike the rules console there is no `isFullAdmin` gate — and with no mutation on the
+  page there is nothing for one to protect.
+- **Tests**: new specs for the two views, the used-by derivation, the version addressing, and the per-type
+  branching. No existing spec changes behaviour; the moved server actions are re-imported, not rewritten.
+
+## Non-goals
+
+- **Registering an evaluator or a new version** (`POST /v1/evaluators`). Deferred to
+  `add-evaluator-version-authoring`, together with the editable form and the "save as new version" flow
+  that is the only save path an immutable registry can offer.
+- **Diffing two versions.** Also deferred to that follow-up, where `CompareVersions` and `DiffField` are
+  reused for `request_template` and `response_schema`.
+- **A `type` column in the listing.** `GET /v1/evaluators` returns only `{name, latest_version,
+  created_at}`, so a type column would need either a per-row read — which the rules listing requirement
+  already forbids for its own evaluator cell — or a join from the rules listing that leaves every unused
+  evaluator blank, where an em dash would read as "no type" rather than "no rule". Type is shown on the
+  detail page instead.
+- **Deleting or retiring an unused evaluator.** The service exposes no endpoint for it. The used-by count
+  reports the dead weight; it cannot clear it.
+- **Making the rules listing's evaluator cell a link.** The row already navigates to the rule; a second
+  target inside the cell would make one click mean two things.

--- a/openspec/changes/add-evaluators-console/specs/analytics/spec.md
+++ b/openspec/changes/add-evaluators-console/specs/analytics/spec.md
@@ -1,0 +1,523 @@
+## ADDED Requirements
+
+### Requirement: Evaluators page route and access guard
+
+The system SHALL expose an Analytics page at `/evaluators`, present in the `ApplicationRoute` enum
+(`types/routes.ts`) as `AnalyticsEvaluators`, with the route directory `src/app/[lang]/evaluators/`. The
+page SHALL be a server component declaring `export const dynamic = 'force-dynamic'` that calls
+`isAnalyticsForbidden()` before any data access and renders `Page403` when it returns `true`, matching the
+guard the Tables, Enrichment rules, Queries, and Conversations pages already use. User-facing strings SHALL
+read "Evaluators".
+
+The access check SHALL be that guard **alone**. `GET /v1/evaluators`, `GET /v1/evaluators/{name}`, and
+`GET /v1/evaluators/{name}/versions/{version}` carry no `@FullAdminOnly` on the service, and neither this
+page nor the detail page mutates anything, so no `isFullAdmin` gate SHALL be applied to either surface or to
+any control on them. This differs deliberately from the rules console, whose create action is full-admin
+because registering a rule is.
+
+A registry holding no evaluators is an ordinary state and SHALL render as the console with an empty grid. A
+**failed** listing fetch SHALL also render the console, with the load failure stated on the page, and SHALL
+NOT resolve to a not-found result — the same reasoning the rules listing already applies: an operator must
+be able to tell "nothing registered" from "the service is unreachable".
+
+The route SHALL be registered in the breadcrumb configuration so the trail reads from the Evaluators
+listing to the evaluator.
+
+#### Scenario: Page renders for a permitted caller
+
+- **WHEN** `isAnalyticsForbidden()` returns `false` and `/evaluators` is requested
+- **THEN** the page fetches the evaluators list on the server and renders the listing seeded with it
+
+#### Scenario: An empty registry renders as an empty grid
+
+- **WHEN** the evaluators listing resolves with no evaluators
+- **THEN** the console renders with an empty grid and no failure message
+
+#### Scenario: A failed listing states the failure instead of a not-found page
+
+- **WHEN** the server-side evaluators listing fetch fails
+- **THEN** the console still renders, reporting that the evaluators could not be loaded
+- **AND** the page does not resolve to a not-found result
+
+#### Scenario: Forbidden caller sees Page403 and no evaluators are fetched
+
+- **WHEN** `isAnalyticsForbidden()` returns `true` and `/evaluators` is requested
+- **THEN** `Page403` is rendered
+- **AND** no evaluators request is issued
+
+#### Scenario: A caller who is not a full admin sees the whole surface
+
+- **WHEN** a caller who is not a full admin opens the listing or an evaluator's detail page
+- **THEN** every part of both pages is presented, with nothing withheld and nothing disabled
+
+### Requirement: Evaluators listing grid
+
+The Evaluators page SHALL render the fetched evaluators as a grid whose columns are **name**, **latest
+version**, **registered at**, and **used by**. Every data column SHALL remain sortable and filterable
+through the grid's standard column controls, and the page SHALL NOT carry a separate filter toolbar.
+
+The grid SHALL NOT carry a **type** column. `GET /v1/evaluators` returns only `{name, latest_version,
+created_at}`, so a type column could be filled only by a per-row version read — which the rules listing
+requirement already forbids for its own evaluator cell — or by a join from the rules listing, which leaves
+every unreferenced evaluator blank, where an em dash reads as "this evaluator has no type" rather than "no
+rule names it". Type is presented on the detail page instead.
+
+Activating a row SHALL navigate to that evaluator's detail route, `/evaluators/{name}`, honouring the
+modifier keys that open a new tab. The **name** cell SHALL be plain text rather than a link, for the same
+reason the rules listing renders its name as text: the column is read and compared across rows, and a link
+per row makes it harder to scan.
+
+The listing SHALL offer no create, edit, or delete action on any row.
+
+#### Scenario: Listing renders the four columns
+
+- **WHEN** the listing renders a registered evaluator
+- **THEN** its name, latest version, registration timestamp, and used-by count are presented
+- **AND** no type column is present
+
+#### Scenario: Navigating to an evaluator
+
+- **WHEN** the user activates an evaluator's row
+- **THEN** the browser navigates to `/evaluators/{name}` for that evaluator
+
+#### Scenario: The name is plain text
+
+- **WHEN** the listing renders an evaluator
+- **THEN** its name is presented as text rather than as a link
+
+#### Scenario: Data columns stay sortable and filterable
+
+- **WHEN** the listing renders
+- **THEN** no data column disables sorting or filtering
+- **AND** no separate filter toolbar is rendered above the grid
+
+#### Scenario: No row offers a mutation
+
+- **WHEN** the listing renders
+- **THEN** no row exposes a create, edit, or delete action
+
+### Requirement: The used-by count is derived from one rules listing and never guesses zero
+
+The **used by** figure SHALL be the number of registered rules whose declared evaluator name equals that
+row's name, counted across every version. It SHALL be derived from a single rules-listing fetch the page
+makes on the server and joined in memory; the grid SHALL NOT issue a per-row request of any kind.
+
+An evaluator that no rule references SHALL report **0**, presented as a value in its own right rather than
+as an em dash or a blank. This figure is the only signal the console can give that a registry entry is dead
+weight, and it is the reason the column exists: no endpoint deletes an evaluator, so an operator can never
+learn this by the entry disappearing.
+
+When the rules listing fails, the column SHALL state that the count is unavailable and SHALL NOT render
+**0**. A fabricated zero would tell an operator an evaluator is unused when the console simply could not
+find out, which is the one wrong answer this column must never give.
+
+#### Scenario: A referenced evaluator reports its rule count
+
+- **WHEN** three registered rules declare the same evaluator name and the listing renders
+- **THEN** that evaluator's used-by cell reads 3
+- **AND** no per-row request is issued for any evaluator
+
+#### Scenario: Rules pinned to different versions of one evaluator all count
+
+- **WHEN** one rule pins version 2 of an evaluator and another tracks its latest version
+- **THEN** that evaluator's used-by cell counts both rules
+
+#### Scenario: An unreferenced evaluator reports zero
+
+- **WHEN** no registered rule names an evaluator
+- **THEN** that evaluator's used-by cell reads 0 rather than blank or an em dash
+
+#### Scenario: A failed rules listing is not reported as unused
+
+- **WHEN** the rules listing fetch fails while the evaluators listing succeeds
+- **THEN** the listing still renders every evaluator
+- **AND** the used-by column states that the count is unavailable rather than reading 0
+
+### Requirement: Evaluator detail route addresses one version through a search param
+
+The system SHALL expose an evaluator detail page at `/evaluators/{name}`, with the route directory
+`src/app/[lang]/evaluators/[name]/`, and SHALL address a single version through the `version` search param:
+`/evaluators/{name}?version=2`. The page SHALL be a server component declaring
+`export const dynamic = 'force-dynamic'` that calls `isAnalyticsForbidden()` before any data access and
+renders `Page403` when it returns `true`. The `{name}` segment SHALL be URL-decoded before use.
+
+With no `version` param the page SHALL read the evaluator's latest version through
+`GET /v1/evaluators/{name}`. With a `version` param that is a positive integer it SHALL read
+`GET /v1/evaluators/{name}/versions/{version}`. A `version` param that is not a positive integer SHALL be
+ignored and the latest version read, so a mistyped URL still shows the evaluator rather than a dead end.
+
+A version read that resolves to nothing SHALL produce a not-found result — a detail page addressed by name
+and version has nothing to show when that pair does not resolve. This covers both an unregistered name and
+a version above the latest.
+
+Because the page is server-rendered and its version lives in the URL, a link to one version SHALL resolve
+to that version for anyone who opens it.
+
+#### Scenario: No version param reads the latest version
+
+- **WHEN** `/evaluators/{name}` is requested with no `version` param
+- **THEN** the evaluator's latest version is read and the detail view renders seeded with it
+
+#### Scenario: A version param reads that version
+
+- **WHEN** `/evaluators/{name}?version=2` is requested and version 2 is registered
+- **THEN** version 2 is read and the detail view renders seeded with it
+
+#### Scenario: An unknown name is not found
+
+- **WHEN** the evaluator read resolves to no evaluator
+- **THEN** the page resolves to a not-found result
+
+#### Scenario: A version above the latest is not found
+
+- **WHEN** `?version=9` is requested for an evaluator whose latest version is 4
+- **THEN** the version read resolves to nothing and the page resolves to a not-found result
+
+#### Scenario: A malformed version param falls back to the latest
+
+- **WHEN** `?version=abc` or `?version=0` is requested for a registered evaluator
+- **THEN** the latest version is read and rendered
+- **AND** the page does not resolve to a not-found result
+
+#### Scenario: Forbidden caller sees Page403 and no evaluator is fetched
+
+- **WHEN** `isAnalyticsForbidden()` returns `true` and `/evaluators/{name}` is requested
+- **THEN** `Page403` is rendered
+- **AND** no evaluator request is issued
+
+### Requirement: The version switcher enumerates every version without a per-version request
+
+The detail page SHALL present a version switcher offering every version from `1` to the evaluator's
+`latest_version`, marking which one is currently shown. Selecting a version SHALL navigate to that
+version's URL rather than re-fetching in place, so the address bar always names what is on screen — the
+same navigate-on-change behaviour the deployment-images version select already has.
+
+A version response carries its own `version` but not the evaluator's `latest_version`, so the page SHALL
+read the evaluators listing alongside the addressed version to obtain it. The switcher SHALL therefore
+issue **no** request of its own, and no request per offered version.
+
+When that listing read fails while the version read succeeds, the page SHALL still render the version it
+was asked for, the switcher SHALL offer only that version, and the page SHALL state that the version list
+could not be loaded. A degraded switcher is preferable to a page that cannot render a version it
+successfully read.
+
+#### Scenario: Every version is offered
+
+- **WHEN** an evaluator whose latest version is 4 is opened
+- **THEN** the switcher offers versions 1, 2, 3, and 4
+- **AND** no request is issued per offered version
+
+#### Scenario: Selecting a version navigates
+
+- **WHEN** the user selects version 2 while version 4 is shown
+- **THEN** the browser navigates to that evaluator's URL carrying `version=2`
+
+#### Scenario: The shown version is marked
+
+- **WHEN** `?version=2` is open
+- **THEN** the switcher presents version 2 as the current selection
+
+#### Scenario: A failed version list degrades the switcher rather than the page
+
+- **WHEN** the evaluators listing read fails and the addressed version read succeeds
+- **THEN** the version's own content is rendered
+- **AND** the switcher offers only that version and the page states that the version list could not be
+  loaded
+
+### Requirement: The two registration timestamps are labelled by what each dates
+
+An evaluator carries two distinct `created_at` values, and the service does not relate them: the one in the
+evaluators listing dates when the **name** was first registered, and the one in a version response dates
+when **that version** was registered. They routinely differ — a name registered days before the version now
+running is the normal case, not an anomaly.
+
+The detail page SHALL present both, each labelled by what it dates, and SHALL NOT present either as the
+other or fold them into a single value. When the name's registration timestamp is unavailable because the
+listing read failed, it SHALL be reported as unavailable rather than filled in from the version's.
+
+#### Scenario: Both timestamps are shown with distinct labels
+
+- **WHEN** an evaluator whose name was registered before the version being shown is opened
+- **THEN** both timestamps are presented
+- **AND** each is labelled to say whether it dates the evaluator or the version
+
+#### Scenario: An unavailable name timestamp is not substituted
+
+- **WHEN** the evaluators listing read failed
+- **THEN** the name's registration timestamp is reported as unavailable
+- **AND** the version's own timestamp is not presented in its place
+
+### Requirement: A sql evaluator omits the members its type forbids
+
+The service accepts a different member set per evaluator `type`, enforced on registration rather than by
+schema: an `llm` evaluator requires `preset` and `model`, while a `sql` evaluator is **rejected** if it
+carries `preset`, `model`, `params`, `request_template`, `input_vars`, or `response_schema`, and must give
+every output variable a `sql` expression.
+
+For a `sql` evaluator the detail page SHALL therefore omit those six members entirely — no section, no
+label, no placeholder. Presenting them as "not set" would state that they could be set, which for this type
+is false.
+
+For an `llm` evaluator a member the type permits but the version does not carry SHALL be presented as
+explicitly unset rather than omitted, so an operator can tell a member that is absent from one that is
+forbidden. `type` and `output_vars` are the only members both types carry, and both SHALL always be
+presented.
+
+An evaluator whose `type` is neither `llm` nor `sql` SHALL render the members the version actually carries
+rather than an empty page, so a value added to the service later degrades to a plain reading instead of a
+blank screen.
+
+#### Scenario: A sql evaluator hides the forbidden members
+
+- **WHEN** a `sql` evaluator version is opened
+- **THEN** no preset, model, params, request template, input variables, or response schema section is
+  present
+- **AND** its type and output variables are presented
+
+#### Scenario: An llm evaluator distinguishes unset from forbidden
+
+- **WHEN** an `llm` evaluator version carrying no `params` is opened
+- **THEN** the params section is present and states that none are set
+- **AND** the request template and response schema sections are present
+
+#### Scenario: An unrecognised type still renders what the version carries
+
+- **WHEN** a version reports a `type` that is neither `llm` nor `sql`
+- **THEN** the members that version actually carries are presented
+
+### Requirement: Evaluator facts and params are presented as values, not as a blob
+
+The detail page SHALL present `type`, `preset`, and `model` as labelled read-only values, and `params` as a
+key/value list — one row per entry, each key labelled and its value beside it. `params` SHALL NOT be
+rendered as a JSON blob: the map holds a handful of model knobs such as `max_tokens` and `temperature`, and
+those are read one at a time.
+
+`preset` has exactly one value the service defines, `chat_completion`, which the model layer SHALL name as
+an enum member rather than a bare string. A value the enum does not name SHALL still be rendered verbatim.
+
+#### Scenario: Params are readable one entry at a time
+
+- **WHEN** an `llm` version carrying `max_tokens` and `temperature` is opened
+- **THEN** each key is presented with its own value
+- **AND** the params are not presented as a single JSON document
+
+#### Scenario: An unknown preset renders as reported
+
+- **WHEN** a version reports a preset the console does not know
+- **THEN** that value is presented as the service reported it
+
+### Requirement: The request template and the response schema are presented read-only and bounded
+
+`request_template` is a single-line JSON string that can run to thousands of characters, and
+`response_schema` is a JSON document. Both SHALL be presented in a read-only editor with word wrap, a
+bounded height, and its own scroll, so neither can push the rest of the page out of reach. Both SHALL be
+copyable in full.
+
+Neither SHALL be editable, and neither SHALL be validated or reformatted in a way that changes what the
+service stores. A `request_template` that is not parseable JSON SHALL be rendered verbatim rather than
+reported as an error — the service accepts it, so the console is not the authority on its shape.
+
+The request template SHALL be readable without an extra interaction: it is the member an operator opens
+this page to read.
+
+#### Scenario: The template is bounded and scrolls on its own
+
+- **WHEN** a version whose request template is several thousand characters long is opened
+- **THEN** the template is presented within a bounded height that scrolls
+- **AND** the sections below it remain reachable
+
+#### Scenario: The template is readable on arrival
+
+- **WHEN** an `llm` version is opened
+- **THEN** its request template content is presented without a further interaction
+
+#### Scenario: Neither is editable
+
+- **WHEN** a version is opened
+- **THEN** neither the request template nor the response schema accepts input
+
+#### Scenario: An unparseable template is shown as stored
+
+- **WHEN** a version's request template is not valid JSON
+- **THEN** it is rendered verbatim and no error is reported
+
+### Requirement: Declared variables are presented with the expression that produces each
+
+The detail page SHALL present `input_vars` as a two-column reading of **name** and **type**, and
+`output_vars` as a three-column reading of **name**, **type**, and the **expression** that produces the
+value — the variable's `jsonata` for an `llm` evaluator and its `sql` for a `sql` evaluator.
+
+An expression is code and can be long: a `sql` output variable is routinely a full `json_extract_string(...)`
+call. Expressions SHALL be rendered monospaced, and where one is truncated to fit, its full text SHALL
+remain reachable through a mechanism a keyboard user can reach — a `title` attribute alone SHALL NOT be
+that mechanism.
+
+An evaluator declaring no input variables SHALL state that rather than render an empty column frame with
+no explanation.
+
+#### Scenario: Output variables name their producing expression
+
+- **WHEN** a `sql` version whose output variables each carry a `sql` expression is opened
+- **THEN** each variable is presented with its name, type, and that expression
+- **AND** the expressions are rendered monospaced
+
+#### Scenario: A truncated expression stays reachable
+
+- **WHEN** an output variable's expression is too long for its column
+- **THEN** the full expression is reachable without a pointer hover
+
+#### Scenario: No declared input variables is stated
+
+- **WHEN** a version declares no input variables
+- **THEN** the page states that none are declared
+
+### Requirement: The rules that reference an evaluator are listed on its detail page
+
+The detail page SHALL list the registered rules whose declared evaluator name is this evaluator's, across
+every version, derived from the rules listing the page reads on the server. Each entry SHALL name the rule
+and link to `/enrichment-rules/{id}`, and SHALL state which version of this evaluator that rule resolves
+to — the version it pins, or that it tracks the latest.
+
+When no rule references the evaluator, the page SHALL say so explicitly. That is the state an operator is
+looking for: nothing else in the console reports it, and no endpoint lets them act on it by deleting the
+entry.
+
+When the rules listing fails, the page SHALL state that the referencing rules could not be loaded, and
+SHALL NOT state that none reference it.
+
+#### Scenario: Referencing rules link to themselves
+
+- **WHEN** two registered rules declare this evaluator
+- **THEN** both are listed, each linking to its own rule detail page
+
+#### Scenario: A rule's pin is stated
+
+- **WHEN** one referencing rule pins version 2 and another declares no version
+- **THEN** the first is shown as pinned to version 2 and the second as tracking the latest
+
+#### Scenario: An unreferenced evaluator says so
+
+- **WHEN** no registered rule declares this evaluator
+- **THEN** the page states that no rule references it
+
+#### Scenario: A failed rules listing is not reported as unreferenced
+
+- **WHEN** the rules listing fetch fails
+- **THEN** the page states that the referencing rules could not be loaded
+- **AND** it does not state that no rule references the evaluator
+
+### Requirement: The console never mutates the evaluator registry and says why
+
+`POST /v1/evaluators` is the service's only evaluator mutation; `PUT /v1/evaluators/{name}/versions/{version}`
+and `DELETE /v1/evaluators/{name}/versions/{version}` exist only to answer HTTP 409 with error code
+`evaluator_immutable`, and no endpoint deletes an evaluator by name. A registered version can never be
+changed, and a registered evaluator can never be removed.
+
+Neither the listing nor the detail page SHALL offer an edit, delete, or register affordance. The detail page
+SHALL state that versions are immutable and that a new version is registered through the API, so the
+absence of those controls reads as the contract it is rather than as a screen someone left unfinished.
+
+#### Scenario: No mutation is offered on either page
+
+- **WHEN** the listing or a detail page renders for any caller, full admin included
+- **THEN** no control edits, deletes, or registers an evaluator or a version
+
+#### Scenario: The detail page states the immutability
+
+- **WHEN** a version is opened
+- **THEN** the page states that registered versions cannot be changed and that a new version is registered
+  through the API
+
+### Requirement: One evaluator type badge is shared by both consoles
+
+The evaluator type badge — currently written inline in the rules listing's evaluator cell — SHALL be a
+single component that both the rules listing and the evaluators console render, so the two never disagree
+about how `llm` and `sql` look.
+
+The badge SHALL carry the type as text. Colour SHALL NOT be the only carrier of the distinction.
+
+#### Scenario: Both consoles render the same badge
+
+- **WHEN** the rules listing shows a rule's resolved evaluator and the evaluator detail page shows the same
+  evaluator
+- **THEN** both present the type through the same badge
+
+#### Scenario: The type is legible without colour
+
+- **WHEN** a type badge renders
+- **THEN** the type is stated as text
+
+### Requirement: Evaluator reads are served by their own server-action module
+
+The three evaluator readers — the listing, the latest version, and one pinned version — SHALL live in
+`src/app/[lang]/evaluators/actions.ts` rather than in the enrichment-rules action module that declares them
+today, so the module a reader lives in matches the surface that owns it. The enrichment-rules console SHALL
+keep calling all three, importing them from the new module; their behaviour SHALL NOT change.
+
+#### Scenario: The rules console still resolves an evaluator
+
+- **WHEN** the create-rule modal or the rule detail page resolves an evaluator after the move
+- **THEN** the same evaluator definition is returned as before
+
+#### Scenario: The rules action module no longer declares them
+
+- **WHEN** the enrichment-rules action module is read
+- **THEN** it declares no evaluator reader
+
+## MODIFIED Requirements
+
+### Requirement: Analytics menu group with Query Builder and Tables sub-items
+
+The left-navigation menu configuration (`MENU_CONFIGURATION` in `menu-configuration.tsx`) SHALL define an "Analytics" menu group whose sub-items are, in order, "Tables" (linking to the Tables route), "Enrichment rules" (linking to the Enrichment rules route), "Evaluators" (linking to the Evaluators route), "Queries" (linking to the Queries route), and "Conversations" (linking to the Conversations route). The group MUST use its own icon and follow the existing `MenuGroupConfiguration` shape. Routes SHALL be present in the `ApplicationRoute` enum (`types/routes.ts`) — `/queries`, `/tables`, `/enrichment-rules`, `/evaluators`, and `/conversations-trace` — and labels SHALL exist in `MenuI18nKey` (`constants/i18n.ts`) with English strings in `locales/en.ts` ("Analytics", "Queries", "Tables", "Enrichment rules", "Evaluators", "Conversations"). The Conversations label MUST be a distinct `MenuI18nKey` member from the one used by the existing DIAL Core `/conversations` item, even though both render the same English string.
+
+"Evaluators" SHALL sit directly after "Enrichment rules" rather than before it. An evaluator cannot be registered from this console, so a position ahead of Enrichment rules would read as the first step of a workflow that does not start here; the evaluators page is a reference surface an operator reaches from a rule, and placing it next to rules keeps the enrichment pair adjacent.
+
+The Enrichment rules route SHALL be spelled `/enrichment-rules`, not `/rules`: `src/components/Rules/` and the `RuleFolderProvider` in the app's provider stack already denote entity **access rules**, an unrelated capability, and a `/rules` route would shadow that meaning in the menu, in breadcrumbs, and in the codebase.
+
+The standalone `/query-builder` route SHALL NOT be present in the menu or in the `ApplicationRoute` enum. Requests to `/query-builder` SHALL redirect to `/queries` so existing links resolve.
+
+#### Scenario: Group and sub-items render when flag enabled
+
+- **WHEN** `featureFlags.analyticsEnabled` is `true` and the sidebar menu renders
+- **THEN** an "Analytics" group is present
+- **AND** expanding it shows a "Tables" sub-item linking to `/tables`
+- **AND** it shows an "Enrichment rules" sub-item linking to `/enrichment-rules`
+- **AND** it shows an "Evaluators" sub-item linking to `/evaluators`, ordered after "Enrichment rules"
+- **AND** it shows a "Queries" sub-item linking to `/queries`
+- **AND** it shows a "Conversations" sub-item linking to `/conversations-trace`
+- **AND** no "Query Builder" sub-item is present
+
+#### Scenario: The retired route redirects
+
+- **WHEN** the user navigates to `/query-builder`
+- **THEN** the browser is redirected to `/queries`
+
+### Requirement: Read-only rule facts are presented separately from editable ones
+
+A rule carries members the service derives and the API refuses to accept: `id`, `grain_key`,
+`version_column`, `generation`, `created_at`, `updated_at`, and the resolved `evaluator` definition. The
+detail page SHALL present these as read-only, visually separated from the editable form, so it is
+unambiguous which values an operator can change. `version_column` SHALL render as an em dash when the
+read source declares no scan metadata.
+
+The resolved evaluator SHALL link to that evaluator's detail page at the version the rule resolved to. The
+rule states which evaluator runs but nothing about what it does, and this fact is where an operator asking
+that question already is.
+
+These members SHALL NOT be sent when the rule is saved.
+
+#### Scenario: Derived facts are shown but not editable
+
+- **WHEN** a rule is opened
+- **THEN** its `grain_key`, `generation`, `created_at`, `updated_at`, and resolved evaluator are presented
+  as read-only values
+
+#### Scenario: An absent version column reads as an em dash
+
+- **WHEN** the rule's read source declares no scan metadata
+- **THEN** `version_column` renders as an em dash rather than as blank
+
+#### Scenario: The resolved evaluator opens its own page
+
+- **WHEN** the user activates the resolved evaluator on a rule pinned to version 2
+- **THEN** the browser navigates to that evaluator's detail page addressing version 2

--- a/openspec/changes/add-evaluators-console/tasks.md
+++ b/openspec/changes/add-evaluators-console/tasks.md
@@ -1,0 +1,204 @@
+## Delivery: two PRs off this one change
+
+One change, one delta spec, two pull requests — each tracked by its own ticket. Group boundaries align with
+PR boundaries, so no group is split across the two. The change archives once, after PR B.
+
+| | Ticket | Groups |
+| --- | --- | --- |
+| **PR A** (first) | [#4289](https://github.com/epam/ai-dial-admin-frontend/issues/4289) — Evaluators listing page | 1–4 |
+| **PR B** (second) | [#4290](https://github.com/epam/ai-dial-admin-frontend/issues/4290) — Evaluator detail page | 5–8 |
+
+Listing first, because the menu item and the breadcrumb entry both belong to the listing route and land with
+it. Detail-first would leave PR A with either a menu entry that resolves to nothing or a detail page with no
+menu entry and a breadcrumb parent that does not resolve.
+
+**Nothing in PR A links to a route that does not exist yet.** The listing grid ships with its name column as
+plain text and no row navigation; PR B adds row activation once the detail route resolves. Because this is a
+single change with a single delta describing the end state, that is task ordering rather than a requirement
+written and then modified.
+
+Groups 9 and 10 are per-PR, not a third PR: each PR carries the specs for the code it lands and runs the
+quality gate itself.
+
+## 1. Listing groundwork — PR A (#4289)
+
+- [x] 1.1 In `src/models/analytics/evaluator.ts`, add `EvaluatorListRow` — the type the evaluators grid
+  renders, carrying `usedBy: number | null` — kept distinct from `Evaluator` so the two `created_at` fields
+  can never be held in one variable (design.md, Risks).
+- [x] 1.2 Add `AnalyticsEvaluators = '/evaluators'` to `ApplicationRoute` in `src/types/routes.ts`.
+- [x] 1.3 Add `MenuI18nKey.Evaluators` to `src/constants/i18n.ts` with `'Evaluators'` in
+  `src/locales/en.ts`, and add the `Evaluators` sub-item to the Analytics group in
+  `src/components/Menu/menu-configuration.tsx`, positioned **directly after** `EnrichmentRules`.
+- [x] 1.4 Register `ApplicationRoute.AnalyticsEvaluators` in `src/components/Breadcrumbs/constants.ts`
+  following the `AnalyticsEnrichmentRules` shape (named segment + non-linking leaf), which covers both this
+  route and the detail route PR B adds.
+- [x] 1.5 Add the `AnalyticsEvaluatorsI18nKey` enum in `src/constants/i18n.ts` with its English strings in
+  `src/locales/en.ts`, covering the listing's needs: the four column headers, the used-by unavailable state,
+  the empty-registry text, and the load-failure message. PR B extends the same enum.
+
+## 2. Server actions module — PR A (#4289)
+
+- [x] 2.1 Create `src/app/[lang]/evaluators/actions.ts` (`'use server'`) holding `getEvaluators`,
+  `getEvaluator`, and `getEvaluatorVersion`, moved verbatim from
+  `src/app/[lang]/enrichment-rules/actions.ts` including the shared `token()` helper usage. All three move
+  together even though the listing only calls one — splitting the module across two PRs would leave
+  `enrichment-rules/actions.ts` half-emptied in between.
+- [x] 2.2 Delete those three from `src/app/[lang]/enrichment-rules/actions.ts` and repoint its three
+  importers: `src/components/Analytics/EnrichmentRules/use-rule-resolution.ts`,
+  `src/components/Analytics/EnrichmentRules/EnrichmentRulesView.tsx`, and
+  `src/app/[lang]/enrichment-rules/[id]/page.tsx`. The move also repoints the auto-mocks in six existing
+  specs that mock the module by path — `CreateRulePopup`, `EnrichmentRulesView`, `EnrichmentRulesPermissions`,
+  `RuleDetailView`, `RuleDetailPermissions`, and `use-rule-form` — each gaining
+  `vi.mock('@/src/app/[lang]/evaluators/actions')` alongside the existing one.
+
+## 3. Used-by derivation — PR A (#4289)
+
+- [x] 3.1 Add a pure helper under `src/utils/analytics/` that counts rules per evaluator name from
+  `EnrichmentRuleListItem[]`, keyed on the rule's declared `evaluator_name`, returning a
+  `Record<string, number>`.
+- [x] 3.2 Add a pure helper in the same module that selects the rules referencing one evaluator name and
+  reports, per rule, whether it pins a version or tracks the latest (reusing `isPinnedToLatest` from
+  `src/components/Analytics/EnrichmentRules/utils.ts`). Written here alongside its sibling; its consumer is
+  the used-by panel in PR B.
+
+## 4. Evaluators listing page — PR A (#4289)
+
+- [x] 4.1 Create `src/app/[lang]/evaluators/page.tsx`: `export const dynamic = 'force-dynamic'`,
+  `isAnalyticsForbidden()` → `Page403`, then two separate `try` blocks — the evaluators listing and the
+  rules listing — each logged with `errorObjLog`. A failed evaluators listing renders the console with a
+  load-failure flag rather than `notFound()`.
+- [x] 4.2 Shape the rows on the server: `toEvaluatorRows(evaluators, usage)` sets `usedBy` to the count, or
+  to `null` when the rules listing failed, and the page passes `hasUsageError` alongside. Never substitute
+  `0` (design.md Decision 1). The count map is a `Map`, not a `Record`, and stays server-side — a plain
+  object mishandles an evaluator named `constructor`, `toString`, or `__proto__`, all of which the service
+  permits.
+- [x] 4.3 Create `src/components/Analytics/Evaluators/EvaluatorsView.tsx` as the client view: `GridView`
+  with the four columns (name, latest version, registered at, used by), no `type` column, no create/edit/
+  delete action, and the stated load-failure banner. The name column is plain text; **row navigation is
+  task 8.2**, once the detail route resolves. Adding the menu sub-item in 1.3 also updates
+  `src/components/Menu/tests/menu-configuration.spec.ts`, which asserts the Analytics sub-items in order.
+
+## 5. Detail groundwork — PR B (#4290)
+
+- [ ] 5.1 In `src/models/analytics/evaluator.ts`, add `EvaluatorPreset`
+  (`ChatCompletion = 'chat_completion'`) and retype `Evaluator.preset` from `string` to `EvaluatorPreset`.
+  Nothing branches on it — see design.md Decision 10.
+- [ ] 5.2 Extend `AnalyticsEvaluatorsI18nKey` with the detail page's strings: the two distinctly-labelled
+  timestamps, the section headings, the empty-input-vars and no-referencing-rules statements, the
+  immutability statement, and the version-list-degraded message.
+- [ ] 5.3 Move `EvaluatorTypeLlm` / `EvaluatorTypeSql` out of `AnalyticsEnrichmentRulesI18nKey` into
+  `AnalyticsEvaluatorsI18nKey` (`src/constants/i18n.ts` + `src/locales/en.ts`); the rendered strings stay
+  `'LLM'` and `'SQL'`.
+
+## 6. Shared pieces — PR B (#4290)
+
+- [ ] 6.1 Move `src/components/Assets/Modals/VersionsControl.tsx` to
+  `src/components/Common/VersionsControl/VersionsControl.tsx`, drop the `as CompareView` cast, and update
+  the import in `src/components/Assets/Modals/CompareVersions.tsx` (design.md Decision 8).
+- [ ] 6.2 Add an opt-in `isInitiallyOpen?: boolean` prop to `src/components/Common/CodeViewer/CodeViewer.tsx`
+  seeding its `isOpen` state, defaulting to today's collapsed behaviour so its four existing consumers are
+  unaffected.
+- [ ] 6.3 In the same component, pair the toggle's `aria-expanded` with `aria-controls` against a `useId`
+  id on the content region (`.claude/rules/a11y.md`).
+- [ ] 6.4 Extract the type badge from `src/components/Analytics/EnrichmentRules/EvaluatorCell.tsx` into
+  `src/components/Analytics/Evaluators/EvaluatorTypeBadge.tsx`, carrying its `TYPE_COLOR` / `TYPE_LABEL`
+  maps and reading the relocated i18n keys; have `EvaluatorCell` render it.
+
+## 7. Evaluator detail page — PR B (#4290)
+
+- [ ] 7.1 Create `src/app/[lang]/evaluators/[name]/page.tsx`: guard, decode `{name}`, parse `?version`
+  permissively (a non-positive-integer is ignored and the latest is read), then three separate `try`
+  blocks — the addressed version, the evaluators listing, the rules listing — with the failure handling in
+  design.md Decision 4. A null version read calls `notFound()`.
+- [ ] 7.2 Create `src/components/Analytics/Evaluators/EvaluatorDetailView.tsx` composing the sections in
+  spec order as plain `<section>` elements with `aria-label` — no accordion (design.md Decision 6).
+- [ ] 7.3 Header: name, `EvaluatorTypeBadge`, the version switcher, and both timestamps under distinct
+  labels, with the name's timestamp reading unavailable when the listing read failed.
+- [ ] 7.4 Create `src/components/Analytics/Evaluators/EvaluatorVersionSwitcher.tsx` wrapping the relocated
+  `VersionsControl`: options `1..latest_version` built with no request, `router.push` to the version URL on
+  change, and a single-option degraded mode plus a stated failure when `latest_version` is unknown.
+- [ ] 7.5 Facts block: `type`, `preset`, `model` via `LabelledText`; `params` as a CSS-grid key/value
+  reading, one row per entry, not a JSON blob.
+- [ ] 7.6 Render `request_template` through `CodeViewer` with `isInitiallyOpen`, and `response_schema`
+  through `CodeViewer` collapsed.
+- [ ] 7.7 Create `src/components/Analytics/Evaluators/EvaluatorVarsGrid.tsx` — a CSS-grid reading of
+  `input_vars` (name, type) and `output_vars` (name, type, producing expression), expressions monospaced
+  and truncated with `DialEllipsisTooltip`, and an explicit statement when no input variables are declared.
+- [ ] 7.8 Create `src/components/Analytics/Evaluators/EvaluatorUsedByPanel.tsx` listing the referencing
+  rules with links to `/enrichment-rules/{id}` and each rule's pin, an explicit "no rule references this"
+  state, and a stated failure that is never rendered as "none".
+- [ ] 7.9 Branch the whole composition on `type === EvaluatorType.Sql` to omit preset, model, params,
+  request template, input vars, and response schema entirely; for `llm`, a permitted-but-absent member
+  renders as explicitly unset. An unrecognised type falls through to rendering what the version carries.
+- [ ] 7.10 State the registry's immutability on the page: versions cannot be changed and a new version is
+  registered through the API.
+
+## 8. Navigation into the detail page — PR B (#4290)
+
+- [ ] 8.1 Add an `evaluatorDetailHref(name, version?)` helper alongside the Evaluators view that URL-encodes
+  the name and appends `?version=` only when a version is given, mirroring `ruleDetailHref`.
+- [ ] 8.2 Add row activation to `EvaluatorsView`: `navigateEntityUrl` on `onCellClicked`, honouring the
+  modifier keys that open a new tab, mirroring `EnrichmentRulesView`. The name column stays plain text.
+- [ ] 8.3 In `src/components/Analytics/EnrichmentRules/Properties/RuleReadOnlyFacts.tsx`, make the resolved
+  evaluator a link to `evaluatorDetailHref(rule.evaluator.name, rule.evaluator.version)`. Leave the rules
+  **listing** evaluator cell as text — the row already navigates to the rule.
+
+## 9. Tests — split per PR
+
+One spec per source file, as the sibling `EnrichmentRules/tests/` folder does — a component spec per
+component, a `*Permissions.spec.tsx` per page for the guard and the page-level reads. **9.1–9.3 land with
+PR A; 9.4–9.10 land with PR B.**
+
+- [x] 9.1 `src/utils/analytics/tests/` — unit-test the two used-by helpers from group 3: counting across
+  versions, a zero for an unreferenced evaluator, and the pin-versus-latest report per rule.
+- [x] 9.2 `Evaluators/tests/EvaluatorsView.spec.tsx` — the four columns present and no `type` column, the
+  name rendered as text, zero rendered as a value, the unavailable state when the usage map is `null`, and
+  no mutation action on any row.
+- [x] 9.3 `src/app/[lang]/evaluators/tests/page.spec.tsx` — the listing page's access and failure
+  behaviour: `Page403` with no fetch when forbidden, the usage map left null rather than emptied when the
+  rules listing fails, and a stated failure rather than a not-found result. Written against the page
+  component itself (`await Page()`), following `conversations-trace/tests/page.spec.tsx`, because the guard
+  is only observable there — a `*Permissions.spec.tsx` on the view could not reach it, and the view carries
+  no role gate to test since the whole surface is open.
+  The empty-registry and no-mutation-control cases live in 9.2, where the view is rendered.
+- [ ] 9.4 `Evaluators/tests/EvaluatorDetailView.spec.tsx` — both types in one file, since it is one
+  component. For `llm`: both timestamps under distinct labels, params read one entry at a time, the request
+  template readable without a further interaction, the response schema present, and a version carrying no
+  `params` stating them unset rather than omitting the section. For `sql`: no preset, model, params,
+  request-template, input-vars, or response-schema section, with type and output variables still presented.
+  Mock `@monaco-editor/react` locally as `CodeViewer.spec.tsx` does.
+- [ ] 9.5 `Evaluators/tests/EvaluatorVersionSwitcher.spec.tsx` — every version from 1 to latest offered with
+  no per-version request, the shown version marked, selection pushing the version URL, and the degraded
+  single-option mode when `latest_version` is unknown.
+- [ ] 9.6 `Evaluators/tests/EvaluatorUsedByPanel.spec.tsx` — referencing rules linking to their own pages,
+  the pin stated per rule, the explicit unreferenced state, and a failed listing never reading as "none".
+- [ ] 9.7 `Evaluators/tests/EvaluatorVarsGrid.spec.tsx` — output variables presented with their producing
+  expression, the full expression reachable without a pointer hover, and the no-input-variables statement.
+- [ ] 9.8 `Evaluators/tests/EvaluatorDetailPermissions.spec.tsx` — the detail page's guard plus its version
+  addressing: `Page403` with no fetch when forbidden, no param reads latest, a valid param reads that
+  version, a malformed param falls back to latest without a not-found, and an unresolvable version is not
+  found.
+- [ ] 9.9 Extend `Evaluators/tests/EvaluatorsView.spec.tsx` with row activation navigating to the detail
+  route, update `src/components/Analytics/EnrichmentRules/tests/cells.spec.tsx` for the relocated type i18n
+  key, and assert in the rule detail's existing spec that the resolved evaluator links to the evaluator page
+  at the rule's resolved version.
+- [ ] 9.10 Add a `CodeViewer` case for `isInitiallyOpen` in its existing spec, confirming the default keeps
+  today's collapsed behaviour for its four consumers.
+
+Note on browser verification: the user was asked, per the `tasks` rule in `openspec/config.yaml`, whether to
+add a `spec-browser-verify` task for this change's browser-observable scenarios, and declined. The rule was
+followed, not skipped — no verification task is included by decision.
+
+## 10. Quality checks — run in both PRs
+
+- [x] 10.1 Run `npx vitest run` from `apps/ai-dial-admin/` for the touched specs while iterating, then
+  `npm run test` for the full gate.
+- [x] 10.2 Run `npm run lint` and `npm run format` and resolve anything this change introduced.
+- [x] 10.3 Type-check with `npx tsc -p apps/ai-dial-admin/tsconfig.app.json --noEmit` (not
+  `tsconfig.json` — it picks up stale `.next` types).
+- [x] 10.4 No doc under `docs/` describes the Analytics menu group, so none needs updating; confirm nothing
+  new landed there before closing out.
+
+Group 10 ran clean for PR A: full suite 9,795 passing / 4 skipped, lint 0 errors (134 warnings, unchanged
+from the pre-existing baseline), prettier clean, and `tsc -p tsconfig.app.json` reporting nothing in any
+file this change touches. Re-run the same four before PR B.


### PR DESCRIPTION
## Summary

This PR adds the Analytics Evaluators listing page as the first part of the add-evaluators-console feature. It displays a table of evaluators with their names, latest versions, registration dates, and usage information pulled from enrichment rules.

This is **PR A of 2** — the detail page and row navigation land in PR B (#4290) once that route is ready.

## Issues

- Issue #4289

## Key Changes

- [apps/ai-dial-admin/src/app/[lang]/evaluators/page.tsx](https://github.com/EPAM/ai-dial-admin-frontend/blob/feat/add-evaluators-listing/apps/ai-dial-admin/src/app/%5Blang%5D/evaluators/page.tsx) — new route page that fetches evaluators and enrichment rules
- [apps/ai-dial-admin/src/components/Analytics/Evaluators/EvaluatorsView.tsx](https://github.com/EPAM/ai-dial-admin-frontend/blob/feat/add-evaluators-listing/apps/ai-dial-admin/src/components/Analytics/Evaluators/EvaluatorsView.tsx) — evaluators grid component
- [apps/ai-dial-admin/src/utils/analytics/evaluator-usage.ts](https://github.com/EPAM/ai-dial-admin-frontend/blob/feat/add-evaluators-listing/apps/ai-dial-admin/src/utils/analytics/evaluator-usage.ts) — utility to calculate evaluator usage from enrichment rules
- [apps/ai-dial-admin/src/models/analytics/evaluator.ts](https://github.com/EPAM/ai-dial-admin-frontend/blob/feat/add-evaluators-listing/apps/ai-dial-admin/src/models/analytics/evaluator.ts) — data models for evaluator summary and row data
- Menu navigation and i18n strings for the new page

## New Components

- `EvaluatorsView` — table component displaying evaluators with name, version, registration date, and usage columns

## Checklist

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #4289)` (comma-separated list of issues)