### PR TITLE
fix: [Assets] reference short-name-keyed entities by bare name (Issue #4309)

### DIFF
--- a/apps/ai-dial-admin/src/components/Assets/Models/tests/Properties.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Models/tests/Properties.spec.tsx
@@ -58,10 +58,10 @@ describe('Model asset Properties :: routing-critical fields', () => {
 });
 
 describe('Model asset Properties :: identity fields', () => {
-  test('Should show the canonical deployment id callers invoke, not the bare resource name', () => {
+  test('Should show the bare deployment id callers invoke, since Core keys models by short name', () => {
     renderProperties({ name: 'gpt-4' });
 
-    expect(screen.getByText('models/platform/gpt-4')).toBeInTheDocument();
+    expect(screen.getByText('gpt-4')).toBeInTheDocument();
   });
 
   test('Should render an optional display version field', () => {

--- a/apps/ai-dial-admin/src/server/config-entities/tests/read.spec.ts
+++ b/apps/ai-dial-admin/src/server/config-entities/tests/read.spec.ts
@@ -36,8 +36,8 @@ describe('getConfigEntityOptions', () => {
     const result = await getConfigEntityOptions(TOKEN_MOCK, ConfigFileEntityType.Interceptors);
 
     expect(result.success && result.data.options).toEqual([
-      { name: 'from-file', origin: ConfigEntityOrigin.ConfigFile },
       { name: 'from-api', origin: ConfigEntityOrigin.Api },
+      { name: 'from-file', origin: ConfigEntityOrigin.ConfigFile },
     ]);
     expect(result.success && result.data.failures).toEqual([]);
   });

--- a/apps/ai-dial-admin/src/utils/config-entities/options.ts
+++ b/apps/ai-dial-admin/src/utils/config-entities/options.ts
@@ -8,26 +8,52 @@ import { ConfigEntityOrigin, ConfigFileEntityType } from '@/src/types/config-fil
 import { PLATFORM_ROOT_FOLDER } from '@/src/utils/files/root-folder';
 
 /**
+ * The entity types DIAL Core keys by bare short name in its merged `Config` maps, for both the
+ * config-file and API-written populations (`MergedConfigStore.isShortNameKeyed` returns true for
+ * exactly these). A reference to one of these resolves with a plain `containsKey(ref)` against that
+ * one map, so it is the bare name regardless of which population it came from. Routes and keys are
+ * not short-name-keyed — an API-written route is still `routes/<bucket>/<name>`, a key
+ * `keys/<bucket>/<name>` — so they keep the origin-based canonical form below.
+ */
+const SHORT_NAME_KEYED_TYPES: ReadonlySet<ConfigFileEntityType> = new Set<ConfigFileEntityType>([
+  ConfigFileEntityType.Models,
+  ConfigFileEntityType.Interceptors,
+  ConfigFileEntityType.Roles,
+  ConfigFileEntityType.Applications,
+  ConfigFileEntityType.Toolsets,
+]);
+
+/**
  * The exact string Core resolves an option to. `ConfigPostProcessor.validateCrossReferences` checks
- * a reference with `interceptors.containsKey(ref)` against `MergedConfigStore`'s single map, whose
- * keys are bare names for config-file entries and `{type}/{bucket}/{name}` for API-written ones
- * (`MergedConfigStore.canonicalId`). The two forms are different keys, not aliases.
+ * a reference with `interceptors.containsKey(ref)` against `MergedConfigStore`'s single map. For the
+ * five short-name-keyed types that map's keys are bare names from both populations, so the reference
+ * is the bare name regardless of origin. For routes and keys the two populations are still keyed
+ * differently — config-file entries by bare name, API-written entries by `{type}/platform/{name}`
+ * (`MergedConfigStore.canonicalId`) — so the origin decides the form there.
  *
  * The single source of truth for the form. The reverse direction is `getInterceptorsGridData`, which
  * matches a stored selection against `row.name` — which is why `toConfigEntityRows` puts the reference
  * there rather than the bare name.
  */
-export const getConfigEntityReference = (option: ConfigEntityOption, type: ConfigFileEntityType): string =>
-  option.origin === ConfigEntityOrigin.ConfigFile ? option.name : `${type}/${PLATFORM_ROOT_FOLDER}/${option.name}`;
+export const getConfigEntityReference = (option: ConfigEntityOption, type: ConfigFileEntityType): string => {
+  if (SHORT_NAME_KEYED_TYPES.has(type)) {
+    return option.name;
+  }
+  return option.origin === ConfigEntityOrigin.ConfigFile
+    ? option.name
+    : `${type}/${PLATFORM_ROOT_FOLDER}/${option.name}`;
+};
 
 /**
  * Composes Core's two populations of one entity type into a single option list, in the same pairing
  * `MergedConfigStore` merges and cross-reference validation checks against — so every offered option
  * resolves, and a selection cannot produce a write Core rejects as unresolvable.
  *
- * A name present in both populations yields two options: the forms are not interchangeable, so
- * collapsing them would make the stored reference ambiguous. Duplicates *within* one population are
- * collapsed, since there the reference is identical.
+ * A name present in both populations yields a single option, keeping the API-written (platform) one:
+ * Core's merged map keys the five short-name-keyed types by bare name from both populations, and a
+ * blob write supersedes the file entry via ordinary `Map.put`, so the platform entity is the live one
+ * and offering the file duplicate would let a user select an entity Core has shadowed. Duplicates
+ * *within* one population are collapsed, since there the reference is identical.
  *
  * Partial failure degrades rather than empties: whichever population was read is still offered and
  * the failure is reported alongside it. Only a total failure returns a failure.
@@ -56,9 +82,15 @@ export const unionConfigEntityOptions = (
     failures.push(configFile.failure);
   }
 
+  // API-written options first so they occupy a name's slot; a config-file entry of the same name is
+  // dropped, mirroring Core's blob-supersedes-file `Map.put`. Names unique to one population are kept.
+  const apiOptions = toOptions(apiWritten.success ? apiWritten.data : [], ConfigEntityOrigin.Api);
+  const seen = new Set(apiOptions.map((option) => option.name));
   const options = [
-    ...toOptions(configFile.success ? configFile.data : [], ConfigEntityOrigin.ConfigFile),
-    ...toOptions(apiWritten.success ? apiWritten.data : [], ConfigEntityOrigin.Api),
+    ...apiOptions,
+    ...toOptions(configFile.success ? configFile.data : [], ConfigEntityOrigin.ConfigFile).filter(
+      (option) => !seen.has(option.name) && seen.add(option.name),
+    ),
   ];
 
   return { success: true, data: { options, failures } };

--- a/apps/ai-dial-admin/src/utils/config-entities/tests/options.spec.ts
+++ b/apps/ai-dial-admin/src/utils/config-entities/tests/options.spec.ts
@@ -12,26 +12,23 @@ const failed = (reason = ConfigFileFailureReason.RequestFailed): ConfigFileReadR
 });
 
 describe('unionConfigEntityOptions', () => {
-  test('offers both populations', () => {
+  test('offers both populations, platform options first', () => {
     const result = unionConfigEntityOptions(ok(['api-one']), ok(['file-one']));
 
     expect(result.success).toBe(true);
     expect(result.success && result.data.options).toEqual([
-      { name: 'file-one', origin: ConfigEntityOrigin.ConfigFile },
       { name: 'api-one', origin: ConfigEntityOrigin.Api },
+      { name: 'file-one', origin: ConfigEntityOrigin.ConfigFile },
     ]);
     expect(result.success && result.data.failures).toEqual([]);
   });
 
-  test('keeps a name present in both populations as two distinguishable options', () => {
+  test('collapses a name present in both populations to a single platform-origin option', () => {
     const result = unionConfigEntityOptions(ok(['shared']), ok(['shared']));
 
     const options = result.success ? result.data.options : [];
-    expect(options).toHaveLength(2);
-    expect(options.map((option) => option.origin)).toEqual([ConfigEntityOrigin.ConfigFile, ConfigEntityOrigin.Api]);
-    expect(
-      new Set(options.map((option) => getConfigEntityReference(option, ConfigFileEntityType.Interceptors))),
-    ).toEqual(new Set(['shared', 'interceptors/platform/shared']));
+    expect(options).toHaveLength(1);
+    expect(options[0]).toEqual({ name: 'shared', origin: ConfigEntityOrigin.Api });
   });
 
   test('collapses duplicates within a single population', () => {
@@ -68,25 +65,52 @@ describe('unionConfigEntityOptions', () => {
 describe('getConfigEntityReference', () => {
   // Asserted as literal strings on purpose: comparing against the helper that produced them would
   // pass for any consistent-but-wrong form, and a wrong form is a save Core rejects at write time.
-  test('references a config-file entity by bare name', () => {
+  test('references a short-name-keyed entity by bare name from either origin', () => {
     expect(
       getConfigEntityReference(
         { name: 'default', origin: ConfigEntityOrigin.ConfigFile },
         ConfigFileEntityType.Interceptors,
       ),
     ).toBe('default');
-  });
-
-  test('references an API-written entity by canonical id', () => {
     expect(
       getConfigEntityReference({ name: 'default', origin: ConfigEntityOrigin.Api }, ConfigFileEntityType.Interceptors),
-    ).toBe('interceptors/platform/default');
+    ).toBe('default');
   });
 
-  test('uses the entity type in the canonical id', () => {
+  test('references every short-name-keyed type by bare name from the API population', () => {
+    expect(
+      getConfigEntityReference({ name: 'gpt-4', origin: ConfigEntityOrigin.Api }, ConfigFileEntityType.Models),
+    ).toBe('gpt-4');
     expect(
       getConfigEntityReference({ name: 'admin', origin: ConfigEntityOrigin.Api }, ConfigFileEntityType.Roles),
-    ).toBe('roles/platform/admin');
+    ).toBe('admin');
+    expect(
+      getConfigEntityReference({ name: 'my-app', origin: ConfigEntityOrigin.Api }, ConfigFileEntityType.Applications),
+    ).toBe('my-app');
+    expect(
+      getConfigEntityReference({ name: 'my-toolset', origin: ConfigEntityOrigin.Api }, ConfigFileEntityType.Toolsets),
+    ).toBe('my-toolset');
+  });
+
+  test('references a route by bare name from the config-file population and canonical id from the API population', () => {
+    expect(
+      getConfigEntityReference(
+        { name: 'my-route', origin: ConfigEntityOrigin.ConfigFile },
+        ConfigFileEntityType.Routes,
+      ),
+    ).toBe('my-route');
+    expect(
+      getConfigEntityReference({ name: 'my-route', origin: ConfigEntityOrigin.Api }, ConfigFileEntityType.Routes),
+    ).toBe('routes/platform/my-route');
+  });
+
+  test('references a key by bare name from the config-file population and canonical id from the API population', () => {
+    expect(
+      getConfigEntityReference({ name: 'my-key', origin: ConfigEntityOrigin.ConfigFile }, ConfigFileEntityType.Keys),
+    ).toBe('my-key');
+    expect(
+      getConfigEntityReference({ name: 'my-key', origin: ConfigEntityOrigin.Api }, ConfigFileEntityType.Keys),
+    ).toBe('keys/platform/my-key');
   });
 });
 
@@ -97,18 +121,17 @@ describe('a name containing the canonical separator', () => {
     const options = result.success ? result.data.options : [];
 
     expect(options).toEqual([{ name: trap, origin: ConfigEntityOrigin.ConfigFile }]);
-    // Stored as the bare name it is, so it resolves to the config-file entity — not to an API-written
+    // Stored as the bare name it is, so it resolves to that config-file entity — not to an API-written
     // `looks-canonical` that may also exist.
     expect(getConfigEntityReference(options[0], ConfigFileEntityType.Interceptors)).toBe(trap);
   });
 
-  test('still yields two distinct references when the same name exists in both populations', () => {
+  test('collapses to a single reference when the same name exists in both populations', () => {
     const result = unionConfigEntityOptions(ok(['shared']), ok(['shared']));
     const options = result.success ? result.data.options : [];
 
     expect(options.map((option) => getConfigEntityReference(option, ConfigFileEntityType.Interceptors))).toEqual([
       'shared',
-      'interceptors/platform/shared',
     ]);
   });
 });

--- a/apps/ai-dial-admin/src/utils/config-entities/tests/rows.spec.ts
+++ b/apps/ai-dial-admin/src/utils/config-entities/tests/rows.spec.ts
@@ -13,10 +13,10 @@ const OPTIONS: ConfigEntityOption[] = [
 const rows = () => toConfigEntityRows(OPTIONS, ConfigFileEntityType.Interceptors);
 
 describe('toConfigEntityRows', () => {
-  test('carries the reference in name, the bare name in displayName, and the origin', () => {
+  test('carries the bare name in both name and displayName for a short-name-keyed type, plus the origin', () => {
     expect(rows()).toEqual([
       { name: 'from-file', displayName: 'from-file', origin: ConfigEntityOrigin.ConfigFile },
-      { name: 'interceptors/platform/from-api', displayName: 'from-api', origin: ConfigEntityOrigin.Api },
+      { name: 'from-api', displayName: 'from-api', origin: ConfigEntityOrigin.Api },
     ]);
   });
 
@@ -28,30 +28,17 @@ describe('toConfigEntityRows', () => {
 });
 
 describe('selection round-trip through the shared interceptor picker', () => {
-  // The picker matches a stored selection with `entity.name === selected`, and Core stores an
-  // API-written entity's canonical id. A row keyed by the bare name would leave such a selection
-  // permanently unmatched — invisible in the tab while still present on the resource.
-  test('matches a stored canonical-id selection', () => {
-    const selected = getInterceptorsGridData(rows(), ['interceptors/platform/from-api']);
-
-    expect(selected).toHaveLength(1);
-    expect(selected[0].displayName).toBe('from-api');
-  });
-
-  test('matches a bare-name selection saved before the change', () => {
-    const selected = getInterceptorsGridData(rows(), ['from-file']);
-
-    expect(selected).toHaveLength(1);
-    expect(selected[0].name).toBe('from-file');
-  });
-
-  test('preserves selection order rather than option order', () => {
-    const selected = getInterceptorsGridData(rows(), ['interceptors/platform/from-api', 'from-file']);
+  // The picker matches a stored selection with `entity.name === selected`. Core keys interceptors by
+  // bare short name from both populations, so a stored selection is the bare name regardless of origin.
+  test('matches a stored bare-name selection from either origin', () => {
+    const selected = getInterceptorsGridData(rows(), ['from-api', 'from-file']);
 
     expect(selected.map((row) => row.displayName)).toEqual(['from-api', 'from-file']);
   });
 
-  test('does not match an API-written entity by its bare name', () => {
-    expect(getInterceptorsGridData(rows(), ['from-api'])).toEqual([]);
+  test('preserves selection order rather than option order', () => {
+    const selected = getInterceptorsGridData(rows(), ['from-api', 'from-file']);
+
+    expect(selected.map((row) => row.displayName)).toEqual(['from-api', 'from-file']);
   });
 });

--- a/apps/ai-dial-admin/src/utils/models/deployment-id.ts
+++ b/apps/ai-dial-admin/src/utils/models/deployment-id.ts
@@ -1,9 +1,7 @@
-import { MODELS_PREFIX } from '@/src/constants/publications-core';
-
 /**
- * The identifier a caller invokes an asset model by. DIAL Core keys API-written entities in its merged
- * config by canonical id and sets each deployment's name from that key, so a model this UI lists as
- * `gpt-4` is addressed as `models/platform/gpt-4` — whereas a model defined in Core's static config
- * keeps its bare name. Both populations coexist in one map, so the two forms are not interchangeable.
+ * The identifier a caller invokes an asset model by. DIAL Core keys API-written models in its merged
+ * config by their bare short name and sets each deployment's name from that key, so a model this UI
+ * lists as `gpt-4` is addressed as `gpt-4` — the same value from both the API-written and config-file
+ * populations, which now share one map key.
  */
-export const getModelDeploymentId = (name?: string): string => (name ? `${MODELS_PREFIX}${name}` : '');
+export const getModelDeploymentId = (name?: string): string => (name ? name : '');

--- a/apps/ai-dial-admin/src/utils/models/tests/deployment-id.spec.ts
+++ b/apps/ai-dial-admin/src/utils/models/tests/deployment-id.spec.ts
@@ -5,12 +5,12 @@ import { isEntitiesWithDisplayVersion } from '@/src/utils/is-view';
 import { getModelDeploymentId } from '../deployment-id';
 
 describe('Models Utils :: getModelDeploymentId', () => {
-  test('Should prefix the resource name with the platform bucket', () => {
-    expect(getModelDeploymentId('gpt-4')).toBe('models/platform/gpt-4');
+  test('Should return the bare resource name, since Core keys models by short name', () => {
+    expect(getModelDeploymentId('gpt-4')).toBe('gpt-4');
   });
 
   test('Should not alter a name that already contains dots or dashes', () => {
-    expect(getModelDeploymentId('gpt-4.1-mini')).toBe('models/platform/gpt-4.1-mini');
+    expect(getModelDeploymentId('gpt-4.1-mini')).toBe('gpt-4.1-mini');
   });
 
   test.each([undefined, ''])('Should return an empty string for %s rather than a bare prefix', (name) => {

--- a/openspec/changes/archive/2026-08-28-fix-asset-entity-short-name-references/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-28-fix-asset-entity-short-name-references/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-28

--- a/openspec/changes/archive/2026-08-28-fix-asset-entity-short-name-references/design.md
+++ b/openspec/changes/archive/2026-08-28-fix-asset-entity-short-name-references/design.md
@@ -1,0 +1,81 @@
+## Context
+
+DIAL Core PR #1813 (`a61481de`, "short-name resolution via direct keying") changed how the merged `Config` maps are keyed. For five entity types — `MODEL`, `INTERCEPTOR`, `ROLE`, `APPLICATION`, `TOOL_SET` — the map key changed from the canonical id (`{type}/platform/{name}`) to the **bare short name**. `MergedConfigStore.isShortNameKeyed` returns `true` for exactly those five and `false` for everything else. A reference is now validated with a plain `containsKey(ref)` against that one map (`ConfigPostProcessor.validateCrossReferences`).
+
+The admin frontend's reference-form logic was built against the *old* canonical-id keying. The central helper `getConfigEntityReference` (`utils/config-entities/options.ts`) emits `{type}/platform/{name}` for any API-written (platform) option, and `getModelDeploymentId` (`utils/models/deployment-id.ts`) emits `models/platform/{name}`. So a dependency saved today — an interceptor on a model, a role on a route/key — carries a canonical id that Core's short-name map can no longer resolve, producing the `… not found in config` rejection in issue #4309.
+
+A second, coupled behavior: `unionConfigEntityOptions` currently emits **two** options when a name exists in both the config-file and API-written populations, because the two populations produced *different* reference forms (bare name vs canonical id) and so were legitimately distinct keys. After the short-name change both populations produce the *same* reference for the same name; keeping both would render a duplicate picker row, and Core's new semantics are that the blob (platform) entry supersedes the file entry via ordinary `Map.put`.
+
+Routes (`routes/<bucket>/<name>`) and keys (`keys/<bucket>/<name>`) remain canonical-id-keyed for API-sourced entries — `Config.java` field comments and the `ConfigPostProcessor` structural pass (`processStructural` / `rejectSlashKeyedNames`) explicitly carve them out as "key by canonical id legitimately". App-runner schemas are keyed by JSON-Schema `$id`, a separate mechanism.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Store the bare short name as the dependency reference for the five short-name-keyed types (models, interceptors, roles, applications, toolsets), from both populations, so the reference resolves against Core's new map.
+- Keep the canonical-id reference form for routes and keys (the two non-short-name-keyed types that are still offered through the same picker pipeline).
+- Collapse the config-file/platform merge on name collision, keeping the platform (API-written) option, to match Core's blob-supersedes-file semantics and avoid duplicate picker rows.
+- Update the specs that encoded the old canonical-id form and the "keep both on collision" merge rule.
+
+**Non-Goals:**
+- Rewriting already-stored references that carry the old canonical form — those are a Core-side migration concern (Core's own PR #1813 notes that operators should reconfigure `Role.limits` etc. to short names). This change prevents *new* bad writes.
+- Changing how entities are listed/read from Core (metadata + config-file routes), only what is stored on selection and how the two populations merge.
+- Changing routes, keys, or app-runner (schema) keying.
+- Changing the admin-BE-vs-Asset interceptor merge (`mergeInterceptorOrigins`) — a different population pair from the config-file/platform merge.
+
+## Decisions
+
+### Decision 1: `getConfigEntityReference` becomes type-aware, not just origin-aware
+
+Today the helper branches on `origin` only: `ConfigFile` → bare name, `Api` → `{type}/platform/{name}`. After #1813, the reference form is determined by **which type is being referenced**, not by which population it came from: the five short-name-keyed types take the bare name from *both* origins; routes and keys take the canonical id from *both* origins (a config-file route is still referenced by bare name today, though — see the audit note below).
+
+**Chosen:** branch on `type` first, then `origin` only for the non-short-name types:
+- For `Models`, `Interceptors`, `Roles`, `Applications`, `Toolsets` → return `option.name` regardless of origin.
+- For `Routes`, `Keys` → keep the existing origin branch: `ConfigFile` → bare name, `Api` → `{type}/platform/{name}`.
+
+A small `SHORT_NAME_KEYED` set (mirroring Core's `isShortNameKeyed`) makes the branch explicit and self-documenting.
+
+**Alternatives considered:**
+- *Always bare name for every type.* Rejected — breaks routes and keys, which Core still keys by canonical id. This is the over-correction flagged in the proposal.
+- *Two separate helpers, one per keying family.* Rejected — duplicates the origin logic and splits the single source of truth the existing `rows.ts`/`options.ts` comments call out. One type-aware helper keeps one source of truth.
+
+**Note on config-file routes/keys:** `getConfigEntityReference` currently returns the bare name for a `ConfigFile`-origin route, and the canonical id for an `Api`-origin route. That asymmetry is unchanged here — Core keys file-sourced routes by name and API-sourced routes by canonical id, so the origin branch for routes/keys stays. The audit task confirms no consumer assumes a single shape across origins for routes/keys.
+
+### Decision 2: `getModelDeploymentId` returns the bare name
+
+`getModelDeploymentId` exists to show the identifier a caller invokes an API-written model by. Under the new keying that identifier is the bare name. Change it to return `name ?? ''` and drop the `MODELS_PREFIX` composition. The `Properties` component that renders it (`components/Assets/Models/Properties.tsx`) needs no structural change — it already displays whatever the helper returns.
+
+**Why not remove the helper entirely:** it still carries the "what a caller invokes this model by" intent and the empty-name guard, and call sites read more clearly with it than with a raw `name`. Removing it would spread the `name ?? ''` guard to every call site.
+
+### Decision 3: `unionConfigEntityOptions` collapses on collision, platform wins
+
+Change the merge so that when a name appears in both populations, only the API-written (platform) option is emitted; the config-file duplicate is dropped. This matches Core's "a blob write naturally supersedes the file entry via ordinary `Map.put`". Duplicates *within* one population are still collapsed (unchanged). Partial-failure degradation is unchanged: whichever population was read is still offered, with the failure reported.
+
+**Implementation shape:** build the API-origin options first, then add file-origin options whose name is not already present — so the API option occupies the slot and the file duplicate is skipped. The `origin` discriminator is still carried (a platform-only name still shows `Api`; a file-only name still shows `ConfigFile`).
+
+**Alternatives considered:**
+- *Keep both, let the picker dedupe by reference.* Rejected — after the short-name change both rows would have the same `name` reference and the same display name, producing a true duplicate the grid cannot distinguish; and it would contradict Core's supersession semantics.
+- *Collapse to the file option on collision.* Rejected — Core's `Map.put` order is blob-after-file, so the platform entity is the live one; offering the file entry would let a user select an entity Core has shadowed.
+
+### Decision 4: Audit prefix-parsing consumers before assuming they're unaffected
+
+Several utilities parse a `{prefix}/` off a stored value: `utils/deployment-navigation.ts` (`APPLICATIONS_PREFIX`), `server/publications/resolver/registry.ts` (`APPLICATIONS_PREFIX`, `TOOLSETS_PREFIX`), `components/Applications/ParametersTab/utils.ts` (`applications/`), `utils/toolset/toolset-auth.ts` (`toolsets/`). These appear to operate on **blob-storage resource paths** (the `applications/…`, `toolsets/…` forms used for Core resource URLs), not on the `Config` map keys / stored dependency references this change touches. The blob-path prefixes (`applications/`, `toolsets/`, without `platform/`) are a different concern from the config-reference form (`applications/platform/{name}`, now bare `name`).
+
+**Chosen:** include an explicit audit task rather than assume. Each consumer is checked: does it parse a value that *this change* alters (a stored interceptor/role/model/application/toolset dependency reference), or does it parse a blob-storage resource path that this change does not touch? Only the former need updating.
+
+## Risks / Trade-offs
+
+- **[Existing stored references still fail against Core #1813]** → This is a pre-existing condition Core's own migration note already acknowledges (operators reconfigure). The frontend fix prevents new bad writes but does not migrate old ones. Documented in the proposal's Migration note; no frontend-side rewrite is attempted.
+- **[Frontend change is correct only against Core ≥ #1813]** → Against an older Core, bare-name references for the five types would not resolve. The deployment pairs this frontend version with Core ≥ #1813; no version-gate is added because the admin frontend is deployed in lockstep with its Core, not against arbitrary older versions.
+- **[A consumer silently parses the old canonical form]** → Mitigated by Decision 4's audit task, which must land before the change is considered complete. If a consumer is found that parses stored dependency references, it is updated in the same change.
+- **[Merge collapse hides a file-only entity that a user previously relied on]** → Not a regression: under Core #1813 that file entity is already shadowed at runtime by the platform entry of the same name. The picker now reflects what Core actually serves.
+- **[Routes/keys asymmetry across origins is subtle]** → Preserved deliberately (Core keys them differently per origin). The type-aware helper's route/key branch keeps the origin split; the audit confirms no caller assumes one shape.
+
+## Migration Plan
+
+1. Deploy alongside Core ≥ #1813. The frontend and Core are released together (milestone `release-0.21`).
+2. No data migration on the frontend. Resources saved before this change that carry canonical-id references for the five types already fail against the new Core; operators reconfigure those references to short names per Core's migration note.
+3. Rollback: revert the frontend change. Against the *new* Core, the old frontend would resume writing canonical ids — which fail, so rollback is only meaningful if Core is also rolled back to pre-#1813. Coordinated rollback, not frontend-only.
+
+## Open Questions
+
+- Does the *entity* interceptor attach picker (Entities > Applications/Models/AppRunners, via `mergeInterceptorOrigins`) also store a canonical id for `Asset`-origin interceptors, or only the `Assets > Models` / `Assets > App Runners` path (via `readConfigEntities`)? The audit task covers both; the implementation scope expands only if the entity path is also affected.

--- a/openspec/changes/archive/2026-08-28-fix-asset-entity-short-name-references/proposal.md
+++ b/openspec/changes/archive/2026-08-28-fix-asset-entity-short-name-references/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+DIAL Core PR #1813 re-keyed the merged `Config` maps for models, applications, toolsets, interceptors, and roles from their canonical id (`{type}/platform/{name}`) to the **bare short name**. A reference is now validated with a plain `containsKey(ref)` against that short-name key. The admin frontend still stores the old canonical form for API-written (platform) entities, so any dependency the UI attaches — an interceptor on a model, a role on a route/key — is written as e.g. `interceptors/platform/my-ic`, which Core can no longer resolve. Issue #4309 is the reported instance: saving a model with an Assets-created interceptor fails with `Interceptor 'interceptors/platform/<name>' not found in config`. This is a P1 affecting every asset-entity dependency picker for the five short-name-keyed types.
+
+## What Changes
+
+- **Reference form for the five short-name-keyed types (models, interceptors, roles, applications, toolsets) becomes the bare name regardless of origin.** The central helper `getConfigEntityReference` and the model-specific `getModelDeploymentId` stop emitting `{type}/platform/{name}` for API-written entities and emit `option.name` instead. This is what Core's `containsKey` now resolves against.
+- **Routes and keys keep their canonical id.** Core still keys routes as `routes/<bucket>/<name>` and keys as `keys/<bucket>/<name>` for blob/API-sourced entries (`MergedConfigStore.isShortNameKeyed` returns false for `ROUTE` and `PROJECT_KEY`; the structural pass carves them out as "key by canonical id legitimately"). Converting them to short names would invert the bug. `getConfigEntityReference` therefore becomes type-aware, not just origin-aware: short-name form for the five types, canonical form for routes and keys.
+- **App runners (`APP_TYPE_SCHEMA`) keep their own keying** — Core keys schemas by JSON-Schema `$id`, a separate mechanism, untouched here.
+- **The config-file / platform merge collapses on name collision, platform wins.** `unionConfigEntityOptions` currently emits two options when a name exists in both populations, because the two reference forms were distinct keys. After the short-name change both populations produce the same reference, so two options would be a duplicate row. Core's new semantics are that a blob (platform) entry supersedes the file entry via ordinary `Map.put`; the merge must match that — keep only the API/platform option on a name collision, drop the config-file duplicate.
+- Update the specs that encode the old canonical-id reference form and the "keep both on collision" merge rule to the new behavior.
+- Update the unit specs that assert the old literal forms (`utils/config-entities/tests/options.spec.ts`, `utils/models/tests/deployment-id.spec.ts`).
+
+### Non-goals
+
+- No change to how entities are **read/listed** from Core (metadata + config-file routes), only to the reference stored when one is selected as a dependency and to the merge of the two populations.
+- No change to routes, keys, or app-runner (schema) keying — those remain canonical / `$id`.
+- No change to the admin-BE-vs-Asset interceptor merge (`mergeInterceptorOrigins`) — that is a different population pair from the config-file/platform merge.
+- No change to the blob-storage resource path prefixes used by the publications resolver (`APPLICATIONS_PREFIX = 'applications/'`, `TOOLSETS_PREFIX = 'toolsets/'`); those describe storage paths, not `Config` map keys.
+
+## Capabilities
+
+### New Capabilities
+<!-- None — this corrects existing reference-form behavior, it does not introduce a new capability. -->
+
+### Modified Capabilities
+- `core-config-file-client`: owns the per-origin reference-form contract and the merge rule. The reference-form requirement changes — the five short-name-keyed types (models, interceptors, roles, applications, toolsets) are now referenced by bare name from both populations, not by canonical id for the API-written half; routes and keys keep their canonical-id form. The "keep both entries on a name collision" merge requirement changes to "platform wins, collapse the duplicate".
+- `assets-models`: the canonical deployment-identity requirement changes — the identifier callers use to invoke an API-written model is now the bare name, so the detail view surfaces the bare name, not `models/platform/{name}`.
+
+The other asset-entity capabilities (`assets-interceptors`, `assets-roles`, `assets-app-runners`, `assets-routes`, `assets-keys`) consume the shared helpers governed by `core-config-file-client`; their spec text does not itself assert a reference form, so they need no delta — the behavior change flows through the shared helper.
+
+## Impact
+
+- **Code:**
+  - `utils/config-entities/options.ts` — `getConfigEntityReference` becomes type-aware (short-name form for the five short-name-keyed types; canonical form for routes/keys); `unionConfigEntityOptions` collapses on name collision keeping the API/platform option.
+  - `utils/models/deployment-id.ts` — `getModelDeploymentId` returns the bare name.
+  - `utils/config-entities/rows.ts` — unchanged structurally, but the `name` it carries is now the bare form for the five types.
+  - Matching logic (`getInterceptorsGridData`, `getRolesGridData`) is form-agnostic (`name === selected`) and works either way once both sides agree; no change expected, but must be re-verified.
+  - Consumers that **parse** a stored reference back out (e.g. strip a `{type}/platform/` prefix to recover a display name) will break if not updated — an audit task covers this. Known prefix consumers: `utils/deployment-navigation.ts` (`APPLICATIONS_PREFIX`), `server/publications/resolver/registry.ts`, `components/Applications/ParametersTab/utils.ts`, `utils/toolset/toolset-auth.ts`. These touch blob-storage paths, not stored config references, so are likely unaffected — the audit confirms rather than assumes.
+- **Tests:** `utils/config-entities/tests/options.spec.ts` (the "two distinguishable options" and "canonical id" assertions flip), `utils/models/tests/deployment-id.spec.ts` (expects bare name), `utils/config-entities/tests/rows.spec.ts` (`interceptors/platform/from-api` → `from-api`), `server/config-entities/tests/read.spec.ts`.
+- **Backend dependency:** requires DIAL Core at or past PR #1813 (`a61481de`, "short-name resolution via direct keying"). The frontend change is correct only against that Core version; against an older Core it would break the five types. No admin-backend change.
+- **Migration:** existing stored resources that already carry canonical-id references (e.g. a model saved before this change with `interceptors/platform/my-ic`) will, on Core #1813, already be failing to resolve — Core's known migration note covers operators reconfiguring such references to short names. The frontend fix prevents *new* bad writes; it does not rewrite existing stored references.

--- a/openspec/changes/archive/2026-08-28-fix-asset-entity-short-name-references/specs/assets-models/spec.md
+++ b/openspec/changes/archive/2026-08-28-fix-asset-entity-short-name-references/specs/assets-models/spec.md
@@ -1,0 +1,8 @@
+## MODIFIED Requirements
+
+### Requirement: The canonical deployment identity is visible
+Because DIAL Core keys API-written models by their **bare short name** and sets the deployment's name from that key, the identifier callers use to invoke a model created through this surface is the bare name — the same value the list displays, not a `models/platform/{name}` canonical id. The system SHALL surface that deployment identifier on the model asset's detail view.
+
+#### Scenario: The detail view shows the deployment identifier
+- **WHEN** a user opens a model asset's detail view
+- **THEN** the deployment identifier — the model's bare name — is shown and can be copied

--- a/openspec/changes/archive/2026-08-28-fix-asset-entity-short-name-references/specs/core-config-file-client/spec.md
+++ b/openspec/changes/archive/2026-08-28-fix-asset-entity-short-name-references/specs/core-config-file-client/spec.md
@@ -1,0 +1,40 @@
+## MODIFIED Requirements
+
+### Requirement: Each option carries its origin and the reference form that origin requires
+DIAL Core keys the five deployment/role entity types — models, interceptors, roles, applications, and toolsets — in its merged `Config` maps by their **bare short name**, for both the config-file and API-written (platform) populations alike (`MergedConfigStore.isShortNameKeyed` returns true for exactly those five). Core validates a reference with a plain `containsKey(ref)` against that one map. Routes and keys are not short-name-keyed: an API-written route is still referenced by its canonical id (`routes/<bucket>/<name>`) and an API-written key by `keys/<bucket>/<name>`, while their config-file entries keep bare names. The system SHALL attach an explicit origin discriminator to every option and SHALL derive the stored reference from the entity **type** (short-name form for the five short-name-keyed types; the existing origin-based form for routes and keys), rather than inferring either from the shape of a value.
+
+#### Scenario: A short-name-keyed entity is referenced by bare name from either population
+- **WHEN** an option of a short-name-keyed type (model, interceptor, role, application, or toolset) is selected, regardless of whether it originated in the config-file or API-written population
+- **THEN** the value stored on the resource is that entity's bare name
+
+#### Scenario: A route is referenced by its population-appropriate form
+- **WHEN** an option originating in the config-file route population is selected
+- **THEN** the value stored on the resource is that route's bare name
+- **AND WHEN** an option originating in the API-written route population is selected
+- **THEN** the value stored on the resource is that route's canonical id `routes/<bucket>/<name>`
+
+#### Scenario: A key is referenced by its population-appropriate form
+- **WHEN** an option originating in the config-file key population is selected
+- **THEN** the value stored on the resource is that key's bare name
+- **AND WHEN** an option originating in the API-written key population is selected
+- **THEN** the value stored on the resource is that key's canonical id `keys/<bucket>/<name>`
+
+#### Scenario: Origin is explicit, not inferred
+- **WHEN** an option is built
+- **THEN** it carries an origin discriminator as data, so a name that happens to contain a separator is never mistaken for a canonical id
+
+### Requirement: A name present in both populations is offered once, with the platform entry winning
+Because the five short-name-keyed types share one map key (the bare name) across both populations, a name present in both would yield two options with the same stored reference — a duplicate Core resolves by letting the blob (platform) entry supersede the file entry via ordinary `Map.put`. The system SHALL offer a name present in both populations as a single option, keeping the API-written (platform) option and dropping the config-file duplicate, and SHALL still carry the origin discriminator on the surviving option. Duplicates within a single population are still collapsed to one.
+
+#### Scenario: A name in both populations yields one platform-origin option
+- **WHEN** the same entity name of a short-name-keyed type exists in both the config-file and API-written populations
+- **THEN** a single option is offered, carrying the `Api` (platform) origin, and selecting it stores the bare name
+- **AND** the config-file entry of that name is not offered as a separate option
+
+#### Scenario: Duplicates within one population are collapsed
+- **WHEN** the same name appears more than once within a single population
+- **THEN** it is offered once
+
+#### Scenario: A name present in only one population is offered from that population
+- **WHEN** an entity name exists in only the config-file or only the API-written population
+- **THEN** it is offered as one option carrying its actual origin

--- a/openspec/changes/archive/2026-08-28-fix-asset-entity-short-name-references/tasks.md
+++ b/openspec/changes/archive/2026-08-28-fix-asset-entity-short-name-references/tasks.md
@@ -1,0 +1,27 @@
+## 1. Reference-form helpers
+
+- [x] 1.1 Make `getConfigEntityReference` (`utils/config-entities/options.ts`) type-aware: for the five short-name-keyed types (Models, Interceptors, Roles, Applications, Toolsets) return `option.name` regardless of origin; for Routes and Keys keep the existing origin branch (ConfigFile → bare name, Api → `{type}/platform/{name}`). Introduce an explicit `SHORT_NAME_KEYED` set mirroring Core's `isShortNameKeyed`.
+- [x] 1.2 Change `getModelDeploymentId` (`utils/models/deployment-id.ts`) to return the bare name (`name ?? ''`), dropping the `MODELS_PREFIX` composition.
+
+## 2. Merge collapse
+
+- [x] 2.1 Change `unionConfigEntityOptions` (`utils/config-entities/options.ts`) so a name present in both populations yields a single API-written (platform) option; drop the config-file duplicate. Duplicates within one population stay collapsed; partial-failure degradation is unchanged. The `origin` discriminator is still carried on the surviving option.
+
+## 3. Consumer audit
+
+- [x] 3.1 Audit prefix-parsing consumers for stored dependency references this change alters: `utils/deployment-navigation.ts`, `server/publications/resolver/registry.ts`, `components/Applications/ParametersTab/utils.ts`, `utils/toolset/toolset-auth.ts`. For each, determine whether it parses a stored interceptor/role/model/application/toolset dependency reference (update it) or a blob-storage resource path (leave it). Record the finding.
+      - **Finding:** all four parse blob-storage resource paths (`applications/{path}`, `toolsets/{path}` via the resource `.path` field), not stored `Config` dependency references. None altered by this change; no updates needed.
+- [x] 3.2 Check the entity interceptor-attach path (`mergeInterceptorOrigins` in `components/EntityView/Interceptors/utils.ts` and its callers in `Interceptors.tsx` / `CollapsableInterceptors.tsx`) for whether an `Asset`-origin interceptor is stored by canonical id; if so, store the bare name there too.
+      - **Finding:** `Interceptors.tsx` stores `i.name` on attach. Asset interceptors come from `assetApi.list` → `mergeInterceptorResource` → `flatMetadataFields` → `parseEncodedFlatPath(metadata.url, prefix)`, which sets `name` to the **bare name** and `path` to the full `interceptors/platform/…` form. So the entity path already stores the bare name and is correct under the new keying; no change needed.
+
+## 4. Tests
+
+- [x] 4.1 Update `utils/config-entities/tests/options.spec.ts`: the "two distinguishable options on collision" and "canonical id for API-written" assertions flip to bare-name / single-platform-option semantics; add route and key cases preserving canonical-id form for API origin.
+- [x] 4.2 Update `utils/models/tests/deployment-id.spec.ts` to expect the bare name.
+- [x] 4.3 Update `utils/config-entities/tests/rows.spec.ts` (`interceptors/platform/from-api` → `from-api`).
+- [x] 4.4 Run the full suite from `apps/ai-dial-admin/` as the final gate: `npx vitest run --coverage`. Confirm the coverage threshold is not regressed and lint passes.
+      - **Result:** 903 test files passed (10179 tests), 0 failures, exit 0 — coverage gate held. Lint: the touched files are clean; the one remaining lint error is pre-existing in `src/app/error.tsx` (not touched by this change).
+
+## 5. Notes
+
+No spec-browser-verify task is included: the user opted for unit-test coverage only. The unit tests in group 4 cover the changed reference-form and merge-collapse logic directly; browser-observable behavior (picker row count, model detail identifier) flows from that logic and is not separately gated against a live stack.

--- a/openspec/specs/assets-models/spec.md
+++ b/openspec/specs/assets-models/spec.md
@@ -185,11 +185,11 @@ The system SHALL provide an Interceptors tab on the model asset detail view, edi
 - **THEN** each option's `Source` column reads which of Core's two populations it came from
 
 ### Requirement: The canonical deployment identity is visible
-Because DIAL Core keys API-written models by their canonical id and sets the deployment's name from that key, the identifier callers use to invoke a model created through this surface is `models/platform/{name}`, not the bare name the list displays. The system SHALL surface that canonical identifier on the model asset's detail view.
+Because DIAL Core keys API-written models by their **bare short name** and sets the deployment's name from that key, the identifier callers use to invoke a model created through this surface is the bare name — the same value the list displays, not a `models/platform/{name}` canonical id. The system SHALL surface that deployment identifier on the model asset's detail view.
 
-#### Scenario: The detail view shows the canonical identifier
+#### Scenario: The detail view shows the deployment identifier
 - **WHEN** a user opens a model asset's detail view
-- **THEN** the canonical deployment identifier `models/platform/{name}` is shown and can be copied
+- **THEN** the deployment identifier — the model's bare name — is shown and can be copied
 
 ### Requirement: A model rejected from the merged config is distinguishable, with its reasons
 DIAL Core serves a valid model and an invalid one through two different projections: a successful read reports a valid status, while an entity that failed validation during the merged-config rebuild is served with an invalid status and, for admin callers, an accompanying list of validation warnings naming the offending fields. The system SHALL distinguish the two states in the detail view and SHALL surface the warnings when present.

--- a/openspec/specs/core-config-file-client/spec.md
+++ b/openspec/specs/core-config-file-client/spec.md
@@ -62,27 +62,40 @@ The two populations do not carry the same data, and neither carries a descriptio
 - **THEN** that option's origin is visible, so the absence reads as a property of its source rather than as missing data
 
 ### Requirement: Each option carries its origin and the reference form that origin requires
-The two populations are referenced differently: a config-file entity by its bare name, an API-written entity by its canonical id (`{type}/platform/{name}`). The same display name may exist in both. The system SHALL attach an explicit origin discriminator to every option and SHALL derive the stored reference from that origin, rather than inferring either from the shape of a value.
+DIAL Core keys the five deployment/role entity types — models, interceptors, roles, applications, and toolsets — in its merged `Config` maps by their **bare short name**, for both the config-file and API-written (platform) populations alike (`MergedConfigStore.isShortNameKeyed` returns true for exactly those five). Core validates a reference with a plain `containsKey(ref)` against that one map. Routes and keys are not short-name-keyed: an API-written route is still referenced by its canonical id (`routes/<bucket>/<name>`) and an API-written key by `keys/<bucket>/<name>`, while their config-file entries keep bare names. The system SHALL attach an explicit origin discriminator to every option and SHALL derive the stored reference from the entity **type** (short-name form for the five short-name-keyed types; the existing origin-based form for routes and keys), rather than inferring either from the shape of a value.
 
-#### Scenario: A config-file entity is referenced by bare name
-- **WHEN** an option originating in the config-file population is selected
+#### Scenario: A short-name-keyed entity is referenced by bare name from either population
+- **WHEN** an option of a short-name-keyed type (model, interceptor, role, application, or toolset) is selected, regardless of whether it originated in the config-file or API-written population
 - **THEN** the value stored on the resource is that entity's bare name
 
-#### Scenario: An API-written entity is referenced by canonical id
-- **WHEN** an option originating in the API-written population is selected
-- **THEN** the value stored on the resource is that entity's canonical id
+#### Scenario: A route is referenced by its population-appropriate form
+- **WHEN** an option originating in the config-file route population is selected
+- **THEN** the value stored on the resource is that route's bare name
+- **AND WHEN** an option originating in the API-written route population is selected
+- **THEN** the value stored on the resource is that route's canonical id `routes/<bucket>/<name>`
+
+#### Scenario: A key is referenced by its population-appropriate form
+- **WHEN** an option originating in the config-file key population is selected
+- **THEN** the value stored on the resource is that key's bare name
+- **AND WHEN** an option originating in the API-written key population is selected
+- **THEN** the value stored on the resource is that key's canonical id `keys/<bucket>/<name>`
 
 #### Scenario: Origin is explicit, not inferred
 - **WHEN** an option is built
 - **THEN** it carries an origin discriminator as data, so a name that happens to contain a separator is never mistaken for a canonical id
 
-### Requirement: A name present in both populations is offered once per origin and distinguishable
-Because the same name can exist in both populations and the two are referenced differently, collapsing them would make the stored reference ambiguous. The system SHALL keep both entries and SHALL make their origin visible to the user.
+### Requirement: A name present in both populations is offered once, with the platform entry winning
+Because the five short-name-keyed types share one map key (the bare name) across both populations, a name present in both would yield two options with the same stored reference — a duplicate Core resolves by letting the blob (platform) entry supersede the file entry via ordinary `Map.put`. The system SHALL offer a name present in both populations as a single option, keeping the API-written (platform) option and dropping the config-file duplicate, and SHALL still carry the origin discriminator on the surviving option. Duplicates within a single population are still collapsed to one.
 
-#### Scenario: A name in both populations yields two distinguishable options
-- **WHEN** the same entity name exists in both the config-file and API-written populations
-- **THEN** both are offered, each showing which population it came from, and selecting one stores that population's reference form
+#### Scenario: A name in both populations yields one platform-origin option
+- **WHEN** the same entity name of a short-name-keyed type exists in both the config-file and API-written populations
+- **THEN** a single option is offered, carrying the `Api` (platform) origin, and selecting it stores the bare name
+- **AND** the config-file entry of that name is not offered as a separate option
 
 #### Scenario: Duplicates within one population are collapsed
 - **WHEN** the same name appears more than once within a single population
 - **THEN** it is offered once
+
+#### Scenario: A name present in only one population is offered from that population
+- **WHEN** an entity name exists in only the config-file or only the API-written population
+- **THEN** it is offered as one option carrying its actual origin


### PR DESCRIPTION
DIAL Core PR #1813 re-keyed the merged Config maps for models, interceptors, roles, applications, and toolsets from canonical id ({type}/platform/{name}) to the bare short name, validating references with containsKey(ref). The admin frontend still stored the old canonical form for API-written entities, so every dependency attached through the Assets > Models / Assets > App Runners pickers failed Core's lookup ('Interceptor ... not found in config').

- getConfigEntityReference is now type-aware: the five short-name-keyed types resolve to option.name from both populations; routes and keys keep their canonical-id form (Core still keys those by canonical id).
- getModelDeploymentId returns the bare name; the detail view surfaces the bare deployment identifier.
- unionConfigEntityOptions collapses a name present in both populations to a single platform-wins option, matching Core's blob-supersedes-file Map.put semantics.

OpenSpec change archived; specs synced into core-config-file-client and assets-models.

**Description:**

<SHORT_DESCRIPTION>

Issues:

- Issue #4309


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
