### PR TITLE
fix(Assets/Roles): use Core-compatible resource-type keys in platform role sharing (Issue #4353)

### DIFF
--- a/.claude/reference/areas.md
+++ b/.claude/reference/areas.md
@@ -54,6 +54,7 @@ Use `Parent/Child` for a single leaf, or just `Parent` when several children cha
 | `Assets/Files` | `files` | `Assets`, `Publications/Assets/Files` |
 | `Assets/Models` | `assets-models` | `Assets/Models` |
 | `Assets/AppRunners` | `assets-app-runners` | `Assets/AppRunners` |
+| `Assets/Roles` | `assets-roles` | `Assets/Platform/Roles` |
 
 ### `Deployments`
 | Area | Route slug | Component folder |

--- a/apps/ai-dial-admin/src/components/Assets/Platform/Roles/Sharing.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Platform/Roles/Sharing.tsx
@@ -9,7 +9,6 @@ import { ColDef, GridApi, GridReadyEvent } from 'ag-grid-community';
 import { SHARING_COLUMNS } from '@/src/components/EntityView/Roles/utils';
 import GridView from '@/src/components/Grid/GridView/GridView';
 import { SharingGridData } from '@/src/components/Roles/models';
-import { getDefaultPlaceholder, isResetToDefaultHidden } from '@/src/components/Roles/utils';
 import { ACTION_COLUMN, ACTIONS_COLUMN_CEL_ID } from '@/src/constants/ag-grid';
 import { getResetOperation } from '@/src/constants/grid-columns/actions';
 import { RolesI18nKey } from '@/src/constants/i18n';
@@ -18,7 +17,8 @@ import { useIsReadOnlyAdmin } from '@/src/hooks/use-is-read-only-admin';
 import { useI18n } from '@/src/locales/client';
 import { DialRole } from '@/src/models/dial/role';
 import { DialRoleResource } from '@/src/models/dial/resource';
-import { applySharingChange, getAssetSharingData } from './utils';
+import { platformSharingTypeLabels } from './constants';
+import { applySharingChange, getAssetSharingData, getDefaultPlaceholder, isResetToDefaultHidden } from './utils';
 
 interface Props {
   isSkipRefresh: boolean;
@@ -28,8 +28,11 @@ interface Props {
 
 /**
  * Adapted from `Entities > Roles`' `RoleSharing` (`components/Roles/View/Properties/Sharing.tsx`),
- * reusing its grid columns/placeholder/reset-visibility helpers verbatim — but sourcing rows via
- * `getAssetSharingData` and writing through `toCoreShareField` instead, since Core's own
+ * reusing its `SHARING_COLUMNS`/`getResetOperation` grid shell — but with its own
+ * `PlatformSharingType`-keyed placeholder/reset-visibility/label helpers (this folder's `utils.ts`/
+ * `constants.ts`), since Core's `Role.share` map is keyed by its uppercase `ResourceTypes.name()`
+ * (e.g. `TOOL_SET`), not the admin-backend's lowercase `SharingType` convention. Rows come from
+ * `getAssetSharingData` and writes go through `toCoreShareField`, since Core's own
  * `ShareResourceLimit` is a different shape from the admin-backend's `DialRoleShare`: its two fields
  * are snake_case (`invitation_ttl`/`max_accepted_users`), and `invitationTtl` is already in hours on
  * the wire — no ms<->hours conversion, unlike the admin-backend field of the same name.
@@ -80,7 +83,13 @@ const RoleSharing: FC<Props> = ({ isSkipRefresh, selectedRole, onChangeRole }) =
   }, [selectedRole.share]);
 
   const columns: ColDef[] = useMemo(() => {
-    const baseColumns = SHARING_COLUMNS(t, onChangeTypeSharing, getDefaultPlaceholder, isReadOnlyAdmin);
+    const baseColumns = SHARING_COLUMNS(
+      t,
+      onChangeTypeSharing,
+      getDefaultPlaceholder,
+      isReadOnlyAdmin,
+      platformSharingTypeLabels,
+    );
     const actions = isReadOnlyAdmin ? [] : [getResetOperation(onResetSharingToDefault, isResetToDefaultHidden)];
     return [...baseColumns, ...(actions.length ? [ACTION_COLUMN(actions, true)] : [])];
   }, [onChangeTypeSharing, onResetSharingToDefault, t, isReadOnlyAdmin]);

--- a/apps/ai-dial-admin/src/components/Assets/Platform/Roles/constants.ts
+++ b/apps/ai-dial-admin/src/components/Assets/Platform/Roles/constants.ts
@@ -1,0 +1,30 @@
+import { MenuI18nKey } from '@/src/constants/i18n';
+import { DialRoleShare } from '@/src/models/dial/role-limits';
+import { PlatformSharingType } from './models';
+
+/**
+ * Placeholder defaults for the sharing grid, matching Core's own `ShareService.DEFAULT_LIMITS` (see
+ * `utils.ts`'s `getAssetSharingData` doc-comment for how `-1` — Core's "not provided" sentinel — maps
+ * to these placeholders). Max users defaults to `10` for the four types Core caps by default;
+ * `PROMPT`/`FILE`/`CONVERSATION` default to `Integer.MAX_VALUE` on Core's side, which this grid shows
+ * as no specific placeholder rather than a literal huge number.
+ */
+export const platformSharingDefaults: Record<PlatformSharingType, DialRoleShare> = {
+  [PlatformSharingType.APPLICATION]: { invitationTtl: '72', maxAcceptedUsers: '10' },
+  [PlatformSharingType.TOOL_SET]: { invitationTtl: '72', maxAcceptedUsers: '10' },
+  [PlatformSharingType.CREDENTIALS]: { invitationTtl: '72', maxAcceptedUsers: '10' },
+  [PlatformSharingType.SKILL]: { invitationTtl: '72', maxAcceptedUsers: '10' },
+  [PlatformSharingType.PROMPT]: { invitationTtl: '72', maxAcceptedUsers: '' },
+  [PlatformSharingType.FILE]: { invitationTtl: '72', maxAcceptedUsers: '' },
+  [PlatformSharingType.CONVERSATION]: { invitationTtl: '72', maxAcceptedUsers: '' },
+};
+
+export const platformSharingTypeLabels: Record<PlatformSharingType, MenuI18nKey> = {
+  [PlatformSharingType.APPLICATION]: MenuI18nKey.Applications,
+  [PlatformSharingType.TOOL_SET]: MenuI18nKey.Toolsets,
+  [PlatformSharingType.PROMPT]: MenuI18nKey.Prompts,
+  [PlatformSharingType.FILE]: MenuI18nKey.Files,
+  [PlatformSharingType.CONVERSATION]: MenuI18nKey.Conversations,
+  [PlatformSharingType.CREDENTIALS]: MenuI18nKey.Credentials,
+  [PlatformSharingType.SKILL]: MenuI18nKey.Skills,
+};

--- a/apps/ai-dial-admin/src/components/Assets/Platform/Roles/models.ts
+++ b/apps/ai-dial-admin/src/components/Assets/Platform/Roles/models.ts
@@ -1,0 +1,17 @@
+/**
+ * The resource types DIAL Core allows a role to override sharing limits for. Values match Core's own
+ * `ResourceTypes.name()` exactly (uppercase, `SKILL` singular) — that name is the literal key Core
+ * reads a role's `share` map with (`ShareService.getLimit`), so a mismatch here means the UI silently
+ * reads and writes the wrong entries. Distinct from `Entities > Roles`' lowercase `SharingType`
+ * (`components/Roles/types.ts`), which models the admin-backend's own convention for a different
+ * backend and wire shape.
+ */
+export enum PlatformSharingType {
+  APPLICATION = 'APPLICATION',
+  TOOL_SET = 'TOOL_SET',
+  PROMPT = 'PROMPT',
+  FILE = 'FILE',
+  CONVERSATION = 'CONVERSATION',
+  CREDENTIALS = 'CREDENTIALS',
+  SKILL = 'SKILL',
+}

--- a/apps/ai-dial-admin/src/components/Assets/Platform/Roles/tests/Sharing.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Platform/Roles/tests/Sharing.spec.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+import { DialRoleResource } from '@/src/models/dial/resource';
+import { PlatformSharingType } from '../models';
+import RoleSharing from '../Sharing';
+
+vi.mock('@/src/hooks/use-is-read-only-admin', () => ({
+  useIsReadOnlyAdmin: vi.fn(() => false),
+}));
+
+interface MockColDef {
+  field?: string;
+  valueFormatter?: (params: { value: string }) => string;
+  cellRendererParams?: { getDefaultPlaceholder?: (node: unknown, colDef: unknown) => string };
+}
+
+interface MockRow {
+  name: PlatformSharingType;
+  invitationTtl?: string;
+  maxAcceptedUsers?: string;
+}
+
+vi.mock('@/src/components/Grid/GridView/GridView', () => ({
+  default: ({ onGridReady }: { onGridReady: (event: unknown) => void }) => {
+    let rowData: MockRow[] = [];
+    let columnDefs: MockColDef[] = [];
+    onGridReady({
+      api: {
+        updateGridOptions: (options: { rowData?: MockRow[]; columnDefs?: MockColDef[] }) => {
+          rowData = options.rowData ?? rowData;
+          columnDefs = options.columnDefs ?? columnDefs;
+        },
+        isDestroyed: () => false,
+        refreshCells: () => {},
+      },
+    });
+
+    const typeColumn = columnDefs.find((c) => c.field === 'name');
+    const maxUsersColumn = columnDefs.find((c) => c.field === 'maxAcceptedUsers');
+    const ttlColumn = columnDefs.find((c) => c.field === 'invitationTtl');
+
+    return (
+      <div>
+        <div>rows: {rowData.length}</div>
+        <div>types: {rowData.map((row) => typeColumn?.valueFormatter?.({ value: row.name })).join('|')}</div>
+        {rowData.map((row) => (
+          <div key={row.name}>
+            <span>
+              {row.name}:maxUsersPlaceholder=
+              {row.maxAcceptedUsers ??
+                maxUsersColumn?.cellRendererParams?.getDefaultPlaceholder?.(
+                  { data: row },
+                  { field: 'maxAcceptedUsers' },
+                )}
+            </span>
+            <span>
+              {row.name}:invitationTtlPlaceholder=
+              {row.invitationTtl ??
+                ttlColumn?.cellRendererParams?.getDefaultPlaceholder?.({ data: row }, { field: 'invitationTtl' })}
+            </span>
+          </div>
+        ))}
+      </div>
+    );
+  },
+}));
+
+const role = (overrides: Partial<DialRoleResource> = {}): DialRoleResource =>
+  ({ name: 'my-role', path: 'my-role', folderId: '', ...overrides }) as DialRoleResource;
+
+describe('RoleSharing', () => {
+  test('lists all seven sharing types, including Credentials and Skills', () => {
+    render(<RoleSharing selectedRole={role()} onChangeRole={vi.fn()} isSkipRefresh={false} />);
+
+    expect(screen.getByText('rows: 7')).toBeTruthy();
+    expect(screen.getByText(/Menu\.Credentials/)).toBeTruthy();
+    expect(screen.getByText(/Menu\.Skills/)).toBeTruthy();
+  });
+
+  test("shows the toolset row's max-users placeholder as 10, same as applications", () => {
+    render(<RoleSharing selectedRole={role()} onChangeRole={vi.fn()} isSkipRefresh={false} />);
+
+    expect(screen.getByText(`${PlatformSharingType.TOOL_SET}:maxUsersPlaceholder=10`)).toBeTruthy();
+    expect(screen.getByText(`${PlatformSharingType.APPLICATION}:maxUsersPlaceholder=10`)).toBeTruthy();
+  });
+
+  test('renders a stored -1 as empty, falling through to the default placeholder, not as a literal -1', () => {
+    render(
+      <RoleSharing
+        selectedRole={role({
+          share: { [PlatformSharingType.TOOL_SET]: { max_accepted_users: -1, invitation_ttl: -1 } },
+        })}
+        onChangeRole={vi.fn()}
+        isSkipRefresh={false}
+      />,
+    );
+
+    expect(screen.getByText(`${PlatformSharingType.TOOL_SET}:maxUsersPlaceholder=10`)).toBeTruthy();
+    expect(screen.getByText(`${PlatformSharingType.TOOL_SET}:invitationTtlPlaceholder=72`)).toBeTruthy();
+  });
+});

--- a/apps/ai-dial-admin/src/components/Assets/Platform/Roles/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/Assets/Platform/Roles/tests/utils.spec.ts
@@ -1,7 +1,14 @@
 import { describe, expect, test } from 'vitest';
 
 import { DialRoleResource } from '@/src/models/dial/resource';
-import { applySharingChange, getAssetSharingData, toCoreShareField } from '../utils';
+import { PlatformSharingType } from '../models';
+import {
+  applySharingChange,
+  getAssetSharingData,
+  getDefaultPlaceholder,
+  isResetToDefaultHidden,
+  toCoreShareField,
+} from '../utils';
 
 describe('toCoreShareField', () => {
   test("maps invitationTtl to Core's snake_case invitation_ttl", () => {
@@ -14,32 +21,48 @@ describe('toCoreShareField', () => {
 });
 
 describe('getAssetSharingData', () => {
-  test('reads invitation_ttl/max_accepted_users directly, with no ms<->hours conversion', () => {
+  test("reads invitation_ttl/max_accepted_users under Core's uppercase resource-type key", () => {
     const role = {
-      share: { application: { invitation_ttl: 24, max_accepted_users: 5 } },
+      share: { [PlatformSharingType.APPLICATION]: { invitation_ttl: 24, max_accepted_users: 5 } },
     } as DialRoleResource;
 
-    const row = getAssetSharingData(role).find((r) => r.name === 'application');
+    const row = getAssetSharingData(role).find((r) => r.name === PlatformSharingType.APPLICATION);
 
     expect(row?.invitationTtl).toBe('24');
     expect(row?.maxAcceptedUsers).toBe('5');
   });
 
-  test('lists all five sharing types even when the role has no share entries', () => {
+  test('lists all seven sharing types, including Credentials and Skills, even when the role has no share entries', () => {
     const rows = getAssetSharingData({} as DialRoleResource);
 
-    expect(rows).toHaveLength(5);
+    expect(rows).toHaveLength(7);
+    expect(rows.map((row) => row.name)).toEqual(Object.values(PlatformSharingType));
     expect(rows.every((row) => row.invitationTtl === undefined && row.maxAcceptedUsers === undefined)).toBe(true);
   });
 
   test('leaves a type with no share entry as undefined rather than "0"', () => {
-    const role = { share: { application: { invitation_ttl: 24 } } } as DialRoleResource;
+    const role = {
+      share: { [PlatformSharingType.APPLICATION]: { invitation_ttl: 24 } },
+    } as DialRoleResource;
 
-    const applicationRow = getAssetSharingData(role).find((r) => r.name === 'application');
-    const toolsetRow = getAssetSharingData(role).find((r) => r.name === 'tool_set');
+    const applicationRow = getAssetSharingData(role).find((r) => r.name === PlatformSharingType.APPLICATION);
+    const toolsetRow = getAssetSharingData(role).find((r) => r.name === PlatformSharingType.TOOL_SET);
 
     expect(applicationRow?.maxAcceptedUsers).toBeUndefined();
     expect(toolsetRow?.invitationTtl).toBeUndefined();
+  });
+
+  test('treats Core\'s -1 "not provided" sentinel as absent, not as a literal -1', () => {
+    const role = {
+      share: {
+        [PlatformSharingType.TOOL_SET]: { invitation_ttl: -1, max_accepted_users: -1 },
+      },
+    } as DialRoleResource;
+
+    const row = getAssetSharingData(role).find((r) => r.name === PlatformSharingType.TOOL_SET);
+
+    expect(row?.invitationTtl).toBeUndefined();
+    expect(row?.maxAcceptedUsers).toBeUndefined();
   });
 });
 
@@ -47,45 +70,126 @@ describe('applySharingChange', () => {
   test('writes the raw value to invitation_ttl with no ms<->hours conversion', () => {
     const role = {} as DialRoleResource;
 
-    const result = applySharingChange(role, 'application', 'invitationTtl', 24);
+    const result = applySharingChange(role, PlatformSharingType.APPLICATION, 'invitationTtl', 24);
 
     // Not `24 * 60 * 60 * 1000` — Core's own field is already in hours.
-    expect(result.share?.application?.invitation_ttl).toBe(24);
+    expect(result.share?.[PlatformSharingType.APPLICATION]?.invitation_ttl).toBe(24);
   });
 
   test('writes the raw value to max_accepted_users', () => {
     const role = {} as DialRoleResource;
 
-    const result = applySharingChange(role, 'application', 'maxAcceptedUsers', 5);
+    const result = applySharingChange(role, PlatformSharingType.APPLICATION, 'maxAcceptedUsers', 5);
 
-    expect(result.share?.application?.max_accepted_users).toBe(5);
+    expect(result.share?.[PlatformSharingType.APPLICATION]?.max_accepted_users).toBe(5);
   });
 
   test('preserves the other field on the same sharing type when only one is edited', () => {
-    const role = { share: { application: { max_accepted_users: 5 } } } as DialRoleResource;
+    const role = {
+      share: { [PlatformSharingType.APPLICATION]: { max_accepted_users: 5 } },
+    } as DialRoleResource;
 
-    const result = applySharingChange(role, 'application', 'invitationTtl', 24);
+    const result = applySharingChange(role, PlatformSharingType.APPLICATION, 'invitationTtl', 24);
 
-    expect(result.share?.application).toEqual({ max_accepted_users: 5, invitation_ttl: 24 });
+    expect(result.share?.[PlatformSharingType.APPLICATION]).toEqual({ max_accepted_users: 5, invitation_ttl: 24 });
   });
 
-  test('drops the sharing type entry once every field on it is empty', () => {
-    const role = { share: { application: { invitation_ttl: 24 } } } as DialRoleResource;
+  test('clearing a field removes it from the entry, leaving a sibling field intact', () => {
+    const role = {
+      share: { [PlatformSharingType.APPLICATION]: { max_accepted_users: 5, invitation_ttl: 24 } },
+    } as DialRoleResource;
 
-    const result = applySharingChange(role, 'application', 'invitationTtl', 0 as unknown as number);
-    // A falsy-but-present value ('' from the grid) clears the entry; 0 is a legitimate value for a
-    // numeric field, so exercise the actual "every field empty" path with '' instead.
-    const cleared = applySharingChange(role, 'application', 'invitationTtl', '' as unknown as number);
+    const result = applySharingChange(role, PlatformSharingType.APPLICATION, 'invitationTtl', '' as unknown as number);
 
-    expect(result.share?.application).toBeDefined();
-    expect(cleared.share?.application).toBeUndefined();
+    expect(result.share?.[PlatformSharingType.APPLICATION]).toEqual({ max_accepted_users: 5 });
+  });
+
+  test('drops the sharing type entry once every field on it is cleared', () => {
+    const role = {
+      share: { [PlatformSharingType.APPLICATION]: { invitation_ttl: 24 } },
+    } as DialRoleResource;
+
+    const cleared = applySharingChange(role, PlatformSharingType.APPLICATION, 'invitationTtl', '' as unknown as number);
+
+    expect(cleared.share?.[PlatformSharingType.APPLICATION]).toBeUndefined();
+  });
+
+  test('writes a literal 0 when the user enters it manually, rather than treating it as clearing the field', () => {
+    const role = {} as DialRoleResource;
+
+    const result = applySharingChange(role, PlatformSharingType.APPLICATION, 'maxAcceptedUsers', 0);
+
+    expect(result.share?.[PlatformSharingType.APPLICATION]).toEqual({ max_accepted_users: 0 });
   });
 
   test('leaves other sharing types untouched', () => {
-    const role = { share: { conversation: { invitation_ttl: 72 } } } as DialRoleResource;
+    const role = {
+      share: { [PlatformSharingType.CONVERSATION]: { invitation_ttl: 72 } },
+    } as DialRoleResource;
 
-    const result = applySharingChange(role, 'application', 'invitationTtl', 24);
+    const result = applySharingChange(role, PlatformSharingType.APPLICATION, 'invitationTtl', 24);
 
-    expect(result.share?.conversation).toEqual({ invitation_ttl: 72 });
+    expect(result.share?.[PlatformSharingType.CONVERSATION]).toEqual({ invitation_ttl: 72 });
+  });
+});
+
+describe('getDefaultPlaceholder', () => {
+  test('returns 10 for toolsets, same as applications', () => {
+    const applicationPlaceholder = getDefaultPlaceholder(
+      { data: { name: PlatformSharingType.APPLICATION } } as never,
+      { field: 'maxAcceptedUsers' } as never,
+    );
+    const toolsetPlaceholder = getDefaultPlaceholder(
+      { data: { name: PlatformSharingType.TOOL_SET } } as never,
+      { field: 'maxAcceptedUsers' } as never,
+    );
+
+    expect(toolsetPlaceholder).toBe('10');
+    expect(toolsetPlaceholder).toBe(applicationPlaceholder);
+  });
+
+  test('returns 10 for the newly added Credentials and Skills types', () => {
+    expect(
+      getDefaultPlaceholder(
+        { data: { name: PlatformSharingType.CREDENTIALS } } as never,
+        {
+          field: 'maxAcceptedUsers',
+        } as never,
+      ),
+    ).toBe('10');
+    expect(
+      getDefaultPlaceholder(
+        { data: { name: PlatformSharingType.SKILL } } as never,
+        {
+          field: 'maxAcceptedUsers',
+        } as never,
+      ),
+    ).toBe('10');
+  });
+
+  test('returns 72 for invitation TTL regardless of type', () => {
+    expect(
+      getDefaultPlaceholder(
+        { data: { name: PlatformSharingType.FILE } } as never,
+        {
+          field: 'invitationTtl',
+        } as never,
+      ),
+    ).toBe('72');
+  });
+});
+
+describe('isResetToDefaultHidden', () => {
+  const buildApi = (invitationTtl: unknown, maxAcceptedUsers: unknown) => ({
+    getColumn: (key: string) => key,
+    getCellValue: ({ colKey }: { colKey: string }) => (colKey === 'invitationTtl' ? invitationTtl : maxAcceptedUsers),
+  });
+
+  test('is hidden when neither field has an override', () => {
+    expect(isResetToDefaultHidden(buildApi(undefined, undefined) as never, {} as never)).toBe(true);
+  });
+
+  test('is shown once either field has an override', () => {
+    expect(isResetToDefaultHidden(buildApi('24', undefined) as never, {} as never)).toBe(false);
   });
 });

--- a/apps/ai-dial-admin/src/components/Assets/Platform/Roles/utils.ts
+++ b/apps/ai-dial-admin/src/components/Assets/Platform/Roles/utils.ts
@@ -1,7 +1,10 @@
+import { ColDef, Column, GridApi, IRowNode } from 'ag-grid-community';
+
 import { SharingGridData } from '@/src/components/Roles/models';
-import { SharingType } from '@/src/components/Roles/types';
 import { DialRoleResource } from '@/src/models/dial/resource';
-import { DialCoreRoleShare } from '@/src/models/dial/role-limits';
+import { DialCoreRoleShare, DialRoleShare } from '@/src/models/dial/role-limits';
+import { platformSharingDefaults } from './constants';
+import { PlatformSharingType } from './models';
 
 /** Maps a sharing grid column's camelCase `token` to Core's own snake_case `ShareResourceLimit` field. */
 const CAMEL_TO_CORE_SHARE_FIELD: Record<string, keyof DialCoreRoleShare> = {
@@ -12,37 +15,43 @@ const CAMEL_TO_CORE_SHARE_FIELD: Record<string, keyof DialCoreRoleShare> = {
 export const toCoreShareField = (token: string): keyof DialCoreRoleShare =>
   CAMEL_TO_CORE_SHARE_FIELD[token] ?? (token as keyof DialCoreRoleShare);
 
+/** Core's own sentinel for "not provided" on both `ShareResourceLimit` fields. */
+const CORE_UNSET_SHARE_VALUE = -1;
+
+const isUnsetShareValue = (value?: number | null): boolean => value == null || value === CORE_UNSET_SHARE_VALUE;
+
 /**
- * Builds sharing grid rows from a role asset's own `share` shape. Unlike `Entities > Roles`'
+ * Builds sharing grid rows from a role asset's own `share` shape, keyed by Core's own uppercase
+ * `ResourceTypes.name()` (e.g. `TOOL_SET`, `SKILL`) — the exact key `ShareService.getLimit` reads —
+ * rather than `Entities > Roles`' lowercase `SharingType` convention. A stored value of `-1` (Core's
+ * "not provided" sentinel for both fields) is treated the same as absent, so the row falls through to
+ * the grid's default placeholder instead of showing the literal `-1`. Unlike `Entities > Roles`'
  * `getSharingData` (`components/Roles/utils.ts`), this applies no ms<->hours conversion: Core's
  * `ShareResourceLimit.invitationTtl` is documented, on the Core class itself, as already measured
  * in hours — so the raw value is exactly what the shared grid's "Expiration time (hours)" column
  * should show and edit, unlike the admin-backend's own `invitationTtl`, which is stored in ms.
  */
 export const getAssetSharingData = (role?: DialRoleResource): SharingGridData[] => {
-  const types = [
-    SharingType.APPLICATION,
-    SharingType.TOOL_SET,
-    SharingType.PROMPT,
-    SharingType.FILE,
-    SharingType.CONVERSATION,
-  ];
-
-  return types.map((type) => {
+  return Object.values(PlatformSharingType).map((type) => {
     const shareData = role?.share?.[type];
     return {
       name: type,
-      invitationTtl: shareData?.invitation_ttl != null ? String(shareData.invitation_ttl) : undefined,
-      maxAcceptedUsers: shareData?.max_accepted_users != null ? String(shareData.max_accepted_users) : undefined,
+      invitationTtl: isUnsetShareValue(shareData?.invitation_ttl) ? undefined : String(shareData!.invitation_ttl),
+      maxAcceptedUsers: isUnsetShareValue(shareData?.max_accepted_users)
+        ? undefined
+        : String(shareData!.max_accepted_users),
     };
   });
 };
 
 /**
  * The sharing grid's edit handler as a pure transform: writes `value` to `sharingTypeName`'s Core
- * field (mapped from the grid column's camelCase `token` via `toCoreShareField`), dropping the
- * entry entirely once every one of its fields is empty — same "clear on all-blank" rule
- * `Entities > Roles`' `RoleSharing` applies. No ms<->hours conversion: `value` is already in the
+ * field (mapped from the grid column's camelCase `token` via `toCoreShareField`). Clearing a field
+ * removes that field from the entry entirely, the same "absent means unset" pattern the sibling
+ * `RoleCostLimit`'s `onChangeToken` (`CostLimits.tsx`) uses — rather than writing an empty string,
+ * which Core's Jackson deserializer would otherwise silently coerce to `0` on a primitive numeric
+ * field. A value of `0` is only ever written when the user enters it. The entry is dropped from
+ * `share` entirely once it has no fields left. No ms<->hours conversion: `value` is already in the
  * unit Core's `ShareResourceLimit.invitationTtl` field expects.
  */
 export const applySharingChange = (
@@ -52,16 +61,43 @@ export const applySharingChange = (
   value: number,
 ): DialRoleResource => {
   const field = toCoreShareField(token);
-  const newValue = {
-    ...role.share?.[sharingTypeName],
-    [field]: value,
-  };
+  const newValue = { ...role.share?.[sharingTypeName] };
+  if (value === null || value === undefined || (value as unknown) === '') {
+    delete newValue[field];
+  } else {
+    newValue[field] = value;
+  }
   const share = {
     ...role.share,
     [sharingTypeName]: newValue,
   };
-  if (Object.values(newValue).every((val) => val === null || val === undefined || (val as unknown) === '')) {
+  if (Object.keys(newValue).length === 0) {
     delete share[sharingTypeName];
   }
   return { ...role, share };
+};
+
+/**
+ * The sharing grid's default-placeholder lookup for this surface, against `platformSharingDefaults`
+ * rather than `Entities > Roles`' own `sharingDefaults` (`components/Roles/utils.ts`) — the two
+ * surfaces disagree on the default max users for `TOOL_SET`, and this one additionally covers
+ * `CREDENTIALS`/`SKILL`, which the admin-backend surface doesn't have.
+ */
+export const getDefaultPlaceholder = (node: IRowNode, colDef: ColDef): string => {
+  const field = colDef.field as keyof DialRoleShare;
+  const name = node.data.name as PlatformSharingType;
+  return platformSharingDefaults[name][field] as string;
+};
+
+/** Hides the reset-to-default row action once neither field on the row has an override. */
+export const isResetToDefaultHidden = (api: GridApi, node: IRowNode): boolean => {
+  const invitationTtl = api.getCellValue({
+    colKey: api.getColumn('invitationTtl') as Column,
+    rowNode: node,
+  });
+  const maxAcceptedUsers = api.getCellValue({
+    colKey: api.getColumn('maxAcceptedUsers') as Column,
+    rowNode: node,
+  });
+  return !(invitationTtl || maxAcceptedUsers);
 };

--- a/apps/ai-dial-admin/src/components/EntityView/Roles/utils.ts
+++ b/apps/ai-dial-admin/src/components/EntityView/Roles/utils.ts
@@ -144,14 +144,15 @@ export const SHARING_COLUMNS = (
   onChange?: (value: number, data: DialRole, token: string) => void,
   getDefaultPlaceholder?: (node: IRowNode, colDef: ColDef) => string,
   isReadOnlyAdmin?: boolean,
+  typeLabels: Record<string, string> = sharingTypes,
 ): ColDef[] => [
   {
     headerName: 'Type',
     field: 'name',
     filter: false,
     floatingFilter: false,
-    valueFormatter: ({ value }) => formatType(value, t),
-    tooltipValueGetter: ({ value }) => formatType(value, t),
+    valueFormatter: ({ value }) => formatType(value, t, typeLabels),
+    tooltipValueGetter: ({ value }) => formatType(value, t, typeLabels),
   },
   {
     headerName: 'Expiration time (hours)',
@@ -187,8 +188,8 @@ export const SHARING_COLUMNS = (
   },
 ];
 
-const formatType = (value: string, t: (stringToTranslate: string) => string) => {
-  const typeFieldKey = sharingTypes[value as keyof typeof sharingTypes];
+const formatType = (value: string, t: (stringToTranslate: string) => string, typeLabels: Record<string, string>) => {
+  const typeFieldKey = typeLabels[value];
   if (typeFieldKey) {
     return t(typeFieldKey);
   }

--- a/apps/ai-dial-admin/src/constants/i18n.ts
+++ b/apps/ai-dial-admin/src/constants/i18n.ts
@@ -37,6 +37,7 @@ export enum MenuI18nKey {
   Prompts = 'Menu.Prompts',
   Files = 'Menu.Files',
   Skills = 'Menu.Skills',
+  Credentials = 'Menu.Credentials',
   Runs = 'Menu.Runs',
   TestSuites = 'Menu.TestSuites',
   Datasets = 'Menu.Datasets',

--- a/apps/ai-dial-admin/src/locales/en.ts
+++ b/apps/ai-dial-admin/src/locales/en.ts
@@ -138,6 +138,7 @@ export default {
     Prompts: 'Prompts',
     Files: 'Files',
     Skills: 'Skills',
+    Credentials: 'Credentials',
     FoldersStorage: 'Folders Storage',
 
     Dashboard: 'Dashboard',

--- a/openspec/changes/archive/2026-09-01-fix-platform-role-sharing-resource-types/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-01-fix-platform-role-sharing-resource-types/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-01

--- a/openspec/changes/archive/2026-09-01-fix-platform-role-sharing-resource-types/design.md
+++ b/openspec/changes/archive/2026-09-01-fix-platform-role-sharing-resource-types/design.md
@@ -1,0 +1,182 @@
+## Context
+
+`Assets > Platform > Roles`' Sharing tab (`components/Assets/Platform/Roles/Sharing.tsx`) is the
+Core-direct surface for editing a `Role` resource's `share` map — a different backend and wire shape
+from `Entities > Roles`' admin-backend-driven `RoleSharing`. Its own doc-comment says it was "adapted
+from `Entities > Roles`'... reusing its grid columns/placeholder/reset-visibility helpers verbatim" —
+but that reuse went one step too far: it also inherited the admin-backend surface's lowercase
+`SharingType` enum and `sharingDefaults` map, neither of which matches Core's actual wire shape.
+
+Core's `ShareService` looks up a role's per-type override by `resourceType.name()` — the Java enum's
+name, e.g. `"TOOL_SET"`, `"APPLICATION"`, `"SKILL"` — and falls back to its own hardcoded
+`DEFAULT_LIMITS` when no override exists:
+
+```java
+private static final Map<ResourceType, ShareResourceLimit> DEFAULT_LIMITS = Map.of(
+    ResourceTypes.APPLICATION,  new ShareResourceLimit(10, 72),
+    ResourceTypes.CONVERSATION, new ShareResourceLimit(Integer.MAX_VALUE, 72),
+    ResourceTypes.FILE,         new ShareResourceLimit(Integer.MAX_VALUE, 72),
+    ResourceTypes.PROMPT,       new ShareResourceLimit(Integer.MAX_VALUE, 72),
+    ResourceTypes.TOOL_SET,     new ShareResourceLimit(10, 72),
+    ResourceTypes.CREDENTIALS,  new ShareResourceLimit(10, 72),
+    ResourceTypes.SKILL,        new ShareResourceLimit(10, 72));
+```
+
+`ShareResourceLimit` itself defaults both fields to `-1` when unset:
+
+```java
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ShareResourceLimit {
+    int maxAcceptedUsers = -1;   // unset sentinel
+    long invitationTtl = -1;     // unset sentinel
+}
+```
+
+Since `-1` is a primitive `int`/`long` default (not `null`), and an empty JSON string deserializes
+into a primitive numeric field as `0` (Jackson's default scalar coercion), both ends of this surface
+need to treat "no value" as a value distinct from `0` and `-1` — that's the throughline connecting
+every symptom in the linked issue and the follow-up requests.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make `Assets/Platform/Roles`' sharing grid read and write the exact map keys Core uses
+  (`resourceType.name()`), so defaults, resets, and persisted overrides all operate on real data.
+- Match Core's own default limits (including the two new types) instead of the admin-backend surface's.
+- Treat Core's `-1` sentinel as "unset" on read, and never write an empty string or a synthesized `0`
+  on clear.
+- Keep the fix scoped to `Assets/Platform/Roles` — `Entities > Roles` (`components/Roles/**`) is
+  correct for its own backend and stays untouched.
+
+**Non-Goals:**
+- No change to `Entities > Roles`' `SharingType`/`sharingDefaults`/`DialRoleShare` — those model a
+  genuinely different (admin-backend) wire shape and are out of scope.
+- No attempt to unify the two surfaces on one shared resource-type enum. They diverge by design (one
+  is Core's `ResourceTypes.name()`, the other is the admin-backend's own lowercase convention); forcing
+  them onto one type would make one of the two surfaces read wrong again the next time either backend's
+  shape moves independently.
+- No change to `ms`↔`hours` handling for `invitationTtl` — Core's field is already hours-native, and
+  `Assets/Platform/Roles/utils.ts`'s existing doc-comment on this is correct and unaffected.
+- No change to `CostLimits.tsx` — it already implements the "delete key on empty" pattern correctly;
+  it's a reference, not a target.
+
+## Decisions
+
+**A platform-only `SharingType`, not a shared/renamed one.** Add
+`components/Assets/Platform/Roles/types.ts` (or a `models.ts`, per `code-standards.md`'s
+types/interfaces placement) with its own enum:
+
+```ts
+export enum PlatformSharingType {
+  APPLICATION = 'APPLICATION',
+  TOOL_SET = 'TOOL_SET',
+  PROMPT = 'PROMPT',
+  FILE = 'FILE',
+  CONVERSATION = 'CONVERSATION',
+  CREDENTIALS = 'CREDENTIALS',
+  SKILL = 'SKILL',
+}
+```
+
+`SKILL`, singular, matching `ResourceTypes.SKILL` — not `SKILLS` as the triggering ticket text says.
+The Java enum's `name()` is the literal map key Core reads (`ShareService.getLimit`); a mismatch here
+reproduces exactly the class of bug this change fixes. Alternative considered: reuse
+`DialModelResourceType`-style naming already in `models/dial/resource.ts` — rejected, because those
+enums model different concepts (model kind, not shareable-resource kind) and happen to also be
+uppercase by coincidence, not by any shared contract worth coupling to.
+
+**A platform-only defaults map**, alongside the enum, mirroring `ShareService.DEFAULT_LIMITS` exactly
+(as placeholder strings, matching the existing `getDefaultPlaceholder` cell-renderer contract):
+
+```ts
+export const platformSharingDefaults: Record<PlatformSharingType, SharingGridData placeholder shape> = {
+  [PlatformSharingType.APPLICATION]: { invitationTtl: '72', maxAcceptedUsers: '10' },
+  [PlatformSharingType.TOOL_SET]:    { invitationTtl: '72', maxAcceptedUsers: '10' },
+  [PlatformSharingType.CREDENTIALS]: { invitationTtl: '72', maxAcceptedUsers: '10' },
+  [PlatformSharingType.SKILL]:       { invitationTtl: '72', maxAcceptedUsers: '10' },
+  [PlatformSharingType.PROMPT]:       { invitationTtl: '72', maxAcceptedUsers: '' },
+  [PlatformSharingType.FILE]:        { invitationTtl: '72', maxAcceptedUsers: '' },
+  [PlatformSharingType.CONVERSATION]: { invitationTtl: '72', maxAcceptedUsers: '' },
+};
+```
+
+`CONVERSATION`/`FILE`/`PROMPT` keep an empty max-users placeholder rather than displaying
+`Integer.MAX_VALUE` as a number — Core's own default for those is effectively "unlimited", which the
+existing `EditableCellRenderer`/`UNLIMITED_ACCEPTED_USERS` machinery already renders as the
+"Unlimited" placeholder-primary state once wired to the real sentinel, not as a literal huge number.
+
+Also add a platform-only `platformSharingTypeLabels` map (`PlatformSharingType -> MenuI18nKey`), same
+shape as `Roles/constants.ts`'s `sharingTypes`, feeding `SHARING_COLUMNS`' `formatType`. New
+`MenuI18nKey.Credentials = 'Menu.Credentials'` key + `en.ts` entry (`Menu.Skills` already exists for
+`SKILL`'s label).
+
+**`-1` is "unset" in `getAssetSharingData`.** Change:
+
+```ts
+invitationTtl: shareData?.invitation_ttl != null ? String(shareData.invitation_ttl) : undefined,
+```
+
+to also exclude `-1`:
+
+```ts
+const isUnset = (value?: number | null) => value == null || value === -1;
+invitationTtl: isUnset(shareData?.invitation_ttl) ? undefined : String(shareData!.invitation_ttl),
+```
+
+applied to both fields. This makes the row fall through to `getDefaultPlaceholder`, showing an empty
+input with the default placeholder — exactly the requested behavior — with no special-casing needed
+in the cell renderer itself (`EditableCellRenderer` already treats `undefined` as "no value, show
+placeholder").
+
+**Per-field delete on clear in `applySharingChange`**, mirroring `CostLimits.tsx`'s `onChangeToken`:
+
+```ts
+export const applySharingChange = (role, sharingTypeName, token, value) => {
+  const field = toCoreShareField(token);
+  const newValue = { ...role.share?.[sharingTypeName] };
+  if (value === '' || value == null) {
+    delete newValue[field];
+  } else {
+    newValue[field] = value;
+  }
+  const share = { ...role.share, [sharingTypeName]: newValue };
+  if (Object.keys(newValue).length === 0) {
+    delete share[sharingTypeName];
+  }
+  return { ...role, share };
+};
+```
+
+This keeps the existing "drop the whole entry once every field is gone" behavior (now driven by
+`Object.keys(...).length === 0` instead of `every field is blank`) while fixing the actual defect: a
+sibling field that still has a value no longer leaves the cleared field behind as `''`, which is what
+was getting silently coerced to `0` server-side. A value of literal `0` (user-typed) still flows
+through the `else` branch unchanged, satisfying "save 0 only if the user enters it manually."
+
+**Test rewrite, not patch.** `components/Assets/Platform/Roles/tests/utils.spec.ts` currently encodes
+the lowercase-key, 5-type, "blank-entry-only" assumptions as passing assertions — per
+`.claude/rules/testing.md`'s general expectation that tests assert real behavior, these get rewritten
+against the corrected contract (uppercase keys, 7 types, `-1`-as-unset, per-field delete on clear)
+rather than patched around the edges.
+
+## Risks / Trade-offs
+
+- **Existing role resources with lowercase `share` keys** (if any were ever persisted by the buggy
+  code) become orphaned — the new uppercase lookup won't find them, and their old override is
+  effectively lost on the next load. → Acceptable: the buggy code could never *display* those values
+  correctly either (same lowercase/uppercase mismatch bit the read path too), so no working state
+  regresses; a role appearing to reset to Core defaults after this fix is a correction, not a
+  regression. Not raising this as a migration task per `openspec/config.yaml`'s no-manual-verification
+  rule and because there is no read path today that would even notice the difference.
+- **Two parallel `SharingType`-like enums in the codebase** (`Roles/types.ts` lowercase,
+  `Assets/Platform/Roles/types.ts` uppercase) is a legitimate source of future confusion. →
+  Mitigated by each file's doc-comment stating explicitly which backend/surface it belongs to (matching
+  the existing convention already established by `Assets/Platform/Roles/utils.ts`'s own doc-comment).
+- **`CONVERSATION`/`FILE`/`PROMPT` max-users placeholder stays blank** rather than showing a literal
+  "Unlimited" hint out of the gate. → Out of scope per the triggering request, which only calls out the
+  toolset default; can be revisited separately if desired.
+
+## Open Questions
+
+None outstanding — the resource-type naming and scope questions were resolved during exploration
+(`SKILL` singular, platform-only modules, no `Entities > Roles` changes).

--- a/openspec/changes/archive/2026-09-01-fix-platform-role-sharing-resource-types/proposal.md
+++ b/openspec/changes/archive/2026-09-01-fix-platform-role-sharing-resource-types/proposal.md
@@ -1,0 +1,64 @@
+## Why
+
+`Assets > Platform > Roles`' Sharing tab (`components/Assets/Platform/Roles/Sharing.tsx`) reuses
+`Entities > Roles`' `SharingType` enum, `sharingDefaults`, and `getDefaultPlaceholder`/`isResetToDefaultHidden`
+verbatim. Those were built for the admin-backend's `DialRoleShare` shape, whose resource-type keys are
+lowercase (`application`, `tool_set`, ...). But Core's `Role.share` map is keyed by
+`ResourceTypes.name()` — the Java enum's uppercase name (`APPLICATION`, `TOOL_SET`, ...) — so this
+surface has been reading and writing the wrong map keys since it was introduced: every default
+placeholder, reset-to-default computation, and persisted override for this grid operates on data that
+was never actually there. GitHub issue #4353 ("Reset to default limits for one entity changes another
+entity's Expiration time") is a symptom of this — the grid's per-row state was never grounded in real
+data to begin with.
+
+DIAL Core has also added two new shareable resource types since this surface was built
+(`CREDENTIALS`, `SKILL`), and defines its own default limits (`ShareResourceLimit`) that this surface
+doesn't match: Core defaults an unset field to the sentinel `-1`, and gives `TOOL_SET` the same
+max-users default (`10`) as `APPLICATION` — neither of which the current UI reflects.
+
+## What Changes
+
+- Introduce a platform-specific resource-type source of truth (uppercase names matching
+  `ResourceTypes.name()`: `APPLICATION`, `TOOL_SET`, `PROMPT`, `FILE`, `CONVERSATION`, `CREDENTIALS`,
+  `SKILL`) used only by `Assets/Platform/Roles`, separate from `Entities > Roles`' lowercase
+  `SharingType`.
+- Add a platform-specific default-limits map matching Core's `ShareService.DEFAULT_LIMITS`: max users
+  `10` for `APPLICATION`, `TOOL_SET`, `CREDENTIALS`, `SKILL`; unspecified for `CONVERSATION`, `FILE`,
+  `PROMPT`; invitation TTL `72` for all seven.
+- Treat Core's `-1` sentinel (its "unset" default for both `max_accepted_users` and `invitation_ttl`)
+  as absent when reading a role's `share` map — shown as an empty input with the default placeholder,
+  not as a literal `-1`.
+- Fix `applySharingChange` to delete an individual field from a sharing-type entry when the user
+  clears it, rather than writing `''`/`0` — mirroring the sibling `CostLimits.tsx`'s
+  `onChangeToken` pattern (delete the key when the value is empty, only ever write a literal `0` when
+  the user types it). A left-over empty string on a primitive Core field currently gets silently
+  coerced to `0` on the wire.
+- Add `CREDENTIALS` and `SKILL` as sharing rows, with a `Menu.Credentials` label (no i18n key exists
+  yet; `Menu.Skills` already does).
+- Rewrite `components/Assets/Platform/Roles/tests/utils.spec.ts`, which currently asserts the
+  lowercase keys and a fixed count of 5 types — every assertion there encodes the bug being fixed.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `platform-roles`: the "Role asset Properties tab" requirement's sharing-grid behavior changes —
+  resource-type keys, default values, `-1`-as-unset handling, per-field clearing, and the addition of
+  two new shareable resource types.
+
+## Impact
+
+- `apps/ai-dial-admin/src/components/Assets/Platform/Roles/Sharing.tsx`
+- `apps/ai-dial-admin/src/components/Assets/Platform/Roles/utils.ts` (`getAssetSharingData`,
+  `applySharingChange`, `toCoreShareField`)
+- New platform-only resource-type/defaults modules (constants + models), not shared with
+  `components/Roles/types.ts` / `constants.ts` / `utils.ts` (`Entities > Roles` stays untouched — its
+  admin-backend-shaped `DialRoleShare`/`SharingType`/`sharingDefaults` are correct for that surface).
+- `apps/ai-dial-admin/src/constants/i18n.ts` / `locales/en.ts` — new `Menu.Credentials` key.
+- `apps/ai-dial-admin/src/components/Assets/Platform/Roles/tests/utils.spec.ts` — rewritten.
+- No admin-backend or API-route changes; this is a client-only correction against Core's existing
+  `Role`/`ShareResourceLimit` wire shape.

--- a/openspec/changes/archive/2026-09-01-fix-platform-role-sharing-resource-types/specs/platform-roles/spec.md
+++ b/openspec/changes/archive/2026-09-01-fix-platform-role-sharing-resource-types/specs/platform-roles/spec.md
@@ -1,0 +1,64 @@
+## MODIFIED Requirements
+
+### Requirement: Properties tab content
+The system SHALL render the role asset's Properties tab with a cost-limit toggle and, when enabled,
+minute/day/week/month cost-limit number inputs, plus a sharing grid (invitation TTL and max accepted
+users per shareable resource type with a reset-to-default action). Cost-limit values SHALL be plain
+numbers, not strings. A token whose Core-side value is too large for JavaScript to represent exactly
+(DIAL Core's `Long.MAX_VALUE` "unlimited" default) SHALL be treated as absent — shown as unset and
+omitted from the write — rather than displayed or persisted as an approximate, rounded number.
+
+The sharing grid SHALL list exactly the seven resource types DIAL Core allows a role to override —
+`APPLICATION`, `TOOL_SET`, `PROMPT`, `FILE`, `CONVERSATION`, `CREDENTIALS`, and `SKILL` — keyed on the
+role resource's `share` map by that exact uppercase name, matching Core's own
+`ResourceTypes.name()`. Max accepted users SHALL default to `10` for `APPLICATION`, `TOOL_SET`,
+`CREDENTIALS`, and `SKILL`, and SHALL have no specific default placeholder for `PROMPT`, `FILE`, and
+`CONVERSATION`; invitation TTL SHALL default to `72` hours for every type. A stored value of `-1` for
+either field (DIAL Core's own "not provided" sentinel) SHALL be treated as absent — shown as an empty
+input with the default placeholder — rather than displayed as the literal value `-1`. Clearing a
+field the user had set SHALL remove that field from the resource type's `share` entry entirely; a
+stored value of `0` SHALL only be written when the user explicitly enters `0`.
+
+#### Scenario: Cost limits are editable and persist
+- **WHEN** a user enables the cost-limit toggle, sets a value for a token, and saves
+- **THEN** the value is stored on the role resource's `costLimit` as a number and reappears on reload
+
+#### Scenario: Disabling the cost-limit toggle clears every token
+- **WHEN** a user disables the cost-limit toggle
+- **THEN** every cost-limit token is removed from the resource's `costLimit`, rather than being set to
+  an explicit sentinel value
+
+#### Scenario: An out-of-range cost-limit token is treated as unlimited, not an approximate number
+- **WHEN** a cost-limit token's stored value is too large for JavaScript to represent exactly
+- **THEN** the field is shown as unset rather than a rounded number, and saving without changing it
+  leaves that token unset on the resource
+
+#### Scenario: Sharing settings are editable and persist under Core's uppercase resource-type keys
+- **WHEN** a user sets an invitation TTL or max-accepted-users value for a resource type and saves
+- **THEN** the value is stored on the role resource's `share` map under that type's uppercase name
+  (e.g. `share.TOOL_SET.max_accepted_users`) and reappears on reload
+
+#### Scenario: Resetting a sharing row clears its override
+- **WHEN** a user resets a sharing row to default
+- **THEN** that resource type's entry is removed from the `share` map
+
+#### Scenario: Toolset max users defaults to 10, same as applications
+- **WHEN** a user opens the sharing grid for a role with no `TOOL_SET` override
+- **THEN** the max-users input for the Toolsets row is empty and shows a `10` placeholder, matching
+  the Applications row
+
+#### Scenario: A -1 stored value shows as unset, not as a literal -1
+- **WHEN** a role's `share` map has an entry whose `max_accepted_users` or `invitation_ttl` is `-1`
+- **THEN** the corresponding input is shown empty with its default placeholder, not the value `-1`
+
+#### Scenario: Clearing one field of a sharing row leaves the other field intact and omits the cleared field
+- **WHEN** a user clears the max-users value on a row that also has an invitation-TTL override, and
+  saves
+- **THEN** the resource type's `share` entry keeps its `invitation_ttl` and no longer has a
+  `max_accepted_users` field at all — not a value of `0` or an empty string
+
+#### Scenario: Credentials and Skills are available as shareable resource types
+- **WHEN** a user opens the sharing grid
+- **THEN** rows for Credentials (`CREDENTIALS`) and Skills (`SKILL`) are shown alongside Applications,
+  Toolsets, Prompts, Files, and Conversations, each defaulting to 10 max users and a 72-hour
+  invitation TTL

--- a/openspec/changes/archive/2026-09-01-fix-platform-role-sharing-resource-types/tasks.md
+++ b/openspec/changes/archive/2026-09-01-fix-platform-role-sharing-resource-types/tasks.md
@@ -1,0 +1,53 @@
+## 1. Platform-only resource-type model
+
+- [x] 1.1 Add `apps/ai-dial-admin/src/components/Assets/Platform/Roles/models.ts` (or `types.ts`, per
+      `code-standards.md`'s types/interfaces placement) with `PlatformSharingType` enum:
+      `APPLICATION`, `TOOL_SET`, `PROMPT`, `FILE`, `CONVERSATION`, `CREDENTIALS`, `SKILL` — values
+      matching Core's `ResourceTypes.name()` exactly (uppercase, `SKILL` singular).
+- [x] 1.2 Add `platformSharingDefaults` (`Record<PlatformSharingType, ...>`) to
+      `Assets/Platform/Roles/constants.ts`, matching Core's `ShareService.DEFAULT_LIMITS`: max users
+      `'10'` for `APPLICATION`/`TOOL_SET`/`CREDENTIALS`/`SKILL`, `''` for `PROMPT`/`FILE`/`CONVERSATION`;
+      invitation TTL `'72'` for all seven.
+- [x] 1.3 Add `platformSharingTypeLabels` (`Record<PlatformSharingType, MenuI18nKey>`) to the same file,
+      reusing existing `MenuI18nKey.Applications/Toolsets/Prompts/Files/Conversations/Skills`.
+- [x] 1.4 Add `MenuI18nKey.Credentials = 'Menu.Credentials'` to `constants/i18n.ts` and the matching
+      `Menu.Credentials: 'Credentials'` entry to `locales/en.ts`.
+
+## 2. Fix the read/write path in `Assets/Platform/Roles/utils.ts`
+
+- [x] 2.1 Update `getAssetSharingData` to iterate `PlatformSharingType`'s seven values instead of the
+      lowercase `SharingType` import, and to treat both `invitation_ttl === -1` and
+      `max_accepted_users === -1` as absent (in addition to the existing `!= null` check), so those
+      rows fall through to the default placeholder.
+- [x] 2.2 Update `applySharingChange` to delete the individual field from the sharing-type entry when
+      the incoming value is `''`/`null`/`undefined`, rather than assigning the empty value — mirroring
+      `CostLimits.tsx`'s `onChangeToken` — and to drop the whole entry once it has no fields left
+      (replacing the current "every field is blank" check with an emptiness check on the entry itself).
+- [x] 2.3 Remove the now-unused import of `SharingType` from `@/src/components/Roles/types` in this
+      file; leave `Entities > Roles`' own `components/Roles/**` untouched.
+
+## 3. Wire the platform Sharing component to the new model
+
+- [x] 3.1 In `Assets/Platform/Roles/Sharing.tsx`, replace the `getDefaultPlaceholder`/
+      `isResetToDefaultHidden` imports from `@/src/components/Roles/utils` with platform-local
+      equivalents built against `platformSharingDefaults` (same signatures/contract
+      `SHARING_COLUMNS`/`getResetOperation` already expect).
+- [x] 3.2 Update `SHARING_COLUMNS`'s type-column `formatType` usage (or pass a platform-local label
+      lookup) so the Type column renders via `platformSharingTypeLabels` for this surface instead of
+      `Entities > Roles`' `sharingTypes` map.
+
+## 4. Tests
+
+- [x] 4.1 Rewrite `components/Assets/Platform/Roles/tests/utils.spec.ts` for the corrected contract:
+      uppercase keys, seven types (including `CREDENTIALS`/`SKILL`), `-1`-as-unset on both fields, and
+      per-field delete on clear (a cleared field disappears from the entry while a sibling field with a
+      value is preserved; the whole entry is dropped only once no fields remain).
+- [x] 4.2 Add/update a component test for `Sharing.tsx` covering: the Toolset row's default `10`
+      max-users placeholder, the Credentials/Skills rows appearing, and a `-1`-valued stored field
+      rendering as empty with its placeholder — per `.claude/rules/testing.md`'s `getByRole` query
+      convention.
+
+## 5. Quality gate
+
+- [x] 5.1 Run `npm run lint`, `npm run format`, and the full `npm run test` suite from
+      `apps/ai-dial-admin/` and fix any failures.

--- a/openspec/specs/platform-roles/spec.md
+++ b/openspec/specs/platform-roles/spec.md
@@ -89,6 +89,17 @@ numbers, not strings. A token whose Core-side value is too large for JavaScript 
 (DIAL Core's `Long.MAX_VALUE` "unlimited" default) SHALL be treated as absent — shown as unset and
 omitted from the write — rather than displayed or persisted as an approximate, rounded number.
 
+The sharing grid SHALL list exactly the seven resource types DIAL Core allows a role to override —
+`APPLICATION`, `TOOL_SET`, `PROMPT`, `FILE`, `CONVERSATION`, `CREDENTIALS`, and `SKILL` — keyed on the
+role resource's `share` map by that exact uppercase name, matching Core's own
+`ResourceTypes.name()`. Max accepted users SHALL default to `10` for `APPLICATION`, `TOOL_SET`,
+`CREDENTIALS`, and `SKILL`, and SHALL have no specific default placeholder for `PROMPT`, `FILE`, and
+`CONVERSATION`; invitation TTL SHALL default to `72` hours for every type. A stored value of `-1` for
+either field (DIAL Core's own "not provided" sentinel) SHALL be treated as absent — shown as an empty
+input with the default placeholder — rather than displayed as the literal value `-1`. Clearing a
+field the user had set SHALL remove that field from the resource type's `share` entry entirely; a
+stored value of `0` SHALL only be written when the user explicitly enters `0`.
+
 #### Scenario: Cost limits are editable and persist
 - **WHEN** a user enables the cost-limit toggle, sets a value for a token, and saves
 - **THEN** the value is stored on the role resource's `costLimit` as a number and reappears on reload
@@ -103,13 +114,35 @@ omitted from the write — rather than displayed or persisted as an approximate,
 - **THEN** the field is shown as unset rather than a rounded number, and saving without changing it
   leaves that token unset on the resource
 
-#### Scenario: Sharing settings are editable and persist
+#### Scenario: Sharing settings are editable and persist under Core's uppercase resource-type keys
 - **WHEN** a user sets an invitation TTL or max-accepted-users value for a resource type and saves
-- **THEN** the value is stored on the role resource's `share` map and reappears on reload
+- **THEN** the value is stored on the role resource's `share` map under that type's uppercase name
+  (e.g. `share.TOOL_SET.max_accepted_users`) and reappears on reload
 
 #### Scenario: Resetting a sharing row clears its override
 - **WHEN** a user resets a sharing row to default
 - **THEN** that resource type's entry is removed from the `share` map
+
+#### Scenario: Toolset max users defaults to 10, same as applications
+- **WHEN** a user opens the sharing grid for a role with no `TOOL_SET` override
+- **THEN** the max-users input for the Toolsets row is empty and shows a `10` placeholder, matching
+  the Applications row
+
+#### Scenario: A -1 stored value shows as unset, not as a literal -1
+- **WHEN** a role's `share` map has an entry whose `max_accepted_users` or `invitation_ttl` is `-1`
+- **THEN** the corresponding input is shown empty with its default placeholder, not the value `-1`
+
+#### Scenario: Clearing one field of a sharing row leaves the other field intact and omits the cleared field
+- **WHEN** a user clears the max-users value on a row that also has an invitation-TTL override, and
+  saves
+- **THEN** the resource type's `share` entry keeps its `invitation_ttl` and no longer has a
+  `max_accepted_users` field at all — not a value of `0` or an empty string
+
+#### Scenario: Credentials and Skills are available as shareable resource types
+- **WHEN** a user opens the sharing grid
+- **THEN** rows for Credentials (`CREDENTIALS`) and Skills (`SKILL`) are shown alongside Applications,
+  Toolsets, Prompts, Files, and Conversations, each defaulting to 10 max users and a 72-hour
+  invitation TTL
 
 ### Requirement: Core validates a write; the client adds no meta-schema layer
 The system SHALL rely on Core's own server-side validation — Core deserializes a role write into its


### PR DESCRIPTION
**Description:**

Fixes the resource-type key mapping in the platform role sharing grid. The sharing surface was using lowercase keys from the admin-backend's `SharingType` enum (e.g., `application`, `tool_set`), but DIAL Core's `Role.share` map uses uppercase keys matching Java's `ResourceTypes.name()` (e.g., `APPLICATION`, `TOOL_SET`). This caused all sharing defaults, reset-to-default computations, and persisted overrides to operate on data that didn't actually exist.

Also adds two new shareable resource types (`CREDENTIALS`, `SKILL`) that Core defines, and corrects the default limits to match Core's `ShareResourceLimit` — max users `10` for `APPLICATION`, `TOOL_SET`, `CREDENTIALS`, `SKILL`; invitation TTL `72` for all seven types. Treats Core's `-1` sentinel (unset default) as absent, and fixes per-field clearing to delete the field rather than writing an empty string.

Issues:

- Issue #4353

**Key Changes:**

- [apps/ai-dial-admin/src/components/Assets/Platform/Roles/constants.ts](https://github.com/epam/ai-dial-admin-frontend/blob/fix/platform-role-sharing-resource-types/apps/ai-dial-admin/src/components/Assets/Platform/Roles/constants.ts) — new platform-specific resource-type and defaults map matching Core's `ShareResourceLimit`
- [apps/ai-dial-admin/src/components/Assets/Platform/Roles/models.ts](https://github.com/epam/ai-dial-admin-frontend/blob/fix/platform-role-sharing-resource-types/apps/ai-dial-admin/src/components/Assets/Platform/Roles/models.ts) — new `PlatformSharingType` enum with uppercase keys
- [apps/ai-dial-admin/src/components/Assets/Platform/Roles/utils.ts](https://github.com/epam/ai-dial-admin-frontend/blob/fix/platform-role-sharing-resource-types/apps/ai-dial-admin/src/components/Assets/Platform/Roles/utils.ts) — fix `applySharingChange` to delete empty fields, add platform-specific placeholder/reset helpers
- [apps/ai-dial-admin/src/components/Assets/Platform/Roles/Sharing.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/fix/platform-role-sharing-resource-types/apps/ai-dial-admin/src/components/Assets/Platform/Roles/Sharing.tsx) — use platform helpers instead of admin-backend ones
- [apps/ai-dial-admin/src/components/EntityView/Roles/utils.ts](https://github.com/epam/ai-dial-admin-frontend/blob/fix/platform-role-sharing-resource-types/apps/ai-dial-admin/src/components/EntityView/Roles/utils.ts) — add labels parameter to `SHARING_COLUMNS`
- [apps/ai-dial-admin/src/components/Assets/Platform/Roles/tests/utils.spec.ts](https://github.com/epam/ai-dial-admin-frontend/blob/fix/platform-role-sharing-resource-types/apps/ai-dial-admin/src/components/Assets/Platform/Roles/tests/utils.spec.ts) — rewritten to assert uppercase keys and seven resource types
- [apps/ai-dial-admin/src/constants/i18n.ts](https://github.com/epam/ai-dial-admin-frontend/blob/fix/platform-role-sharing-resource-types/apps/ai-dial-admin/src/constants/i18n.ts) / [locales/en.ts](https://github.com/epam/ai-dial-admin-frontend/blob/fix/platform-role-sharing-resource-types/apps/ai-dial-admin/src/locales/en.ts) — add `Menu.Credentials` key
- [.claude/reference/areas.md](https://github.com/epam/ai-dial-admin-frontend/blob/fix/platform-role-sharing-resource-types/.claude/reference/areas.md) — add `Assets/Roles` to area taxonomy
- [openspec/specs/platform-roles/spec.md](https://github.com/epam/ai-dial-admin-frontend/blob/fix/platform-role-sharing-resource-types/openspec/specs/platform-roles/spec.md) — specification of the platform roles asset surface

**New Components:**

- `PlatformSharingType` enum — uppercase resource-type keys matching Core's `ResourceTypes.name()`
- Platform-specific `sharingTypeLabels`, `defaultLimits`, `getDefaultPlaceholder`, `isResetToDefaultHidden` — isolated from the admin-backend's `Entities > Roles` equivalents

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #4353)`
