### PR TITLE
fix(Assets/Files): remove bucket prefix from export archive path (Issue #4345)

### DIFF
--- a/apps/ai-dial-admin/src/server/files/export.ts
+++ b/apps/ai-dial-admin/src/server/files/export.ts
@@ -60,12 +60,13 @@ export const resolveExportEntries = async (
 };
 
 /**
- * A single selected file flattens to `public/<filename>`; a folder selection's children are
- * re-rooted to `public/<lastFolderSegment>/<path-relative-to-that-folder>`.
+ * A single selected file flattens to `<filename>`; a folder selection's children are re-rooted to
+ * `<lastFolderSegment>/<path-relative-to-that-folder>`. The archive path is bucket-agnostic — the
+ * destination folder chosen at import time determines the final storage location.
  */
 export const toExportArchivePath = (storagePath: string, exportFolderPath: string | null): string => {
   if (exportFolderPath === null) {
-    return `public/${getFolderNameAndPath(storagePath).name}`;
+    return getFolderNameAndPath(storagePath).name;
   }
 
   const normalizedFolder = exportFolderPath.endsWith('/') ? exportFolderPath : `${exportFolderPath}/`;
@@ -74,7 +75,7 @@ export const toExportArchivePath = (storagePath: string, exportFolderPath: strin
     ? storagePath.slice(normalizedFolder.length)
     : storagePath;
 
-  return `public/${lastSegment}/${relativePath}`;
+  return `${lastSegment}/${relativePath}`;
 };
 
 const generateExportFileName = (paths: string[]): string => {

--- a/apps/ai-dial-admin/src/server/files/tests/export.spec.ts
+++ b/apps/ai-dial-admin/src/server/files/tests/export.spec.ts
@@ -112,20 +112,20 @@ describe('Server :: Files :: export :: resolveExportEntries', () => {
 });
 
 describe('Server :: Files :: export :: toExportArchivePath', () => {
-  test('a single selected file flattens to public/<filename>', () => {
-    expect(toExportArchivePath('bucket/folder/doc.txt', null)).toBe('public/doc.txt');
+  test('a single selected file flattens to <filename> with no bucket prefix', () => {
+    expect(toExportArchivePath('bucket/folder/doc.txt', null)).toBe('doc.txt');
   });
 
-  test('a folder selection is re-rooted under public/<lastSegment>/<relativePath>', () => {
-    expect(toExportArchivePath('bucket/folder/sub/doc.txt', 'bucket/folder/')).toBe('public/folder/sub/doc.txt');
+  test('a folder selection is re-rooted under <lastSegment>/<relativePath> with no bucket prefix', () => {
+    expect(toExportArchivePath('bucket/folder/sub/doc.txt', 'bucket/folder/')).toBe('folder/sub/doc.txt');
   });
 
   test('a direct child of the exported folder has no extra nesting', () => {
-    expect(toExportArchivePath('bucket/folder/doc.txt', 'bucket/folder/')).toBe('public/folder/doc.txt');
+    expect(toExportArchivePath('bucket/folder/doc.txt', 'bucket/folder/')).toBe('folder/doc.txt');
   });
 
   test('a deeply nested descendant preserves its full relative path', () => {
-    expect(toExportArchivePath('bucket/folder/a/b/c/deep.txt', 'bucket/folder/')).toBe('public/folder/a/b/c/deep.txt');
+    expect(toExportArchivePath('bucket/folder/a/b/c/deep.txt', 'bucket/folder/')).toBe('folder/a/b/c/deep.txt');
   });
 });
 
@@ -159,11 +159,7 @@ describe('Server :: Files :: export :: buildFilesExportZip', () => {
       .filter((entry) => !entry.dir)
       .map((entry) => entry.name)
       .sort();
-    expect(filePaths).toEqual([
-      'files/public/folder/a.txt',
-      'files/public/folder/sub/b.txt',
-      'files/public/single.txt',
-    ]);
+    expect(filePaths).toEqual(['files/folder/a.txt', 'files/folder/sub/b.txt', 'files/single.txt']);
   });
 
   test('a single-item selection produces a name-derived filename', async () => {

--- a/openspec/changes/archive/2026-08-31-fix-files-export-duplicate-bucket/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-31-fix-files-export-duplicate-bucket/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-31

--- a/openspec/changes/archive/2026-08-31-fix-files-export-duplicate-bucket/proposal.md
+++ b/openspec/changes/archive/2026-08-31-fix-files-export-duplicate-bucket/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+Exporting a folder from Assets → Files and re-importing it into the same destination folder creates a
+duplicate nested parent: `Files > public > public > test_01` instead of `Files > public > test_01`.
+The export embeds the storage bucket (`public/`) into the archive path, and the import prepends the
+destination folder (also `public/`) on top of it, doubling the bucket segment.
+
+## What Changes
+
+- **`toExportArchivePath`** in `server/files/export.ts`: remove the hardcoded `public/` prefix from
+  both branches. A single-file entry becomes `files/<filename>`; a folder selection's entries become
+  `files/<lastFolderSegment>/<relative-path>`. The archive path is now bucket-agnostic — the
+  destination folder chosen at import time determines where files land.
+- **`export.spec.ts`**: update expected archive paths (the assertions currently bake in `public/`).
+- **`specs/files-core-api/spec.md`**: correct the two scenarios ("Single file exported flat" and
+  "Folder exported with re-rooted structure") and the requirement prose, which currently specify the
+  buggy `files/public/…` shape.
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `files-core-api`: the archive-path requirement and its two scenarios currently specify `files/public/<…>`,
+  which encodes the bug. The corrected requirement is `files/<…>` (no bucket prefix).
+
+## Impact
+
+- **`apps/ai-dial-admin/src/server/files/export.ts`** — `toExportArchivePath` (2 lines + JSDoc).
+- **`apps/ai-dial-admin/src/server/files/tests/export.spec.ts`** — expected values in
+  `toExportArchivePath` and `buildFilesExportZip` test suites.
+- **`openspec/specs/files-core-api/spec.md`** — requirement prose and two scenarios.
+- No UI, no API-route, no import-path changes — the import side is correct as-is.
+- **Backward compat**: archives exported before this fix contain `public/` in their paths and will
+  still produce a doubled folder on import. This is acceptable for a pre-release (0.21.0-dev).

--- a/openspec/changes/archive/2026-08-31-fix-files-export-duplicate-bucket/specs/files-core-api/spec.md
+++ b/openspec/changes/archive/2026-08-31-fix-files-export-duplicate-bucket/specs/files-core-api/spec.md
@@ -1,0 +1,17 @@
+## MODIFIED Requirements
+
+### Requirement: Archive path differs for single-file vs. folder selection
+The system SHALL place a single selected file at `files/<filename>` in the archive (no bucket
+prefix), and SHALL re-root a selected folder's contents under
+`files/<lastFolderSegment>/<path-relative-to-that-folder>`, preserving the folder's internal
+structure. The archive path SHALL be bucket-agnostic — the destination folder chosen at import time
+determines the final storage location.
+
+#### Scenario: Single file exported flat
+- **WHEN** a single file (not a folder) is selected for export
+- **THEN** its archive entry is `files/<filename>` with no bucket prefix
+
+#### Scenario: Folder exported with re-rooted structure
+- **WHEN** a folder is selected for export
+- **THEN** each of its child files' archive entries are re-rooted under `files/<lastFolderSegment>/`,
+  preserving their relative path inside that folder, with no bucket prefix in the archive path

--- a/openspec/changes/archive/2026-08-31-fix-files-export-duplicate-bucket/tasks.md
+++ b/openspec/changes/archive/2026-08-31-fix-files-export-duplicate-bucket/tasks.md
@@ -1,0 +1,29 @@
+<!-- No spec-browser-verify task: both modified scenarios describe server-side archive entry paths,
+     not UI state. Coverage is provided by the unit tests below. -->
+
+## 1. Fix export archive path
+
+- [x] 1.1 In `apps/ai-dial-admin/src/server/files/export.ts`, remove the hardcoded `public/` prefix
+  from both branches of `toExportArchivePath`: the single-file branch (`exportFolderPath === null`)
+  returns `getFolderNameAndPath(storagePath).name`; the folder branch returns
+  `${lastSegment}/${relativePath}`. Update the JSDoc comment to reflect the new contract.
+
+## 2. Update tests
+
+- [x] 2.1 In `apps/ai-dial-admin/src/server/files/tests/export.spec.ts`, update the four
+  `toExportArchivePath` assertions to remove the `public/` prefix from expected values.
+- [x] 2.2 In the same file, update the `buildFilesExportZip` test's expected `filePaths` array to
+  remove the `public/` prefix from each entry (e.g. `files/folder/a.txt` instead of
+  `files/public/folder/a.txt`).
+
+## 3. Update spec
+
+- [x] 3.1 In `openspec/specs/files-core-api/spec.md`, apply the delta: replace the
+  "Archive path differs for single-file vs. folder selection" requirement prose and its two scenarios
+  with the corrected versions from the delta spec (no `public/` prefix, bucket-agnostic language).
+
+## 4. Quality gate
+
+- [x] 4.1 Run `npx vitest run src/server/files/tests/export.spec.ts` from `apps/ai-dial-admin/`
+  and confirm all tests pass.
+- [x] 4.2 Run `npm run lint` and `npm run format` from the repo root and confirm no new errors.

--- a/openspec/specs/files-core-api/spec.md
+++ b/openspec/specs/files-core-api/spec.md
@@ -88,15 +88,20 @@ The system SHALL build a zip archive of selected files/folders by resolving each
 - **THEN** that file is fetched and included in the archive rather than the export hanging indefinitely
 
 ### Requirement: Archive path differs for single-file vs. folder selection
-The system SHALL place a single selected file at `files/public/<filename>` in the archive, and SHALL re-root a selected folder's contents under `files/public/<lastFolderSegment>/<path-relative-to-that-folder>`, preserving the folder's internal structure.
+The system SHALL place a single selected file at `files/<filename>` in the archive (no bucket
+prefix), and SHALL re-root a selected folder's contents under
+`files/<lastFolderSegment>/<path-relative-to-that-folder>`, preserving the folder's internal
+structure. The archive path SHALL be bucket-agnostic — the destination folder chosen at import time
+determines the final storage location.
 
 #### Scenario: Single file exported flat
 - **WHEN** a single file (not a folder) is selected for export
-- **THEN** its archive entry is `files/public/<filename>`
+- **THEN** its archive entry is `files/<filename>` with no bucket prefix
 
 #### Scenario: Folder exported with re-rooted structure
 - **WHEN** a folder is selected for export
-- **THEN** each of its child files' archive entries are re-rooted under `files/public/<lastFolderSegment>/`, preserving their relative path inside that folder
+- **THEN** each of its child files' archive entries are re-rooted under `files/<lastFolderSegment>/`,
+  preserving their relative path inside that folder, with no bucket prefix in the archive path
 
 ### Requirement: Folder export expands recursively at any depth
 The system SHALL include every descendant file of a selected folder in the export, at any nesting depth — not only the folder's direct children.


### PR DESCRIPTION
**Description:**

Exporting a folder from Assets → Files and re-importing it into the same destination folder (e.g. `public/`) caused a duplicated bucket segment: `Files > public > public > test_01` instead of `Files > public > test_01`. The root cause was that `toExportArchivePath` hardcoded a `public/` prefix into every archive entry. When the import destination also adds that folder, the bucket name was doubled.

This fix removes the hardcoded `public/` prefix from both branches of `toExportArchivePath`, making the archive path bucket-agnostic. The destination folder selected at import time now determines the final storage location entirely.

Issues:

- Issue #4345

**Key Changes:**

- [apps/ai-dial-admin/src/server/files/export.ts](https://github.com/epam/ai-dial-admin-frontend/blob/fix/remove-bucket-prefix-from-export-archive-path/apps/ai-dial-admin/src/server/files/export.ts) — remove hardcoded `public/` prefix from single-file and folder-selection archive paths
- [apps/ai-dial-admin/src/server/files/tests/export.spec.ts](https://github.com/epam/ai-dial-admin-frontend/blob/fix/remove-bucket-prefix-from-export-archive-path/apps/ai-dial-admin/src/server/files/tests/export.spec.ts) — update expected archive paths to match the corrected behaviour
- [openspec/specs/files-core-api/spec.md](https://github.com/epam/ai-dial-admin-frontend/blob/fix/remove-bucket-prefix-from-export-archive-path/openspec/specs/files-core-api/spec.md) — correct requirement prose and scenarios to specify bucket-agnostic archive paths
- [openspec/changes/archive/2026-08-31-fix-files-export-duplicate-bucket/](https://github.com/epam/ai-dial-admin-frontend/blob/fix/remove-bucket-prefix-from-export-archive-path/openspec/changes/archive/2026-08-31-fix-files-export-duplicate-bucket/) — archive the completed OpenSpec change

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #4345)`