### PR TITLE
feat(analytics/EnrichmentRules): add JSON editor to enrichment rule detail page (Issue #4286)

### DIFF
--- a/apps/ai-dial-admin/src/app/[lang]/enrichment-rules/[id]/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/enrichment-rules/[id]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from 'next/navigation';
 
 import RuleDetailView from '@/src/components/Analytics/EnrichmentRules/RuleDetailView';
 import Page403 from '@/src/components/Page403/Page403';
+import { SaveValidationContextProvider } from '@/src/context/SaveValidationContext';
 import { EnrichmentRule } from '@/src/models/analytics/rule';
 import { EvaluatorSummary } from '@/src/models/analytics/evaluator';
 import { isAnalyticsForbidden } from '@/src/server/analytics/analytics-access';
@@ -47,11 +48,13 @@ export default async function Page({ params }: { params: Promise<{ id: string }>
   }
 
   return (
-    <RuleDetailView
-      originalRule={rule}
-      evaluators={evaluators ?? []}
-      hasEvaluatorsError={evaluators == null}
-      takenTargets={takenTargets}
-    />
+    <SaveValidationContextProvider>
+      <RuleDetailView
+        originalRule={rule}
+        evaluators={evaluators ?? []}
+        hasEvaluatorsError={evaluators == null}
+        takenTargets={takenTargets}
+      />
+    </SaveValidationContextProvider>
   );
 }

--- a/apps/ai-dial-admin/src/components/Analytics/EnrichmentRules/RuleDetailView.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/EnrichmentRules/RuleDetailView.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FC, useCallback, useEffect, useState } from 'react';
+import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 
 import {
   ButtonAppearance,
@@ -16,13 +16,18 @@ import RuleProperties from '@/src/components/Analytics/EnrichmentRules/Propertie
 import RuleReadOnlyFacts from '@/src/components/Analytics/EnrichmentRules/Properties/RuleReadOnlyFacts';
 import { useRuleForm } from '@/src/components/Analytics/EnrichmentRules/use-rule-form';
 import ChangedEntityButtons from '@/src/components/EntityHeaderControls/Buttons/ChangedEntityButtons';
+import { showEditorErrorNotifications } from '@/src/components/EntityHeaderControls/Buttons/utils';
+import JsonToggle from '@/src/components/EntityHeaderControls/JsonToggle/JsonToggle';
+import EntityJsonEditor from '@/src/components/EntityTabs/JsonEditor/JsonEditor';
 import RuleEnabledBadge from '@/src/components/Analytics/EnrichmentRules/RuleEnabledBadge';
 import { AnalyticsEnrichmentRulesI18nKey, ButtonsI18nKey } from '@/src/constants/i18n';
 import { useAppContext } from '@/src/context/AppContext';
 import { useNotification } from '@/src/context/NotificationContext';
+import { useSaveValidationContext, ValidationActionType } from '@/src/context/SaveValidationContext';
 import { useI18n } from '@/src/locales/client';
 import { EvaluatorSummary } from '@/src/models/analytics/evaluator';
-import { EnrichmentRule } from '@/src/models/analytics/rule';
+import { RuleDraft } from '@/src/models/analytics/enrichment-rules-ui';
+import { EnrichmentRule, TriggerKind } from '@/src/models/analytics/rule';
 import { isEqualSkippingUndefined } from '@/src/utils/is-equals-entity';
 import { getErrorNotification, getSuccessNotification } from '@/src/utils/notification';
 import { buildRuleDto, toRuleDraft } from '@/src/utils/analytics/rule-dto';
@@ -39,26 +44,61 @@ const RuleDetailView: FC<Props> = ({ originalRule, evaluators, hasEvaluatorsErro
   const router = useRouter();
   const { isFullAdmin } = useAppContext();
   const { showNotification } = useNotification();
+  const { dispatch, jsonErrors } = useSaveValidationContext();
 
   const form = useRuleForm({ rule: originalRule, takenTargets });
   const { draft, reset, buildDto, target } = form;
 
   const [isSaving, setIsSaving] = useState(false);
   const [isTogglePromptOpen, setIsTogglePromptOpen] = useState(false);
+  const [isEditorEnabled, setIsEditorEnabled] = useState(false);
+  // State rather than derived: `EntityJsonEditor` compares `entity` by identity against the object it last
+  // handed up, so a per-render object re-creates the Monaco model on every accepted keystroke.
+  const [documentSeed, setDocumentSeed] = useState<RuleDraft | null>(null);
+
+  const assemblyContext = useMemo(
+    () => ({ grainKey: form.grainKey, sourceTable: target?.source_table }),
+    [form.grainKey, target?.source_table],
+  );
+
+  const storedDocument = useMemo(
+    () => buildRuleDto(toRuleDraft(originalRule), assemblyContext),
+    [originalRule, assemblyContext],
+  );
+
+  const draftDocument = useMemo(() => buildRuleDto(draft, assemblyContext), [draft, assemblyContext]);
 
   // DTOs rather than draft-vs-rule: read-only members and the follow/pin inference would each read as an
   // edit that was never made.
-  const isChanged = !isEqualSkippingUndefined(
-    buildRuleDto(draft, { grainKey: form.grainKey, sourceTable: target?.source_table }),
-    buildRuleDto(toRuleDraft(originalRule), { grainKey: form.grainKey, sourceTable: target?.source_table }),
-  );
+  const isChanged = !isEqualSkippingUndefined(draftDocument, storedDocument);
 
-  useEffect(() => reset(originalRule), [originalRule, reset]);
+  const shouldCheckFields = !isEditorEnabled;
+  // `group_by` is rebuilt from the resolved target rather than carried through, so saving before the target
+  // resolves sends no group key and the full replace erases it — the one field check the editor keeps.
+  const isGroupKeyMissing = draft.trigger_kind === TriggerKind.Group && !form.grainKey;
+  // EntityJsonEditor forwards only a successful parse, so a broken document leaves `isChanged` false — and
+  // a first edit that breaks it would then offer neither Discard nor Save.
+  const hasJsonErrors = isEditorEnabled && Boolean(jsonErrors?.length);
+  const isChangeBarShown = isFullAdmin && (isChanged || hasJsonErrors);
 
-  const onDiscard = useCallback(() => reset(originalRule), [originalRule, reset]);
+  useEffect(() => {
+    reset(originalRule);
+    setDocumentSeed((seed) => (seed ? storedDocument : seed));
+  }, [originalRule, reset, storedDocument]);
+
+  const onDiscard = useCallback(() => {
+    dispatch({ type: ValidationActionType.Reset });
+    reset(originalRule);
+    setDocumentSeed(storedDocument);
+  }, [dispatch, originalRule, reset, storedDocument]);
+
+  const onToggleEditor = useCallback(() => {
+    if (!isEditorEnabled) setDocumentSeed(draftDocument);
+    setIsEditorEnabled((prev) => !prev);
+  }, [isEditorEnabled, draftDocument]);
 
   const onSave = useCallback(async () => {
-    if (!form.isValid || isSaving) return;
+    if ((shouldCheckFields && !form.isValid) || isGroupKeyMissing || isSaving) return;
 
     setIsSaving(true);
     const res = await updateRule(originalRule.id, buildDto());
@@ -78,7 +118,27 @@ const RuleDetailView: FC<Props> = ({ originalRule, evaluators, hasEvaluatorsErro
         res.requestId,
       ),
     );
-  }, [form.isValid, isSaving, originalRule.id, buildDto, showNotification, t, router]);
+  }, [
+    shouldCheckFields,
+    form.isValid,
+    isGroupKeyMissing,
+    isSaving,
+    originalRule.id,
+    buildDto,
+    showNotification,
+    t,
+    router,
+  ]);
+
+  const onTryToSave = useCallback(() => {
+    if (isEditorEnabled && jsonErrors?.length) {
+      const errorNotifications = showEditorErrorNotifications(jsonErrors, showNotification, t);
+      dispatch({ type: ValidationActionType.SetJsonEditorNotifications, errors: errorNotifications });
+      return;
+    }
+
+    void onSave();
+  }, [isEditorEnabled, jsonErrors, showNotification, t, dispatch, onSave]);
 
   // Built from the stored rule rather than the draft: PUT is a full replace, so sending the draft here
   // would persist edits the operator has not saved.
@@ -86,7 +146,7 @@ const RuleDetailView: FC<Props> = ({ originalRule, evaluators, hasEvaluatorsErro
     setIsTogglePromptOpen(false);
     setIsSaving(true);
     const res = await updateRule(originalRule.id, {
-      ...buildRuleDto(toRuleDraft(originalRule), { grainKey: form.grainKey, sourceTable: target?.source_table }),
+      ...storedDocument,
       enabled: !originalRule.enabled,
     });
     setIsSaving(false);
@@ -104,7 +164,7 @@ const RuleDetailView: FC<Props> = ({ originalRule, evaluators, hasEvaluatorsErro
         res.requestId,
       ),
     );
-  }, [originalRule, form.grainKey, target?.source_table, showNotification, t, router]);
+  }, [originalRule, storedDocument, showNotification, t, router]);
 
   const toggleLabel = t(
     originalRule.enabled ? AnalyticsEnrichmentRulesI18nKey.DisableRule : AnalyticsEnrichmentRulesI18nKey.EnableRule,
@@ -119,32 +179,43 @@ const RuleDetailView: FC<Props> = ({ originalRule, evaluators, hasEvaluatorsErro
     onClick: () => setIsTogglePromptOpen(true),
   };
 
+  // Outlined danger, the treatment SimpleButtonsWrapper gives Delete: disabling stops an enrichment other
+  // things depend on, while enabling only restores the expected state.
+  const enabledToggle = originalRule.enabled ? (
+    <DialDangerButton {...toggleProps} appearance={ButtonAppearance.Outlined} />
+  ) : (
+    <DialPrimaryButton {...toggleProps} />
+  );
+
+  const fieldsContent = (
+    <>
+      <RuleReadOnlyFacts rule={originalRule} />
+
+      <div className="flex flex-col gap-y-6 pt-6">
+        <RuleProperties form={form} evaluators={evaluators} hasEvaluatorsError={hasEvaluatorsError} />
+      </div>
+    </>
+  );
+
   return (
     <div className="flex flex-col flex-1 min-h-0 w-full bg-layer-2 rounded p-4 pb-14 lg:pb-4 relative gap-4">
       <div className="flex flex-row items-start justify-between gap-4">
         <div className="flex flex-col gap-1">
-          <RuleEnabledBadge enabled={originalRule.enabled} className="self-start" />
+          {!isEditorEnabled && <RuleEnabledBadge enabled={originalRule.enabled} className="self-start" />}
           <h1 className="text-primary dial-h4">{originalRule.name}</h1>
         </div>
 
-        {isFullAdmin && (
-          <div className="flex flex-row items-center gap-3">
-            {isChanged && (
-              <ChangedEntityButtons
-                disableSave={!form.isValid || isSaving}
-                onDiscard={onDiscard}
-                onSave={() => void onSave()}
-              />
-            )}
-            {originalRule.enabled ? (
-              // Outlined danger, the treatment SimpleButtonsWrapper gives Delete: disabling stops an
-              // enrichment other things depend on, while enabling only restores the expected state.
-              <DialDangerButton {...toggleProps} appearance={ButtonAppearance.Outlined} />
-            ) : (
-              <DialPrimaryButton {...toggleProps} />
-            )}
-          </div>
-        )}
+        <div className="flex flex-row items-center gap-3">
+          {isChangeBarShown && (
+            <ChangedEntityButtons
+              disableSave={(shouldCheckFields && !form.isValid) || isGroupKeyMissing || isSaving}
+              onDiscard={onDiscard}
+              onSave={onTryToSave}
+            />
+          )}
+          {isFullAdmin && !isEditorEnabled && enabledToggle}
+          {!isChangeBarShown && <JsonToggle isEditorEnabled={isEditorEnabled} onToggleEditor={onToggleEditor} />}
+        </div>
       </div>
 
       {isTogglePromptOpen && (
@@ -170,11 +241,11 @@ const RuleDetailView: FC<Props> = ({ originalRule, evaluators, hasEvaluatorsErro
       )}
 
       <div className="flex-1 overflow-auto min-h-0 flex flex-col">
-        <RuleReadOnlyFacts rule={originalRule} />
-
-        <div className="flex flex-col gap-y-6 pt-6">
-          <RuleProperties form={form} evaluators={evaluators} hasEvaluatorsError={hasEvaluatorsError} />
-        </div>
+        {isEditorEnabled ? (
+          <EntityJsonEditor entity={documentSeed} setSelectedEntity={form.replaceDraft} readonly={!isFullAdmin} />
+        ) : (
+          fieldsContent
+        )}
       </div>
     </div>
   );

--- a/apps/ai-dial-admin/src/components/Analytics/EnrichmentRules/tests/RuleJsonEditor.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/EnrichmentRules/tests/RuleJsonEditor.spec.tsx
@@ -1,0 +1,232 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import RuleDetailView from '@/src/components/Analytics/EnrichmentRules/RuleDetailView';
+import { AnalyticsEnrichmentRulesI18nKey, ButtonsI18nKey, EntitiesI18nKey } from '@/src/constants/i18n';
+import { EvaluatorType } from '@/src/models/analytics/evaluator';
+import { EnrichmentRule, TriggerKind } from '@/src/models/analytics/rule';
+
+vi.mock('@/src/app/[lang]/enrichment-rules/actions');
+vi.mock('@/src/app/[lang]/evaluators/actions');
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }) }));
+
+// The suite-wide SaveValidationContext mock pins `jsonErrors` empty and hands out a fresh
+// `showNotification` per call, so the marker cases need their own controllable pair.
+const mocks = vi.hoisted(() => ({
+  jsonErrors: [] as { message: string; startLineNumber: number }[],
+  dispatch: vi.fn(),
+  showNotification: vi.fn(() => 'notification-id'),
+  isFullAdmin: { value: true },
+  editorProps: { current: {} as Record<string, unknown> },
+}));
+
+vi.mock('@/src/context/SaveValidationContext', () => ({
+  SaveValidationContextProvider: ({ children }: { children: React.ReactNode }) => children,
+  useSaveValidationContext: () => ({
+    isValid: true,
+    dispatch: mocks.dispatch,
+    jsonErrors: mocks.jsonErrors,
+    jsonErrorNotifications: [],
+  }),
+  useJsonEditorValidation: () => ({ editorId: 'e1', setJsonErrors: vi.fn(), removeEditor: vi.fn() }),
+  ValidationActionType: { SetJsonEditorNotifications: 'SET_JSON_EDITOR_NOTIFICATIONS', Reset: 'RESET' },
+}));
+
+vi.mock('@/src/context/NotificationContext', () => ({
+  useNotification: () => ({ showNotification: mocks.showNotification, removeNotification: vi.fn() }),
+}));
+
+vi.mock('@/src/context/AppContext', () => ({
+  useAppContext: () => ({
+    isFullAdmin: mocks.isFullAdmin.value,
+    isReadOnlyAdmin: !mocks.isFullAdmin.value,
+    isEnableAuth: true,
+  }),
+}));
+
+vi.mock('@/src/components/EntityTabs/JsonEditor/JsonEditor', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  default: (props: any) => {
+    mocks.editorProps.current = props;
+    return (
+      <div role="application" aria-label="JSON editor">
+        <button type="button" onClick={() => props.setSelectedEntity({ ...props.entity, filter_sql: 'x > 1' })}>
+          edit-json
+        </button>
+      </div>
+    );
+  },
+}));
+
+const rule: EnrichmentRule = {
+  id: 'rule-1',
+  name: 'insights-live',
+  evaluator_name: 'conversation-insights',
+  evaluator: { name: 'conversation-insights', version: 2, type: EvaluatorType.Llm },
+  target_enrichment: 'conversation_insights',
+  trigger_kind: TriggerKind.OnIngest,
+  enabled: true,
+  grain_key: 'conversation_id',
+  generation: 3,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-02-01T00:00:00Z',
+};
+
+const renderView = () => render(<RuleDetailView originalRule={rule} evaluators={[]} takenTargets={[]} />);
+
+const queryToggleRow = () => screen.queryByRole('switch');
+const toggle = () => within(screen.getByRole('switch')).getByRole('checkbox');
+const enableEditor = (user: ReturnType<typeof userEvent.setup>) => user.click(toggle());
+const saveButton = () => screen.queryByRole('button', { name: ButtonsI18nKey.Save });
+const discardButton = () => screen.queryByRole('button', { name: ButtonsI18nKey.Discard });
+
+// Discard opens a confirmation whose confirm control carries the same label, so the prompt's own button is
+// the last one on screen.
+const confirmDiscard = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(discardButton() as HTMLElement);
+  const buttons = screen.getAllByRole('button', { name: ButtonsI18nKey.Discard });
+  await user.click(buttons[buttons.length - 1]);
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.jsonErrors = [];
+  mocks.isFullAdmin.value = true;
+  mocks.editorProps.current = {};
+});
+
+describe('RuleDetailView — entering the JSON editor', () => {
+  test('offers the toggle with nothing pending', () => {
+    renderView();
+
+    expect(queryToggleRow()).toBeInTheDocument();
+    expect(screen.getByText(EntitiesI18nKey.JSONEditor)).toBeInTheDocument();
+  });
+
+  test('offers the toggle to a caller who may not save', () => {
+    mocks.isFullAdmin.value = false;
+    renderView();
+
+    expect(queryToggleRow()).toBeInTheDocument();
+  });
+
+  test('a caller who may not save gets a read-only editor', async () => {
+    mocks.isFullAdmin.value = false;
+    const user = userEvent.setup();
+    renderView();
+
+    await enableEditor(user);
+
+    expect(mocks.editorProps.current.readonly).toBe(true);
+  });
+
+  test('enabling it withdraws the facts, the fields, the badge and the enable action', async () => {
+    const user = userEvent.setup();
+    renderView();
+
+    await enableEditor(user);
+
+    expect(screen.getByRole('application', { name: 'JSON editor' })).toBeInTheDocument();
+    expect(screen.queryByText(AnalyticsEnrichmentRulesI18nKey.Generation)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: AnalyticsEnrichmentRulesI18nKey.DisableRule })).not.toBeInTheDocument();
+  });
+
+  test('the rule name remains', async () => {
+    const user = userEvent.setup();
+    renderView();
+
+    await enableEditor(user);
+
+    expect(screen.getByRole('heading', { name: rule.name })).toBeInTheDocument();
+  });
+
+  test('the document omits the members the service assigns', async () => {
+    const user = userEvent.setup();
+    renderView();
+
+    await enableEditor(user);
+
+    expect(mocks.editorProps.current.entity).not.toHaveProperty('id');
+    expect(mocks.editorProps.current.entity).not.toHaveProperty('generation');
+  });
+});
+
+describe('RuleDetailView — the identity row while a change is pending', () => {
+  test('editing the document withdraws the toggle and offers Discard and Save', async () => {
+    const user = userEvent.setup();
+    renderView();
+
+    await enableEditor(user);
+    await user.click(screen.getByRole('button', { name: 'edit-json' }));
+
+    expect(queryToggleRow()).not.toBeInTheDocument();
+    expect(discardButton()).toBeInTheDocument();
+    expect(saveButton()).toBeInTheDocument();
+  });
+
+  test('breaking the document without changing the draft still offers a way out', async () => {
+    mocks.jsonErrors = [{ message: 'Expected comma', startLineNumber: 4 }];
+    const user = userEvent.setup();
+    renderView();
+
+    await enableEditor(user);
+
+    expect(queryToggleRow()).not.toBeInTheDocument();
+    expect(discardButton()).toBeInTheDocument();
+    expect(saveButton()).toBeEnabled();
+  });
+
+  test('the toggle returns once the document parses again', async () => {
+    mocks.jsonErrors = [{ message: 'Expected comma', startLineNumber: 4 }];
+    const user = userEvent.setup();
+    renderView();
+
+    await enableEditor(user);
+    expect(queryToggleRow()).not.toBeInTheDocument();
+
+    mocks.jsonErrors = [];
+    await confirmDiscard(user);
+
+    expect(queryToggleRow()).toBeInTheDocument();
+  });
+
+  test('discarding clears the validation state before resetting', async () => {
+    mocks.jsonErrors = [{ message: 'Expected comma', startLineNumber: 4 }];
+    const user = userEvent.setup();
+    renderView();
+
+    await enableEditor(user);
+    await confirmDiscard(user);
+
+    expect(mocks.dispatch).toHaveBeenCalledWith({ type: 'RESET' });
+  });
+});
+
+describe('RuleDetailView — saving from the JSON editor', () => {
+  test('unparseable JSON is reported per line and nothing is sent', async () => {
+    mocks.jsonErrors = [
+      { message: 'Expected comma', startLineNumber: 4 },
+      { message: 'Unexpected token', startLineNumber: 9 },
+    ];
+    const user = userEvent.setup();
+    renderView();
+
+    await enableEditor(user);
+    await user.click(saveButton() as HTMLElement);
+
+    expect(mocks.showNotification).toHaveBeenCalledTimes(2);
+  });
+
+  test('the fields shape check does not disable Save while the editor is on', async () => {
+    const user = userEvent.setup();
+    renderView();
+
+    await enableEditor(user);
+    await user.click(screen.getByRole('button', { name: 'edit-json' }));
+
+    // The form reports invalid until its evaluator and target resolve, which they never do here because the
+    // actions are mocked.
+    expect(saveButton()).toBeEnabled();
+  });
+});

