### PR TITLE
fix: [Eval][Test Suites] Multi-request: adding a second /chat/completions request auto-generates a duplicate column name, causing a silent save failure (Issue #4294)

### DIFF
--- a/apps/ai-dial-admin/src/components/TestSuites/EndpointSchema/Columns/Columns.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/EndpointSchema/Columns/Columns.tsx
@@ -4,7 +4,13 @@ import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import OpenPopup from '@/public/images/icons/open-pop-up.svg';
-import { ButtonAppearance, DialNeutralButton, DialPrimaryButton } from '@epam/ai-dial-ui-kit';
+import {
+  ButtonAppearance,
+  DialNeutralButton,
+  DialNotification,
+  DialPrimaryButton,
+  NotificationVariant,
+} from '@epam/ai-dial-ui-kit';
 import { IconPlus } from '@tabler/icons-react';
 import { ColDef, GridApi, GridReadyEvent } from 'ag-grid-community';
 import { JSONSchema7 } from 'json-schema';
@@ -19,6 +25,7 @@ import { useSaveValidationContext, ValidationActionType } from '@/src/context/Sa
 import { useI18n } from '@/src/locales/client';
 import { ResponseColumn } from '@/src/models/evaluation/test-suite';
 import { JsonataVariable } from '@/src/models/jsonata';
+import { DuplicateResponseColumn } from '@/src/utils/evaluation/request-chain';
 import DocumentationModal from './DocumentationModal';
 
 interface ColumnsProps {
@@ -27,6 +34,7 @@ interface ColumnsProps {
   isSkipRefresh?: boolean;
   responseSchema: JSONSchema7;
   jsonataVariables?: JsonataVariable[];
+  duplicateColumn?: DuplicateResponseColumn;
 }
 
 const Columns: FC<ColumnsProps> = ({
@@ -35,6 +43,7 @@ const Columns: FC<ColumnsProps> = ({
   responseSchema,
   isSkipRefresh,
   jsonataVariables,
+  duplicateColumn,
 }) => {
   const t = useI18n();
   const { isValid, dispatch } = useSaveValidationContext();
@@ -126,8 +135,18 @@ const Columns: FC<ColumnsProps> = ({
     }
   }, [dispatch, isSkipRefresh, rowData]);
 
+  const duplicateMessage = duplicateColumn
+    ? t(
+        duplicateColumn.inPreviousRequest
+          ? TestSuitesI18nKey.DuplicateResponseColumnNameInPreviousRequest
+          : TestSuitesI18nKey.DuplicateResponseColumnName,
+        { name: duplicateColumn.name },
+      )
+    : undefined;
+
   return (
     <div className="flex flex-col gap-4 flex-1 min-h-0">
+      {duplicateMessage && <DialNotification variant={NotificationVariant.Error} message={duplicateMessage} />}
       <div className="flex flex-row justify-between items-center">
         <span className="text-secondary small">{t(TestSuitesI18nKey.ColumnsDescription)}</span>
         <div className="flex flex-row gap-2">

--- a/apps/ai-dial-admin/src/components/TestSuites/EndpointSchema/Columns/tests/Columns.spec.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/EndpointSchema/Columns/tests/Columns.spec.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+import { TestSuitesI18nKey } from '@/src/constants/i18n';
+import Columns from '../Columns';
+
+vi.mock('@/src/components/Grid/GridView/GridView', () => ({
+  default: () => <div>Grid</div>,
+}));
+
+vi.mock('@epam/ai-dial-ui-kit', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@epam/ai-dial-ui-kit')>();
+
+  return {
+    ...actual,
+    DialNotification: ({ message }: { message: string }) => <div role="alert">{message}</div>,
+  };
+});
+
+describe('Columns', () => {
+  test('shows a previous-request duplicate error banner', () => {
+    render(
+      <Columns
+        responseColumns={[{ name: 'answer', displayName: 'answer', expression: 'a', type: 'string' }]}
+        onChangeResponseColumns={vi.fn()}
+        responseSchema={{}}
+        duplicateColumn={{ name: 'answer', inPreviousRequest: true }}
+      />,
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent(TestSuitesI18nKey.DuplicateResponseColumnNameInPreviousRequest);
+  });
+
+  test('shows a sibling duplicate error banner', () => {
+    render(
+      <Columns
+        responseColumns={[
+          { name: 'answer', displayName: 'answer', expression: 'a', type: 'string' },
+          { name: 'answer', displayName: 'answer', expression: 'b', type: 'string' },
+        ]}
+        onChangeResponseColumns={vi.fn()}
+        responseSchema={{}}
+        duplicateColumn={{ name: 'answer', inPreviousRequest: false }}
+      />,
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent(TestSuitesI18nKey.DuplicateResponseColumnName);
+  });
+
+  test('hides the error banner when there is no duplicate', () => {
+    render(
+      <Columns
+        responseColumns={[{ name: 'answer', displayName: 'answer', expression: 'a', type: 'string' }]}
+        onChangeResponseColumns={vi.fn()}
+        responseSchema={{}}
+      />,
+    );
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});

--- a/apps/ai-dial-admin/src/components/TestSuites/EndpointSchema/EndpointSchema.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/EndpointSchema/EndpointSchema.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Dispatch, FC, SetStateAction, useCallback, useState } from 'react';
+import { Dispatch, FC, SetStateAction, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { DialNoDataContent, DialSelect, DialTabs, SelectOption, SelectSize, SelectVariant } from '@epam/ai-dial-ui-kit';
 import { JSONSchema7 } from 'json-schema';
@@ -9,25 +9,61 @@ import SchemaGrid from '@/src/components/Common/SchemaGrid/SchemaGrid';
 import JsonEditor from '@/src/components/EntityTabs/JsonEditor/JsonEditor';
 import { CompareI18nKey, EntitiesI18nKey, TestSuitesI18nKey } from '@/src/constants/i18n';
 import { APPLICATION_JSON_TYPE } from '@/src/constants/request-headers';
+import { useSaveValidationContext, ValidationActionType } from '@/src/context/SaveValidationContext';
 import { useI18n } from '@/src/locales/client';
 import { DialScheme } from '@/src/models/dial/scheme';
 import { ResponseColumn, TestSuite } from '@/src/models/evaluation/test-suite';
 import { JsonataVariable } from '@/src/models/jsonata';
+import { findDuplicateResponseColumnName } from '@/src/utils/evaluation/request-chain';
 import { EntityViewTab, getEndpointSchemaTabs } from '@/src/utils/tabs/utils';
 import Columns from './Columns/Columns';
+
+const COLUMN_UNIQUENESS_FIELD = 'columnUniqueness';
 
 interface Props {
   testSuite: TestSuite;
   onChangeTestSuite: (testSuite: TestSuite, isSkipRefresh?: boolean) => void;
   isSkipRefresh?: boolean;
   jsonataVariables?: JsonataVariable[];
+  takenColumnNames?: string[];
 }
 
-const EndpointSchema: FC<Props> = ({ testSuite, onChangeTestSuite, isSkipRefresh, jsonataVariables }) => {
+const EndpointSchema: FC<Props> = ({
+  testSuite,
+  onChangeTestSuite,
+  isSkipRefresh,
+  jsonataVariables,
+  takenColumnNames = [],
+}) => {
   const t = useI18n();
-  const tabs = getEndpointSchemaTabs(t);
-  const [activeSchemaTab, setActiveSchemaTab] = useState(tabs[0].id);
+  const { dispatch } = useSaveValidationContext();
+  const [activeSchemaTab, setActiveSchemaTab] = useState(getEndpointSchemaTabs(t)[0].id);
   const [isJsonView, setIsJsonView] = useState(false);
+
+  const duplicateColumn = useMemo(
+    () => findDuplicateResponseColumnName(testSuite.responseColumns || [], takenColumnNames),
+    [testSuite.responseColumns, takenColumnNames],
+  );
+
+  const tabs = useMemo(
+    () =>
+      getEndpointSchemaTabs(t).map((tab) =>
+        tab.id === EntityViewTab.Columns ? { ...tab, invalid: !!duplicateColumn } : tab,
+      ),
+    [t, duplicateColumn],
+  );
+
+  useEffect(() => {
+    dispatch({
+      type: ValidationActionType.SetField,
+      field: COLUMN_UNIQUENESS_FIELD,
+      isValid: !duplicateColumn,
+    });
+
+    return () => {
+      dispatch({ type: ValidationActionType.RemoveField, field: COLUMN_UNIQUENESS_FIELD });
+    };
+  }, [dispatch, duplicateColumn]);
 
   const viewOptions: SelectOption[] = [
     { value: 'table', label: t(EntitiesI18nKey.Table) },
@@ -120,6 +156,7 @@ const EndpointSchema: FC<Props> = ({ testSuite, onChangeTestSuite, isSkipRefresh
               responseSchema={(testSuite.endpointRef?.responseBodySchema || {}) as JSONSchema7}
               isSkipRefresh={isSkipRefresh}
               jsonataVariables={jsonataVariables}
+              duplicateColumn={duplicateColumn}
             />
           )}
         </>

--- a/apps/ai-dial-admin/src/components/TestSuites/EndpointSchema/tests/EndpointSchema.spec.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/EndpointSchema/tests/EndpointSchema.spec.tsx
@@ -1,16 +1,69 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, test, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { BasicI18nKey, TestSuitesI18nKey } from '@/src/constants/i18n';
+import { BasicI18nKey, TabsI18nKey, TestSuitesI18nKey } from '@/src/constants/i18n';
+import { ValidationActionType } from '@/src/context/SaveValidationContext';
 import { TestSuite } from '@/src/models/evaluation/test-suite';
 import EndpointSchema from '../EndpointSchema';
+
+const mockDispatch = vi.fn();
+
+vi.mock('@/src/context/SaveValidationContext', () => ({
+  useSaveValidationContext: () => ({ isValid: true, dispatch: mockDispatch }),
+  ValidationActionType: {
+    SetField: 'SET_FIELD_VALIDATION',
+    RemoveField: 'REMOVE_FIELD_VALIDATION',
+  },
+}));
+
+vi.mock('@epam/ai-dial-ui-kit', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@epam/ai-dial-ui-kit')>();
+
+  return {
+    ...actual,
+    DialTabs: ({
+      tabs,
+      onClick,
+    }: {
+      tabs: Array<{ id: string; label: ReactNode; invalid?: boolean }>;
+      onClick: (id: string) => void;
+    }) => (
+      <div role="tablist">
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            role="tab"
+            aria-invalid={tab.invalid ? 'true' : undefined}
+            onClick={() => onClick(tab.id)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+    ),
+  };
+});
 
 vi.mock('@/src/components/Common/SchemaGrid/SchemaGrid', () => ({
   default: () => <button type="button">Basic.AddField</button>,
 }));
 
 vi.mock('../Columns/Columns', () => ({
-  default: () => <div>Columns</div>,
+  default: ({ duplicateColumn }: { duplicateColumn?: { name: string; inPreviousRequest: boolean } }) => (
+    <div>
+      Columns
+      {duplicateColumn && (
+        <div>
+          {duplicateColumn.inPreviousRequest
+            ? TestSuitesI18nKey.DuplicateResponseColumnNameInPreviousRequest
+            : TestSuitesI18nKey.DuplicateResponseColumnName}
+        </div>
+      )}
+    </div>
+  ),
 }));
 
 vi.mock('@/src/components/EntityTabs/JsonEditor/JsonEditor', () => ({
@@ -22,7 +75,16 @@ const configuredSuite: TestSuite = {
   endpointRef: { method: 'POST', relativeUrlPattern: '/v1/chat' },
 };
 
+const suiteWithDuplicateAnswer: TestSuite = {
+  ...configuredSuite,
+  responseColumns: [{ name: 'answer', displayName: 'answer', expression: 'a', type: 'string' }],
+};
+
 describe('EndpointSchema', () => {
+  beforeEach(() => {
+    mockDispatch.mockClear();
+  });
+
   test('shows Change method guidance and hides Add Field when the endpoint is not configured', () => {
     render(<EndpointSchema testSuite={{ id: 'suite-1' }} onChangeTestSuite={vi.fn()} />);
 
@@ -36,5 +98,57 @@ describe('EndpointSchema', () => {
 
     expect(screen.getByRole('button', { name: BasicI18nKey.AddField })).toBeInTheDocument();
     expect(screen.queryByText(TestSuitesI18nKey.ConfigureEndpointFirst)).not.toBeInTheDocument();
+  });
+
+  test('marks the Columns tab invalid and blocks save when a column name is taken', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <EndpointSchema testSuite={suiteWithDuplicateAnswer} onChangeTestSuite={vi.fn()} takenColumnNames={['answer']} />,
+    );
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: ValidationActionType.SetField,
+      field: 'columnUniqueness',
+      isValid: false,
+    });
+
+    const columnsTab = screen.getByRole('tab', { name: TabsI18nKey.Columns });
+    expect(columnsTab).toHaveAttribute('aria-invalid', 'true');
+
+    await user.click(columnsTab);
+
+    expect(screen.getByText(TestSuitesI18nKey.DuplicateResponseColumnNameInPreviousRequest)).toBeInTheDocument();
+  });
+
+  test('marks the Columns tab valid when column names are unique', () => {
+    render(
+      <EndpointSchema
+        testSuite={suiteWithDuplicateAnswer}
+        onChangeTestSuite={vi.fn()}
+        takenColumnNames={['history']}
+      />,
+    );
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: ValidationActionType.SetField,
+      field: 'columnUniqueness',
+      isValid: true,
+    });
+    expect(screen.getByRole('tab', { name: TabsI18nKey.Columns })).not.toHaveAttribute('aria-invalid');
+  });
+
+  test('removes the columnUniqueness field on unmount', () => {
+    const { unmount } = render(
+      <EndpointSchema testSuite={configuredSuite} onChangeTestSuite={vi.fn()} takenColumnNames={[]} />,
+    );
+
+    mockDispatch.mockClear();
+    unmount();
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: ValidationActionType.RemoveField,
+      field: 'columnUniqueness',
+    });
   });
 });

--- a/apps/ai-dial-admin/src/components/TestSuites/Methods/Methods.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/Methods/Methods.tsx
@@ -12,6 +12,7 @@ import { TestSuitesI18nKey } from '@/src/constants/i18n';
 import { useI18n } from '@/src/locales/client';
 import { Deployment } from '@/src/models/evaluation/deployment';
 import { TestSuite, TestSuiteEndpointRef } from '@/src/models/evaluation/test-suite';
+import { uniquifyResponseColumns } from '@/src/utils/evaluation/request-chain';
 import MethodInfo from './MethodInfo';
 import MethodItem from './MethodItem';
 
@@ -20,10 +21,11 @@ interface Props {
   onChange: Dispatch<SetStateAction<TestSuite>>;
   selectedTarget?: Deployment | null;
   isCreate?: boolean;
+  takenColumnNames?: string[];
   children?: ReactNode;
 }
 
-const Methods: FC<Props> = ({ testSuite, selectedTarget, onChange, isCreate, children }) => {
+const Methods: FC<Props> = ({ testSuite, selectedTarget, onChange, isCreate, takenColumnNames = [], children }) => {
   const t = useI18n();
 
   const [activeMethodIndex, setActiveMethodIndex] = useState<number | null>();
@@ -44,6 +46,7 @@ const Methods: FC<Props> = ({ testSuite, selectedTarget, onChange, isCreate, chi
         onChange((prev: TestSuite) => ({
           ...prev,
           ...CHAT_COMPLETION_SUITE,
+          responseColumns: uniquifyResponseColumns(CHAT_COMPLETION_SUITE.responseColumns, takenColumnNames),
         }));
       } else {
         const route = methods[index - 1];
@@ -54,7 +57,7 @@ const Methods: FC<Props> = ({ testSuite, selectedTarget, onChange, isCreate, chi
         }));
       }
     },
-    [methods, onChange],
+    [methods, onChange, takenColumnNames],
   );
 
   useEffect(() => {

--- a/apps/ai-dial-admin/src/components/TestSuites/Methods/tests/Methods.spec.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/Methods/tests/Methods.spec.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import Methods from '../Methods';
 
@@ -145,5 +146,41 @@ describe('Methods component', () => {
     rerender(<Methods testSuite={testSuite} selectedTarget={selectedApplication} onChange={onChange} />);
 
     expect(mockGetDeployment).toHaveBeenCalledTimes(1);
+  });
+
+  test('keeps the default chat-completion column name when it is not taken', async () => {
+    const user = userEvent.setup();
+    const testSuite: any = { endpointRef: {} };
+    const selectedApplication: any = { deploymentId: 'test-deployment', $type: 'application' };
+
+    render(<Methods testSuite={testSuite} selectedTarget={selectedApplication} onChange={onChange} />);
+
+    await user.click(await screen.findByRole('button', { name: 'POST /chat/completions' }));
+
+    const updater = onChange.mock.calls.at(-1)?.[0];
+    expect(typeof updater).toBe('function');
+    expect(updater({}).responseColumns[0]).toEqual(expect.objectContaining({ name: 'answer', displayName: 'answer' }));
+  });
+
+  test('uniquifies the default chat-completion column name against taken names', async () => {
+    const user = userEvent.setup();
+    const testSuite: any = { endpointRef: {} };
+    const selectedApplication: any = { deploymentId: 'test-deployment', $type: 'application' };
+
+    render(
+      <Methods
+        testSuite={testSuite}
+        selectedTarget={selectedApplication}
+        onChange={onChange}
+        takenColumnNames={['answer', 'history']}
+      />,
+    );
+
+    await user.click(await screen.findByRole('button', { name: 'POST /chat/completions' }));
+
+    const updater = onChange.mock.calls.at(-1)?.[0];
+    expect(updater({}).responseColumns[0]).toEqual(
+      expect.objectContaining({ name: 'answer2', displayName: 'answer2' }),
+    );
   });
 });

--- a/apps/ai-dial-admin/src/components/TestSuites/Modals/ChangeMethodModal/ChangeMethodModal.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/Modals/ChangeMethodModal/ChangeMethodModal.tsx
@@ -17,6 +17,7 @@ export interface ChangeMethodModalProps {
   selectedApplication: Deployment | null;
   isOpen?: boolean;
   onClose?: () => void;
+  takenColumnNames?: string[];
 }
 
 const ChangeMethodModal: FC<ChangeMethodModalProps> = ({
@@ -25,6 +26,7 @@ const ChangeMethodModal: FC<ChangeMethodModalProps> = ({
   selectedApplication,
   isOpen = false,
   onClose,
+  takenColumnNames,
 }) => {
   const t = useI18n();
   const { isValid } = useSaveValidationContext();
@@ -60,7 +62,12 @@ const ChangeMethodModal: FC<ChangeMethodModalProps> = ({
       className="h-[800px]"
     >
       <div className="size-full flex flex-col gap-4 px-6 py-4">
-        <Methods selectedTarget={selectedApplication} testSuite={currentSuite} onChange={setCurrentSuite}>
+        <Methods
+          selectedTarget={selectedApplication}
+          testSuite={currentSuite}
+          onChange={setCurrentSuite}
+          takenColumnNames={takenColumnNames}
+        >
           <DialNotification message={t(TestSuitesI18nKey.MethodChangeWarning)} variant={NotificationVariant.Warning} />
         </Methods>
       </div>

--- a/apps/ai-dial-admin/src/components/TestSuites/View/McpToolSchema.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/View/McpToolSchema.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FC, useCallback, useMemo, useState } from 'react';
+import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { DialSelect, DialTabs, SelectOption, SelectSize, SelectVariant } from '@epam/ai-dial-ui-kit';
 import { JSONSchema7 } from 'json-schema';
@@ -10,11 +10,15 @@ import TableView from '@/src/components/Common/ViewSelector/TableView';
 import Columns from '@/src/components/TestSuites/EndpointSchema/Columns/Columns';
 import { TOOL_SCHEMA_COLUMNS } from '@/src/constants/grid-columns/grid-columns';
 import { CompareI18nKey, EntitiesI18nKey, TestSuitesI18nKey } from '@/src/constants/i18n';
+import { useSaveValidationContext, ValidationActionType } from '@/src/context/SaveValidationContext';
 import { useI18n } from '@/src/locales/client';
 import { DialScheme } from '@/src/models/dial/scheme';
 import { ResponseColumn, TestSuite } from '@/src/models/evaluation/test-suite';
+import { findDuplicateResponseColumnName } from '@/src/utils/evaluation/request-chain';
 import { EntityViewTab, getMcpToolSchemaTabs } from '@/src/utils/tabs/utils';
 import { convertSchemaToTable } from '@/src/utils/schema';
+
+const COLUMN_UNIQUENESS_FIELD = 'columnUniqueness';
 
 interface Props {
   testSuite: TestSuite;
@@ -24,11 +28,36 @@ interface Props {
 
 const McpToolSchema: FC<Props> = ({ testSuite, onChangeTestSuite, isSkipRefresh }) => {
   const t = useI18n();
-  const tabs = getMcpToolSchemaTabs(t);
-  const [activeTab, setActiveTab] = useState(tabs[0].id);
+  const { dispatch } = useSaveValidationContext();
+  const [activeTab, setActiveTab] = useState(getMcpToolSchemaTabs(t)[0].id);
   const [isJsonView, setIsJsonView] = useState(false);
 
   const SCHEMA_COLUMNS = useMemo(() => TOOL_SCHEMA_COLUMNS(t), [t]);
+
+  const duplicateColumn = useMemo(
+    () => findDuplicateResponseColumnName(testSuite.responseColumns || [], []),
+    [testSuite.responseColumns],
+  );
+
+  const tabs = useMemo(
+    () =>
+      getMcpToolSchemaTabs(t).map((tab) =>
+        tab.id === EntityViewTab.Columns ? { ...tab, invalid: !!duplicateColumn } : tab,
+      ),
+    [t, duplicateColumn],
+  );
+
+  useEffect(() => {
+    dispatch({
+      type: ValidationActionType.SetField,
+      field: COLUMN_UNIQUENESS_FIELD,
+      isValid: !duplicateColumn,
+    });
+
+    return () => {
+      dispatch({ type: ValidationActionType.RemoveField, field: COLUMN_UNIQUENESS_FIELD });
+    };
+  }, [dispatch, duplicateColumn]);
 
   const viewOptions: SelectOption[] = [
     { value: 'table', label: t(EntitiesI18nKey.Table) },
@@ -104,6 +133,7 @@ const McpToolSchema: FC<Props> = ({ testSuite, onChangeTestSuite, isSkipRefresh 
           onChangeResponseColumns={onChangeResponseColumns}
           responseSchema={(toolRef?.outputSchema || {}) as JSONSchema7}
           isSkipRefresh={isSkipRefresh}
+          duplicateColumn={duplicateColumn}
         />
       )}
     </div>

--- a/apps/ai-dial-admin/src/components/TestSuites/View/MethodTabContent.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/View/MethodTabContent.tsx
@@ -33,6 +33,7 @@ import {
   getRequestCount,
   getRequestLabel,
   getRequestName,
+  getTakenResponseColumnNames,
   removeRequestAt,
   toRequestView,
   updateRequestName,
@@ -120,6 +121,11 @@ const DeploymentMethodContent: FC<Props> = ({ testSuite, onChange, isSkipRefresh
     [testSuite, selectedRequestIndex, describeRequest],
   );
 
+  const takenColumnNames = useMemo(
+    () => getTakenResponseColumnNames(testSuite, selectedRequestIndex),
+    [testSuite, selectedRequestIndex],
+  );
+
   const previousColumnNames = previousOutputVariables.map((variable) => `$${variable.name}`);
   const previousOutputsMessage = previousColumnNames.length
     ? t(TestSuitesI18nKey.RequestChainPreviousOutputsColumnsInfo, { columns: previousColumnNames.join(', ') })
@@ -182,6 +188,7 @@ const DeploymentMethodContent: FC<Props> = ({ testSuite, onChange, isSkipRefresh
           onChangeTestSuite={onChangeRequestView}
           isSkipRefresh={isSkipRefresh}
           jsonataVariables={previousOutputVariables}
+          takenColumnNames={takenColumnNames}
         />
 
         {isChangeMethodModalOpen &&
@@ -192,6 +199,7 @@ const DeploymentMethodContent: FC<Props> = ({ testSuite, onChange, isSkipRefresh
               selectedApplication={selectedApplication}
               isOpen={isChangeMethodModalOpen}
               onClose={() => setIsChangeMethodModalOpen(false)}
+              takenColumnNames={takenColumnNames}
             />,
             document.body,
           )}

--- a/apps/ai-dial-admin/src/constants/i18n.ts
+++ b/apps/ai-dial-admin/src/constants/i18n.ts
@@ -1867,6 +1867,8 @@ export enum TestSuitesI18nKey {
   EditField = 'TestSuites.EditField',
   NoSchemaFields = 'TestSuites.NoSchemaFields',
   DuplicateFieldName = 'TestSuites.DuplicateFieldName',
+  DuplicateResponseColumnName = 'TestSuites.DuplicateResponseColumnName',
+  DuplicateResponseColumnNameInPreviousRequest = 'TestSuites.DuplicateResponseColumnNameInPreviousRequest',
   MetricNameInvalidChars = 'TestSuites.MetricNameInvalidChars',
   SchemaDescription = 'TestSuites.SchemaDescription',
   FinalPath = 'TestSuites.FinalPath',

--- a/apps/ai-dial-admin/src/locales/en.ts
+++ b/apps/ai-dial-admin/src/locales/en.ts
@@ -1911,6 +1911,8 @@ export default {
     EditField: 'Edit field',
     NoSchemaFields: 'No schema fields',
     DuplicateFieldName: 'Field name already exists',
+    DuplicateResponseColumnName: "Column name '{name}' is already used.",
+    DuplicateResponseColumnNameInPreviousRequest: "Column name '{name}' is already used in a previous request.",
     MetricNameInvalidChars: 'Name must not contain "::" symbols',
     SchemaDescription: 'Define the data fields available in test cases',
     FinalPath: 'Final path',

--- a/apps/ai-dial-admin/src/utils/evaluation/request-chain.ts
+++ b/apps/ai-dial-admin/src/utils/evaluation/request-chain.ts
@@ -81,6 +81,88 @@ export const getChainResponseColumns = (suite: TestSuite): ResponseColumn[] => [
   ...(suite.additionalRequests ?? []).flatMap((request: TestSuiteAdditionalRequest) => request.responseColumns ?? []),
 ];
 
+/** Column names already used by every chain request except `excludeIndex`. */
+export const getTakenResponseColumnNames = (suite: TestSuite, excludeIndex: number): string[] => {
+  const names: string[] = [];
+
+  if (excludeIndex !== 0) {
+    names.push(...(suite.responseColumns ?? []).map((column) => column.name).filter(Boolean));
+  }
+
+  (suite.additionalRequests ?? []).forEach((request, index) => {
+    if (index + 1 === excludeIndex) {
+      return;
+    }
+    names.push(...(request.responseColumns ?? []).map((column) => column.name).filter(Boolean));
+  });
+
+  return names;
+};
+
+export const uniqueResponseColumnName = (base: string, taken: Iterable<string>): string => {
+  const takenSet = new Set(taken);
+  if (!base || !takenSet.has(base)) {
+    return base;
+  }
+
+  let suffix = 2;
+  while (takenSet.has(`${base}${suffix}`)) {
+    suffix += 1;
+  }
+
+  return `${base}${suffix}`;
+};
+
+export const uniquifyResponseColumns = (columns: ResponseColumn[], taken: Iterable<string>): ResponseColumn[] => {
+  const takenSet = new Set(taken);
+
+  return columns.map((column) => {
+    const name = uniqueResponseColumnName(column.name, takenSet);
+    takenSet.add(name);
+    if (name === column.name) {
+      return column;
+    }
+
+    return { ...column, name, displayName: name };
+  });
+};
+
+export interface DuplicateResponseColumn {
+  name: string;
+  inPreviousRequest: boolean;
+}
+
+/**
+ * First non-blank column name that collides with `taken` (another request) or a sibling
+ * in `columns`. Prefer a previous-request collision when both apply for the same name.
+ */
+export const findDuplicateResponseColumnName = (
+  columns: ResponseColumn[],
+  taken: Iterable<string>,
+): DuplicateResponseColumn | undefined => {
+  const takenSet = new Set(taken);
+  const seen = new Set<string>();
+
+  for (const column of columns) {
+    const name = column.name;
+    if (!name) {
+      continue;
+    }
+
+    if (takenSet.has(name)) {
+      return { name, inPreviousRequest: true };
+    }
+
+    if (seen.has(name)) {
+      return { name, inPreviousRequest: false };
+    }
+
+    seen.add(name);
+  }
+
+  return undefined;
+};
+
 /**
  * JSONata variables that request `index` inherits from the chain — one per named response column of
  * every preceding request, in chain order. `describeRequest` receives the producing request's index so

--- a/apps/ai-dial-admin/src/utils/evaluation/tests/request-chain.spec.ts
+++ b/apps/ai-dial-admin/src/utils/evaluation/tests/request-chain.spec.ts
@@ -9,8 +9,12 @@ import {
   getRequestCount,
   getRequestLabel,
   getRequestName,
+  getTakenResponseColumnNames,
+  findDuplicateResponseColumnName,
   removeRequestAt,
   toRequestView,
+  uniqueResponseColumnName,
+  uniquifyResponseColumns,
   updateRequestName,
 } from '../request-chain';
 import { TestSuite } from '@/src/models/evaluation/test-suite';
@@ -346,5 +350,129 @@ describe('getPreviousOutputVariables', () => {
 
     expect(getPreviousOutputVariables(sparseSuite, 2)).toEqual([]);
     expect(getPreviousOutputVariables(sparseSuite, 3)).toEqual([{ name: 'b', description: undefined }]);
+  });
+});
+
+describe('getTakenResponseColumnNames', () => {
+  const suite: TestSuite = {
+    responseColumns: [{ name: 'answer', displayName: 'answer', expression: 'a', type: 'string' }],
+    additionalRequests: [
+      { responseColumns: [{ name: 'verification', displayName: 'verification', expression: 'v', type: 'string' }] },
+      { responseColumns: [{ name: 'answer2', displayName: 'answer2', expression: 'a', type: 'string' }] },
+    ],
+  };
+
+  test('excludes request 0 columns when excludeIndex is 0', () => {
+    expect(getTakenResponseColumnNames(suite, 0)).toEqual(['verification', 'answer2']);
+  });
+
+  test('includes request 0 columns and skips the excluded additional request', () => {
+    expect(getTakenResponseColumnNames(suite, 2)).toEqual(['answer', 'verification']);
+  });
+
+  test('returns an empty array when the suite has no columns', () => {
+    expect(getTakenResponseColumnNames({}, 0)).toEqual([]);
+  });
+
+  test('skips blank column names', () => {
+    expect(
+      getTakenResponseColumnNames({ responseColumns: [{ name: '', displayName: '', expression: '', type: '' }] }, 1),
+    ).toEqual([]);
+  });
+});
+
+describe('uniqueResponseColumnName', () => {
+  test('returns the base name when it is not taken', () => {
+    expect(uniqueResponseColumnName('answer', [])).toBe('answer');
+    expect(uniqueResponseColumnName('answer', ['history'])).toBe('answer');
+  });
+
+  test('appends 2 when the base name is taken', () => {
+    expect(uniqueResponseColumnName('answer', ['answer'])).toBe('answer2');
+  });
+
+  test('increments the suffix until the name is free', () => {
+    expect(uniqueResponseColumnName('answer', ['answer', 'answer2', 'answer3'])).toBe('answer4');
+  });
+
+  test('returns an empty string unchanged', () => {
+    expect(uniqueResponseColumnName('', ['answer'])).toBe('');
+  });
+});
+
+describe('uniquifyResponseColumns', () => {
+  test('leaves columns unchanged when their names are free', () => {
+    const columns = [{ name: 'answer', displayName: 'answer', expression: 'a', type: 'string' }];
+
+    expect(uniquifyResponseColumns(columns, [])).toEqual(columns);
+  });
+
+  test('renames name and displayName together when the name is taken', () => {
+    const columns = [{ name: 'answer', displayName: 'answer', expression: 'a', type: 'string' }];
+
+    expect(uniquifyResponseColumns(columns, ['answer'])).toEqual([
+      { name: 'answer2', displayName: 'answer2', expression: 'a', type: 'string' },
+    ]);
+  });
+
+  test('does not mutate the input columns', () => {
+    const columns = [{ name: 'answer', displayName: 'answer', expression: 'a', type: 'string' }];
+
+    uniquifyResponseColumns(columns, ['answer']);
+
+    expect(columns[0].name).toBe('answer');
+  });
+});
+
+describe('findDuplicateResponseColumnName', () => {
+  test('returns undefined when all names are unique', () => {
+    expect(
+      findDuplicateResponseColumnName([{ name: 'answer', displayName: 'answer', expression: 'a', type: 'string' }], []),
+    ).toBeUndefined();
+  });
+
+  test('flags a name already used in a previous request', () => {
+    expect(
+      findDuplicateResponseColumnName(
+        [{ name: 'answer', displayName: 'answer', expression: 'a', type: 'string' }],
+        ['answer'],
+      ),
+    ).toEqual({ name: 'answer', inPreviousRequest: true });
+  });
+
+  test('flags a sibling duplicate within the same request', () => {
+    expect(
+      findDuplicateResponseColumnName(
+        [
+          { name: 'answer', displayName: 'answer', expression: 'a', type: 'string' },
+          { name: 'answer', displayName: 'answer', expression: 'b', type: 'string' },
+        ],
+        [],
+      ),
+    ).toEqual({ name: 'answer', inPreviousRequest: false });
+  });
+
+  test('prefers a previous-request collision when both apply for the same name', () => {
+    expect(
+      findDuplicateResponseColumnName(
+        [
+          { name: 'answer', displayName: 'answer', expression: 'a', type: 'string' },
+          { name: 'answer', displayName: 'answer', expression: 'b', type: 'string' },
+        ],
+        ['answer'],
+      ),
+    ).toEqual({ name: 'answer', inPreviousRequest: true });
+  });
+
+  test('skips blank column names', () => {
+    expect(
+      findDuplicateResponseColumnName(
+        [
+          { name: '', displayName: '', expression: '', type: '' },
+          { name: 'answer', displayName: 'answer', expression: 'a', type: 'string' },
+        ],
+        [''],
+      ),
+    ).toBeUndefined();
   });
 });


### PR DESCRIPTION
Uniquify default chat-completion column names across the request chain, and block save with a Columns tab error marker and banner when a duplicate name remains.

**Description:**

<SHORT_DESCRIPTION>

Issues:

- Issue #4294


**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
