### PR TITLE
fix: [Assets][App Runners] fix double-encoding in schema lookup after DIAL Core PR #1813

### DIFF
--- a/apps/ai-dial-admin/src/app/[lang]/platform-app-runners/actions.spec.ts
+++ b/apps/ai-dial-admin/src/app/[lang]/platform-app-runners/actions.spec.ts
@@ -214,9 +214,9 @@ describe('Assets app runner :: server actions', () => {
   test('Should read the resolved schema from Core', async () => {
     (appRunnerSchemaApi.resolvedSchema as any).mockResolvedValue(RESPONSE_MOCK);
 
-    const result = await getResolvedRunnerSchema(ENCODED);
+    const result = await getResolvedRunnerSchema(ID);
 
-    expect(appRunnerSchemaApi.resolvedSchema).toHaveBeenCalledWith(TOKEN_MOCK, ENCODED);
+    expect(appRunnerSchemaApi.resolvedSchema).toHaveBeenCalledWith(TOKEN_MOCK, ID);
     expect(result).toBe(RESPONSE_MOCK);
   });
 
@@ -227,7 +227,7 @@ describe('Assets app runner :: server actions', () => {
       errorMessage: 'Schema not found',
     });
 
-    const result = await getResolvedRunnerSchema(ENCODED);
+    const result = await getResolvedRunnerSchema(ID);
 
     expect(result.success).toBe(false);
     expect(result.errorMessage).toEqual('Schema not found');

--- a/apps/ai-dial-admin/src/components/Assets/Platform/AppRunners/Parameters.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Platform/AppRunners/Parameters.tsx
@@ -10,7 +10,6 @@ import SchemaGrid from '@/src/components/Common/SchemaGrid/SchemaGrid';
 import { EntitiesI18nKey } from '@/src/constants/i18n';
 import { useI18n } from '@/src/locales/client';
 import { DialAppRunnerResource } from '@/src/models/dial/resource';
-import { toCoreRunnerName } from '@/src/utils/app-runners/core-runner-name';
 import { AppRunnerAssetProps } from './models';
 
 interface Props extends AppRunnerAssetProps {
@@ -53,7 +52,7 @@ const AppRunnerAssetParameters: FC<Props> = ({ runner, onChange, isSkipRefresh }
       return;
     }
     setIsLoading(true);
-    getResolvedRunnerSchema(toCoreRunnerName(runner.$id)).then((res) => {
+    getResolvedRunnerSchema(runner.$id).then((res) => {
       setIsLoading(false);
       if (res.success && res.response) {
         setResolvedSchema(res.response as JsonSchema);

--- a/apps/ai-dial-admin/src/components/Assets/Platform/AppRunners/View.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Platform/AppRunners/View.tsx
@@ -26,7 +26,6 @@ import { DialAppRunnerResource, DialResource } from '@/src/models/dial/resource'
 import { DialRole } from '@/src/models/dial/role';
 import { ServerActionResponse } from '@/src/models/server-action';
 import { ApplicationRoute } from '@/src/types/routes';
-import { toCoreRunnerName } from '@/src/utils/app-runners/core-runner-name';
 import { toRunnerReference } from '@/src/utils/app-runners/runner-reference';
 import { validateAppRunner } from '@/src/utils/app-runners/validation';
 import { createSchemaSource } from '@/src/utils/entities/application-source';
@@ -102,7 +101,7 @@ const AppRunnerAssetView: FC<Props> = ({
       return;
     }
 
-    getResolvedRunnerSchema(toCoreRunnerName(id)).then((res) => {
+    getResolvedRunnerSchema(id).then((res) => {
       const resolved = res.success ? (res.response as DialApplicationScheme | undefined) : undefined;
       setApplicationProperties(getSchemaDefaults((resolved ?? originalRunner) as JSONSchema7));
     });

--- a/apps/ai-dial-admin/src/components/Assets/Platform/AppRunners/tests/Parameters.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Platform/AppRunners/tests/Parameters.spec.tsx
@@ -37,7 +37,7 @@ describe('AppRunnerAssetParameters', () => {
     render(<AppRunnerAssetParameters runner={runner({ [ENDPOINT]: 'http://remote/schema' })} onChange={vi.fn()} />);
 
     expect(await screen.findByText('schema-grid:readonly=true')).toBeInTheDocument();
-    expect(getResolvedRunnerSchema).toHaveBeenCalledWith('https%3A%2F%2Fhost%2Frunner');
+    expect(getResolvedRunnerSchema).toHaveBeenCalledWith('https://host/runner');
   });
 
   test('Should surface an error rather than an empty parameter set when Core cannot resolve the schema', async () => {

--- a/apps/ai-dial-admin/src/components/Assets/Platform/AppRunners/tests/create-asset-application.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Platform/AppRunners/tests/create-asset-application.spec.tsx
@@ -129,10 +129,10 @@ describe('App runner asset :: create asset application action', () => {
     expect(lastInitialValues().source).toBeUndefined();
   });
 
-  test('Should resolve the schema against Core by the encoded resource name', () => {
+  test('Should resolve the schema against Core by the raw runner $id', () => {
     renderView();
 
-    expect(getResolvedRunnerSchema).toHaveBeenCalledWith('https%3A%2F%2Fhost%2Frunner');
+    expect(getResolvedRunnerSchema).toHaveBeenCalledWith('https://host/runner');
   });
 
   test('Should seed application properties from the Core-resolved schema', async () => {

--- a/apps/ai-dial-admin/src/server/core/app-runner-schema-api.ts
+++ b/apps/ai-dial-admin/src/server/core/app-runner-schema-api.ts
@@ -11,8 +11,8 @@ const CORE_APP_TYPE_SCHEMA_URL = 'v1/application_type_schemas/schema';
  * external fetch the frontend performs. Core also strips the endpoint fields from this response,
  * which is why it is not a substitute for the plain content read.
  *
- * Lookup is by Core config-map key, which for an API-written runner is its canonical ID
- * (`schemas/platform/{name}`) rather than the runner's own `$id`.
+ * Lookup is by the runner's own `$id`, URL-encoded once for the query string. DIAL Core PR #1813
+ * changed the key from the canonical config-map path (`schemas/platform/{name}`) to the schema's `$id`.
  */
 export class AppRunnerSchemaApi extends CoreApi {
   resolvedSchema(token: Token, name: string): Promise<ServerActionResponse> {

--- a/openspec/changes/archive/2026-08-31-fix-app-runner-schema-lookup/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-31-fix-app-runner-schema-lookup/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-31

--- a/openspec/changes/archive/2026-08-31-fix-app-runner-schema-lookup/proposal.md
+++ b/openspec/changes/archive/2026-08-31-fix-app-runner-schema-lookup/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+DIAL Core PR #1813 changed how it keys app-runner schemas in its config-map — from the canonical prefix path (`schemas/platform/{name}`) to the schema's `$id` directly. The admin FE still passes the old prefix-based key, so the Parameters tab on `Assets > App Runners` always returns "Schema not found".
+
+## What Changes
+
+- Remove the pre-encoding (`toCoreRunnerName`) applied to `runner.$id` before passing it to `getResolvedRunnerSchema` in `Parameters.tsx` and `View.tsx` — the `AppRunnerSchemaApi.resolvedSchema` method already handles the one `encodeURIComponent` needed for the URL query param.
+- Update the stale comment in `AppRunnerSchemaApi` that describes the lookup key as `schemas/platform/{name}`.
+- Update the two tests that assert the now-incorrect double-encoded form.
+
+## Capabilities
+
+### New Capabilities
+
+_(none — this is a bug fix)_
+
+### Modified Capabilities
+
+- `app-runner-resources-core-api`: The "Resolved parameters" requirement's scenario must change: the `id` query param sent to Core is now the runner's `$id`, not `schemas/platform/{encoded $id}`.
+
+## Impact
+
+- `src/components/Assets/Platform/AppRunners/Parameters.tsx` — call site fix
+- `src/components/Assets/Platform/AppRunners/View.tsx` — call site fix
+- `src/server/core/app-runner-schema-api.ts` — comment update
+- `src/app/[lang]/platform-app-runners/actions.spec.ts` — test assertion update
+- `src/components/Assets/Platform/AppRunners/tests/Parameters.spec.tsx` — test assertion update
+- No change to `Entities > Application Runners` (uses a different API path)

--- a/openspec/changes/archive/2026-08-31-fix-app-runner-schema-lookup/specs/app-runner-resources-core-api/spec.md
+++ b/openspec/changes/archive/2026-08-31-fix-app-runner-schema-lookup/specs/app-runner-resources-core-api/spec.md
@@ -1,0 +1,23 @@
+## MODIFIED Requirements
+
+### Requirement: Resolved parameters are read from DIAL Core
+
+The system SHALL read a runner's resolved parameter schema from DIAL Core's `GET /v1/application_type_schemas/schema?id={$id}`, passing the runner's own `$id` (URL-encoded once for the query string) as the `id` query parameter. Core performs the external-schema download declared by `dial:applicationTypeSchemaEndpoint` and the merge itself.
+
+This replaces the previous behaviour where the `id` parameter was the canonical config-map key `schemas/platform/{name}` — DIAL Core PR #1813 changed the key to the schema's `$id` field.
+
+#### Scenario: Parameters read targets Core with the runner's $id
+
+- **WHEN** the Parameters tab loads for an asset runner whose `$id` is `https://mydial.epam.com/custom_application_schemas/qq`
+- **THEN** the request goes to Core's `application_type_schemas/schema` route with `id` set to `https%3A%2F%2Fmydial.epam.com%2Fcustom_application_schemas%2Fqq` (the `$id` URL-encoded once)
+- **AND** the request does NOT use `schemas/platform/` as a prefix in the `id` parameter
+
+#### Scenario: External schema resolution is not reimplemented in the frontend
+
+- **WHEN** a runner declares `dial:applicationTypeSchemaEndpoint`
+- **THEN** the frontend does not fetch that URL itself; the resolved schema returned by Core is used as-is
+
+#### Scenario: A freshly created runner is immediately resolvable
+
+- **WHEN** a runner is created and its Parameters tab is opened straight afterwards
+- **THEN** Core resolves it, because the blob write is folded into the merged config synchronously

--- a/openspec/changes/archive/2026-08-31-fix-app-runner-schema-lookup/tasks.md
+++ b/openspec/changes/archive/2026-08-31-fix-app-runner-schema-lookup/tasks.md
@@ -1,0 +1,21 @@
+## 1. Fix call sites
+
+- [x] 1.1 In `src/components/Assets/Platform/AppRunners/Parameters.tsx` line 56, change `getResolvedRunnerSchema(toCoreRunnerName(runner.$id))` to `getResolvedRunnerSchema(runner.$id)`
+- [x] 1.2 In `src/components/Assets/Platform/AppRunners/View.tsx` line 105, change `getResolvedRunnerSchema(toCoreRunnerName(id))` to `getResolvedRunnerSchema(id)`
+
+## 2. Update stale comment
+
+- [x] 2.1 In `src/server/core/app-runner-schema-api.ts`, replace the comment "Lookup is by Core config-map key, which for an API-written runner is its canonical ID (`schemas/platform/{name}`) rather than the runner's own `$id`." with "Lookup is by the runner's own `$id`, URL-encoded once for the query string. DIAL Core PR #1813 changed the key from the canonical config-map path (`schemas/platform/{name}`) to the schema's `$id` field."
+
+## 3. Update tests
+
+- [x] 3.1 In `src/app/[lang]/platform-app-runners/actions.spec.ts`, update the assertion at line 219 from `expect(appRunnerSchemaApi.resolvedSchema).toHaveBeenCalledWith(TOKEN_MOCK, ENCODED)` to `expect(appRunnerSchemaApi.resolvedSchema).toHaveBeenCalledWith(TOKEN_MOCK, ID)`
+- [x] 3.2 In `src/components/Assets/Platform/AppRunners/tests/Parameters.spec.tsx`, update the assertion at line 40 from `expect(getResolvedRunnerSchema).toHaveBeenCalledWith('https%3A%2F%2Fhost%2Frunner')` to `expect(getResolvedRunnerSchema).toHaveBeenCalledWith('https://host/runner')`
+
+## 4. Quality checks
+
+- [x] 4.1 Run `npx vitest run src/app/[lang]/platform-app-runners/actions.spec.ts src/components/Assets/Platform/AppRunners/tests/Parameters.spec.tsx` from `apps/ai-dial-admin/` and confirm all tests pass
+- [x] 4.2 Run `npm run lint` and `npm run format` and fix any issues
+
+<!-- No browser verification task: all change scenarios' THEN clauses describe HTTP request contracts
+     ("the request goes to Core with id set to ..."), not UI state. Unit tests in task 4.1 cover them. -->

--- a/openspec/specs/app-runner-resources-core-api/spec.md
+++ b/openspec/specs/app-runner-resources-core-api/spec.md
@@ -2,9 +2,7 @@
 
 ## Purpose
 App-runner-resource list, get, create, update, delete, and bulk-delete executed directly against DIAL Core's `ConfigResourceController`-backed `schemas/platform` routes, plus the FE-owned route array/object conversion and the Core-resolved parameters read — created by archiving change `add-app-runner-asset-resource`. This resource kind is flat, unversioned, and stores its request body verbatim (`WriteSpec.entityClass == null`), so Core performs no write-time validation and the frontend strips non-schema fields before every write. Its Core resource name is the runner's own `$id`, percent-encoded one extra layer so a URI survives Core's `ENTITY_NAME_PATTERN`. Distinct from the admin-BE-backed `Entities > Application Runners`, which is unchanged and shares no server actions with it.
-
 ## Requirements
-
 ### Requirement: App-runner resources served directly by DIAL Core
 
 The system SHALL route app-runner-resource list, get, create, update, delete, and bulk-delete operations to DIAL Core's `ConfigResourceController`-backed routes (`GET/PUT/DELETE /v1/schemas/platform/{name}`, list via `GET /v1/metadata/schemas/platform/`) unconditionally — there is no admin-BE fallback and no feature flag. This is a distinct resource kind from `Entities > Application Runners` (admin-BE-backed); the two SHALL NOT share server actions or API clients.
@@ -151,12 +149,15 @@ Core represents `dial:applicationTypeRoutes` as an object keyed by route name wh
 
 ### Requirement: Resolved parameters are read from DIAL Core
 
-The system SHALL read a runner's resolved parameter schema from DIAL Core's `GET /v1/application_type_schemas/schema?id={canonical id}`, passing the canonical ID `schemas/platform/{name}` as the `id` query parameter, instead of the admin BE's `resolvedSchema` endpoint. Core performs the external-schema download declared by `dial:applicationTypeSchemaEndpoint` and the merge itself.
+The system SHALL read a runner's resolved parameter schema from DIAL Core's `GET /v1/application_type_schemas/schema?id={$id}`, passing the runner's own `$id` (URL-encoded once for the query string) as the `id` query parameter. Core performs the external-schema download declared by `dial:applicationTypeSchemaEndpoint` and the merge itself.
 
-#### Scenario: Parameters read targets Core with the canonical id
+This replaces the previous behaviour where the `id` parameter was the canonical config-map key `schemas/platform/{name}` — DIAL Core PR #1813 changed the key to the schema's `$id` field.
 
-- **WHEN** the Parameters tab loads for an asset runner
-- **THEN** the request goes to Core's `application_type_schemas/schema` route with `id` set to `schemas/platform/{encoded $id}`, not to the admin BE
+#### Scenario: Parameters read targets Core with the runner's $id
+
+- **WHEN** the Parameters tab loads for an asset runner whose `$id` is `https://mydial.epam.com/custom_application_schemas/qq`
+- **THEN** the request goes to Core's `application_type_schemas/schema` route with `id` set to `https%3A%2F%2Fmydial.epam.com%2Fcustom_application_schemas%2Fqq` (the `$id` URL-encoded once)
+- **AND** the request does NOT use `schemas/platform/` as a prefix in the `id` parameter
 
 #### Scenario: External schema resolution is not reimplemented in the frontend
 
@@ -195,3 +196,4 @@ The system SHALL expose a list read that returns every app-runner resource in th
 
 - **WHEN** a runner is returned in the list
 - **THEN** its name is the fully decoded `$id` and its path is the singly-encoded form the CRUD calls address
+


### PR DESCRIPTION
Issues:

- Issue #4331 

## Summary

- DIAL Core PR #1813 changed the app-type schema key from `schemas/platform/{name}` to the schema's own `$id` field (a URI)
- `Parameters.tsx` and `View.tsx` were pre-encoding the `$id` via `toCoreRunnerName()` (`encodeURIComponent`), while `AppRunnerSchemaApi.resolvedSchema` already applies `encodeURIComponent` once — causing double-encoding that Core cannot match
- Remove the pre-encoding at both call sites so the raw `$id` flows through; `resolvedSchema` remains the sole encoder

## Changes

- `Parameters.tsx`, `View.tsx`: pass `runner.$id` / `id` directly to `getResolvedRunnerSchema` (remove `toCoreRunnerName` wrapper)
- `app-runner-schema-api.ts`: update stale comment to reflect the new keying behavior
- Tests updated to assert on the decoded `$id` instead of the URL-encoded form

## Test plan

- [ ] `npx vitest run src/app/[lang]/platform-app-runners/actions.spec.ts src/components/Assets/Platform/AppRunners/tests/Parameters.spec.tsx` passes
- [ ] Open an app runner that has `dial:applicationTypeSchemaEndpoint` set and verify its Parameters tab loads the resolved schema from Core (previously 404'd due to double-encoding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)