--- a/apps/ai-dial-admin/src/components/Analytics/EnrichmentRules/tests/RuleJsonRoundTrip.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/EnrichmentRules/tests/RuleJsonRoundTrip.spec.tsx
@@ -1,0 +1,145 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { updateRule } from '@/src/app/[lang]/enrichment-rules/actions';
+import RuleDetailView from '@/src/components/Analytics/EnrichmentRules/RuleDetailView';
+import { ButtonsI18nKey } from '@/src/constants/i18n';
+import { EvaluatorType } from '@/src/models/analytics/evaluator';
+import { EnrichmentRule, TriggerKind } from '@/src/models/analytics/rule';
+
+vi.mock('@/src/app/[lang]/enrichment-rules/actions');
+vi.mock('@/src/app/[lang]/evaluators/actions');
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }) }));
+
+/**
+ * Only Monaco is stubbed, so the real EntityJsonEditor runs: its parse, its remount-on-external-change, and
+ * the path from the typed document to the request all take part. The sibling spec stubs the whole editor.
+ *
+ * Uncontrolled on purpose: Monaco owns its buffer and is re-seeded by the editor's remount key, so a
+ * controlled stub would fight the typing rather than reproduce it.
+ */
+vi.mock('@/src/components/Common/JsonEditorBase/JsonEditorBase', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  default: ({ value, onChange, options }: any) => (
+    <textarea
+      aria-label="json document"
+      readOnly={Boolean(options?.readOnly)}
+      defaultValue={value ?? ''}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}));
+
+const rule: EnrichmentRule = {
+  id: 'rule-1',
+  name: 'insights-live',
+  evaluator_name: 'conversation-insights',
+  evaluator_version: 2,
+  evaluator: { name: 'conversation-insights', version: 2, type: EvaluatorType.Llm },
+  target_enrichment: 'conversation_insights',
+  trigger_kind: TriggerKind.OnIngest,
+  enabled: true,
+  filter_sql: 'turn_count > 1',
+  grain_key: 'conversation_id',
+  generation: 3,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-02-01T00:00:00Z',
+};
+
+const renderView = () => render(<RuleDetailView originalRule={rule} evaluators={[]} takenTargets={[]} />);
+
+// Re-queried rather than cached: the editor may re-create the node, and a stale handle sends `paste` to
+// document.body instead, which silently turns an assertion about typed text into an assertion about nothing.
+const area = () => screen.getByLabelText('json document');
+
+const openEditor = async (user: ReturnType<typeof userEvent.setup>) => {
+  renderView();
+  await user.click(within(screen.getByRole('switch')).getByRole('checkbox'));
+};
+
+const documentOf = () => JSON.parse((area() as HTMLTextAreaElement).value);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const write = async (user: ReturnType<typeof userEvent.setup>, next: any) => {
+  await user.clear(area());
+  await user.paste(JSON.stringify(next, null, 4));
+};
+
+const save = async (user: ReturnType<typeof userEvent.setup>) =>
+  user.click(screen.getByRole('button', { name: ButtonsI18nKey.Save }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(updateRule).mockResolvedValue({ success: true });
+});
+
+describe('RuleDetailView — the typed document reaches the request', () => {
+  test('the document is the request: no members the service assigns', async () => {
+    const user = userEvent.setup();
+    await openEditor(user);
+
+    const document = documentOf();
+    expect(document).toMatchObject({ name: rule.name, filter_sql: rule.filter_sql });
+    expect(document).not.toHaveProperty('id');
+    expect(document).not.toHaveProperty('generation');
+    expect(document).not.toHaveProperty('grain_key');
+  });
+
+  test('changing a member the fields do not present reaches the request', async () => {
+    const user = userEvent.setup();
+    await openEditor(user);
+
+    await write(user, { ...documentOf(), rate_rpm: 120 });
+    await save(user);
+
+    expect(updateRule).toHaveBeenCalledWith(rule.id, expect.objectContaining({ rate_rpm: 120 }));
+  });
+
+  test('deleting the pinned evaluator version unpins the rule, with no error', async () => {
+    const user = userEvent.setup();
+    await openEditor(user);
+
+    const withoutPin = { ...documentOf() };
+    delete withoutPin.evaluator_version;
+    await write(user, withoutPin);
+    await save(user);
+
+    expect(updateRule).toHaveBeenCalledWith(rule.id, expect.not.objectContaining({ evaluator_version: 2 }));
+  });
+
+  test('renaming saves under the new name against the same rule', async () => {
+    const user = userEvent.setup();
+    await openEditor(user);
+
+    await write(user, { ...documentOf(), name: 'insights-live-v2' });
+    await save(user);
+
+    expect(updateRule).toHaveBeenCalledWith(rule.id, expect.objectContaining({ name: 'insights-live-v2' }));
+  });
+
+  test('a value of the wrong type neither breaks the page nor blocks the save', async () => {
+    const user = userEvent.setup();
+    await openEditor(user);
+
+    await write(user, { ...documentOf(), name: 5 });
+
+    expect(area()).toBeInTheDocument();
+    await save(user);
+
+    expect(updateRule).toHaveBeenCalled();
+  });
+
+  test('text that does not parse leaves the draft on its last good value', async () => {
+    const user = userEvent.setup();
+    await openEditor(user);
+
+    await write(user, { ...documentOf(), filter_sql: 'turn_count > 5' });
+    await user.click(area());
+    await user.paste('  <-- not json');
+    expect(() => documentOf()).toThrow();
+    await save(user);
+
+    expect(updateRule).toHaveBeenCalledWith(rule.id, expect.objectContaining({ filter_sql: 'turn_count > 5' }));
+  });
+});

