### PR TITLE
feat: [Eval][Test Suites] Try Out Columns tab shows extracted values only for the first request in a chain (Issue #4302)

### DIFF
--- a/apps/ai-dial-admin/src/components/TestSuites/RequestTemplate/components/TryOut.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/RequestTemplate/components/TryOut.tsx
@@ -29,9 +29,11 @@ import {
   normalizeResponseBodyForColumns,
   unwrapJsonRequestBody,
 } from '@/src/components/TestSuites/utils/column-eval-context';
+import { getRequestTurnCounts, getTryOutSectionShape } from '@/src/utils/evaluation/tryout-sections';
 import CollapsibleSection from './CollapsibleSection';
 import TryOutColumns from './TryOutColumns';
 import TryOutRequestPreview from './TryOutRequestPreview';
+import TryOutRequestTabs from './TryOutRequestTabs';
 import TryOutResponsePreview from './TryOutResponse';
 
 export interface TryOutResponse {
@@ -87,6 +89,21 @@ const TryOut: FC<Props> = ({ testSuite, testCaseId, schema, initialTestCase }) =
   const [history, setHistory] = useState<TryOutHistoryEntry[] | undefined>(undefined);
   const [isRequestSend, setIsRequestSend] = useState(false);
   const [grafanaTraceUrl, setGrafanaTraceUrl] = useState<string | undefined>(undefined);
+  const [selectedRequestIndex, setSelectedRequestIndex] = useState(0);
+  const [isPreviewLoading, setIsPreviewLoading] = useState(() => !response && !!testCaseId);
+
+  const multiTurnLength = initialTestCase?.multiTurnData?.length ?? 0;
+  const turnCounts = useMemo(
+    () => getRequestTurnCounts(testSuite, schema, multiTurnLength),
+    [testSuite, schema, multiTurnLength],
+  );
+  const shape = useMemo(() => getTryOutSectionShape(turnCounts), [turnCounts]);
+  const showRequestTabs = turnCounts.length > 1 && (shape === 'requests' || shape === 'combined');
+  const renderRequestTabs =
+    showRequestTabs &&
+    !isRequestSend &&
+    !isPreviewLoading &&
+    ((!response && !!testCaseId) || (!!response && !!history?.length));
 
   const onChangeRequestBody = useCallback((body: Record<string, unknown>) => {
     setRequestBody(body);
@@ -141,6 +158,10 @@ const TryOut: FC<Props> = ({ testSuite, testCaseId, schema, initialTestCase }) =
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  useEffect(() => {
+    setSelectedRequestIndex(0);
+  }, [history]);
+
   const responseBody = <TryOutResponseBody response={response} isRequestSend={isRequestSend} growOnOpen />;
   const columnsResponseBody = (
     <TryOutResponseBody response={response} isRequestSend={isRequestSend} growOnOpen={false} />
@@ -184,6 +205,13 @@ const TryOut: FC<Props> = ({ testSuite, testCaseId, schema, initialTestCase }) =
             <Tabs tabs={tabs} activeTab={activeTab} onChangeActiveTab={setActiveTab} />
           </div>
         ) : null}
+        {renderRequestTabs ? (
+          <TryOutRequestTabs
+            testSuite={testSuite}
+            selectedIndex={selectedRequestIndex}
+            onSelect={setSelectedRequestIndex}
+          />
+        ) : null}
 
         {activeTab === EntityViewTab.Response && (
           <>
@@ -198,6 +226,8 @@ const TryOut: FC<Props> = ({ testSuite, testCaseId, schema, initialTestCase }) =
                   isRequestSend={isRequestSend}
                   requestBody={requestBody}
                   onChangeRequestBody={onChangeRequestBody}
+                  selectedRequestIndex={renderRequestTabs ? selectedRequestIndex : undefined}
+                  onLoadingChange={setIsPreviewLoading}
                 />
               )}
 
@@ -213,6 +243,7 @@ const TryOut: FC<Props> = ({ testSuite, testCaseId, schema, initialTestCase }) =
                   testSuite={testSuite}
                   schema={schema}
                   multiTurnData={initialTestCase?.multiTurnData}
+                  selectedRequestIndex={renderRequestTabs ? selectedRequestIndex : undefined}
                 />
               )}
             </div>
@@ -231,11 +262,16 @@ const TryOut: FC<Props> = ({ testSuite, testCaseId, schema, initialTestCase }) =
 
         {activeTab === EntityViewTab.Columns && (
           <TryOutColumns
+            testSuite={testSuite}
+            history={history}
+            schema={schema}
+            multiTurnData={initialTestCase?.multiTurnData}
             columns={testSuite.responseColumns}
             response={normalizeResponseBodyForColumns(response?.body as Record<string, unknown>)}
             request={unwrapJsonRequestBody(resolvedRequest.body as Record<string, unknown> | undefined)}
             isLoading={isRequestSend}
             responseBody={columnsResponseBody}
+            selectedRequestIndex={renderRequestTabs ? selectedRequestIndex : undefined}
           />
         )}
       </>

--- a/apps/ai-dial-admin/src/components/TestSuites/RequestTemplate/components/TryOutColumns.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/RequestTemplate/components/TryOutColumns.tsx
@@ -1,82 +1,182 @@
 'use client';
-import { FC, ReactNode, useEffect, useState } from 'react';
+import { FC, ReactNode, useEffect, useMemo, useState } from 'react';
 
 import { DialLoader, DialTag } from '@epam/ai-dial-ui-kit';
 import classNames from 'classnames';
 import { capitalize } from 'lodash';
 
-import { evaluateColumns, EvaluatedColumn } from '@/src/components/TestSuites/utils/evaluate-columns';
-import { TestSuitesI18nKey, ValidityStatusI18nKey } from '@/src/constants/i18n';
+import CopyButton from '@/src/components/Common/CopyButton/CopyButton';
+import JsonEditor from '@/src/components/EntityTabs/JsonEditor/JsonEditor';
+import {
+  evaluateTryOutColumnSections,
+  EvaluatedColumn,
+  TryOutColumnTurnResult,
+  TryOutColumnResults,
+} from '@/src/components/TestSuites/utils/evaluate-columns';
+import { BasicI18nKey, TestSuitesI18nKey, ValidityStatusI18nKey } from '@/src/constants/i18n';
 import { useI18n } from '@/src/locales/client';
-import { ResponseColumn } from '@/src/models/evaluation/test-suite';
+import { ResponseColumn, TestCaseSchema, TestSuite, TryOutHistoryEntry } from '@/src/models/evaluation/test-suite';
 import CollapsibleSection from './CollapsibleSection';
-
-const hasContent = (value?: Record<string, unknown>): boolean => !!value && Object.keys(value).length > 0;
 
 interface Props {
   isLoading?: boolean;
   responseBody: ReactNode;
+  testSuite: TestSuite;
+  history?: TryOutHistoryEntry[];
+  schema?: TestCaseSchema[];
+  multiTurnData?: Record<string, unknown>[];
   columns?: ResponseColumn[];
   response?: Record<string, unknown>;
   request?: Record<string, unknown>;
+  selectedRequestIndex?: number;
 }
 
-const TryOutColumns: FC<Props> = ({ isLoading, responseBody, columns, response, request }) => {
+const ColumnResultsList: FC<{ columns: EvaluatedColumn[] }> = ({ columns }) => {
   const t = useI18n();
-  const [evaluatedColumns, setEvaluatedColumns] = useState<EvaluatedColumn[]>([]);
+
+  return (
+    <div className="flex flex-col gap-3">
+      {columns.map((column, index) => (
+        <div
+          key={`${column.name}-${index}`}
+          className={classNames(
+            'flex flex-col gap-2 rounded p-3 border',
+            column.valid ? 'border-success bg-success' : 'border-error bg-error',
+          )}
+        >
+          <div className="flex flex-row justify-between items-center">
+            <div className="flex flex-row gap-2 items-center">
+              <div className="small-text-semi text-primary">{column.name}</div>
+              <DialTag label={capitalize(column.type)} />
+            </div>
+            <DialTag
+              label={column.valid ? t(ValidityStatusI18nKey.Valid) : t(ValidityStatusI18nKey.Invalid)}
+              className={classNames(
+                column.valid
+                  ? 'border-success bg-controls-accent-success-alpha-hover'
+                  : 'border-error bg-controls-error-alpha-hover',
+              )}
+            />
+          </div>
+          <div className="text-secondary text-sm">{column.expression}</div>
+          <div className="text-primary text-sm overflow-auto">{column.result !== null ? column.result : 'Null'}</div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const TurnColumnSection: FC<{ turn: TryOutColumnTurnResult; showTurnLabel: boolean }> = ({ turn, showTurnLabel }) => {
+  const t = useI18n();
+  const copyText = useMemo(
+    () => (turn.responseBody != null ? JSON.stringify(turn.responseBody, null, 2) : ''),
+    [turn.responseBody],
+  );
+
+  return (
+    <div className="flex flex-col gap-y-4 shrink-0">
+      {showTurnLabel ? (
+        <h2 className="dial-small-text font-semibold">
+          {t(TestSuitesI18nKey.TurnLabel, { index: turn.turnIndex + 1 })}
+        </h2>
+      ) : null}
+      <ColumnResultsList columns={turn.columns} />
+      <CollapsibleSection
+        title={t(BasicI18nKey.Response)}
+        fullViewContent={copyText}
+        headerIcon={<CopyButton value={copyText} valueLabel={t(BasicI18nKey.Response)} />}
+        growOnOpen={false}
+      >
+        <div className="h-64">
+          <JsonEditor
+            entity={(turn.responseBody ?? null) as object | null}
+            options={{ stickyScroll: { enabled: false }, wordWrap: 'off' }}
+            readonly={true}
+          />
+        </div>
+      </CollapsibleSection>
+    </div>
+  );
+};
+
+const TryOutColumns: FC<Props> = ({
+  isLoading,
+  responseBody,
+  testSuite,
+  history,
+  schema,
+  multiTurnData,
+  columns,
+  response,
+  request,
+  selectedRequestIndex = 0,
+}) => {
+  const t = useI18n();
+  const [results, setResults] = useState<TryOutColumnResults>({ shape: 'single', flatColumns: [] });
   const [isEvaluating, setIsEvaluating] = useState(false);
 
   useEffect(() => {
-    if (!hasContent(response) && !hasContent(request)) return;
+    let cancelled = false;
+
     setIsEvaluating(true);
-    evaluateColumns(columns || [], response || {}, request)
+    evaluateTryOutColumnSections({
+      testSuite,
+      history,
+      schema,
+      multiTurnLength: multiTurnData?.length ?? 0,
+      fallbackColumns: columns || [],
+      fallbackResponse: response || {},
+      fallbackRequest: request,
+    })
       .then((res) => {
-        setEvaluatedColumns(res);
+        if (!cancelled) {
+          setResults(res);
+        }
       })
       .finally(() => {
-        setIsEvaluating(false);
+        if (!cancelled) {
+          setIsEvaluating(false);
+        }
       });
-  }, [columns, response, request]);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [testSuite, history, schema, multiTurnData, columns, response, request]);
+
+  const renderGrouped = () => {
+    const group = results.groups?.find((item) => item.requestIndex === selectedRequestIndex);
+    if (!group?.turns.length) {
+      return null;
+    }
+
+    return (
+      <div className="flex flex-col gap-y-6">
+        {group.turns.map((turn) => (
+          <TurnColumnSection
+            key={`turn-${group.requestIndex}-${turn.turnIndex}`}
+            turn={turn}
+            showTurnLabel={group.showTurnLabels}
+          />
+        ))}
+      </div>
+    );
+  };
+
+  const showGrouped = results.shape === 'requests' || results.shape === 'combined';
 
   return (
     <div className="flex-1 flex flex-col gap-y-8 pb-2 min-h-0 overflow-auto">
-      <CollapsibleSection title={t(TestSuitesI18nKey.Results)}>
-        {isLoading || isEvaluating ? (
-          <DialLoader />
-        ) : (
-          <div className="flex flex-col gap-3">
-            {evaluatedColumns.map((column, index) => (
-              <div
-                key={`${column.name}-${index}`}
-                className={classNames(
-                  'flex flex-col gap-2 rounded p-3 border',
-                  column.valid ? 'border-success bg-success' : 'border-error bg-error',
-                )}
-              >
-                <div className="flex flex-row justify-between items-center">
-                  <div className="flex flex-row gap-2 items-center">
-                    <div className="small-text-semi text-primary">{column.name}</div>
-                    <DialTag label={capitalize(column.type)} />
-                  </div>
-                  <DialTag
-                    label={column.valid ? t(ValidityStatusI18nKey.Valid) : t(ValidityStatusI18nKey.Invalid)}
-                    className={classNames(
-                      column.valid
-                        ? 'border-success bg-controls-accent-success-alpha-hover'
-                        : 'border-error bg-controls-error-alpha-hover',
-                    )}
-                  />
-                </div>
-                <div className="text-secondary text-sm">{column.expression}</div>
-                <div className="text-primary text-sm overflow-auto">
-                  {column.result !== null ? column.result : 'Null'}
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
-      </CollapsibleSection>
-      {responseBody}
+      {isLoading || isEvaluating ? (
+        <DialLoader />
+      ) : showGrouped ? (
+        renderGrouped()
+      ) : (
+        <CollapsibleSection title={t(TestSuitesI18nKey.Results)}>
+          <ColumnResultsList columns={results.flatColumns ?? []} />
+        </CollapsibleSection>
+      )}
+      {!showGrouped ? responseBody : null}
     </div>
   );
 };

--- a/apps/ai-dial-admin/src/components/TestSuites/RequestTemplate/components/TryOutRequestPreview.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/RequestTemplate/components/TryOutRequestPreview.tsx
@@ -22,7 +22,6 @@ import {
   shouldShowTurnLabels,
   TryOutSectionGroup,
 } from '@/src/utils/evaluation/tryout-sections';
-import CollapsibleSection from './CollapsibleSection';
 import Variables from './Variables';
 
 interface Props {
@@ -34,6 +33,8 @@ interface Props {
   isRequestSend?: boolean;
   requestBody: Record<string, unknown>;
   onChangeRequestBody: (body: Record<string, unknown>) => void;
+  selectedRequestIndex?: number;
+  onLoadingChange?: (loading: boolean) => void;
 }
 
 const TryOutRequestPreview: FC<Props> = ({
@@ -45,11 +46,13 @@ const TryOutRequestPreview: FC<Props> = ({
   isRequestSend,
   requestBody,
   onChangeRequestBody,
+  selectedRequestIndex = 0,
+  onLoadingChange,
 }) => {
   const t = useI18n();
   const [variables, setVariables] = useState<TemplateVariable[]>([]);
   const [testCase, setTestCase] = useState<TestCase | null>(initialTestCase ?? null);
-  const [isVariablesLoading, setIsVariablesLoading] = useState(false);
+  const [isVariablesLoading, setIsVariablesLoading] = useState(true);
 
   useEffect(() => {
     const fetchVariables = async () => {
@@ -89,6 +92,10 @@ const TryOutRequestPreview: FC<Props> = ({
     void fetchVariables();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    onLoadingChange?.(isVariablesLoading);
+  }, [isVariablesLoading, onLoadingChange]);
 
   const perTurnFields = useMemo(() => perTurnFieldNames(schema), [schema]);
   const multiTurnData = testCase?.multiTurnData;
@@ -170,34 +177,24 @@ const TryOutRequestPreview: FC<Props> = ({
       );
     }
 
-    if (shape === 'requests') {
-      return groupedSlots.flatMap((group) =>
-        group.turns.map(({ item }) =>
-          renderVariables(
-            item.variables,
-            `r-${group.requestIndex}`,
-            t(TestSuitesI18nKey.RequestLabel, { index: group.requestIndex + 1 }),
-          ),
+    if (shape === 'requests' || shape === 'combined') {
+      const group = groupedSlots.find((item) => item.requestIndex === selectedRequestIndex);
+      if (!group) {
+        return null;
+      }
+
+      const showTurnLabels = shouldShowTurnLabels(group, turnCounts);
+
+      return group.turns.map(({ turnIndex, item }) =>
+        renderVariables(
+          item.variables,
+          `${shape}-${group.requestIndex}-${turnIndex}`,
+          showTurnLabels ? t(TestSuitesI18nKey.TurnLabel, { index: turnIndex + 1 }) : undefined,
         ),
       );
     }
 
-    return groupedSlots.map((group) => {
-      const requestTitle = t(TestSuitesI18nKey.RequestLabel, { index: group.requestIndex + 1 });
-      const showTurnLabels = shouldShowTurnLabels(group, turnCounts);
-
-      return (
-        <CollapsibleSection key={`req-${group.requestIndex}`} title={requestTitle} defaultOpen growOnOpen={false}>
-          {group.turns.map(({ turnIndex, item }) =>
-            renderVariables(
-              item.variables,
-              `c-${group.requestIndex}-${turnIndex}`,
-              showTurnLabels ? t(TestSuitesI18nKey.TurnLabel, { index: turnIndex + 1 }) : undefined,
-            ),
-          )}
-        </CollapsibleSection>
-      );
-    });
+    return null;
   })();
 
   return isVariablesLoading || isRequestSend ? (

--- a/apps/ai-dial-admin/src/components/TestSuites/RequestTemplate/components/TryOutRequestTabs.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/RequestTemplate/components/TryOutRequestTabs.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { FC, useMemo } from 'react';
+
+import { DialTabs, TabModel } from '@epam/ai-dial-ui-kit';
+
+import { TestSuitesI18nKey } from '@/src/constants/i18n';
+import { useI18n } from '@/src/locales/client';
+import { TestSuite } from '@/src/models/evaluation/test-suite';
+import { getRequestCount, getRequestLabel } from '@/src/utils/evaluation/request-chain';
+
+interface Props {
+  testSuite: TestSuite;
+  selectedIndex: number;
+  onSelect: (index: number) => void;
+}
+
+const TryOutRequestTabs: FC<Props> = ({ testSuite, selectedIndex, onSelect }) => {
+  const t = useI18n();
+  const requestWord = t(TestSuitesI18nKey.Request);
+
+  const tabs: TabModel[] = useMemo(
+    () =>
+      Array.from({ length: getRequestCount(testSuite) }, (_, index) => ({
+        id: String(index),
+        label: getRequestLabel(testSuite, index, requestWord),
+      })),
+    [testSuite, requestWord],
+  );
+
+  return <DialTabs tabs={tabs} activeTab={String(selectedIndex)} onClick={(id) => onSelect(Number(id))} />;
+};
+
+export default TryOutRequestTabs;

--- a/apps/ai-dial-admin/src/components/TestSuites/RequestTemplate/components/TryOutResponse.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/RequestTemplate/components/TryOutResponse.tsx
@@ -35,6 +35,7 @@ interface Props {
   testSuite?: TestSuite;
   schema?: TestCaseSchema[];
   multiTurnData?: Record<string, unknown>[];
+  selectedRequestIndex?: number;
 }
 
 const JsonCollapsible: FC<{
@@ -108,6 +109,7 @@ const TryOutResponsePreview: FC<Props> = ({
   testSuite,
   schema,
   multiTurnData,
+  selectedRequestIndex = 0,
 }) => {
   const t = useI18n();
   const requestBody = resolvedRequest.body as object;
@@ -150,37 +152,26 @@ const TryOutResponsePreview: FC<Props> = ({
       );
     }
 
-    if (shape === 'requests') {
-      return groups.flatMap((group) =>
-        group.turns.map(({ turnIndex, item }) => (
-          <HistoryEntryPair
-            key={`r-${group.requestIndex}-${turnIndex}`}
-            entry={item}
-            isRequestSend={isRequestSend}
-            sectionTitle={t(TestSuitesI18nKey.RequestLabel, { index: group.requestIndex + 1 })}
-          />
-        )),
-      );
-    }
+    if (shape === 'requests' || shape === 'combined') {
+      const group = groups.find((item) => item.requestIndex === selectedRequestIndex);
+      if (!group) {
+        return null;
+      }
 
-    return groups.map((group) => {
-      const requestTitle = t(TestSuitesI18nKey.RequestLabel, { index: group.requestIndex + 1 });
       const showTurnLabels = shouldShowTurnLabels(group, turnCounts);
 
-      return (
-        <CollapsibleSection key={`req-${group.requestIndex}`} title={requestTitle} defaultOpen growOnOpen={false}>
-          {group.turns.map(({ turnIndex, item }) => (
-            <HistoryEntryPair
-              key={`c-${group.requestIndex}-${turnIndex}`}
-              entry={item}
-              isRequestSend={isRequestSend}
-              sectionTitle={showTurnLabels ? t(TestSuitesI18nKey.TurnLabel, { index: turnIndex + 1 }) : undefined}
-            />
-          ))}
-        </CollapsibleSection>
-      );
-    });
-  }, [history, shape, groups, turnCounts, isRequestSend, t]);
+      return group.turns.map(({ turnIndex, item }) => (
+        <HistoryEntryPair
+          key={`${shape}-${group.requestIndex}-${turnIndex}`}
+          entry={item}
+          isRequestSend={isRequestSend}
+          sectionTitle={showTurnLabels ? t(TestSuitesI18nKey.TurnLabel, { index: turnIndex + 1 }) : undefined}
+        />
+      ));
+    }
+
+    return null;
+  }, [history, shape, groups, turnCounts, isRequestSend, t, selectedRequestIndex]);
 
   return (
     <>

--- a/apps/ai-dial-admin/src/components/TestSuites/RequestTemplate/tests/TryOut.spec.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/RequestTemplate/tests/TryOut.spec.tsx
@@ -3,10 +3,11 @@ import userEvent from '@testing-library/user-event';
 import { ReactNode } from 'react';
 import { describe, expect, test, vi } from 'vitest';
 
-import { tryOutTestSuite } from '@/src/app/[lang]/test-suites/actions';
+import { getTestCaseTemplateVariables, tryOutTestCase, tryOutTestSuite } from '@/src/app/[lang]/test-suites/actions';
 import { convertVariableIntoInitialRequest } from '@/src/components/TestSuites/utils/template-variables';
 import { ButtonsI18nKey, TabsI18nKey, TestSuitesI18nKey } from '@/src/constants/i18n';
-import { SuiteType, TestSuite } from '@/src/models/evaluation/test-suite';
+import { SuiteType, TestCase, TestCaseSchema, TestSuite, TryOutHistoryEntry } from '@/src/models/evaluation/test-suite';
+import { TestCaseItemType } from '@/src/types/evaluation';
 import TryOut from '../components/TryOut';
 
 vi.mock('@/src/app/[lang]/test-suites/actions', () => ({
@@ -141,6 +142,24 @@ const deploymentSuiteWithRequestColumn: TestSuite = {
   responseColumns: [{ name: 'reqFoo', displayName: 'reqFoo', expression: '$request.foo', type: 'STRING' }],
 };
 
+const multiRequestSchema: TestCaseSchema[] = [
+  { name: 'shared', type: TestCaseItemType.STRING, required: false, description: '', perTurn: false },
+];
+
+const multiRequestSuite: TestSuite = {
+  id: 'suite-mr',
+  suiteType: SuiteType.Deployment,
+  endpointRef: { method: 'POST', relativeUrlPattern: '/api/chat' },
+  inputBindings: [{ templateVariable: 'shared', dataField: 'shared' }],
+  additionalRequests: [{ inputBindings: [{ templateVariable: 'shared', dataField: 'shared' }] }],
+};
+
+const multiRequestCase: TestCase = {
+  id: 'case-mr',
+  createdAt: 0,
+  data: { shared: 'value' },
+};
+
 describe('TryOut MCP branch', () => {
   test('shows Tool Arguments Preview label for MCP suite', async () => {
     render(<TryOut testSuite={mcpSuite} />);
@@ -221,5 +240,142 @@ describe('TryOut Columns tab request binding', () => {
     await waitFor(() => {
       expect(screen.getByText('bar')).toBeInTheDocument();
     });
+  });
+});
+
+describe('TryOut request tabs', () => {
+  test('hides request tabs while preview variables are loading', async () => {
+    let resolveVariables: (value: unknown[]) => void = () => undefined;
+    vi.mocked(getTestCaseTemplateVariables).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveVariables = resolve;
+        }),
+    );
+
+    render(
+      <TryOut
+        testSuite={multiRequestSuite}
+        testCaseId="case-mr"
+        schema={multiRequestSchema}
+        initialTestCase={multiRequestCase}
+      />,
+    );
+
+    expect(screen.queryByRole('tab', { name: '1. TestSuites.Request' })).not.toBeInTheDocument();
+
+    resolveVariables([]);
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: '1. TestSuites.Request' })).toBeInTheDocument();
+    });
+  });
+
+  test('shows request tabs for multi-request test case preview', async () => {
+    render(
+      <TryOut
+        testSuite={multiRequestSuite}
+        testCaseId="case-mr"
+        schema={multiRequestSchema}
+        initialTestCase={multiRequestCase}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: '1. TestSuites.Request' })).toBeInTheDocument();
+    });
+    expect(screen.getByRole('tab', { name: '2. TestSuites.Request' })).toBeInTheDocument();
+  });
+
+  test('hides request tabs while sending a test case request', async () => {
+    let resolveTryOut:
+      | ((value: {
+          success: boolean;
+          response: {
+            resolvedRequest: { body: Record<string, unknown> };
+            response: { statusCode: number; body: Record<string, unknown> };
+            history: TryOutHistoryEntry[];
+          };
+        }) => void)
+      | undefined;
+    vi.mocked(tryOutTestCase).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveTryOut = resolve;
+        }),
+    );
+
+    const user = userEvent.setup();
+    render(
+      <TryOut
+        testSuite={multiRequestSuite}
+        testCaseId="case-mr"
+        schema={multiRequestSchema}
+        initialTestCase={multiRequestCase}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: '1. TestSuites.Request' })).toBeInTheDocument();
+    });
+
+    const sendButton = await screen.findByRole('button', { name: ButtonsI18nKey.SendRequest });
+    await user.click(sendButton);
+
+    expect(screen.queryByRole('tab', { name: '1. TestSuites.Request' })).not.toBeInTheDocument();
+
+    resolveTryOut?.({
+      success: true,
+      response: {
+        resolvedRequest: { body: {} },
+        response: { statusCode: 200, body: {} },
+        history: [
+          { resolvedRequest: { body: { req: 1 } }, response: { statusCode: 200, body: { out: 'a' } } },
+          { resolvedRequest: { body: { req: 2 } }, response: { statusCode: 200, body: { out: 'b' } } },
+        ],
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: '1. TestSuites.Request' })).toBeInTheDocument();
+    });
+  });
+
+  test('switches response content when selecting another request tab', async () => {
+    vi.mocked(tryOutTestCase).mockResolvedValueOnce({
+      success: true,
+      response: {
+        resolvedRequest: { body: {} },
+        response: { statusCode: 200, body: {} },
+        history: [
+          { resolvedRequest: { body: { req: 1 } }, response: { statusCode: 200, body: { out: 'a' } } },
+          { resolvedRequest: { body: { req: 2 } }, response: { statusCode: 200, body: { out: 'b' } } },
+        ],
+      },
+    });
+
+    const user = userEvent.setup();
+    render(
+      <TryOut
+        testSuite={multiRequestSuite}
+        testCaseId="case-mr"
+        schema={multiRequestSchema}
+        initialTestCase={multiRequestCase}
+      />,
+    );
+
+    const sendButton = await screen.findByRole('button', { name: ButtonsI18nKey.SendRequest });
+    await user.click(sendButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('JsonEditor:{"req":1}')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('JsonEditor:{"req":2}')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('tab', { name: '2. TestSuites.Request' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('JsonEditor:{"req":2}')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('JsonEditor:{"req":1}')).not.toBeInTheDocument();
   });
 });

--- a/apps/ai-dial-admin/src/components/TestSuites/RequestTemplate/tests/TryOutColumns.spec.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/RequestTemplate/tests/TryOutColumns.spec.tsx
@@ -1,12 +1,38 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { EvaluatedColumn, evaluateColumns } from '@/src/components/TestSuites/utils/evaluate-columns';
-import { ResponseColumn } from '@/src/models/evaluation/test-suite';
+import {
+  EvaluatedColumn,
+  evaluateTryOutColumnSections,
+  TryOutColumnResults,
+} from '@/src/components/TestSuites/utils/evaluate-columns';
+import { TestSuitesI18nKey } from '@/src/constants/i18n';
+import { ResponseColumn, SuiteType, TestSuite, TryOutHistoryEntry } from '@/src/models/evaluation/test-suite';
 import TryOutColumns from '../components/TryOutColumns';
 
-vi.mock('@/src/components/TestSuites/utils/evaluate-columns', () => ({
-  evaluateColumns: vi.fn(() => Promise.resolve([])),
+vi.mock('@/src/components/TestSuites/utils/evaluate-columns', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/src/components/TestSuites/utils/evaluate-columns')>();
+  return {
+    ...actual,
+    evaluateTryOutColumnSections: vi.fn(() => Promise.resolve({ shape: 'single', flatColumns: [] })),
+  };
+});
+
+vi.mock('../components/CollapsibleSection', () => ({
+  default: ({ title, children }: { title: string; children: React.ReactNode }) => (
+    <div>
+      <span data-testid="collapsible-title">{title}</span>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('@/src/components/EntityTabs/JsonEditor/JsonEditor', () => ({
+  default: ({ entity }: { entity: unknown }) => <div>JsonEditor:{JSON.stringify(entity)}</div>,
+}));
+
+vi.mock('@/src/components/Common/CopyButton/CopyButton', () => ({
+  default: () => <button type="button">Copy</button>,
 }));
 
 const makeColumn = (overrides: Partial<ResponseColumn> = {}): ResponseColumn => ({
@@ -26,47 +52,212 @@ const makeEvaluatedColumn = (overrides: Partial<EvaluatedColumn> = {}): Evaluate
   ...overrides,
 });
 
+const baseSuite: TestSuite = { suiteType: SuiteType.Deployment };
+
+const entry = (body: unknown, out: unknown): TryOutHistoryEntry => ({
+  resolvedRequest: { body },
+  response: { statusCode: 200, body: out },
+});
+
 describe('TryOutColumns', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  test('evaluates columns against a response body when no request is supplied', async () => {
-    const columns = [makeColumn()];
-    const response = { foo: 'bar' };
-    vi.mocked(evaluateColumns).mockResolvedValueOnce([makeEvaluatedColumn()]);
+  test('renders flat Results section for single-request suites', async () => {
+    vi.mocked(evaluateTryOutColumnSections).mockResolvedValueOnce({
+      shape: 'single',
+      flatColumns: [makeEvaluatedColumn()],
+    });
 
-    render(<TryOutColumns columns={columns} response={response} responseBody={null} />);
+    render(
+      <TryOutColumns
+        testSuite={baseSuite}
+        columns={[makeColumn()]}
+        response={{ foo: 'bar' }}
+        responseBody={<div>FlatResponseBody</div>}
+      />,
+    );
 
     await waitFor(() => {
       expect(screen.getByText('testCol')).toBeInTheDocument();
     });
-    expect(evaluateColumns).toHaveBeenCalledWith(columns, response, undefined);
+    expect(screen.getByText(TestSuitesI18nKey.Results)).toBeInTheDocument();
+    expect(screen.getByText('FlatResponseBody')).toBeInTheDocument();
+    expect(evaluateTryOutColumnSections).toHaveBeenCalledWith(
+      expect.objectContaining({
+        testSuite: baseSuite,
+        fallbackColumns: [makeColumn()],
+        fallbackResponse: { foo: 'bar' },
+      }),
+    );
   });
 
-  test('evaluates columns against a request when the response body is empty/absent', async () => {
-    const columns = [makeColumn({ expression: '$request.messages[0].content' })];
-    const request = { messages: [{ content: 'Hi' }] };
-    vi.mocked(evaluateColumns).mockResolvedValueOnce([
-      makeEvaluatedColumn({ expression: '$request.messages[0].content' }),
-    ]);
+  test('renders selected request columns for multi-request history', async () => {
+    const threeRequestSuite: TestSuite = {
+      suiteType: SuiteType.Deployment,
+      responseColumns: [makeColumn({ name: 'answer' })],
+      additionalRequests: [
+        { responseColumns: [makeColumn({ name: 'is_correct' })] },
+        { responseColumns: [makeColumn({ name: 'result' })] },
+      ],
+    };
 
-    render(<TryOutColumns columns={columns} request={request} responseBody={null} />);
+    vi.mocked(evaluateTryOutColumnSections).mockResolvedValue({
+      shape: 'requests',
+      groups: [
+        {
+          requestIndex: 0,
+          showTurnLabels: false,
+          turns: [
+            {
+              turnIndex: 0,
+              columns: [makeEvaluatedColumn({ name: 'answer', result: 'A' })],
+              responseBody: { out: 'a' },
+            },
+          ],
+        },
+        {
+          requestIndex: 1,
+          showTurnLabels: false,
+          turns: [
+            {
+              turnIndex: 0,
+              columns: [makeEvaluatedColumn({ name: 'is_correct', result: 'true' })],
+              responseBody: { out: 'b' },
+            },
+          ],
+        },
+        {
+          requestIndex: 2,
+          showTurnLabels: false,
+          turns: [
+            {
+              turnIndex: 0,
+              columns: [makeEvaluatedColumn({ name: 'result', result: 'ok' })],
+              responseBody: { out: 'c' },
+            },
+          ],
+        },
+      ],
+    });
+
+    const history = [entry({ req: 1 }, { out: 'a' }), entry({ req: 2 }, { out: 'b' }), entry({ req: 3 }, { out: 'c' })];
+
+    const { rerender } = render(
+      <TryOutColumns
+        testSuite={threeRequestSuite}
+        history={history}
+        columns={threeRequestSuite.responseColumns}
+        response={{ top: true }}
+        responseBody={<div>TopLevelEnvelope</div>}
+        selectedRequestIndex={0}
+      />,
+    );
 
     await waitFor(() => {
-      expect(screen.getByText('testCol')).toBeInTheDocument();
+      expect(screen.getByText('answer')).toBeInTheDocument();
     });
-    expect(evaluateColumns).toHaveBeenCalledWith(columns, {}, request);
+
+    expect(screen.getByText('JsonEditor:{"out":"a"}')).toBeInTheDocument();
+    expect(screen.queryByText('JsonEditor:{"out":"b"}')).not.toBeInTheDocument();
+    expect(screen.queryByText('TopLevelEnvelope')).not.toBeInTheDocument();
+    expect(screen.queryByText('is_correct')).not.toBeInTheDocument();
+    expect(screen.queryByText(TestSuitesI18nKey.Results)).not.toBeInTheDocument();
+
+    rerender(
+      <TryOutColumns
+        testSuite={threeRequestSuite}
+        history={history}
+        columns={threeRequestSuite.responseColumns}
+        response={{ top: true }}
+        responseBody={<div>TopLevelEnvelope</div>}
+        selectedRequestIndex={1}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('is_correct')).toBeInTheDocument();
+    });
+    expect(screen.getByText('JsonEditor:{"out":"b"}')).toBeInTheDocument();
+    expect(screen.queryByText('answer')).not.toBeInTheDocument();
   });
 
-  test('does not evaluate columns and renders no rows when both response and request are absent/empty', async () => {
-    const columns = [makeColumn()];
+  test('shows Turn labels inside the active request tab for combined suites', async () => {
+    vi.mocked(evaluateTryOutColumnSections).mockResolvedValueOnce({
+      shape: 'combined',
+      groups: [
+        {
+          requestIndex: 0,
+          showTurnLabels: true,
+          turns: [
+            {
+              turnIndex: 0,
+              columns: [makeEvaluatedColumn({ name: 'answer', result: 'a' })],
+              responseBody: { out: 'a' },
+            },
+            {
+              turnIndex: 1,
+              columns: [makeEvaluatedColumn({ name: 'answer', result: 'b' })],
+              responseBody: { out: 'b' },
+            },
+          ],
+        },
+        {
+          requestIndex: 1,
+          showTurnLabels: true,
+          turns: [
+            {
+              turnIndex: 0,
+              columns: [makeEvaluatedColumn({ name: 'is_correct', result: 'yes' })],
+              responseBody: { out: 'c' },
+            },
+          ],
+        },
+      ],
+    } satisfies TryOutColumnResults);
 
-    render(<TryOutColumns columns={columns} response={{}} request={{}} responseBody={null} />);
+    render(
+      <TryOutColumns
+        testSuite={{
+          suiteType: SuiteType.Deployment,
+          inputBindings: [{ templateVariable: 'prompt', dataField: 'prompt' }],
+          additionalRequests: [{ inputBindings: [{ templateVariable: 'prompt', dataField: 'prompt' }] }],
+        }}
+        history={[
+          entry({ r: 0, t: 0 }, { out: 'a' }),
+          entry({ r: 0, t: 1 }, { out: 'b' }),
+          entry({ r: 1, t: 0 }, { out: 'c' }),
+        ]}
+        schema={[]}
+        multiTurnData={[{ prompt: 'a' }, { prompt: 'b' }]}
+        response={{}}
+        responseBody={null}
+        selectedRequestIndex={0}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByText(TestSuitesI18nKey.TurnLabel)).toHaveLength(2);
+    });
+
+    expect(screen.getByText('JsonEditor:{"out":"a"}')).toBeInTheDocument();
+    expect(screen.getByText('JsonEditor:{"out":"b"}')).toBeInTheDocument();
+    expect(screen.queryByText('JsonEditor:{"out":"c"}')).not.toBeInTheDocument();
+  });
+
+  test('renders no column rows when evaluation returns empty flat results', async () => {
+    vi.mocked(evaluateTryOutColumnSections).mockResolvedValueOnce({
+      shape: 'single',
+      flatColumns: [],
+    });
+
+    render(
+      <TryOutColumns testSuite={baseSuite} columns={[makeColumn()]} response={{}} request={{}} responseBody={null} />,
+    );
 
     await waitFor(() => {
       expect(screen.queryByText('testCol')).not.toBeInTheDocument();
     });
-    expect(evaluateColumns).not.toHaveBeenCalled();
   });
 });

--- a/apps/ai-dial-admin/src/components/TestSuites/RequestTemplate/tests/TryOutRequestPreview.spec.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/RequestTemplate/tests/TryOutRequestPreview.spec.tsx
@@ -113,7 +113,7 @@ describe('TryOutRequestPreview section labels', () => {
     expect(getDatasetTestCase).not.toHaveBeenCalled();
   });
 
-  test('renders Request labels for multi-request single-turn', async () => {
+  test('renders variables for the selected request in multi-request single-turn', async () => {
     getTestCaseTemplateVariables.mockResolvedValue([
       {
         name: 'shared',
@@ -131,7 +131,7 @@ describe('TryOutRequestPreview section labels', () => {
       data: { shared: 'value' },
     };
 
-    render(
+    const { rerender } = render(
       <TryOutRequestPreview
         testSuite={multiRequestSuite}
         testCaseId="case-mr"
@@ -140,17 +140,36 @@ describe('TryOutRequestPreview section labels', () => {
         resolvedRequest={{}}
         requestBody={{}}
         onChangeRequestBody={vi.fn()}
+        selectedRequestIndex={0}
       />,
     );
 
     await waitFor(() => {
-      expect(screen.getAllByText(TestSuitesI18nKey.RequestLabel)).toHaveLength(2);
+      expect(screen.getByText('Variables:shared=value')).toBeInTheDocument();
     });
 
     expect(screen.queryByText(TestSuitesI18nKey.TurnLabel)).not.toBeInTheDocument();
+    expect(screen.getAllByText('Variables:shared=value')).toHaveLength(1);
+
+    rerender(
+      <TryOutRequestPreview
+        testSuite={multiRequestSuite}
+        testCaseId="case-mr"
+        schema={schema}
+        initialTestCase={multiRequestCase}
+        resolvedRequest={{}}
+        requestBody={{}}
+        onChangeRequestBody={vi.fn()}
+        selectedRequestIndex={1}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Variables:shared=value')).toBeInTheDocument();
+    });
   });
 
-  test('nests Turns under Request headers for combined suites', async () => {
+  test('shows Turn labels inside the active request tab for combined suites', async () => {
     getTestCaseTemplateVariables.mockResolvedValue(variables);
 
     render(
@@ -162,14 +181,16 @@ describe('TryOutRequestPreview section labels', () => {
         resolvedRequest={{}}
         requestBody={{}}
         onChangeRequestBody={vi.fn()}
+        selectedRequestIndex={0}
       />,
     );
 
     await waitFor(() => {
-      expect(screen.getAllByTestId('collapsible-title')).toHaveLength(2);
+      expect(screen.getAllByText(TestSuitesI18nKey.TurnLabel)).toHaveLength(2);
     });
 
-    expect(screen.getAllByText(TestSuitesI18nKey.TurnLabel)).toHaveLength(4);
+    expect(screen.getByText('Variables:prompt=turn-a')).toBeInTheDocument();
+    expect(screen.getByText('Variables:prompt=turn-b')).toBeInTheDocument();
   });
 
   test('keeps a single Variables section for single-turn cases', async () => {

--- a/apps/ai-dial-admin/src/components/TestSuites/RequestTemplate/tests/TryOutRequestTabs.spec.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/RequestTemplate/tests/TryOutRequestTabs.spec.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test, vi } from 'vitest';
+
+import { TestSuitesI18nKey } from '@/src/constants/i18n';
+import { SuiteType, TestSuite } from '@/src/models/evaluation/test-suite';
+import TryOutRequestTabs from '../components/TryOutRequestTabs';
+
+vi.mock('@epam/ai-dial-ui-kit', () => ({
+  DialTabs: ({
+    tabs,
+    activeTab,
+    onClick,
+  }: {
+    tabs: { id: string; label: string }[];
+    activeTab: string;
+    onClick: (id: string) => void;
+  }) => (
+    <div>
+      {tabs.map((tab) => (
+        <button
+          key={tab.id}
+          type="button"
+          role="tab"
+          aria-selected={tab.id === activeTab}
+          onClick={() => onClick(tab.id)}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+const baseSuite: TestSuite = {
+  suiteType: SuiteType.Deployment,
+  additionalRequests: [{}, {}],
+};
+
+describe('TryOutRequestTabs', () => {
+  test('renders numbered request tabs when requests are unnamed', () => {
+    const onSelect = vi.fn();
+
+    render(<TryOutRequestTabs testSuite={baseSuite} selectedIndex={0} onSelect={onSelect} />);
+
+    expect(screen.getByRole('tab', { name: '1. TestSuites.Request' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: '2. TestSuites.Request' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: '3. TestSuites.Request' })).toBeInTheDocument();
+  });
+
+  test('renders named request tabs when request names are set', () => {
+    const namedSuite: TestSuite = {
+      suiteType: SuiteType.Deployment,
+      requestName: 'Main',
+      additionalRequests: [{ name: 'Follow-up' }],
+    };
+
+    render(<TryOutRequestTabs testSuite={namedSuite} selectedIndex={1} onSelect={vi.fn()} />);
+
+    expect(screen.getByRole('tab', { name: 'Main' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Follow-up' })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  test('calls onSelect with the clicked request index', async () => {
+    const onSelect = vi.fn();
+    const user = userEvent.setup();
+
+    render(<TryOutRequestTabs testSuite={baseSuite} selectedIndex={0} onSelect={onSelect} />);
+
+    await user.click(screen.getByRole('tab', { name: '2. TestSuites.Request' }));
+
+    expect(onSelect).toHaveBeenCalledWith(1);
+  });
+});

--- a/apps/ai-dial-admin/src/components/TestSuites/RequestTemplate/tests/TryOutResponse.spec.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/RequestTemplate/tests/TryOutResponse.spec.tsx
@@ -96,10 +96,10 @@ describe('TryOutResponsePreview history', () => {
     expect(screen.queryByText('TopLevelResponseBody')).not.toBeInTheDocument();
   });
 
-  test('renders Request labels for multi-request only', () => {
+  test('renders Request content for the selected request index', () => {
     const history = [entry({ req: 1 }, { out: 'a' }), entry({ req: 2 }, { out: 'b' })];
 
-    render(
+    const { rerender } = render(
       <TryOutResponsePreview
         response={{ statusCode: 200 }}
         resolvedRequest={{ body: {} }}
@@ -108,14 +108,34 @@ describe('TryOutResponsePreview history', () => {
         testSuite={multiRequestSuite}
         schema={schema}
         multiTurnData={[{ shared: 'x' }]}
+        selectedRequestIndex={0}
       />,
     );
 
-    expect(screen.getAllByText(TestSuitesI18nKey.RequestLabel)).toHaveLength(2);
+    expect(screen.getByText('JsonEditor:{"req":1}')).toBeInTheDocument();
+    expect(screen.getByText('JsonEditor:{"out":"a"}')).toBeInTheDocument();
+    expect(screen.queryByText('JsonEditor:{"req":2}')).not.toBeInTheDocument();
     expect(screen.queryByText(TestSuitesI18nKey.TurnLabel)).not.toBeInTheDocument();
+
+    rerender(
+      <TryOutResponsePreview
+        response={{ statusCode: 200 }}
+        resolvedRequest={{ body: {} }}
+        history={history}
+        responseBody={responseBody}
+        testSuite={multiRequestSuite}
+        schema={schema}
+        multiTurnData={[{ shared: 'x' }]}
+        selectedRequestIndex={1}
+      />,
+    );
+
+    expect(screen.getByText('JsonEditor:{"req":2}')).toBeInTheDocument();
+    expect(screen.getByText('JsonEditor:{"out":"b"}')).toBeInTheDocument();
+    expect(screen.queryByText('JsonEditor:{"req":1}')).not.toBeInTheDocument();
   });
 
-  test('nests Turns under Request headers for combined suites', () => {
+  test('shows Turn labels inside the active request tab for combined suites', () => {
     const history = [
       entry({ r: 0, t: 0 }, { out: 'a' }),
       entry({ r: 0, t: 1 }, { out: 'b' }),
@@ -132,14 +152,14 @@ describe('TryOutResponsePreview history', () => {
         testSuite={combinedSuite}
         schema={schema}
         multiTurnData={[{ prompt: 'a' }, { prompt: 'b' }]}
+        selectedRequestIndex={0}
       />,
     );
 
-    const requestHeaders = screen
-      .getAllByTestId('collapsible-title')
-      .filter((el) => el.textContent === TestSuitesI18nKey.RequestLabel);
-    expect(requestHeaders).toHaveLength(2);
-    expect(screen.getAllByText(TestSuitesI18nKey.TurnLabel)).toHaveLength(4);
+    expect(screen.getAllByText(TestSuitesI18nKey.TurnLabel)).toHaveLength(2);
+    expect(screen.getByText('JsonEditor:{"out":"a"}')).toBeInTheDocument();
+    expect(screen.getByText('JsonEditor:{"out":"b"}')).toBeInTheDocument();
+    expect(screen.queryByText('JsonEditor:{"out":"c"}')).not.toBeInTheDocument();
   });
 
   test('mixed chain: Request 1 has no Turn labels, Request 2 has Turns', () => {
@@ -159,14 +179,12 @@ describe('TryOutResponsePreview history', () => {
         testSuite={mixedSuite}
         schema={schema}
         multiTurnData={[{ prompt: 'a' }, { prompt: 'b' }, { prompt: 'c' }]}
+        selectedRequestIndex={1}
       />,
     );
 
-    const requestHeaders = screen
-      .getAllByTestId('collapsible-title')
-      .filter((el) => el.textContent === TestSuitesI18nKey.RequestLabel);
-    expect(requestHeaders).toHaveLength(2);
     expect(screen.getAllByText(TestSuitesI18nKey.TurnLabel)).toHaveLength(3);
+    expect(screen.queryByText('JsonEditor:{"out":"setup"}')).not.toBeInTheDocument();
   });
 
   test('keeps the single request/response pair when history is absent', () => {

--- a/apps/ai-dial-admin/src/components/TestSuites/utils/evaluate-columns.ts
+++ b/apps/ai-dial-admin/src/components/TestSuites/utils/evaluate-columns.ts
@@ -1,6 +1,18 @@
 import jsonata from 'jsonata';
 
-import { ResponseColumn } from '@/src/models/evaluation/test-suite';
+import {
+  normalizeResponseBodyForColumns,
+  unwrapJsonRequestBody,
+} from '@/src/components/TestSuites/utils/column-eval-context';
+import { ResponseColumn, TestCaseSchema, TestSuite, TryOutHistoryEntry } from '@/src/models/evaluation/test-suite';
+import { toRequestView } from '@/src/utils/evaluation/request-chain';
+import {
+  getRequestTurnCounts,
+  getTryOutSectionShape,
+  groupTryOutSections,
+  shouldShowTurnLabels,
+  TryOutSectionShape,
+} from '@/src/utils/evaluation/tryout-sections';
 
 export interface EvaluatedColumn {
   name: string;
@@ -10,10 +22,73 @@ export interface EvaluatedColumn {
   valid: boolean;
 }
 
+export interface TryOutColumnTurnResult {
+  turnIndex: number;
+  columns: EvaluatedColumn[];
+  responseBody?: unknown;
+}
+
+export interface TryOutColumnGroupResult {
+  requestIndex: number;
+  showTurnLabels: boolean;
+  turns: TryOutColumnTurnResult[];
+}
+
+export interface TryOutColumnResults {
+  shape: TryOutSectionShape;
+  flatColumns?: EvaluatedColumn[];
+  groups?: TryOutColumnGroupResult[];
+}
+
+const hasContent = (value?: Record<string, unknown>): boolean => !!value && Object.keys(value).length > 0;
+
+const parseColumnBindingValue = (result: string): unknown => {
+  if (result === 'true') {
+    return true;
+  }
+  if (result === 'false') {
+    return false;
+  }
+  if (result === '') {
+    return '';
+  }
+
+  try {
+    return JSON.parse(result);
+  } catch {
+    return result;
+  }
+};
+
+const mergeColumnBindings = (
+  bindings: Record<string, unknown>,
+  evaluated: EvaluatedColumn[],
+): Record<string, unknown> => {
+  const next = { ...bindings };
+
+  for (const column of evaluated) {
+    if (!column.name || !column.valid) {
+      continue;
+    }
+    next[column.name] = parseColumnBindingValue(column.result);
+  }
+
+  return next;
+};
+
+const historyEntryDisplayBody = (entry: TryOutHistoryEntry): unknown => (entry.response as { body?: unknown })?.body;
+
+const historyEntryResponse = (entry: TryOutHistoryEntry): Record<string, unknown> =>
+  normalizeResponseBodyForColumns((entry.response as { body?: Record<string, unknown> })?.body) || {};
+
+const historyEntryRequest = (entry: TryOutHistoryEntry): Record<string, unknown> | undefined =>
+  unwrapJsonRequestBody(entry.resolvedRequest?.body as Record<string, unknown> | undefined);
+
 export const evaluateColumns = async (
   columns: ResponseColumn[],
   response: Record<string, unknown>,
   request?: Record<string, unknown>,
+  extraBindings?: Record<string, unknown>,
 ): Promise<EvaluatedColumn[]> => {
   return Promise.all(
     columns.map(async (column) => {
@@ -24,6 +99,7 @@ export const evaluateColumns = async (
         const expr = jsonata(column.expression);
         // Backend/eval column expressions use $_request / $_response; FE docs/examples use $request / $response.
         const bindings = {
+          ...extraBindings,
           request,
           response,
           _request: request,
@@ -50,4 +126,62 @@ export const evaluateColumns = async (
       };
     }),
   );
+};
+
+export const evaluateTryOutColumnSections = async ({
+  testSuite,
+  history,
+  schema,
+  multiTurnLength = 0,
+  fallbackColumns = [],
+  fallbackResponse = {},
+  fallbackRequest,
+}: {
+  testSuite: TestSuite;
+  history?: TryOutHistoryEntry[];
+  schema?: TestCaseSchema[];
+  multiTurnLength?: number;
+  fallbackColumns?: ResponseColumn[];
+  fallbackResponse?: Record<string, unknown>;
+  fallbackRequest?: Record<string, unknown>;
+}): Promise<TryOutColumnResults> => {
+  const turnCounts = getRequestTurnCounts(testSuite, schema, multiTurnLength);
+  const shape = getTryOutSectionShape(turnCounts);
+
+  const useGroupedHistory =
+    !!history?.length && (shape === 'requests' || shape === 'combined') && turnCounts.length > 1;
+
+  if (!useGroupedHistory) {
+    if (!hasContent(fallbackResponse) && !hasContent(fallbackRequest)) {
+      return { shape, flatColumns: [] };
+    }
+
+    const flatColumns = await evaluateColumns(fallbackColumns, fallbackResponse, fallbackRequest);
+    return { shape, flatColumns };
+  }
+
+  const groups = groupTryOutSections(history, turnCounts);
+  let accumulatedBindings: Record<string, unknown> = {};
+  const groupResults: TryOutColumnGroupResult[] = [];
+
+  for (const group of groups) {
+    const requestColumns = toRequestView(testSuite, group.requestIndex).responseColumns ?? [];
+    const turns: TryOutColumnTurnResult[] = [];
+
+    for (const { turnIndex, item } of group.turns) {
+      const response = historyEntryResponse(item);
+      const request = historyEntryRequest(item);
+      const columns = await evaluateColumns(requestColumns, response, request, accumulatedBindings);
+      accumulatedBindings = mergeColumnBindings(accumulatedBindings, columns);
+      turns.push({ turnIndex, columns, responseBody: historyEntryDisplayBody(item) });
+    }
+
+    groupResults.push({
+      requestIndex: group.requestIndex,
+      showTurnLabels: shouldShowTurnLabels(group, turnCounts),
+      turns,
+    });
+  }
+
+  return { shape, groups: groupResults };
 };

--- a/apps/ai-dial-admin/src/components/TestSuites/utils/tests/evaluate-columns.spec.ts
+++ b/apps/ai-dial-admin/src/components/TestSuites/utils/tests/evaluate-columns.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 
-import { ResponseColumn } from '@/src/models/evaluation/test-suite';
-import { evaluateColumns, EvaluatedColumn } from '../evaluate-columns';
+import { ResponseColumn, TestSuite, TryOutHistoryEntry } from '@/src/models/evaluation/test-suite';
+import { evaluateColumns, evaluateTryOutColumnSections, EvaluatedColumn } from '../evaluate-columns';
 
 const makeColumn = (overrides: Partial<ResponseColumn> = {}): ResponseColumn => ({
   name: 'answer',
@@ -260,5 +260,78 @@ describe('evaluateColumns', () => {
     ]);
     expect(results[1].result).toBe('The capital of Belarus is Minsk.');
     expect(results[1].valid).toBe(true);
+  });
+
+  test('should resolve $answer from extraBindings passed by a prior request evaluation', async () => {
+    const columns = [makeColumn({ name: 'followUp', expression: '$answer', type: 'STRING' })];
+    const response = { choices: [{ message: { content: 'later' } }] };
+
+    const results = await evaluateColumns(columns, response, undefined, { answer: 'from request 0' });
+
+    expect(results[0].result).toBe('from request 0');
+    expect(results[0].valid).toBe(true);
+  });
+});
+
+describe('evaluateTryOutColumnSections', () => {
+  const chatResponse = {
+    choices: [{ message: { content: 'Paris' } }],
+  };
+
+  test('returns grouped results for a three-request chain with history', async () => {
+    const suite: TestSuite = {
+      responseColumns: [makeColumn({ name: 'answer', expression: 'choices[0].message.content' })],
+      additionalRequests: [
+        {
+          responseColumns: [makeColumn({ name: 'is_correct', expression: '$answer = "Paris"' })],
+        },
+        {
+          responseColumns: [makeColumn({ name: 'result', expression: '$answer' })],
+        },
+      ],
+    };
+
+    const history: TryOutHistoryEntry[] = [
+      {
+        resolvedRequest: { body: { contentType: 'application/json', content: { q: 1 } } },
+        response: { body: chatResponse },
+      },
+      {
+        resolvedRequest: { body: { contentType: 'application/json', content: { q: 2 } } },
+        response: { body: { ok: true } },
+      },
+      {
+        resolvedRequest: { body: { contentType: 'application/json', content: { q: 3 } } },
+        response: { body: { done: true } },
+      },
+    ];
+
+    const results = await evaluateTryOutColumnSections({
+      testSuite: suite,
+      history,
+      schema: [],
+      multiTurnLength: 1,
+    });
+
+    expect(results.shape).toBe('requests');
+    expect(results.groups).toHaveLength(3);
+    expect(results.groups?.[0].turns[0].columns[0].result).toBe('Paris');
+    expect(results.groups?.[1].turns[0].columns[0].valid).toBe(true);
+    expect(results.groups?.[2].turns[0].columns[0].result).toBe('Paris');
+  });
+
+  test('falls back to flat request #0 columns when history is absent', async () => {
+    const suite: TestSuite = {
+      responseColumns: [makeColumn({ name: 'answer', expression: 'choices[0].message.content' })],
+    };
+
+    const results = await evaluateTryOutColumnSections({
+      testSuite: suite,
+      fallbackColumns: suite.responseColumns,
+      fallbackResponse: chatResponse,
+    });
+
+    expect(results.shape).toBe('single');
+    expect(results.flatColumns?.[0].result).toBe('Paris');
   });
 });


### PR DESCRIPTION
**Description:**

<SHORT_DESCRIPTION>

Issues:

- Issue #4302 


**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