--- a/apps/ai-dial-admin/src/components/Analytics/EnrichmentRules/tests/use-rule-form.spec.ts
+++ b/apps/ai-dial-admin/src/components/Analytics/EnrichmentRules/tests/use-rule-form.spec.ts
@@ -687,3 +687,49 @@ describe('useRuleForm — buildDto', () => {
     expect(result.current.buildDto().source).toBe('legacy_log');
   });
 });
+
+describe('useRuleForm — a draft that came from the JSON editor', () => {
+  test.each([
+    ['output_bindings as a string', { output_bindings: 'x' }],
+    ['output_bindings as an object', { output_bindings: {} }],
+    ['output_bindings holding null', { output_bindings: [null] }],
+    ['output_bindings holding a string', { output_bindings: ['abc'] }],
+    ['name as a number', { name: 5 }],
+    ['trigger_cron as a number on a scheduled rule', { trigger_kind: TriggerKind.Schedule, trigger_cron: 5 }],
+    ['input_bindings as a string', { input_bindings: 'x' }],
+    ['sampling as a string', { sampling: 'x' }],
+  ])('reading %s neither throws nor blanks the form', (_label, patch) => {
+    const { result } = renderForm({ rule: baseRule });
+
+    expect(() => {
+      act(() => result.current.replaceDraft({ ...result.current.draft, ...patch }));
+      void result.current.isValid;
+      void result.current.buildDto();
+    }).not.toThrow();
+  });
+
+  test('a wrongly typed cron does not read as a valid schedule', () => {
+    const { result } = renderForm({ rule: baseRule });
+
+    act(() =>
+      result.current.replaceDraft({
+        ...result.current.draft,
+        trigger_kind: TriggerKind.Schedule,
+        trigger_cron: 5,
+      } as never),
+    );
+
+    expect(result.current.isCronValid).toBe(false);
+  });
+
+  test('replaceDraft replaces rather than merging, so a deleted member is gone', () => {
+    const { result } = renderForm({ rule: { ...baseRule, filter_sql: 'score > 0.5' } });
+
+    const withoutFilter = { ...result.current.draft };
+    delete withoutFilter.filter_sql;
+    act(() => result.current.replaceDraft(withoutFilter));
+
+    expect(result.current.draft.filter_sql).toBeUndefined();
+    expect(result.current.buildDto()).not.toHaveProperty('filter_sql');
+  });
+});

--- a/apps/ai-dial-admin/src/components/Analytics/EnrichmentRules/use-rule-form.ts
+++ b/apps/ai-dial-admin/src/components/Analytics/EnrichmentRules/use-rule-form.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useMemo, useState } from 'react';
+import { Dispatch, SetStateAction, useCallback, useMemo, useState } from 'react';
 
 import {
   getBindingRowError,
@@ -13,6 +13,7 @@ import { CreateRuleDto, EnrichmentRule, TriggerKind } from '@/src/models/analyti
 import { GROUP_FETCH_MAX_ROWS } from '@/src/constants/analytics/enrichment-rules';
 import { isValidSixFieldCron } from '@/src/utils/analytics/cron';
 import { buildRuleDto, toRuleDraft } from '@/src/utils/analytics/rule-dto';
+import { trimmedString } from '@/src/utils/formatting/trimmed-string';
 
 interface Params {
   rule?: EnrichmentRule;
@@ -44,6 +45,8 @@ export const useRuleForm = ({ rule, takenTargets = [] }: Params = {}) => {
 
   const reset = useCallback((next: EnrichmentRule) => setDraft(toRuleDraft(next)), []);
 
+  const replaceDraft: Dispatch<SetStateAction<RuleDraft>> = setDraft;
+
   const availableTargets = useMemo(() => {
     // The edited rule's own target must stay listed, or the select is stranded on a value it does not offer.
     const taken = new Set(takenTargets.filter((name) => name !== rule?.target_enrichment));
@@ -52,10 +55,13 @@ export const useRuleForm = ({ rule, takenTargets = [] }: Params = {}) => {
 
   const { evaluator, grainKey, targetColumns, outputVars } = resolution;
 
-  const boundOutputs = draft.output_bindings ?? [];
+  const boundOutputs = (Array.isArray(draft.output_bindings) ? draft.output_bindings : []).filter(
+    (binding) => Boolean(binding) && typeof binding === 'object',
+  );
   const hasReadyWhen = Boolean(draft.ready_when?.idle || draft.ready_when?.max_staleness || draft.ready_when?.signal);
   const isCostCeilingValid = isPositiveIntegerOrEmpty(draft.ready_when?.cost_ceiling);
-  const isCronValid = Boolean(draft.trigger_cron) && isValidSixFieldCron(draft.trigger_cron ?? '');
+  const isCronValid =
+    Boolean(trimmedString(draft.trigger_cron)) && isValidSixFieldCron(trimmedString(draft.trigger_cron));
   const isSamplingValid = draft.sampling == null || (draft.sampling >= 0 && draft.sampling <= 1);
   // Only a group rule sends `member_select`, and only a group rule shows the control. Validating it for
   // any other kind blocks the save with a message that is not on screen.
@@ -87,7 +93,7 @@ export const useRuleForm = ({ rule, takenTargets = [] }: Params = {}) => {
     !resolution.hasTargetError;
 
   const isValid =
-    Boolean(draft.name?.trim()) &&
+    Boolean(trimmedString(draft.name)) &&
     Boolean(draft.evaluator_name) &&
     Boolean(draft.target_enrichment) &&
     draft.enabled != null &&
@@ -106,6 +112,7 @@ export const useRuleForm = ({ rule, takenTargets = [] }: Params = {}) => {
   return {
     draft,
     onChange,
+    replaceDraft,
     reset,
     buildDto,
     availableTargets,

--- a/apps/ai-dial-admin/src/utils/analytics/evaluator-dto.ts
+++ b/apps/ai-dial-admin/src/utils/analytics/evaluator-dto.ts
@@ -1,3 +1,4 @@
+import { trimmedString } from '@/src/utils/formatting/trimmed-string';
 import {
   CreateEvaluatorDto,
   Evaluator,
@@ -15,10 +16,6 @@ export const toEvaluatorDraft = (evaluator: Evaluator): CreateEvaluatorDto => {
 };
 
 export const getVarExpression = (item: EvaluatorVar): string => item.sql ?? item.jsonata ?? '';
-
-// A draft can hold whatever parsed — `"model": 5`, `"output_vars": {}` — and both exported functions below
-// run during render, where a bare `.trim()` or `.filter()` on one of those blanks the page.
-const trimmed = (value: unknown): string => (typeof value === 'string' ? value.trim() : '');
 
 const asVars = (value: unknown): EvaluatorVar[] =>
   (Array.isArray(value) ? value : []).filter((item): item is EvaluatorVar => Boolean(item) && typeof item === 'object');
@@ -41,7 +38,7 @@ const isEmpty = (value: unknown): boolean =>
 
 const namedVars = (vars: unknown, type: EvaluatorType): EvaluatorVar[] =>
   asVars(vars)
-    .filter((item) => trimmed(item.name))
+    .filter((item) => trimmedString(item.name))
     .map((item) => toTypedVar(item, type));
 
 // Rebuilt from the selected type on every save rather than carried over: the service answers 422 for an
@@ -78,16 +75,16 @@ export const buildEvaluatorDto = (draft: CreateEvaluatorDto): CreateEvaluatorDto
 };
 
 export const isEvaluatorShapeValid = (draft: CreateEvaluatorDto): boolean => {
-  if (!trimmed(draft.name) || !draft.type) return false;
+  if (!trimmedString(draft.name) || !draft.type) return false;
 
   const outputVars = asVars(draft.output_vars);
-  if (!outputVars.length || outputVars.some((item) => !trimmed(item.name) || !item.type)) return false;
+  if (!outputVars.length || outputVars.some((item) => !trimmedString(item.name) || !item.type)) return false;
 
   if (draft.type === EvaluatorType.Sql) {
     return outputVars.every((item) => Boolean(getVarExpression(item)));
   }
 
-  return Boolean(draft.preset) && Boolean(trimmed(draft.model));
+  return Boolean(draft.preset) && Boolean(trimmedString(draft.model));
 };
 
 export const toParamRows = (params: Record<string, unknown> = {}): EvaluatorParamRow[] =>

--- a/apps/ai-dial-admin/src/utils/analytics/rule-dto.ts
+++ b/apps/ai-dial-admin/src/utils/analytics/rule-dto.ts
@@ -1,4 +1,5 @@
 import { RuleDraft, SourceMode } from '@/src/models/analytics/enrichment-rules-ui';
+import { trimmedString } from '@/src/utils/formatting/trimmed-string';
 import { CreateRuleDto, EnrichmentRule, ReadyWhen, TriggerKind } from '@/src/models/analytics/rule';
 
 interface Context {
@@ -44,10 +45,10 @@ export const buildRuleDto = (draft: RuleDraft, { grainKey, sourceTable }: Contex
   READ_ONLY_MEMBERS.forEach((key) => delete dto[key]);
   TRIGGER_OWNED_MEMBERS.forEach((key) => delete dto[key]);
 
-  dto.name = draft.name?.trim() ?? '';
+  dto.name = trimmedString(draft.name);
 
-  if (draft.trigger_kind === TriggerKind.Schedule && draft.trigger_cron) {
-    dto.trigger_cron = draft.trigger_cron.trim();
+  if (draft.trigger_kind === TriggerKind.Schedule && trimmedString(draft.trigger_cron)) {
+    dto.trigger_cron = trimmedString(draft.trigger_cron);
   }
 
   if (draft.trigger_kind === TriggerKind.Group) {
@@ -59,8 +60,12 @@ export const buildRuleDto = (draft: RuleDraft, { grainKey, sourceTable }: Contex
     if (draft.member_select?.limit) {
       dto.member_select = {
         limit: draft.member_select.limit,
-        ...(draft.member_select.prefer_sql?.trim() ? { prefer_sql: draft.member_select.prefer_sql.trim() } : {}),
-        ...(draft.member_select.order_by?.length ? { order_by: draft.member_select.order_by } : {}),
+        ...(trimmedString(draft.member_select.prefer_sql)
+          ? { prefer_sql: trimmedString(draft.member_select.prefer_sql) }
+          : {}),
+        ...(Array.isArray(draft.member_select.order_by) && draft.member_select.order_by.length
+          ? { order_by: draft.member_select.order_by }
+          : {}),
       };
     }
   }
@@ -84,10 +89,10 @@ export const getSourceMode = (source?: string, sourceTable?: string): SourceMode
   !source || source === sourceTable ? SourceMode.Follow : SourceMode.Pin;
 
 const compactReadyWhen = (readyWhen?: ReadyWhen): ReadyWhen | undefined => {
-  if (!readyWhen) return undefined;
+  if (!readyWhen || typeof readyWhen !== 'object') return undefined;
 
   const next: ReadyWhen = {};
-  if (readyWhen.signal?.trim()) next.signal = readyWhen.signal.trim();
+  if (trimmedString(readyWhen.signal)) next.signal = trimmedString(readyWhen.signal);
   if (readyWhen.idle) next.idle = readyWhen.idle;
   if (readyWhen.max_staleness) next.max_staleness = readyWhen.max_staleness;
   if (readyWhen.cost_ceiling) next.cost_ceiling = readyWhen.cost_ceiling;

--- a/apps/ai-dial-admin/src/utils/formatting/tests/trimmed-string.spec.ts
+++ b/apps/ai-dial-admin/src/utils/formatting/tests/trimmed-string.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'vitest';
+
+import { trimmedString } from '@/src/utils/formatting/trimmed-string';
+
+describe('trimmedString', () => {
+  test.each([
+    ['  spaced  ', 'spaced'],
+    ['', ''],
+    ['already', 'already'],
+  ])('trims the string %s', (input, expected) => {
+    expect(trimmedString(input)).toBe(expected);
+  });
+
+  test.each([[5], [true], [{}], [[]], [null], [undefined]])('reads %s as absent rather than throwing', (input) => {
+    expect(trimmedString(input)).toBe('');
+  });
+});

--- a/apps/ai-dial-admin/src/utils/formatting/trimmed-string.ts
+++ b/apps/ai-dial-admin/src/utils/formatting/trimmed-string.ts
@@ -1,0 +1,7 @@
+/**
+ * For members that reach the console as parsed JSON rather than through a typed control — the entity JSON
+ * editors let an operator put anything that parses on a draft. `?.trim()` guards a missing value but not a
+ * value of the wrong type, and these members are read while the page renders, where a `TypeError` reaches
+ * the error boundary and blanks the page.
+ */
+export const trimmedString = (value: unknown): string => (typeof value === 'string' ? value.trim() : '');

--- a/apps/ai-dial-admin/src/utils/tests/rule-dto.spec.ts
+++ b/apps/ai-dial-admin/src/utils/tests/rule-dto.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 
-import { SourceMode } from '@/src/models/analytics/enrichment-rules-ui';
+import { RuleDraft, SourceMode } from '@/src/models/analytics/enrichment-rules-ui';
 import { EnrichmentRule, RulePriority, TriggerKind } from '@/src/models/analytics/rule';
 import { EvaluatorType } from '@/src/models/analytics/evaluator';
 import { buildRuleDto, getReadOnlyMembers, getSourceMode, toRuleDraft } from '@/src/utils/analytics/rule-dto';
@@ -154,5 +154,68 @@ describe('buildRuleDto', () => {
     buildRuleDto({ ...input, trigger_kind: TriggerKind.OnIngest });
 
     expect(input.trigger_cron).toBe('0 0 * * * *');
+  });
+});
+
+describe('buildRuleDto — a draft that came from the JSON editor', () => {
+  test.each([
+    ['name as a number', TriggerKind.OnIngest, { name: 5 }],
+    ['name as an object', TriggerKind.OnIngest, { name: {} }],
+    ['trigger_cron as a number on a scheduled rule', TriggerKind.Schedule, { trigger_cron: 5 }],
+    ['prefer_sql as a number on a group rule', TriggerKind.Group, { member_select: { limit: 1, prefer_sql: 5 } }],
+    ['order_by as a string on a group rule', TriggerKind.Group, { member_select: { limit: 1, order_by: 'x' } }],
+    ['ready_when as a string on a group rule', TriggerKind.Group, { ready_when: 'x' }],
+    ['ready_when.signal as a number on a group rule', TriggerKind.Group, { ready_when: { signal: 5 } }],
+    ['source as a number', TriggerKind.OnIngest, { source: 5 }],
+    ['input_bindings as an object', TriggerKind.OnIngest, { input_bindings: {} }],
+  ])('does not throw on %s', (_label, kind, patch) => {
+    const draft = { ...toRuleDraft(rule), trigger_kind: kind, ...patch } as unknown as RuleDraft;
+
+    expect(() => buildRuleDto(draft, { grainKey: 'g', sourceTable: 'dial_usage_log' })).not.toThrow();
+  });
+
+  test('a member_select order_by that is not a list is dropped rather than sent', () => {
+    const dto = buildRuleDto(
+      {
+        ...toRuleDraft(rule),
+        trigger_kind: TriggerKind.Group,
+        member_select: { limit: 1, order_by: 'x' },
+      } as unknown as RuleDraft,
+      { grainKey: 'g' },
+    );
+
+    expect(dto.member_select).toEqual({ limit: 1 });
+  });
+
+  test('a ready_when that is not an object is dropped rather than sent', () => {
+    const dto = buildRuleDto(
+      { ...toRuleDraft(rule), trigger_kind: TriggerKind.Group, ready_when: 'x' } as unknown as RuleDraft,
+      { grainKey: 'g' },
+    );
+
+    expect(dto).not.toHaveProperty('ready_when');
+  });
+
+  test('a wrongly typed name is dropped rather than faulting, and the service refuses it', () => {
+    // Narrowed to a blank string, then removed by the empty-member prune — so the name is absent rather
+    // than blank, and `@NotBlank` on the service is what refuses it.
+    const dto = buildRuleDto({ ...toRuleDraft(rule), name: 5 } as unknown as RuleDraft);
+
+    expect(dto).not.toHaveProperty('name');
+  });
+
+  test('an assembled request is itself a valid draft, so it round-trips', () => {
+    const context = { grainKey: 'response_id', sourceTable: 'dial_usage_log' };
+    const first = buildRuleDto(toRuleDraft(rule), context);
+
+    expect(buildRuleDto(first as RuleDraft, context)).toEqual(first);
+  });
+
+  test('a rule that follows its target does not come back pinned', () => {
+    const context = { grainKey: 'response_id', sourceTable: 'dial_usage_log' };
+    const followed = buildRuleDto({ ...toRuleDraft(rule), source: 'dial_usage_log' } as RuleDraft, context);
+
+    expect(followed).not.toHaveProperty('source');
+    expect(buildRuleDto(followed as RuleDraft, context)).not.toHaveProperty('source');
   });
 });

--- a/openspec/changes/add-enrichment-rule-json-editor/.openspec.yaml
+++ b/openspec/changes/add-enrichment-rule-json-editor/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-31

--- a/openspec/changes/add-enrichment-rule-json-editor/design.md
+++ b/openspec/changes/add-enrichment-rule-json-editor/design.md
@@ -1,0 +1,148 @@
+## Context
+
+See `proposal.md` — Why. What shapes the approach is how much of this already exists.
+
+The archived change `2026-08-31-add-evaluator-json-editor` built the same editor over the evaluator detail
+page and settled the behaviour: one draft behind both presentations, one write path, the mode taking the
+whole view, the toggle giving way to Discard/Save once something is pending, Monaco's markers gating the
+save. This change repeats that shape on rules. Its design decisions are not re-argued here; only where
+rules differ.
+
+Three differences do the work:
+
+- **`buildRuleDto` is already carry-through.** It spreads the draft and subtracts, with a comment saying
+  that is what stops a full-replace PUT from erasing unpresented members. `buildEvaluatorDto` had to be
+  inverted to reach that; here there is nothing to invert, and the editor's ability to introduce a member
+  falls out of code that already exists.
+- **The draft is not the request.** `useRuleForm` holds a `RuleDraft`; the request is derived on save —
+  trigger-owned members rebuilt from `trigger_kind`, `source` dropped when the rule follows its target,
+  empty members dropped. The evaluator's draft *was* the DTO, so that change had no such choice to make.
+- **The save overwrites in place.** An evaluator save appends an immutable version; a rule save replaces
+  the rule. That is the whole reason these were separate changes.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- The same editor behaviour a reader already knows from the evaluator page, with no rule-specific
+  variation that is not forced by the rule's own shape.
+- A document that is literally the request body, so what is read is what is sent.
+- No new validation, no new i18n key for the toggle, no change to the enable/disable flow.
+
+**Non-Goals:**
+
+- Extracting the shared wiring — see Decisions.
+- Guarding erasure. Specified in the delta as behaviour, not deferred.
+- Anything about the rules listing, or about tables.
+
+## Decisions
+
+### The document is seeded on entry, not derived per render
+
+`EntityJsonEditor` decides whether to re-create the Monaco model by comparing `entity` **by identity**
+against the object it last handed up. The evaluator satisfies that by passing the draft straight back —
+what goes down is what came up. Deriving the document instead breaks it: `buildRuleDto` opens with
+`{ ...draft }`, so the object going down is never the one that came up, and the model is re-created on
+every accepted keystroke.
+
+Measured before the fix: two mounts for one edit, the previous node detached, and `"two words "` coming
+back as `"two words"` — the re-seeded buffer is the re-normalized request, so a trailing space cannot be
+typed and the cursor returns to the top on every character. A `useMemo` does not help; the memo's output
+still is not the object the editor handed up.
+
+So the document is state, seeded from the assembled request when the editor opens and re-seeded only when
+the rule underneath is replaced — a discard, or the re-read after a save. Between those the buffer belongs
+to the caller. The normalization the next decision accepts therefore happens once, on entry, which is what
+the delta says.
+
+### The document shows the request, not the draft
+
+The two candidates are the `RuleDraft` the form holds and the `CreateRuleDto` the save derives from it.
+The DTO wins because the save is a full replace: the body and the rule are the same object, so a document
+that is anything other than the body would mean the caller edits one thing and the console sends another.
+It also makes the erasure honest — a member absent from what you are looking at is a member absent from
+the rule.
+
+The cost is visible on entry rather than hidden: a rule following its target opens without `source`, and
+members left empty are absent rather than blank. Both are specified.
+
+On leaving the editor the document is mapped back through the same shape the form reads, so the fields
+show what the document held. `getSourceMode` already resolves an absent `source` to Follow, which is what
+makes that direction lossless for the one member the DTO drops on purpose.
+
+### The grouping key keeps its guard in both presentations
+
+Bypassing the form's checks in editor mode is deliberate, with one exception. `group_by` is trigger-owned:
+always deleted, then rebuilt from `grainKey`, which the target resolves asynchronously. Unresolved, it is
+blank and the empty-member prune removes it — and the save is a full replace, so the grouping key is
+erased. The fields never allowed that, because `isValid` requires a resolved grain key for a group rule;
+bypassing them must not open it. The check is kept explicitly rather than falling out of `form.isValid`,
+so that the exception is visible.
+
+### Wrongly typed members are narrowed where they are trimmed
+
+`buildRuleDto` calls `draft.name?.trim()`, and `RuleDetailView` calls `buildRuleDto` **in render** — not
+inside a `useMemo` — to derive `isChanged`. A pasted `"name": 5` therefore throws during render and the
+error boundary blanks the page, losing the document. `?.` covers a missing value, not a value of the
+wrong type.
+
+There are four such sites across two files, and three of them are reachable only under a particular
+trigger kind — `trigger_cron`
+for `schedule`, `member_select.prefer_sql` and `ready_when.signal` for `group`. A sweep that fixes the
+trigger kind finds only the name and reads as "one narrow guard"; sweeping all three kinds finds all four.
+Worth stating because the cheap check is the misleading one.
+
+`use-rule-form.ts` needs the same treatment and is easy to miss: it runs `isValid`, `isCronValid` and the
+stranded-binding scan on every render, outside any `useMemo`, so guarding the assembly alone still leaves
+the page able to blank. `?? []` there does not save `output_bindings` holding a string, and a `null` entry
+faults the scan.
+
+Two of the changes in `rule-dto.ts` are **not** throw guards, and were miscounted as such at first: nothing
+downstream calls a method on `member_select.order_by` or on a non-object `ready_when`. `Array.isArray` and
+the object check there change behaviour — such a value is dropped rather than carried — so each carries an
+assertion about what it drops rather than about an absence of faults.
+
+Everything else is safe — the assembly spreads rather than iterating and reads other members without
+calling methods on them — so the fix is a `trimmed()` helper at the trimming sites plus `Array.isArray`
+and an entry filter where the bindings are read, not a rewrite.
+
+The helper is copied rather than shared with `evaluator-dto.ts`, which has an identical one, and copied
+again into the form hook. Sharing it would pull the evaluator module into this PR for a single line,
+against the same reasoning that keeps the wiring duplicated.
+
+Moving the `isChanged` computation into a `useMemo` would not help — it would still run during render.
+The guard belongs in `rule-dto.ts`, where the values are touched.
+
+### The wiring is duplicated, not extracted
+
+The evaluator change's design.md said extraction would happen once a second consumer existed, and this is
+that consumer. The plan is dropped on purpose: extracting now means this PR also rewrites the evaluator
+page, which is still in review, and the shared part is a provider on the page plus a handful of lines
+reading `jsonErrors` before opening the save. The duplication is small and visible; a premature harness
+over two pages that differ in their surrounding controls is not.
+
+That earlier change is archived and is not edited to reflect this. The record of why the plan changed
+lives here instead.
+
+### The toggle moves out of the full-admin guard
+
+The rule page currently wraps its whole action cluster in `{isFullAdmin && (…)}`, so a caller without
+rights sees no controls at all. The toggle has to sit outside that, with the editor read-only, for the
+read path the delta requires. The Discard/Save pair stays inside it.
+
+## Risks / Trade-offs
+
+- **A member is erased by a keystroke and nothing says so.** → Accepted and specified rather than
+  mitigated; the reasoning is in the delta so it reads as a decision. The narrowest real case —
+  `evaluator_version` — carries its own scenario, since it fails silently rather than loudly.
+- **The document is the DTO, so entering the editor visibly normalizes the rule.** → Specified, and the
+  alternative was worse: a document that is not what gets sent.
+- **The form's uniqueness check on `target_enrichment` is bypassed.** → Intended; the service enforces it
+  and its refusal surfaces the same way every other failed save does.
+- **Duplicated wiring drifts from the evaluator's copy.** → Real, and the reason to keep the copy small
+  and identical. A third consumer would be the point to extract.
+- **Monaco markers arrive asynchronously**, so the change bar appears a beat after the document breaks.
+  → Inherited from the evaluator page, not introduced here.
+- **Monaco does not run under jsdom.** → Component tests stub it. The evaluator change learned that
+  stubbing the *whole* editor hides the path between the typed document and the request; one spec here
+  stubs only `JsonEditorBase` so the real `EntityJsonEditor` runs.

--- a/openspec/changes/add-enrichment-rule-json-editor/proposal.md
+++ b/openspec/changes/add-enrichment-rule-json-editor/proposal.md
@@ -1,0 +1,110 @@
+## Why
+
+An enrichment rule carries members the detail page presents no control for. `buildRuleDto` already
+carries them through untouched — the rule form was built that way on purpose, because `PUT /v1/rules/{id}`
+is a full replace and an omitted member is erased. So the console can round-trip a member it does not
+understand, but it cannot let anyone **read or change** one. The only way to see what a rule actually
+holds is to call the service directly.
+
+Every other editable entity in the console answers this with a JSON editor toggle, and the evaluator
+detail page gained one in the change archived as `2026-08-31-add-evaluator-json-editor`. This applies the
+same pattern to the second, and last, analytics entity that can take it.
+
+Rules were deliberately split out of that change rather than shipped alongside it. The reason is the
+full replace: on an evaluator a mistaken document registers a new version and leaves the old one intact,
+while on a rule it overwrites the rule in place, and a member left out is gone. That risk deserved its own
+review rather than riding along with an append-only entity.
+
+## What Changes
+
+- The rule detail view gains a **JSON editor toggle** in the identity row, offered to every caller. The
+  editor is read-only for a caller who may not save, matching how the fields are already gated.
+- **The document is the assembled request, not the form draft.** The rule form keeps a `RuleDraft` and
+  derives the request on save; the editor shows what will be sent. Full replace makes that the honest
+  choice — the document *is* the request body — at the cost of the operator seeing `source` normalized
+  away in Follow mode and empty members dropped on entry.
+- **Editor mode takes the whole view.** Below the identity row there is only the document: the read-only
+  facts panel, the fields, the status badge, and the enable/disable action are all withdrawn. Reaching
+  any of them means leaving the editor.
+- The identity row keeps the rule name plus whichever control applies — the toggle when nothing is
+  pending, Discard/Save when something is. They alternate; they are never both present.
+- Both the editor and the fields edit **one** draft and submit through **one** path, so the same document
+  produces the same request either way.
+- Monaco's parse errors block submission and are reported per line, with the Save control staying enabled
+  and refusing on use. They also raise the Discard/Save pair on their own, because text that does not
+  parse never reaches the draft — without that a caller whose first edit breaks the document is offered
+  no way out and no way to find out what is wrong. No rule-specific validation is added: the form's own
+  checks, including the `target_enrichment` uniqueness check against the other rules, stop gating the
+  save in editor mode, and the service's refusal is what surfaces instead.
+- **BREAKING for the operator, and accepted deliberately**: removing a member from the document erases it
+  from the rule. Deleting `evaluator_version` unpins the rule from its evaluator version with no error at
+  all, because the service accepts that request. This is specified rather than guarded — see Impact.
+
+## Capabilities
+
+### New Capabilities
+
+None. This applies an established console pattern to an entity the analytics spec already owns.
+
+### Modified Capabilities
+
+- `analytics`: adds requirements covering the rule JSON editor — what the document contains, who may open
+  versus edit it, what the mode withdraws, how saving and validation behave in it, and the erasure that
+  full replace makes possible. Extends the existing enrichment-rule requirements rather than replacing
+  them; in particular `Saving replaces the rule whole without discarding unpresented members` continues to
+  hold and is what makes the editor's carry-through work.
+
+## Impact
+
+**Code**
+
+- `apps/ai-dial-admin/src/components/Analytics/EnrichmentRules/RuleDetailView.tsx` — toggle state and
+  placement, the body swap, the save gates. The whole action cluster currently sits inside
+  `{isFullAdmin && (…)}`, so the toggle has to move out of it for a read-only caller to reach the editor.
+- `apps/ai-dial-admin/src/utils/analytics/rule-dto.ts` — `buildRuleDto` throws on `draft.name?.trim()`
+  when the name is not a string. See below.
+- `apps/ai-dial-admin/src/app/[lang]/enrichment-rules/[id]/page.tsx` — must be wrapped in
+  `SaveValidationContextProvider`. `EntityJsonEditor` calls `useJsonEditorValidation()` unconditionally,
+  before consulting `readonly`, so the page throws without it even for a caller who only reads.
+
+**A defect this change has to fix, not merely avoid**
+
+`RuleDetailView` computes `isChanged` by calling `buildRuleDto` **directly in render**, not inside a
+`useMemo`. Once a document can hold anything that parses, a pasted `"name": 5` reaches
+`draft.name?.trim()` and throws during render, which the error boundary turns into a blank page — taking
+the unsaved document with it. `?.` guards a missing value, not a value of the wrong type.
+
+There are six such call sites across two files, not one, and three of them hide behind a trigger kind — which is why a
+first pass over the function found only the name. `trigger_cron` is trimmed only for a `schedule` rule;
+`member_select.prefer_sql` and `ready_when.signal` only for a `group` one. A sweep across all three
+trigger kinds finds all four. The remaining two are in `use-rule-form.ts`, which runs its own checks on
+every render: the same name trim, and a `?? []` on `output_bindings` that does not save a value which is a
+string. Everything else is safe — the assembly spreads rather than iterating, and reads other members
+without calling methods on them.
+
+**What is already in place and must not be re-done**
+
+- `buildRuleDto` is already spread-and-subtract, so a member the console does not name already survives a
+  save. `buildEvaluatorDto` had to be inverted to reach that state; this one is there.
+- `ignoredFields` is unnecessary. `id` is not in the request body — the route addresses the rule and
+  `CreateRuleDto` has no `id` — and `toRuleDraft` already strips every read-only member. Renaming is a
+  legitimate in-place rename here, unlike the evaluator, where a changed name forks the entity.
+- There is no Delete control on this page to withdraw; deletion lives in the listing.
+
+**The erasure, stated as a decision**
+
+No confirmation dialog and no diff of disappearing members. The operator is editing the request body and
+the console presents it as such. Guarding it would mean either a prompt on every save or a comparison the
+fields themselves do not perform, and it would put the rule editor out of step with every other JSON
+editor in the console. The consequence is specified with a scenario so a later reader finds a decision
+rather than an oversight.
+
+## Non-goals
+
+- **Analytics tables.** No full-object write exists: an active table changes only through scoped schema
+  patches, and a draft source table carries an irreversible invariant.
+- **Extracting a shared harness.** The evaluator change's design.md planned to extract the provider and
+  marker-gate wiring once a second consumer existed. That plan is dropped: the few lines are duplicated so
+  this change touches only rules. See design.md.
+- **Any change to the enable/disable flow.** It keeps reading the stored rule rather than the draft, and
+  its existing `ToggleBlockedByEdits` guard is untouched — in editor mode the action is simply absent.

--- a/openspec/changes/add-enrichment-rule-json-editor/specs/analytics/spec.md
+++ b/openspec/changes/add-enrichment-rule-json-editor/specs/analytics/spec.md
@@ -1,0 +1,191 @@
+## ADDED Requirements
+
+### Requirement: The rule detail page can be edited as JSON instead of as fields
+
+The rule detail page SHALL offer a JSON editor as an alternative to its fields: a toggle in the identity
+row, and the rule as one JSON document in place of everything below that row.
+
+The editor and the fields SHALL edit **one** draft. Enabling the editor SHALL seed it from the rule on
+screen, and what the document holds at submission SHALL be what is submitted.
+
+Submitting SHALL go through the same path either way — the same control and the same request — so the
+same document produces the same request no matter which way it was submitted. The editor SHALL NOT
+introduce a second write path.
+
+The toggle SHALL be offered to every caller, and the document SHALL be read-only for a caller who may not
+save, matching the gating the fields already apply. Reading a rule as JSON is useful without the rights to
+change it, and it is the only way to read the members no control presents.
+
+#### Scenario: Enabling the editor replaces the fields with JSON
+
+- **WHEN** the caller enables the JSON editor
+- **THEN** the rule is presented as one block of JSON
+- **AND** the fields are no longer presented
+- **AND** the rule name remains
+
+#### Scenario: The document is seeded from the rule on screen
+
+- **WHEN** the caller enables the JSON editor
+- **THEN** the document holds that rule's values
+
+#### Scenario: A caller who may not save may still read the JSON
+
+- **WHEN** a caller without saving rights enables the JSON editor
+- **THEN** the document is presented
+- **AND** it cannot be edited
+
+#### Scenario: A member no control presents is readable and changeable
+
+- **WHEN** a rule carrying a member the fields do not present is opened as JSON, that member is changed,
+  and the rule is saved
+- **THEN** the request carries the changed value
+
+### Requirement: The document is the request, not the form's working state
+
+The document SHALL present the rule as it will be sent, not the form's intermediate state. Because the
+save is a full replace, the request body and the rule are the same thing, and showing anything else would
+mean the caller edits one document and the console sends another.
+
+Two consequences SHALL be accepted rather than hidden. A rule that follows its target enrichment SHALL
+appear without `source`, since omitting it is how following is expressed. Members left empty SHALL be
+absent rather than present and blank. Both are visible on entering the editor.
+
+Entering the editor SHALL seed the document from the rule as the fields currently hold it, and the
+document SHALL then be the caller's to edit: the console SHALL NOT rewrite it while they type. Re-deriving
+it on every accepted keystroke would replace the buffer with a re-normalized request under the cursor,
+which among other things makes a trailing space impossible to type. The document SHALL be re-seeded only
+when the rule underneath it is replaced — a discard, or a save that re-reads it.
+
+#### Scenario: A rule that follows its target shows no source
+
+- **WHEN** a rule that follows its target enrichment is opened as JSON
+- **THEN** the document carries no `source`
+
+#### Scenario: The document is not rewritten while the caller types
+
+- **WHEN** the caller edits the document so that it still parses
+- **THEN** the text stays exactly as they typed it, trailing spaces and all
+- **AND** their cursor position and undo history are preserved
+
+#### Scenario: Discarding re-seeds the document from the stored rule
+
+- **WHEN** the caller discards while the editor is open
+- **THEN** the document holds the rule as stored
+
+### Requirement: The editor takes the whole view, and an unsaved change closes the way out
+
+While the JSON editor is open, the page SHALL present the document and nothing else below the identity
+row: the read-only facts, the fields, the status badge, and the enable/disable action SHALL all be
+withdrawn. A caller who wants any of them SHALL leave the editor to reach it.
+
+Once the draft differs from the rule on screen, the toggle SHALL NOT be offered either: the identity row
+offers Discard and Save in its place. Leaving the editor is therefore discarding or saving, not toggling
+back, which is what keeps a pending change from being parked behind a presentation the caller switched
+away from.
+
+Because the enable/disable action is absent in this mode, it needs no new guard. Its existing refusal
+while edits are pending SHALL be unchanged.
+
+Discarding SHALL restore the rule as stored and SHALL bring the toggle back.
+
+#### Scenario: The rest of the page is withdrawn while the editor is open
+
+- **WHEN** the caller enables the JSON editor
+- **THEN** the read-only facts are no longer presented
+- **AND** the enable/disable action is no longer offered
+
+#### Scenario: Editing the document withdraws the toggle
+
+- **WHEN** the caller edits the document so that it differs from the rule on screen
+- **THEN** the toggle is no longer offered
+- **AND** Discard and Save are offered instead
+
+#### Scenario: Discarding restores the stored rule and the toggle
+
+- **WHEN** the caller discards while the JSON editor is open
+- **THEN** the document holds the rule as stored
+- **AND** the toggle is offered again
+
+### Requirement: Removing a member from the document erases it from the rule
+
+`PUT /v1/rules/{id}` replaces the rule whole: the service applies every member of the request
+unconditionally, so a member the request omits is set to nothing rather than left alone. The editor
+therefore makes erasure a single keystroke, and this SHALL be treated as the meaning of the document
+rather than as a mistake to intercept.
+
+The console SHALL NOT prompt before a save that drops a member, and SHALL NOT present a comparison
+against the stored rule. The operator is editing the request body and the page presents it as exactly
+that; a guard here would be a check the fields themselves do not perform, and would put this editor out
+of step with every other one in the console.
+
+The sharpest case SHALL be understood as specified behaviour: deleting `evaluator_version` unpins the rule
+from its pinned evaluator version and it resumes following the latest, with no error, because the service
+accepts that request. Required members are the exception — the service rejects a request omitting one, and
+that refusal surfaces as any other does.
+
+#### Scenario: A member deleted from the document is erased from the rule
+
+- **WHEN** the caller deletes an optional member from the document and saves
+- **THEN** the saved rule no longer carries that member
+- **AND** no confirmation was presented before the save
+
+#### Scenario: Deleting the pinned evaluator version unpins the rule
+
+- **WHEN** the caller deletes `evaluator_version` from the document and saves
+- **THEN** the save succeeds
+- **AND** the rule no longer pins an evaluator version
+
+#### Scenario: Omitting a required member is refused by the service
+
+- **WHEN** the caller deletes a member the service requires and saves
+- **THEN** the service's own message is reported
+- **AND** the rule is unchanged
+
+### Requirement: JSON that does not parse blocks the save and reports where
+
+While the JSON editor is open, the form's own checks — including the check that no other rule already
+targets this enrichment — SHALL NOT block the save. The one exception is the grouping key: `group_by` is
+rebuilt from the resolved target rather than carried from the document, so saving a group rule before that
+resolves would send no grouping key and the full replace would erase it. That check SHALL keep applying in
+both presentations. The document is the input, and a document those
+controls could not have produced is not thereby wrong; the service's refusal is what surfaces instead.
+
+JSON that does not parse SHALL block the save, and each parse error SHALL be reported with the line it
+occurred on. The Save control SHALL remain enabled and refuse on use rather than being disabled — a
+caller who has broken the document is better served by being told where than by a control that has gone
+quiet.
+
+Text that does not parse reaches no draft, so the controls SHALL be offered on the strength of the parse
+failure itself and not only on a difference from the stored rule. Otherwise a caller whose **first** edit
+breaks the document is offered neither a Save to be told what is wrong nor a Discard to back out of it.
+The controls SHALL withdraw again once the document parses.
+
+#### Scenario: Unparseable JSON is reported per line and nothing is saved
+
+- **WHEN** the caller saves a document that does not parse
+- **THEN** each parse error is reported with its line number
+- **AND** the rule is unchanged
+
+#### Scenario: Breaking the document before changing anything still offers a way out
+
+- **WHEN** the caller's first edit to the document leaves it unparseable
+- **THEN** Discard and Save are offered
+- **AND** the Save control is offered as enabled
+
+#### Scenario: A group rule cannot be saved before its grain key resolves
+
+- **WHEN** a group rule's target has not resolved, so the grain key is not yet known
+- **THEN** saving is refused by the console rather than sending a request without the grouping key
+
+#### Scenario: A target another rule already uses is refused by the service
+
+- **WHEN** the caller sets `target_enrichment` to one another rule already binds and saves
+- **THEN** the save is not blocked by the console
+- **AND** the service's own message is reported
+
+#### Scenario: A value of the wrong type does not break the page
+
+- **WHEN** the caller sets a member to a value of a type the service does not accept, such as a name
+  holding a number
+- **THEN** the page continues to present the document and the controls
+- **AND** saving reports the service's refusal rather than failing in the console

--- a/openspec/changes/add-enrichment-rule-json-editor/tasks.md
+++ b/openspec/changes/add-enrichment-rule-json-editor/tasks.md
@@ -1,0 +1,89 @@
+## 1. Request assembly
+
+- [x] 1.1 Narrow the trimmed members in `apps/ai-dial-admin/src/utils/analytics/rule-dto.ts`, all four:
+  `name`, `trigger_cron` (schedule only), `member_select.prefer_sql` and `ready_when.signal` (group only).
+  Add `Array.isArray` where `member_select.order_by.length` is read and an object check on `ready_when` —
+  those two do not throw, they change what is carried, so assert the behaviour rather than the absence of
+  a fault. The four trims do throw, and `RuleDetailView` calls `buildRuleDto` during render to derive `isChanged`, so a pasted
+  `"name": 5` blanks the page through the error boundary. A wrongly typed member must read as absent and
+  still be carried to the request, where the service refuses it. Verify by sweeping all three trigger
+  kinds — fixing one kind hides three of the four.
+- [x] 1.3 Narrow the same class in `components/Analytics/EnrichmentRules/use-rule-form.ts`, which runs its
+  own checks on every render outside any `useMemo`: `draft.name`, `draft.trigger_cron` fed to the cron
+  validator, and `draft.output_bindings`, where `?? []` does not save a value that is a string and a
+  non-object entry faults the stranded-binding scan. Sweep the hook end to end, not just the assembly —
+  guarding `rule-dto.ts` alone leaves the page still able to blank.
+- [x] 1.2 Expose a replacing setter from `use-rule-form.ts` so the editor can hand the whole document
+  back. `RuleDraft` is `Partial<CreateRuleDto>`, so an assembled request is already a valid draft and no
+  conversion is needed; `getSourceMode` resolves an absent `source` to Follow, which covers the one member
+  the assembly drops on purpose.
+
+## 2. Page wiring
+
+- [x] 2.1 Wrap `RuleDetailView` in `SaveValidationContextProvider` in
+  `apps/ai-dial-admin/src/app/[lang]/enrichment-rules/[id]/page.tsx`, following
+  `app/[lang]/evaluators/[name]/page.tsx`. Required even for a caller who only reads:
+  `EntityJsonEditor` calls `useJsonEditorValidation()` before consulting `readonly`.
+
+## 3. Editor in the detail view
+
+All in `apps/ai-dial-admin/src/components/Analytics/EnrichmentRules/RuleDetailView.tsx`.
+
+- [x] 3.1 Add `isEditorEnabled` state and render `JsonToggle` in the identity row, **outside** the
+  `{isFullAdmin && (…)}` wrapper that currently encloses every control, so a caller without saving rights
+  can still open the editor. Resolve the slot the way the evaluator view does: Discard/Save while
+  something is pending, the toggle otherwise.
+- [x] 3.2 Swap the whole region below the identity row when the editor is on — `RuleReadOnlyFacts`,
+  `RuleProperties`, `RuleEnabledBadge` and the enable/disable action all withdraw, leaving only
+  `EntityJsonEditor`.
+- [x] 3.3 Feed the editor the assembled request rather than the draft, and route its output back through
+  1.2. Memoise the assembled request: `EntityJsonEditor` decides whether to remount Monaco by comparing
+  `entity` by identity, so a fresh object each render remounts every render and the remount sets state —
+  it does not settle, and the page hangs. No `ignoredFields`: `id` is not in the body and `toRuleDraft` already strips the read-only members.
+  Pass `readonly` for a caller who may not save.
+- [x] 3.4 Stop the form's own checks from gating the save while the editor is on — including
+  `form.isValid` and the `takenTargets` uniqueness check — leaving `isSaving` applying in both modes.
+- [x] 3.5 Gate the save on Monaco markers: read `jsonErrors` from `useSaveValidationContext`, raise one
+  notification per marker via `showEditorErrorNotifications` instead of saving, and store them through
+  `ValidationActionType.SetJsonEditorNotifications` so the editor's unmount cleanup can clear them.
+- [x] 3.6 Raise the Discard/Save pair on markers as well as on a draft difference, since unparseable text
+  never reaches the draft; and dispatch `ValidationActionType.Reset` before discarding, so a marker for a
+  document that no longer exists cannot hold the pair up.
+- [x] 3.7 Leave `onToggleEnabled`, its confirmation, and the `ToggleBlockedByEdits` guard untouched. The
+  action is absent in editor mode, so it needs no new rule.
+
+## 4. Tests
+
+- [x] 4.1 Unit-test the name guard and the seed-from-request mapping in
+  `utils/tests/rule-dto.spec.ts`: a non-string name neither throws nor blocks assembly, and a
+  request round-trips back into a draft that reproduces it — including a Follow-mode rule, whose absent
+  `source` must not come back as a pin.
+- [x] 4.2 Component-test the view in `components/Analytics/EnrichmentRules/tests/RuleJsonEditor.spec.tsx`,
+  stubbing `@/src/components/EntityTabs/JsonEditor/JsonEditor`: the toggle is offered, including to a
+  caller who may not save; enabling it withdraws the facts, the fields, the badge and the enable/disable
+  action; the editor is read-only without rights; editing withdraws the toggle and offers Discard/Save;
+  discarding restores the stored rule and the toggle.
+- [x] 4.3 Component-test the marker gates in the same file, with a controllable `SaveValidationContext`:
+  markers alone raise Discard/Save on an untouched draft, saving then reports one notification per marker
+  and does not submit, the Save control stays enabled, and the pair withdraws once the markers clear.
+- [x] 4.4 Add `components/Analytics/EnrichmentRules/tests/RuleJsonRoundTrip.spec.tsx`, stubbing only
+  `JsonEditorBase` so the real `EntityJsonEditor` runs: a member the fields do not present is readable and
+  reaches the request when changed; a member deleted from the document is absent from the request,
+  `evaluator_version` included; a renamed rule saves under the new name against the same id; unparseable
+  text leaves the last good draft in place. Stubbing the whole editor cannot cover this path — that is how
+  a missing Discard/Save shipped on the evaluator page.
+
+## 5. Review follow-ups
+
+- [x] 5.2 Seed the JSON document on entry instead of deriving it per render, and keep the grouping-key
+  check applying in editor mode. Both came out of review: the derived document broke `EntityJsonEditor`'s
+  identity contract and re-created the Monaco model on every accepted keystroke, and bypassing
+  `form.isValid` also removed the only thing stopping a group rule from saving before its target resolved.
+- [x] 5.3 Cover the two guards in `use-rule-form.ts` that no test reached, re-query the editor node in the
+  round-trip spec so its unparseable-text case actually types unparseable text, and assert the behaviour of
+  the two non-throw guards in `rule-dto.ts`.
+
+## 6. Quality gate
+
+- [x] 6.1 Run `npm run lint`, `npm run format`, and `npm run test` from the repo root; fix anything they
+  report.


### PR DESCRIPTION
## Description

This adds a JSON editor to the enrichment rule detail page, allowing users to directly edit rule definitions in JSON format. The implementation includes automatic JSON formatting and validation to ensure rule integrity. The editor integrates seamlessly with the existing rule form and provides a bridge between UI-based and text-based configuration approaches.

## Issues

- Issue #4286

## Key Changes

- [apps/ai-dial-admin/src/app/[lang]/enrichment-rules/[id]/page.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/feat/add-enrichment-rule-json-editor/apps/ai-dial-admin/src/app/[lang]/enrichment-rules/[id]/page.tsx) — integrated JSON editor modal
- [apps/ai-dial-admin/src/components/Analytics/EnrichmentRules/RuleDetailView.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/feat/add-enrichment-rule-json-editor/apps/ai-dial-admin/src/components/Analytics/EnrichmentRules/RuleDetailView.tsx) — added JSON editor button and modal integration
- [apps/ai-dial-admin/src/utils/formatting/trimmed-string.ts](https://github.com/epam/ai-dial-admin-frontend/blob/feat/add-enrichment-rule-json-editor/apps/ai-dial-admin/src/utils/formatting/trimmed-string.ts) — utility for JSON formatting with trimmed whitespace
- [apps/ai-dial-admin/src/utils/analytics/rule-dto.ts](https://github.com/epam/ai-dial-admin-frontend/blob/feat/add-enrichment-rule-json-editor/apps/ai-dial-admin/src/utils/analytics/rule-dto.ts) — enhanced rule DTO with validation
- [apps/ai-dial-admin/src/utils/analytics/evaluator-dto.ts](https://github.com/epam/ai-dial-admin-frontend/blob/feat/add-enrichment-rule-json-editor/apps/ai-dial-admin/src/utils/analytics/evaluator-dto.ts) — enhanced evaluator DTO support
- [apps/ai-dial-admin/src/components/Analytics/EnrichmentRules/use-rule-form.ts](https://github.com/epam/ai-dial-admin-frontend/blob/feat/add-enrichment-rule-json-editor/apps/ai-dial-admin/src/components/Analytics/EnrichmentRules/use-rule-form.ts) — improved form handling with JSON updates

## New Components

- `RuleJsonEditor.spec.tsx` — component tests for JSON editor
- `RuleJsonRoundTrip.spec.tsx` — round-trip testing for JSON serialization/deserialization
- `trimmed-string.spec.ts` — tests for JSON formatting utility

## Checklist

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #4286)`