### PR TITLE
feat(Assets/Toolsets): add platform toolsets support with restricted actions (Issue #4389)

### DIFF
--- a/apps/ai-dial-admin/src/app/[lang]/assets-toolsets/[id]/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/assets-toolsets/[id]/page.tsx
@@ -1,18 +1,20 @@
 import { notFound } from 'next/navigation';
 
+import PlatformToolsetView from '@/src/components/Assets/Platform/Toolsets/View';
 import ToolsetView from '@/src/components/Assets/Toolsets/View/View';
 import { DEFAULT_ETAG } from '@/src/constants/api-headers';
 import { SaveValidationContextProvider } from '@/src/context/SaveValidationContext';
 import { Asset, AssetToolset } from '@/src/models/dial/deployment-asset';
 import { DialFileNodeType } from '@/src/models/dial/file';
 import { errorObjLog } from '@/src/server/logger';
-import { getToolset, getToolsets } from '../actions';
+import { PLATFORM_ROOT_FOLDER } from '@/src/utils/files/root-folder';
+import { getPlatformToolset, getToolset, getToolsets } from '../actions';
 
 export const dynamic = 'force-dynamic';
 
 export default async function Page(params: {
   params: Promise<{ id: string }>;
-  searchParams: Promise<{ path: string; code?: string }>;
+  searchParams: Promise<{ path?: string; code?: string }>;
 }) {
   let oAuthCode = null;
   let etag = DEFAULT_ETAG;
@@ -20,20 +22,34 @@ export default async function Page(params: {
   let toolsets: AssetToolset[] = [];
   let toolset: AssetToolset | null = null;
 
+  // A `path` query param means this is a public-bucket (versioned, folder-nested) toolset; its
+  // absence means a platform-bucket one — flat, identified by name alone (design.md D3/D5).
+  const searchParams = await params.searchParams;
+  oAuthCode = searchParams.code;
+  const rawPath = searchParams.path;
+  const isPlatformBucket = !rawPath;
+  const name = decodeURIComponent((await params.params).id);
+
   try {
-    const searchParams = await params.searchParams;
-    oAuthCode = searchParams.code;
-    const path = decodeURIComponent(searchParams.path);
-    const name = decodeURIComponent((await params.params).id);
+    if (isPlatformBucket) {
+      const path = `${PLATFORM_ROOT_FOLDER}/${name}`;
 
-    toolset = await getToolset(path, etag).then((res) => {
-      etag = res?.etag || DEFAULT_ETAG;
-      return res?.response as AssetToolset | null;
-    });
+      toolset = await getPlatformToolset(path, etag).then((res) => {
+        etag = res?.etag || DEFAULT_ETAG;
+        return (res?.response as unknown as AssetToolset) || null;
+      });
+    } else {
+      const path = decodeURIComponent(rawPath as string);
 
-    toolsets = ((await getToolsets(toolset?.folderId as string))?.filter(
-      (p) => (p as Asset).nodeType === DialFileNodeType.ITEM && p.name === name,
-    ) || []) as AssetToolset[];
+      toolset = await getToolset(path, etag).then((res) => {
+        etag = res?.etag || DEFAULT_ETAG;
+        return res?.response as AssetToolset | null;
+      });
+
+      toolsets = ((await getToolsets(toolset?.folderId as string))?.filter(
+        (p) => (p as Asset).nodeType === DialFileNodeType.ITEM && p.name === name,
+      ) || []) as AssetToolset[];
+    }
   } catch (e) {
     errorObjLog(e, 'Failed to fetch toolset view data');
   }
@@ -43,7 +59,11 @@ export default async function Page(params: {
 
   return (
     <SaveValidationContextProvider>
-      <ToolsetView oAuthCode={oAuthCode} etag={etag} originalToolset={toolset} toolsets={toolsets || []} />
+      {isPlatformBucket ? (
+        <PlatformToolsetView oAuthCode={oAuthCode} etag={etag} originalToolset={toolset} />
+      ) : (
+        <ToolsetView oAuthCode={oAuthCode} etag={etag} originalToolset={toolset} toolsets={toolsets || []} />
+      )}
     </SaveValidationContextProvider>
   );
 }

--- a/apps/ai-dial-admin/src/app/[lang]/assets-toolsets/actions.spec.ts
+++ b/apps/ai-dial-admin/src/app/[lang]/assets-toolsets/actions.spec.ts
@@ -21,8 +21,15 @@ import {
   importToolsets,
   exportToolsets,
   tryOutAssetTool,
+  bulkDeletePlatformToolsets,
+  createPlatformToolset,
+  getPlatformToolset,
+  getPlatformToolsets,
+  removePlatformToolset,
+  updatePlatformToolset,
 } from './actions';
 import { DialFileNodeType } from '@/src/models/dial/file';
+import { DialPlatformToolsetResource } from '@/src/models/dial/resource';
 import { ResourceType } from '@/src/types/resource-type';
 import { ToolsetAuthCredentialLevel } from '@/src/models/dial/toolset';
 import { ImportFileType } from '@/src/types/import';
@@ -340,5 +347,138 @@ describe('Assets Toolset :: server actions', () => {
     expect(mcpClientModule.buildToolsetMcpUrl).not.toHaveBeenCalled();
     expect(mcpClientModule.callToolViaMcp).toHaveBeenCalledWith(applicationUrl, TOKEN_MOCK, callToolRequest);
     expect(result).toBe(RESPONSE_MOCK);
+  });
+});
+
+describe('Platform toolset server actions', () => {
+  const platformToolset: DialPlatformToolsetResource = {
+    name: 'my-toolset',
+    path: 'platform/my-toolset',
+    folderId: 'platform/',
+    endpoint: 'http://mock',
+  } as DialPlatformToolsetResource;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getUserToken as any).mockResolvedValue(TOKEN_MOCK);
+    (getIsEnableAuthToggle as any).mockReturnValue(true);
+    (assetApi.put as any).mockResolvedValue({ success: true, response: {} });
+    (assetApi.delete as any).mockResolvedValue({ success: true });
+    (assetApi.list as any).mockResolvedValue([]);
+    (assetApi.getMergedWithEtag as any).mockResolvedValue({
+      success: true,
+      response: platformToolset,
+      etag: 'etag-1',
+    });
+  });
+
+  test('createPlatformToolset writes to the bare platform-prefixed path, with no version suffix', async () => {
+    await createPlatformToolset(platformToolset);
+
+    expect(assetApi.put).toHaveBeenCalledOnce();
+    const [, type, path] = (assetApi.put as any).mock.calls[0];
+    expect(type).toBe(ResourceType.TOOLSET);
+    expect(path).toBe('platform/my-toolset');
+    expect(path).not.toContain('__');
+  });
+
+  test('updatePlatformToolset writes to the bare platform-prefixed path, with no version suffix', async () => {
+    await updatePlatformToolset(platformToolset, 'etag-1');
+
+    expect(assetApi.put).toHaveBeenCalledOnce();
+    const [, type, path, , options] = (assetApi.put as any).mock.calls[0];
+    expect(type).toBe(ResourceType.TOOLSET);
+    expect(path).toBe('platform/my-toolset');
+    expect(path).not.toContain('__');
+    expect(options).toEqual({ etag: 'etag-1' });
+  });
+
+  // ConfigResourceController (the platform bucket's write path) deserializes strictly
+  // (FAIL_ON_UNKNOWN_PROPERTIES) — read-only/derived fields the merge reader adds must not round-trip
+  // back onto a write, or Core rejects the whole body ("Failed to parse entity").
+  test('createPlatformToolset strips read-only/derived fields before writing', async () => {
+    const toolsetWithExtras = {
+      ...platformToolset,
+      status: 'valid',
+      validationWarnings: [{ field: 'endpoint' }],
+      author: 'Yauheni Osipau',
+      createdAt: '1',
+      updatedAt: '2',
+      reference: 'b827783e-d894-467f-b790-d2e900cc8365',
+    } as DialPlatformToolsetResource;
+
+    await createPlatformToolset(toolsetWithExtras);
+
+    const [, , , body] = (assetApi.put as any).mock.calls[0];
+    expect(body).not.toHaveProperty('status');
+    expect(body).not.toHaveProperty('validationWarnings');
+    expect(body).not.toHaveProperty('author');
+    expect(body).not.toHaveProperty('createdAt');
+    expect(body).not.toHaveProperty('updatedAt');
+    expect(body).not.toHaveProperty('reference');
+    expect(body).toMatchObject({ name: 'my-toolset', endpoint: 'http://mock' });
+  });
+
+  test('updatePlatformToolset strips read-only/derived fields before writing', async () => {
+    const toolsetWithExtras = {
+      ...platformToolset,
+      status: 'valid',
+      validationWarnings: [{ field: 'endpoint' }],
+      author: 'Yauheni Osipau',
+      createdAt: '1',
+      updatedAt: '2',
+      reference: 'b827783e-d894-467f-b790-d2e900cc8365',
+    } as DialPlatformToolsetResource;
+
+    await updatePlatformToolset(toolsetWithExtras, 'etag-1');
+
+    const [, , , body] = (assetApi.put as any).mock.calls[0];
+    expect(body).not.toHaveProperty('status');
+    expect(body).not.toHaveProperty('validationWarnings');
+    expect(body).not.toHaveProperty('author');
+    expect(body).not.toHaveProperty('createdAt');
+    expect(body).not.toHaveProperty('updatedAt');
+    expect(body).not.toHaveProperty('reference');
+    expect(body).toMatchObject({ name: 'my-toolset', endpoint: 'http://mock' });
+  });
+
+  test('getPlatformToolset reads a platform-prefixed path with the caller-supplied etag', async () => {
+    await getPlatformToolset('platform/my-toolset', 'etag-1');
+
+    expect(assetApi.getMergedWithEtag).toHaveBeenCalledWith(
+      TOKEN_MOCK,
+      ResourceType.TOOLSET,
+      'platform/my-toolset',
+      'etag-1',
+    );
+  });
+
+  test('getPlatformToolsets lists a platform-prefixed path', async () => {
+    await getPlatformToolsets('platform/');
+
+    expect(assetApi.list).toHaveBeenCalledWith(TOKEN_MOCK, ResourceType.TOOLSET, 'platform/');
+  });
+
+  test('removePlatformToolset sends If-Match when a concrete etag is supplied', async () => {
+    await removePlatformToolset('platform/my-toolset', 'etag-1');
+
+    expect(assetApi.delete).toHaveBeenCalledWith(TOKEN_MOCK, ResourceType.TOOLSET, 'platform/my-toolset', 'etag-1');
+  });
+
+  test('removePlatformToolset sends no conditional header when the etag is omitted', async () => {
+    await removePlatformToolset('platform/my-toolset');
+
+    expect(assetApi.delete).toHaveBeenCalledWith(TOKEN_MOCK, ResourceType.TOOLSET, 'platform/my-toolset', undefined);
+  });
+
+  test('bulkDeletePlatformToolsets deletes every path unconditionally', async () => {
+    const paths = [{ path: 'platform/toolset-1' }, { path: 'platform/toolset-2' }];
+
+    await bulkDeletePlatformToolsets(paths);
+
+    expect(assetApi.delete).toHaveBeenCalledTimes(2);
+    paths.forEach(({ path }) => {
+      expect(assetApi.delete).toHaveBeenCalledWith(TOKEN_MOCK, ResourceType.TOOLSET, path);
+    });
   });
 });

--- a/apps/ai-dial-admin/src/app/[lang]/assets-toolsets/actions.ts
+++ b/apps/ai-dial-admin/src/app/[lang]/assets-toolsets/actions.ts
@@ -5,12 +5,16 @@ import { cookies, headers } from 'next/headers';
 import { assetApi, toolsetOpsApi } from '@/src/app/api/api';
 import { ROOT_FOLDER } from '@/src/constants/file';
 import { AssetToolset } from '@/src/models/dial/deployment-asset';
-import { DialToolsetResource, ToolsetAuthCredentialLevel } from '@/src/models/dial/resource';
+import {
+  DialPlatformToolsetResource,
+  DialToolsetResource,
+  ToolsetAuthCredentialLevel,
+} from '@/src/models/dial/resource';
 import { ResourceType } from '@/src/types/resource-type';
 import { getUserToken } from '@/src/utils/auth/auth-request';
 import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
+import { PLATFORM_ROOT_FOLDER } from '@/src/utils/files/root-folder';
 import { getToolsetBasicBody, getToolsetSignInBody } from '@/src/utils/toolset/toolset-auth';
-// import { ToolsetAuthCredentialLevel } from '@/src/models/dial/toolset';
 import { ImportFileType } from '@/src/types/import';
 import { getVersionedName } from '@/src/server/publications/path';
 import { bulkDeleteAssets } from '@/src/server/assets/bulk-delete';
@@ -74,6 +78,76 @@ export async function removeToolset(path: string, etag?: string) {
 export async function bulkDeleteToolsets(paths: { path: string }[]) {
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
   return bulkDeleteAssets(assetApi, token, ResourceType.TOOLSET, paths);
+}
+
+/**
+ * Platform-bucket toolsets ("World B") reuse the same Core `ToolSet` entity as public-bucket ones —
+ * only the bucket segment of the path differs, and the bucket is flat (no folders, no versioning; see
+ * the `platform-toolsets` capability spec). `getToolsets`/`removeToolset`/`bulkDeleteToolsets` already
+ * take an arbitrary path and need no platform-specific logic; `createToolset`/`updateToolset` compute
+ * a `public`-defaulted, version-suffixed path, so their platform counterparts pin `folderId` to the
+ * `platform` bucket and clear `version`, letting `getVersionedName`'s existing no-op-when-absent
+ * branch (see `createToolset`/`updateToolset`) produce the flat `platform/{name}` path without a new
+ * branch there.
+ */
+export async function getPlatformToolsets(path: string) {
+  return getToolsets(path);
+}
+
+/**
+ * Unlike the generic `ResourceController` public-bucket writes go through, `ConfigResourceController`
+ * (the platform bucket's write path) deserializes the request body straight into `ToolSet` via
+ * Jackson with the default `FAIL_ON_UNKNOWN_PROPERTIES` — the same reason `platform-keys/actions.ts`'s
+ * `toKeyPayload` strips extras for `Key.class`. `status`/`validationWarnings` are read-only
+ * projections Core computes, not part of the entity; `author`/`createdAt`/`updatedAt` come from the
+ * metadata node, not `ToolSet` itself; `reference` is a client-only tracking id (see `handleDuplicate`/
+ * `addNewVersion`, which already strip it before any write). None of these round-trip through the
+ * merge readers as content fields, so they must not be sent back on write.
+ */
+function toPlatformToolsetPayload(toolset: DialPlatformToolsetResource) {
+  const {
+    status: __status,
+    validationWarnings: __validationWarnings,
+    author: __author,
+    createdAt: __createdAt,
+    updatedAt: __updatedAt,
+    reference: __reference,
+    ...payload
+  } = toolset as DialPlatformToolsetResource & { reference?: string };
+
+  return payload;
+}
+
+export async function createPlatformToolset(toolset: DialPlatformToolsetResource) {
+  return createToolset({
+    ...toPlatformToolsetPayload(toolset),
+    folderId: `${PLATFORM_ROOT_FOLDER}/`,
+    version: undefined,
+  } as unknown as DialToolsetResource);
+}
+
+export async function getPlatformToolset(path: string, etag: string) {
+  const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
+  return assetApi.getMergedWithEtag<DialPlatformToolsetResource>(token, ResourceType.TOOLSET, path, etag);
+}
+
+export async function updatePlatformToolset(toolset: DialPlatformToolsetResource, etag: string) {
+  return updateToolset(
+    {
+      ...toPlatformToolsetPayload(toolset),
+      folderId: `${PLATFORM_ROOT_FOLDER}/`,
+      version: undefined,
+    } as unknown as AssetToolset,
+    etag,
+  );
+}
+
+export async function removePlatformToolset(path: string, etag?: string) {
+  return removeToolset(path, etag);
+}
+
+export async function bulkDeletePlatformToolsets(paths: { path: string }[]) {
+  return bulkDeleteToolsets(paths);
 }
 
 export async function moveToolsets(paths: string[], newPath: string, overwrite?: boolean, duplicateName?: string) {

--- a/apps/ai-dial-admin/src/components/Assets/Apps/tests/View.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Apps/tests/View.spec.tsx
@@ -23,6 +23,21 @@ vi.mock('@/src/app/[lang]/assets-applications/actions', () => ({
   importApps: vi.fn(),
   exportApps: vi.fn(),
   bulkDeleteApps: vi.fn(),
+  getPlatformApplication: vi.fn(),
+  createPlatformApplication: vi.fn(),
+  bulkDeletePlatformApplications: vi.fn(),
+}));
+
+vi.mock('@/src/app/[lang]/assets-toolsets/actions', () => ({
+  getToolset: vi.fn(),
+  createToolset: vi.fn(),
+  exportToolsets: vi.fn(),
+  importToolsets: vi.fn(),
+  moveToolsets: vi.fn(),
+  bulkDeleteToolsets: vi.fn(),
+  getPlatformToolset: vi.fn(),
+  createPlatformToolset: vi.fn(),
+  bulkDeletePlatformToolsets: vi.fn(),
 }));
 
 describe('AppView', () => {

--- a/apps/ai-dial-admin/src/components/Assets/BaseAssetList/BaseAssetList.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/BaseAssetList/BaseAssetList.tsx
@@ -13,16 +13,10 @@ import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { createSkill, createSkillFolder } from '@/src/app/[lang]/skills/actions';
 import { changeFolder, removeFolder, removeSkillFolder } from '@/src/app/[lang]/folders-storage/actions';
 import {
-  bulkDeletePlatformApplications,
-  createPlatformApplication,
-  getPlatformApplication,
-} from '@/src/app/[lang]/assets-applications/actions';
-import {
   getDeleteNotificationContent,
   getExportNotificationContent,
   getImportNotificationContent,
   getVersionsPerName,
-  isPlatformApplicationsBucket,
 } from '@/src/components/Assets/utils';
 import FileManager from '@/src/components/Common/FileManager/FileManager';
 import { isItemOpenable } from '@/src/components/Common/FileManager/utils';
@@ -34,12 +28,7 @@ import { useNotification } from '@/src/context/NotificationContext';
 import { useI18n } from '@/src/locales/client';
 import { DialApplicationScheme } from '@/src/models/dial/application';
 import { AssetApp, AssetWithVersion } from '@/src/models/dial/deployment-asset';
-import {
-  DialAppRunnerResource,
-  DialPlatformApplicationResource,
-  DialResource,
-  PlatformAsset,
-} from '@/src/models/dial/resource';
+import { DialAppRunnerResource, DialResource, PlatformAsset } from '@/src/models/dial/resource';
 import { ImportData } from '@/src/models/import-asset';
 import { ServerActionResponse } from '@/src/models/server-action';
 import { ConflictResolutionPolicy, ImportFileType } from '@/src/types/import';
@@ -48,7 +37,12 @@ import { downloadFile, downloadJson } from '@/src/utils/download';
 import { getCreateNotificationDescription, getCreateNotificationTitle } from '@/src/utils/entities/create-entity';
 import { filterNames } from '@/src/utils/entities/filter-names';
 import { getJsonFileName } from '@/src/utils/import/get-json-name';
-import { getRootFolder, isFlatPlatformView, PLATFORM_ROOT_FOLDER } from '@/src/utils/files/root-folder';
+import {
+  getRootFolder,
+  isFlatPlatformView,
+  isPlatformDualBucketView,
+  PLATFORM_ROOT_FOLDER,
+} from '@/src/utils/files/root-folder';
 import { getErrorNotification, getSuccessNotification } from '@/src/utils/notification';
 import { getUrnForEntity, onOpenInNewTab } from '@/src/utils/open-in-new-tab';
 import { useRouter } from 'next/navigation';
@@ -69,6 +63,9 @@ import {
   getResourceTypeByRoute,
   ImportAssetActionMap,
   MoveAssetActionMap,
+  PlatformBulkDeleteAssetActionMap,
+  PlatformCreateAssetActionMap,
+  PlatformGetAssetActionMap,
   enrichConversationWithVersion,
 } from './utils';
 import { ImportResult } from '@/src/components/Assets/types';
@@ -133,10 +130,11 @@ const BaseAssetList: FC<Props> = ({ view, runners }) => {
       }
 
       const { path } = files[0] as AssetWithVersion;
-      // Applications is the only view where the "get" call to make depends on which bucket the
-      // clicked row belongs to, not just on the view (design.md D2/`platform-applications`).
-      const getAsset = isPlatformApplicationsBucket(view, path)
-        ? getPlatformApplication
+      // Applications and Toolsets are the only views where the "get" call to make depends on which
+      // bucket the clicked row belongs to, not just on the view (design.md D2/
+      // `platform-applications`/`platform-toolsets`).
+      const getAsset = isPlatformDualBucketView(view, path)
+        ? PlatformGetAssetActionMap[view]!
         : GetAssetActionMap[view as BaseAssetRoute];
       const fullAsset = await getAsset(path, DEFAULT_ETAG);
       setDuplicateItem(fullAsset?.response as AssetWithVersion);
@@ -280,29 +278,25 @@ const BaseAssetList: FC<Props> = ({ view, runners }) => {
 
       // A real skill and its folder marker are different Core operations for this type (design D2),
       // so Skill is called directly here rather than through `CreateAssetActionMap`, whose single
-      // function per type every other entry can serve unmodified. Applications is the other
-      // exception: which "create" call to make depends on the destination bucket, not just the view
-      // (design.md D2/`platform-applications`) — `createPlatformApplication` pins the path to the
-      // flat `platform` bucket regardless of the `folderId` passed here.
+      // function per type every other entry can serve unmodified. Applications and Toolsets are the
+      // other exception: which "create" call to make depends on the destination bucket, not just
+      // the view (design.md D2/`platform-applications`/`platform-toolsets`) — the platform variant
+      // pins the path to the flat `platform` bucket regardless of the `folderId` passed here.
       const createAsset =
         view === ApplicationRoute.Skills
           ? () => {
               const { name, description } = asset as unknown as { name?: string; description?: string };
               return createSkill(name || '', description || '', folderPath);
             }
-          : isPlatformApplicationsBucket(view, folderPath)
-            ? () =>
-                createPlatformApplication({
-                  ...asset,
-                  folderId: folderPath,
-                } as unknown as DialPlatformApplicationResource)
+          : isPlatformDualBucketView(view, folderPath)
+            ? () => PlatformCreateAssetActionMap[view]!({ ...asset, folderId: folderPath })
             : () => CreateAssetActionMap[view as CreateAssetRoute]({ ...asset, folderId: folderPath });
 
       return createAsset().then((res) => {
         if (res.success) {
           fetchFiles?.(folderPath);
           if (isCreateDuplicate) {
-            const isFlatAsset = isFlatPlatformView(view) || isPlatformApplicationsBucket(view, folderPath);
+            const isFlatAsset = isFlatPlatformView(view) || isPlatformDualBucketView(view, folderPath);
             const entityLabel = isFlatAsset
               ? asset.name || (asset as DialAppRunnerResource).$id
               : `${asset.name}__${asset.version}`;
@@ -312,10 +306,18 @@ const BaseAssetList: FC<Props> = ({ view, runners }) => {
                 getCreateNotificationDescription(view, entityLabel, t),
               ),
             );
+            // `getPlatformAssetDuplicate` strips `folderId` from `asset` (Core's platform-bucket
+            // write doesn't want it) — harmless for the six genuinely flat views, whose
+            // `getEntityPath` case never reads `folderId`, but `AssetsApplications`/
+            // `AssetsToolsets` need it back here to recognize the redirect target as
+            // platform-bucket; otherwise `getEntityPath` falls through to the versioned-path
+            // branch and builds `?path=undefined{name}__` (design.md D5).
             router.push(
               getUrnForEntity(
                 view,
-                isFlatAsset ? asset : { name: asset.name, version: asset.version, folderId: folderPath },
+                isFlatAsset
+                  ? { ...asset, folderId: folderPath }
+                  : { name: asset.name, version: asset.version, folderId: folderPath },
               ),
             );
           }
@@ -334,20 +336,21 @@ const BaseAssetList: FC<Props> = ({ view, runners }) => {
   const handleDuplicate = useCallback(
     (asset: AssetWithVersion) => {
       const platformAsset = asset as unknown as PlatformAsset;
-      // A platform-bucket application row duplicates the same flat, unversioned way the six other
-      // flat platform views already do (design.md D2/`platform-applications`) — the row's own path
-      // decides it, since AssetsApplications isn't itself flagged `isFlatPlatformView`.
-      const isPlatformApplicationDuplicate = isPlatformApplicationsBucket(
+      // A platform-bucket application/toolset row duplicates the same flat, unversioned way the six
+      // other flat platform views already do (design.md D2/`platform-applications`/
+      // `platform-toolsets`) — the row's own path decides it, since neither dual-bucket view is
+      // itself flagged `isFlatPlatformView`.
+      const isPlatformDualBucketDuplicate = isPlatformDualBucketView(
         view,
         platformAsset.path || platformAsset.folderId,
       );
-      if (isFlatPlatformView(view) || isPlatformApplicationDuplicate) {
+      if (isFlatPlatformView(view) || isPlatformDualBucketDuplicate) {
         const duplicate = getPlatformAssetDuplicate(view, platformAsset);
         // `getRootFolder(view)`'s fallback (used when the second argument is omitted) resolves to
-        // `platform` for every genuinely flat view, but AssetsApplications' own root is `public` —
+        // `platform` for every genuinely flat view, but a dual-bucket view's own root is `public` —
         // it serves both buckets — so a platform-bucket duplicate must pin its destination
         // explicitly rather than relying on that fallback.
-        const flatDestinationFolder = isPlatformApplicationDuplicate ? `${PLATFORM_ROOT_FOLDER}/` : void 0;
+        const flatDestinationFolder = isPlatformDualBucketDuplicate ? `${PLATFORM_ROOT_FOLDER}/` : void 0;
         handleCreateAsset(duplicate as unknown as AssetWithVersion, flatDestinationFolder, true);
         handleModalClose();
         return;
@@ -545,8 +548,8 @@ const BaseAssetList: FC<Props> = ({ view, runners }) => {
       const folders = deletedItems.filter((item) => item.nodeType === DialFileNodeType.FOLDER);
       // Selection is already scoped to one folder (confirmed in design.md), so a batch is always
       // single-bucket — resolving by the first asset's path is enough, no mixed-bucket case exists.
-      const bulkDeleteAsset = isPlatformApplicationsBucket(view, assets[0]?.path)
-        ? bulkDeletePlatformApplications
+      const bulkDeleteAsset = isPlatformDualBucketView(view, assets[0]?.path)
+        ? PlatformBulkDeleteAssetActionMap[view]!
         : BulkDeleteAssetActionMap[view as BaseAssetRoute];
 
       const promises = [];

--- a/apps/ai-dial-admin/src/components/Assets/BaseAssetList/Modals.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/BaseAssetList/Modals.tsx
@@ -9,7 +9,7 @@ import DuplicateAsset from '@/src/components/Assets/Deployments/DuplicateAsset';
 import DuplicatePlatformAsset from '@/src/components/Assets/Modals/DuplicatePlatformAsset';
 import DuplicatePlatformKeyModal from '@/src/components/Assets/Platform/Keys/DuplicatePlatformKeyModal';
 import { DialKeyResource, PlatformAsset } from '@/src/models/dial/resource';
-import { isFlatPlatformView } from '@/src/utils/files/root-folder';
+import { isFlatPlatformView, isPlatformDualBucketView } from '@/src/utils/files/root-folder';
 import { ApplicationRoute } from '@/src/types/routes';
 import { ModalType } from './types';
 import { AssetsFolderContext } from '@/src/context/assets/AssetsFolderContext';
@@ -109,7 +109,12 @@ const Modals: FC<Props> = ({
       {isModalOpen &&
         modalType === ModalType.duplicate &&
         view !== ApplicationRoute.PlatformKeys &&
-        (isFlatPlatformView(view) ? (
+        // A platform-bucket application/toolset row duplicates the same flat, unversioned way the
+        // six other flat platform views already do (design.md D2/`platform-applications`/
+        // `platform-toolsets`) — the row's own path decides it, since neither dual-bucket view is
+        // itself flagged `isFlatPlatformView`.
+        (isFlatPlatformView(view) ||
+        isPlatformDualBucketView(view, (duplicateItem as PlatformAsset)?.path || duplicateItem?.folderId) ? (
           <DuplicatePlatformAsset
             view={view}
             isModalOpen={isModalOpen}

--- a/apps/ai-dial-admin/src/components/Assets/BaseAssetList/tests/Modals.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/BaseAssetList/tests/Modals.spec.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+import { ApplicationRoute } from '@/src/types/routes';
+import Modals from '../Modals';
+import { ModalType } from '../types';
+
+vi.mock('@/src/components/Assets/Modals/DuplicatePlatformAsset', () => ({
+  default: () => <div>duplicate-platform-asset</div>,
+}));
+vi.mock('@/src/components/Assets/Deployments/DuplicateAsset', () => ({
+  default: () => <div>duplicate-asset</div>,
+}));
+
+const renderDuplicateModal = (view: ApplicationRoute, duplicateItem: Record<string, unknown>) => {
+  render(
+    <Modals
+      view={view}
+      isModalOpen
+      modalType={ModalType.duplicate}
+      duplicateItem={duplicateItem as never}
+      hasSelectedItems={false}
+      getContext={() => ({}) as never}
+      onClose={vi.fn()}
+      onRemove={vi.fn()}
+    />,
+  );
+};
+
+/**
+ * Regression: a platform-bucket application/toolset row must duplicate the same flat, unversioned
+ * way the six other flat platform views already do (design.md D2/`platform-applications`/
+ * `platform-toolsets`) — not the versioned `DuplicateAsset` flow (select new version vs. new entity,
+ * enter a version) that a public-bucket row still gets.
+ */
+describe('Modals :: duplicate modal dispatch for dual-bucket views', () => {
+  test.each([ApplicationRoute.AssetsApplications, ApplicationRoute.AssetsToolsets])(
+    'renders DuplicatePlatformAsset, not DuplicateAsset, for a platform-bucket %s row',
+    (view) => {
+      renderDuplicateModal(view, { name: 'pl_Ts', folderId: 'platform/', path: 'platform/pl_Ts' });
+
+      expect(screen.getByText('duplicate-platform-asset')).toBeInTheDocument();
+      expect(screen.queryByText('duplicate-asset')).not.toBeInTheDocument();
+    },
+  );
+
+  test.each([ApplicationRoute.AssetsApplications, ApplicationRoute.AssetsToolsets])(
+    'renders DuplicateAsset, unchanged, for a public-bucket %s row',
+    (view) => {
+      renderDuplicateModal(view, { name: 'MyEntity', folderId: 'public/', path: 'public/MyEntity__1.0' });
+
+      expect(screen.getByText('duplicate-asset')).toBeInTheDocument();
+      expect(screen.queryByText('duplicate-platform-asset')).not.toBeInTheDocument();
+    },
+  );
+});

--- a/apps/ai-dial-admin/src/components/Assets/BaseAssetList/tests/platform-applications-bucket.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/BaseAssetList/tests/platform-applications-bucket.spec.tsx
@@ -161,6 +161,21 @@ describe('BaseAssetList :: AssetsApplications bucket-aware branches', () => {
     expect(createApp).not.toHaveBeenCalled();
   });
 
+  // Regression: `getPlatformAssetDuplicate` strips `folderId`/`path` from the duplicated asset
+  // (Core's platform-bucket write doesn't want them) — the post-duplicate redirect must restore a
+  // bucket signal itself, or `getEntityPath` falls through to the versioned-path branch and builds
+  // `?path=undefined{name}__` instead of a bare, no-`?path=` platform URL (design.md D5).
+  test('Confirming a duplicate of a platform-bucket asset redirects to the bare name, with no ?path=', async () => {
+    const push = vi.fn();
+    vi.mocked(useRouter).mockReturnValue({ push } as unknown as ReturnType<typeof useRouter>);
+
+    render(<BaseAssetList view={ApplicationRoute.AssetsApplications} />);
+
+    fireEvent.click(screen.getByText('confirm-duplicate-platform'));
+
+    await vi.waitFor(() => expect(push).toHaveBeenCalledWith('/assets-applications/copy-of-platform-app'));
+  });
+
   test('Confirming a duplicate of a public-bucket asset calls createApp, not createPlatformApplication', async () => {
     render(<BaseAssetList view={ApplicationRoute.AssetsApplications} />);
 

--- a/apps/ai-dial-admin/src/components/Assets/BaseAssetList/tests/platform-toolsets-bucket.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/BaseAssetList/tests/platform-toolsets-bucket.spec.tsx
@@ -1,0 +1,234 @@
+import { DialFileNodeType } from '@epam/ai-dial-ui-kit';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useRouter } from 'next/navigation';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  bulkDeletePlatformToolsets,
+  bulkDeleteToolsets,
+  createPlatformToolset,
+  createToolset,
+  getPlatformToolset,
+  getToolset,
+} from '@/src/app/[lang]/assets-toolsets/actions';
+import { ApplicationRoute } from '@/src/types/routes';
+import BaseAssetList from '../BaseAssetList';
+
+vi.mock('@/src/app/[lang]/assets-toolsets/actions', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/src/app/[lang]/assets-toolsets/actions')>()),
+  getToolset: vi
+    .fn()
+    .mockResolvedValue({ success: true, response: { name: 'toolset', path: 'public/folder/toolset__1.0' } }),
+  createToolset: vi.fn().mockResolvedValue({ success: true, response: {} }),
+  bulkDeleteToolsets: vi.fn().mockResolvedValue({ success: true }),
+  getPlatformToolset: vi
+    .fn()
+    .mockResolvedValue({ success: true, response: { name: 'platform-toolset', path: 'platform/platform-toolset' } }),
+  createPlatformToolset: vi.fn().mockResolvedValue({ success: true, response: {} }),
+  bulkDeletePlatformToolsets: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+// Stable references across renders: BaseAssetList's mount effect depends on `data`/
+// `fetchedFoldersData` referentially, so a mock returning fresh `{}`/`[]` literals per call would
+// retrigger that effect (and its state updates) forever — `vi.hoisted` keeps one shared instance.
+const { mockData, mockFetchedFoldersData } = vi.hoisted(() => ({
+  mockData: [] as unknown[],
+  mockFetchedFoldersData: {} as Record<string, unknown[]>,
+}));
+
+vi.mock('@/src/context/assets/ToolsetsFolderContext', () => ({
+  useToolsetFolder: () => ({
+    fetchFiles: vi.fn(),
+    filePath: '',
+    data: mockData,
+    fetchedFoldersData: mockFetchedFoldersData,
+    setFilePath: vi.fn(),
+  }),
+  ToolsetFolderProvider: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock('@/src/components/Common/FileManager/FileManager', () => ({
+  __esModule: true,
+  default: (props: any) => (
+    <>
+      <button
+        onClick={() =>
+          props.customDuplicateAction([
+            { name: 'platform-toolset', path: 'platform/platform-toolset', nodeType: DialFileNodeType.ITEM },
+          ])
+        }
+      >
+        fetch-duplicate-platform
+      </button>
+      <button
+        onClick={() =>
+          props.customDuplicateAction([
+            { name: 'toolset', path: 'public/folder/toolset__1.0', nodeType: DialFileNodeType.ITEM },
+          ])
+        }
+      >
+        fetch-duplicate-public
+      </button>
+      <button
+        onClick={() =>
+          props.customDeleteItemsAction(
+            [{ name: 'platform-toolset', path: 'platform/platform-toolset', nodeType: DialFileNodeType.ITEM }],
+            'platform/',
+          )
+        }
+      >
+        select-delete-platform
+      </button>
+      <button
+        onClick={() =>
+          props.customDeleteItemsAction(
+            [{ name: 'toolset', path: 'public/folder/toolset__1.0', nodeType: DialFileNodeType.ITEM }],
+            'public/folder/',
+          )
+        }
+      >
+        select-delete-public
+      </button>
+    </>
+  ),
+}));
+
+vi.mock('../Modals', () => ({
+  __esModule: true,
+  default: (props: any) => (
+    <>
+      <button onClick={() => props.onCreate({ name: 'new-platform-toolset', endpoint: '' }, 'platform/')}>
+        create-platform
+      </button>
+      <button onClick={() => props.onCreate({ name: 'new-toolset', endpoint: '' }, 'public/folder/')}>
+        create-public
+      </button>
+      {/* Fixed fixtures, decoupled from `duplicateItem` state — this isolates `handleDuplicate`'s own
+          bucket-branch decision from `handleDuplicateModalOpen`'s async fetch, tested separately above. */}
+      <button
+        onClick={() =>
+          props.onDuplicate({
+            name: 'copy-of-platform-toolset',
+            path: 'platform/platform-toolset',
+            folderId: undefined,
+          })
+        }
+      >
+        confirm-duplicate-platform
+      </button>
+      <button
+        onClick={() =>
+          props.onDuplicate({ name: 'copy-of-toolset', folderId: 'public/folder/', path: 'public/folder/toolset__1.0' })
+        }
+      >
+        confirm-duplicate-public
+      </button>
+      <button onClick={() => props.onRemove()}>confirm-remove</button>
+    </>
+  ),
+}));
+
+/**
+ * Toolsets is the second view where which server action to call depends on the target's bucket
+ * (`platform/` vs `public/`), resolved per call rather than by view alone (design.md D2/
+ * `platform-toolsets`) — mirrors `platform-applications-bucket.spec.tsx`. This asserts each of
+ * `BaseAssetList`'s bucket-aware branches routes to the platform function for a platform-bucket
+ * target and to the existing public function otherwise.
+ */
+describe('BaseAssetList :: AssetsToolsets bucket-aware branches', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useRouter).mockReturnValue({ push: vi.fn() } as unknown as ReturnType<typeof useRouter>);
+  });
+
+  test('Fetching a duplicate source on a platform-bucket row calls getPlatformToolset, not getToolset', async () => {
+    render(<BaseAssetList view={ApplicationRoute.AssetsToolsets} />);
+
+    fireEvent.click(screen.getByText('fetch-duplicate-platform'));
+
+    await vi.waitFor(() =>
+      expect(getPlatformToolset).toHaveBeenCalledWith('platform/platform-toolset', expect.anything()),
+    );
+    expect(getToolset).not.toHaveBeenCalled();
+  });
+
+  test('Fetching a duplicate source on a public-bucket row calls getToolset, not getPlatformToolset', async () => {
+    render(<BaseAssetList view={ApplicationRoute.AssetsToolsets} />);
+
+    fireEvent.click(screen.getByText('fetch-duplicate-public'));
+
+    await vi.waitFor(() => expect(getToolset).toHaveBeenCalledWith('public/folder/toolset__1.0', expect.anything()));
+    expect(getPlatformToolset).not.toHaveBeenCalled();
+  });
+
+  test('Confirming a duplicate of a platform-bucket asset calls createPlatformToolset, not createToolset', async () => {
+    render(<BaseAssetList view={ApplicationRoute.AssetsToolsets} />);
+
+    fireEvent.click(screen.getByText('confirm-duplicate-platform'));
+
+    await vi.waitFor(() => expect(createPlatformToolset).toHaveBeenCalledOnce());
+    expect(createToolset).not.toHaveBeenCalled();
+  });
+
+  // Regression: `getPlatformAssetDuplicate` strips `folderId`/`path` from the duplicated asset
+  // (Core's platform-bucket write doesn't want them) — the post-duplicate redirect must restore a
+  // bucket signal itself, or `getEntityPath` falls through to the versioned-path branch and builds
+  // `?path=undefined{name}__` instead of a bare, no-`?path=` platform URL (design.md D5).
+  test('Confirming a duplicate of a platform-bucket asset redirects to the bare name, with no ?path=', async () => {
+    const push = vi.fn();
+    vi.mocked(useRouter).mockReturnValue({ push } as unknown as ReturnType<typeof useRouter>);
+
+    render(<BaseAssetList view={ApplicationRoute.AssetsToolsets} />);
+
+    fireEvent.click(screen.getByText('confirm-duplicate-platform'));
+
+    await vi.waitFor(() => expect(push).toHaveBeenCalledWith('/assets-toolsets/copy-of-platform-toolset'));
+  });
+
+  test('Confirming a duplicate of a public-bucket asset calls createToolset, not createPlatformToolset', async () => {
+    render(<BaseAssetList view={ApplicationRoute.AssetsToolsets} />);
+
+    fireEvent.click(screen.getByText('confirm-duplicate-public'));
+
+    await vi.waitFor(() => expect(createToolset).toHaveBeenCalledOnce());
+    expect(createPlatformToolset).not.toHaveBeenCalled();
+  });
+
+  test('Create targeting the platform bucket calls createPlatformToolset, not createToolset', async () => {
+    render(<BaseAssetList view={ApplicationRoute.AssetsToolsets} />);
+
+    fireEvent.click(screen.getByText('create-platform'));
+
+    await vi.waitFor(() => expect(createPlatformToolset).toHaveBeenCalledOnce());
+    expect(createToolset).not.toHaveBeenCalled();
+  });
+
+  test('Create targeting the public bucket calls createToolset, not createPlatformToolset', async () => {
+    render(<BaseAssetList view={ApplicationRoute.AssetsToolsets} />);
+
+    fireEvent.click(screen.getByText('create-public'));
+
+    await vi.waitFor(() => expect(createToolset).toHaveBeenCalledOnce());
+    expect(createPlatformToolset).not.toHaveBeenCalled();
+  });
+
+  test('Bulk delete of platform-bucket rows calls bulkDeletePlatformToolsets, not bulkDeleteToolsets', async () => {
+    render(<BaseAssetList view={ApplicationRoute.AssetsToolsets} />);
+
+    fireEvent.click(screen.getByText('select-delete-platform'));
+    fireEvent.click(screen.getByText('confirm-remove'));
+
+    await vi.waitFor(() => expect(bulkDeletePlatformToolsets).toHaveBeenCalledOnce());
+    expect(bulkDeleteToolsets).not.toHaveBeenCalled();
+  });
+
+  test('Bulk delete of public-bucket rows calls bulkDeleteToolsets, not bulkDeletePlatformToolsets', async () => {
+    render(<BaseAssetList view={ApplicationRoute.AssetsToolsets} />);
+
+    fireEvent.click(screen.getByText('select-delete-public'));
+    fireEvent.click(screen.getByText('confirm-remove'));
+
+    await vi.waitFor(() => expect(bulkDeleteToolsets).toHaveBeenCalledOnce());
+    expect(bulkDeletePlatformToolsets).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ai-dial-admin/src/components/Assets/BaseAssetList/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/Assets/BaseAssetList/tests/utils.spec.ts
@@ -91,23 +91,29 @@ describe('BaseAssetList', () => {
     });
   });
 
-  describe('getGridColumns — Assets Applications bucket switch', () => {
+  describe('getGridColumns — dual-bucket views', () => {
     const onChange = vi.fn();
 
-    test('uses the flat platform-entity column set (no Version column) while browsing the platform bucket', () => {
-      const columns = getGridColumns(ApplicationRoute.AssetsApplications, onChange, {}, false, 'platform/');
-      const colIds = columns.map((c) => c.colId);
+    test.each([ApplicationRoute.AssetsApplications, ApplicationRoute.AssetsToolsets])(
+      '%s uses the flat platform-entity column set (no Version column) while browsing the platform bucket',
+      (view) => {
+        const columns = getGridColumns(view, onChange, {}, false, 'platform/');
+        const colIds = columns.map((c) => c.colId);
 
-      expect(colIds).not.toContain(FileManagerColumnKey.Version);
-      expect(colIds).toEqual(getGridColumns(ApplicationRoute.PlatformKeys, onChange, {}, false).map((c) => c.colId));
-    });
+        expect(colIds).not.toContain(FileManagerColumnKey.Version);
+        expect(colIds).toEqual(getGridColumns(ApplicationRoute.PlatformKeys, onChange, {}, false).map((c) => c.colId));
+      },
+    );
 
-    test('keeps the existing Version column while browsing the public bucket', () => {
-      const withPublicPath = getGridColumns(ApplicationRoute.AssetsApplications, onChange, {}, false, 'public/');
-      const withoutPath = getGridColumns(ApplicationRoute.AssetsApplications, onChange, {}, false);
+    test.each([ApplicationRoute.AssetsApplications, ApplicationRoute.AssetsToolsets])(
+      '%s keeps the existing Version column while browsing the public bucket',
+      (view) => {
+        const withPublicPath = getGridColumns(view, onChange, {}, false, 'public/');
+        const withoutPath = getGridColumns(view, onChange, {}, false);
 
-      expect(withPublicPath.map((c) => c.colId)).toContain(FileManagerColumnKey.Version);
-      expect(withPublicPath.map((c) => c.colId)).toEqual(withoutPath.map((c) => c.colId));
-    });
+        expect(withPublicPath.map((c) => c.colId)).toContain(FileManagerColumnKey.Version);
+        expect(withPublicPath.map((c) => c.colId)).toEqual(withoutPath.map((c) => c.colId));
+      },
+    );
   });
 });

--- a/apps/ai-dial-admin/src/components/Assets/BaseAssetList/utils.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/BaseAssetList/utils.tsx
@@ -55,7 +55,13 @@ import { usePromptFolder } from '@/src/context/assets/PromptFolderContext';
 import { useSkillFolder } from '@/src/context/assets/SkillFolderContext';
 import { useToolsetFolder } from '@/src/context/assets/ToolsetsFolderContext';
 import { AssetWithVersion } from '@/src/models/dial/deployment-asset';
-import { DialAppRunnerResource, DialModelResource, PlatformAsset } from '@/src/models/dial/resource';
+import {
+  DialAppRunnerResource,
+  DialModelResource,
+  DialPlatformApplicationResource,
+  DialPlatformToolsetResource,
+  PlatformAsset,
+} from '@/src/models/dial/resource';
 import { ServerActionResponse } from '@/src/models/server-action';
 import { ImportFileType } from '@/src/types/import';
 import { ResourceType } from '@/src/types/resource-type';
@@ -362,7 +368,13 @@ export const GetAssetActionMap = {
  * falling back to `GetAssetActionMap`/`CreateAssetActionMap`/`BulkDeleteAssetActionMap` otherwise.
  */
 export const PlatformGetAssetActionMap: Partial<
-  Record<ApplicationRoute, (path: string, etag: string) => ReturnType<typeof getPlatformApplication>>
+  Record<
+    ApplicationRoute,
+    (
+      path: string,
+      etag: string,
+    ) => Promise<ServerActionResponse<DialPlatformApplicationResource | DialPlatformToolsetResource>>
+  >
 > = {
   [ApplicationRoute.AssetsApplications]: getPlatformApplication,
   [ApplicationRoute.AssetsToolsets]: getPlatformToolset,
@@ -402,10 +414,10 @@ export const CreateAssetActionMap: Record<
 export const PlatformCreateAssetActionMap: Partial<
   Record<ApplicationRoute, (asset: AssetWithVersion) => Promise<ServerActionResponse<Record<string, unknown>>>>
 > = {
-  [ApplicationRoute.AssetsApplications]: createPlatformApplication as (
+  [ApplicationRoute.AssetsApplications]: createPlatformApplication as unknown as (
     asset: AssetWithVersion,
   ) => Promise<ServerActionResponse<Record<string, unknown>>>,
-  [ApplicationRoute.AssetsToolsets]: createPlatformToolset as (
+  [ApplicationRoute.AssetsToolsets]: createPlatformToolset as unknown as (
     asset: AssetWithVersion,
   ) => Promise<ServerActionResponse<Record<string, unknown>>>,
 };

--- a/apps/ai-dial-admin/src/components/Assets/BaseAssetList/utils.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/BaseAssetList/utils.tsx
@@ -1,8 +1,11 @@
 import {
   bulkDeleteApps,
+  bulkDeletePlatformApplications,
   createApp,
+  createPlatformApplication,
   exportApps,
   getApp,
+  getPlatformApplication,
   importApps,
   moveApps,
 } from '@/src/app/[lang]/assets-applications/actions';
@@ -18,9 +21,12 @@ import { bulkDeleteRoles, createRole, getRole } from '@/src/app/[lang]/platform-
 import { bulkDeleteRoutes, createRoute, getRoute } from '@/src/app/[lang]/platform-routes/actions';
 import { bulkDeleteSkills, getSkill } from '@/src/app/[lang]/skills/actions';
 import {
+  bulkDeletePlatformToolsets,
   bulkDeleteToolsets,
+  createPlatformToolset,
   createToolset,
   exportToolsets,
+  getPlatformToolset,
   getToolset,
   importToolsets,
   moveToolsets,
@@ -33,7 +39,6 @@ import {
   getPrompt,
   movePrompts,
 } from '@/src/app/[lang]/prompts/actions';
-import { isPlatformApplicationsBucket } from '@/src/components/Assets/utils';
 import SelectCellRenderer, { SelectCellRendererParams } from '@/src/components/Grid/CellRenderers/SelectCellRenderer';
 import { TEMP_FOLDER } from '@/src/constants/file';
 import { FileManagerI18nKey } from '@/src/constants/i18n';
@@ -54,7 +59,7 @@ import { DialAppRunnerResource, DialModelResource, PlatformAsset } from '@/src/m
 import { ServerActionResponse } from '@/src/models/server-action';
 import { ImportFileType } from '@/src/types/import';
 import { ResourceType } from '@/src/types/resource-type';
-import { isFlatPlatformView } from '@/src/utils/files/root-folder';
+import { isFlatPlatformView, isPlatformDualBucketView } from '@/src/utils/files/root-folder';
 import { ApplicationRoute } from '@/src/types/routes';
 import { ToolsetTransport } from '@/src/types/toolset';
 import { compareVersions, getNameVersionFromAsset } from '@/src/utils/entities/versions';
@@ -150,7 +155,7 @@ export const getGridColumns = (
   // metadata-only shape (no Version column — a skill's folder listing carries no version info) even
   // though it isn't a flat platform view: it nests in folders like Toolsets, just without content to
   // read a display name from.
-  if (isFlatPlatformView(view) || view === ApplicationRoute.Skills || isPlatformApplicationsBucket(view, currentPath)) {
+  if (isFlatPlatformView(view) || view === ApplicationRoute.Skills || isPlatformDualBucketView(view, currentPath)) {
     return [
       NAME_COLUMN(view === ApplicationRoute.PlatformAppRunners ? 'ID' : 'Name') as ColDef,
       AUTHOR_COLUMN,
@@ -350,6 +355,19 @@ export const GetAssetActionMap = {
   [ApplicationRoute.Skills]: getSkill,
 };
 
+/**
+ * Applications and Toolsets are the only views whose "get"/"create"/"bulk-delete" call depends on
+ * which bucket the target belongs to, not just on the view (design.md D2/`platform-applications`/
+ * `platform-toolsets`). Callers resolve this map by view for a target in the `platform` bucket,
+ * falling back to `GetAssetActionMap`/`CreateAssetActionMap`/`BulkDeleteAssetActionMap` otherwise.
+ */
+export const PlatformGetAssetActionMap: Partial<
+  Record<ApplicationRoute, (path: string, etag: string) => ReturnType<typeof getPlatformApplication>>
+> = {
+  [ApplicationRoute.AssetsApplications]: getPlatformApplication,
+  [ApplicationRoute.AssetsToolsets]: getPlatformToolset,
+};
+
 export const CreateAssetActionMap: Record<
   CreateAssetRoute,
   (asset: AssetWithVersion) => Promise<ServerActionResponse<Record<string, unknown>>>
@@ -377,6 +395,17 @@ export const CreateAssetActionMap: Record<
     asset: AssetWithVersion,
   ) => Promise<ServerActionResponse<Record<string, unknown>>>,
   [ApplicationRoute.PlatformKeys]: createKey as (
+    asset: AssetWithVersion,
+  ) => Promise<ServerActionResponse<Record<string, unknown>>>,
+};
+
+export const PlatformCreateAssetActionMap: Partial<
+  Record<ApplicationRoute, (asset: AssetWithVersion) => Promise<ServerActionResponse<Record<string, unknown>>>>
+> = {
+  [ApplicationRoute.AssetsApplications]: createPlatformApplication as (
+    asset: AssetWithVersion,
+  ) => Promise<ServerActionResponse<Record<string, unknown>>>,
+  [ApplicationRoute.AssetsToolsets]: createPlatformToolset as (
     asset: AssetWithVersion,
   ) => Promise<ServerActionResponse<Record<string, unknown>>>,
 };
@@ -425,6 +454,13 @@ export const BulkDeleteAssetActionMap = {
   [ApplicationRoute.PlatformRoles]: bulkDeleteRoles,
   [ApplicationRoute.PlatformKeys]: bulkDeleteKeys,
   [ApplicationRoute.Skills]: bulkDeleteSkills,
+};
+
+export const PlatformBulkDeleteAssetActionMap: Partial<
+  Record<ApplicationRoute, (paths: { path: string }[]) => Promise<ServerActionResponse<Record<string, unknown>>>>
+> = {
+  [ApplicationRoute.AssetsApplications]: bulkDeletePlatformApplications,
+  [ApplicationRoute.AssetsToolsets]: bulkDeletePlatformToolsets,
 };
 
 export const enrichConversationWithVersion = (conversation: AssetWithVersion): AssetWithVersion => {

--- a/apps/ai-dial-admin/src/components/Assets/Modals/DeleteAssetsModal.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Modals/DeleteAssetsModal.tsx
@@ -94,7 +94,7 @@ const DeleteAssetsModal: FC<Props> = ({
   );
 
   const getDeleteModalContent = useCallback(() => {
-    const columnDefs = getGridColumns(view, hasFoldersToDelete, selectedVersionsMap);
+    const columnDefs = getGridColumns(view, hasFoldersToDelete, selectedVersionsMap, itemsToDelete);
 
     return (
       <div className="px-6 dial-small mb-6">

--- a/apps/ai-dial-admin/src/components/Assets/Modals/DuplicatePlatformAsset.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Modals/DuplicatePlatformAsset.tsx
@@ -6,10 +6,17 @@ import IdControl from '@/src/components/BaseControls/Id/Id';
 import { ButtonsI18nKey } from '@/src/constants/i18n';
 import { useSaveValidationContext } from '@/src/context/SaveValidationContext';
 import { useI18n } from '@/src/locales/client';
-import { DialAppRunnerResource, DialModelResource, PlatformAsset } from '@/src/models/dial/resource';
+import {
+  DialAppRunnerResource,
+  DialModelResource,
+  DialPlatformApplicationResource,
+  DialPlatformToolsetResource,
+  PlatformAsset,
+} from '@/src/models/dial/resource';
 import { ApplicationRoute } from '@/src/types/routes';
 import { CORE_UNENCODABLE_ID_CHARS } from '@/src/utils/app-runners/constants';
 import { getClonedEntityName, getCloneTitle } from '@/src/utils/entities/duplicate-entity';
+import { DUAL_BUCKET_VIEWS } from '@/src/utils/files/root-folder';
 
 interface Props {
   view: ApplicationRoute;
@@ -24,8 +31,15 @@ const DuplicatePlatformAsset: FC<Props> = ({ view, isModalOpen, names, entity, o
   const t = useI18n();
   const { isValid } = useSaveValidationContext();
   const isRunner = view === ApplicationRoute.PlatformAppRunners;
+  // Applications/Toolsets carry their display name as `display_name` (snake_case, inherited from
+  // `DialResource`), unlike Models/Interceptors' camelCase `displayName` — Core reuses the same
+  // entity class for both buckets, so the field name doesn't change for a platform-bucket row.
+  const isDualBucketAsset = DUAL_BUCKET_VIEWS.includes(view);
   const hasDisplayName =
-    isRunner || view === ApplicationRoute.PlatformModels || view === ApplicationRoute.PlatformInterceptors;
+    isRunner ||
+    view === ApplicationRoute.PlatformModels ||
+    view === ApplicationRoute.PlatformInterceptors ||
+    isDualBucketAsset;
 
   const [clonedAsset, setClonedAsset] = useState<PlatformAsset>(() =>
     isRunner
@@ -42,17 +56,22 @@ const DuplicatePlatformAsset: FC<Props> = ({ view, isModalOpen, names, entity, o
 
   const onChangeDisplayName = useCallback(
     (displayName?: string) => {
-      setClonedAsset((asset) =>
-        isRunner ? { ...asset, 'dial:applicationTypeDisplayName': displayName } : { ...asset, displayName },
-      );
+      setClonedAsset((asset) => {
+        if (isRunner) {
+          return { ...asset, 'dial:applicationTypeDisplayName': displayName };
+        }
+        return isDualBucketAsset ? { ...asset, display_name: displayName } : { ...asset, displayName };
+      });
     },
-    [isRunner],
+    [isRunner, isDualBucketAsset],
   );
 
   const id = isRunner ? (clonedAsset as DialAppRunnerResource).$id : clonedAsset.name;
   const displayName = isRunner
     ? (clonedAsset as DialAppRunnerResource)['dial:applicationTypeDisplayName']
-    : (clonedAsset as DialModelResource).displayName;
+    : isDualBucketAsset
+      ? (clonedAsset as DialPlatformApplicationResource | DialPlatformToolsetResource).display_name
+      : (clonedAsset as DialModelResource).displayName;
 
   return (
     <DialFormPopup

--- a/apps/ai-dial-admin/src/components/Assets/Modals/tests/DuplicatePlatformAsset.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Modals/tests/DuplicatePlatformAsset.spec.tsx
@@ -92,4 +92,31 @@ describe('DuplicatePlatformAsset', () => {
 
     expect(screen.getAllByRole('textbox')).toHaveLength(1);
   });
+
+  // Regression: platform-bucket applications/toolsets duplicate the flat, unversioned way every
+  // other platform entity does (design.md's `platform-applications`/`platform-toolsets`
+  // capabilities) — but their display name is `display_name` (snake_case), not `displayName`.
+  describe.each([
+    { view: ApplicationRoute.AssetsApplications, label: 'application' },
+    { view: ApplicationRoute.AssetsToolsets, label: 'toolset' },
+  ])('a platform-bucket $label', ({ view }) => {
+    const platformEntity = { name: 'pl_Ts', display_name: 'Platform Thing', folderId: 'platform/' } as PlatformAsset;
+
+    test('offers only an id and a display name, this asset having no version or folder', () => {
+      renderModal(view, platformEntity);
+
+      expect(screen.getAllByRole('textbox')).toHaveLength(2);
+    });
+
+    test('suffixes the name without brackets and duplicates under the edited name and display_name', async () => {
+      const user = userEvent.setup();
+      const { onDuplicate } = renderModal(view, platformEntity);
+
+      expect(screen.getAllByRole('textbox')[0]).toHaveValue('pl_Ts-copy');
+
+      await user.click(screen.getByRole('button', { name: ButtonsI18nKey.Duplicate }));
+
+      expect(onDuplicate).toHaveBeenCalledWith({ ...platformEntity, name: 'pl_Ts-copy' });
+    });
+  });
 });

--- a/apps/ai-dial-admin/src/components/Assets/Modals/tests/utils.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Modals/tests/utils.spec.tsx
@@ -44,6 +44,30 @@ describe('Assets Modals utils', () => {
       expect(columns).toHaveLength(2);
       expect(!!columns.some((column) => (column as ColDef).colId === FileManagerColumnKey.Size)).toBeTruthy();
     });
+
+    // Regression: a platform-bucket application/toolset row has no version, so the bulk-delete
+    // confirmation grid should show Name+Author instead of Name+Version there.
+    test.each([ApplicationRoute.AssetsApplications, ApplicationRoute.AssetsToolsets])(
+      'returns Name and Author columns for a platform-bucket %s delete',
+      (view) => {
+        const columns = getGridColumns(view, false, undefined, [{ folderId: 'platform/' } as unknown as DialFile]);
+
+        expect(columns).toEqual([
+          expect.objectContaining({ colId: FileManagerColumnKey.Name }),
+          expect.objectContaining({ colId: FileManagerColumnKey.Author }),
+        ]);
+      },
+    );
+
+    test.each([ApplicationRoute.AssetsApplications, ApplicationRoute.AssetsToolsets])(
+      'keeps Name and Version columns for a public-bucket %s delete',
+      (view) => {
+        const columns = getGridColumns(view, false, undefined, [{ folderId: 'public/folder/' } as unknown as DialFile]);
+
+        expect(!!columns.some((column) => (column as ColDef).colId === FileManagerColumnKey.Version)).toBeTruthy();
+        expect(columns.some((column) => (column as ColDef).colId === FileManagerColumnKey.Author)).toBeFalsy();
+      },
+    );
   });
 
   describe('getDeleteModalTitle', () => {

--- a/apps/ai-dial-admin/src/components/Assets/Modals/utils.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Modals/utils.tsx
@@ -5,16 +5,25 @@ import { ApplicationRoute } from '@/src/types/routes';
 import { FileManagerI18nKey } from '@/src/constants/i18n';
 import { DialFileNodeType } from '@/src/models/dial/file';
 import { enrichConversationWithVersion } from '@/src/components/Assets/BaseAssetList/utils';
+import { isPlatformBucketPath } from '@/src/utils/files/root-folder';
 
 export const getGridColumns = (
   view: ApplicationRoute,
   hasFoldersToDelete: boolean,
   selectedVersionsMap?: Record<string, string[]>,
+  itemsToDelete?: DialFile[],
 ) => {
   const GRID_NAME_COLUMN = {
     colId: FileManagerColumnKey.Name,
     field: 'name',
     headerName: 'Display name',
+    width: 200,
+  };
+
+  const AUTHOR_COLUMN = {
+    colId: FileManagerColumnKey.Author,
+    field: 'author',
+    headerName: 'Author',
     width: 200,
   };
 
@@ -52,9 +61,20 @@ export const getGridColumns = (
   };
 
   switch (view) {
-    case ApplicationRoute.Prompts:
+    // A platform-bucket application/toolset row has no version — showing Name+Version here would
+    // repeat the same "no version" gap the delete-notification fix addresses, so this shows
+    // Name+Author instead, matching the flat column set the row's own list view already uses.
     case ApplicationRoute.AssetsApplications:
-    case ApplicationRoute.AssetsToolsets:
+    case ApplicationRoute.AssetsToolsets: {
+      const isPlatformBucketDelete =
+        !hasFoldersToDelete &&
+        isPlatformBucketPath((itemsToDelete?.[0] as { folderId?: string } | undefined)?.folderId);
+      if (isPlatformBucketDelete) {
+        return [GRID_NAME_COLUMN, AUTHOR_COLUMN];
+      }
+      return hasFoldersToDelete ? [NAME_COLUMN('Display name'), VERSION_COLUMN] : [GRID_NAME_COLUMN, VERSION_COLUMN];
+    }
+    case ApplicationRoute.Prompts:
     case ApplicationRoute.Conversations:
       return hasFoldersToDelete ? [NAME_COLUMN('Display name'), VERSION_COLUMN] : [GRID_NAME_COLUMN, VERSION_COLUMN];
     case ApplicationRoute.Files:

--- a/apps/ai-dial-admin/src/components/Assets/Platform/Toolsets/View.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Platform/Toolsets/View.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { cloneDeep } from 'lodash';
+
+import {
+  removePlatformToolset,
+  signInToolset,
+  signOutToolset,
+  updatePlatformToolset,
+} from '@/src/app/[lang]/assets-toolsets/actions';
+import ResourceAuthButtons from '@/src/components/Assets/Resources/Auth/ResourceAuthButtons';
+import TabsContent from '@/src/components/Assets/Toolsets/View/TabsContent';
+import { JsonConfiguration } from '@/src/components/EntityHeaderControls/models';
+import SimpleEntityHeader from '@/src/components/EntityHeaderControls/SimpleHeader';
+import EntityJsonEditor from '@/src/components/EntityTabs/JsonEditor/JsonEditor';
+import { useAppContext } from '@/src/context/AppContext';
+import { useToolsetFolder } from '@/src/context/assets/ToolsetsFolderContext';
+import { useNotification } from '@/src/context/NotificationContext';
+import { useProtectedRequest } from '@/src/hooks/use-protected-request';
+import { useI18n } from '@/src/locales/client';
+import { AssetToolset } from '@/src/models/dial/deployment-asset';
+import { DialPlatformToolsetResource, DialToolsetResource } from '@/src/models/dial/resource';
+import { ApplicationRoute } from '@/src/types/routes';
+import { getUpdateNotificationDescription, getUpdateNotificationTitle } from '@/src/utils/entities/update-entity';
+import { isEqualSkippingUndefined } from '@/src/utils/is-equals-entity';
+import { getErrorNotification, getSuccessNotification } from '@/src/utils/notification';
+import { EntityViewTab, getTabsForAsset } from '@/src/utils/tabs/utils';
+
+interface Props {
+  etag: string;
+  oAuthCode?: string | null;
+  originalToolset: AssetToolset;
+}
+
+/**
+ * Platform-bucket toolset detail view. Core gives platform-bucket toolsets full field/tab/auth parity
+ * with public-bucket ones — verified against `ai-dial-core`'s `ToolSetService` (auth-secret
+ * encryption and credential-locator scope both derive from the resource's own bucket, not the bucket
+ * type) and `ToolsetOpsApi` (discovered-tools/sign-in/sign-out all resolve by the toolset's path,
+ * regardless of bucket) — see design.md's Context. So this reuses the exact same
+ * `Assets/Toolsets/View/TabsContent`/`ResourceAuthButtons` the public Toolsets view uses, passing
+ * `view={ApplicationRoute.AssetsToolsets}` through them. Only the header chrome (no version
+ * selector, no publish, no move) and which server actions get called differ here — mirrors
+ * `Assets/Platform/Applications/View.tsx`.
+ */
+const PlatformToolsetView: FC<Props> = ({ etag, oAuthCode, originalToolset }) => {
+  const t = useI18n();
+  const router = useRouter();
+  const { featureFlags } = useAppContext();
+  const { fetchFiles } = useToolsetFolder();
+  const { showNotification } = useNotification();
+  const getReqRef = useRef(useProtectedRequest());
+
+  const tabs = useMemo(() => getTabsForAsset(t, ApplicationRoute.AssetsToolsets, featureFlags), [t, featureFlags]);
+  const [activeTab, setActiveTab] = useState(EntityViewTab.Properties);
+  const [selectedToolset, setSelectedToolset] = useState(cloneDeep(originalToolset));
+  const [isChanged, setIsChanged] = useState(false);
+  const [isEditorEnabled, setIsEditorEnabled] = useState(false);
+  const [discardKey, setDiscardKey] = useState(0);
+
+  const jsonConfiguration = useMemo<JsonConfiguration>(
+    () => ({
+      isEditorEnabled,
+      onToggleEditor: () => setIsEditorEnabled((prev) => !prev),
+    }),
+    [isEditorEnabled],
+  );
+
+  useEffect(() => {
+    setSelectedToolset(cloneDeep(originalToolset));
+  }, [originalToolset]);
+
+  useEffect(() => {
+    if (Object.keys(selectedToolset).length && originalToolset) {
+      setIsChanged(!isEqualSkippingUndefined(originalToolset, selectedToolset));
+    }
+  }, [selectedToolset, originalToolset]);
+
+  const onDiscard = useCallback(() => {
+    setDiscardKey((prev) => prev + 1);
+    setSelectedToolset(cloneDeep(originalToolset));
+  }, [originalToolset]);
+
+  const onSave = useCallback(() => {
+    getReqRef
+      .current(updatePlatformToolset, selectedToolset as unknown as DialPlatformToolsetResource, etag)
+      .then((res) => {
+        if (res.success) {
+          showNotification(
+            getSuccessNotification(
+              getUpdateNotificationTitle(ApplicationRoute.AssetsToolsets, t),
+              getUpdateNotificationDescription(ApplicationRoute.AssetsToolsets, selectedToolset.name, t),
+            ),
+          );
+          fetchFiles(selectedToolset.folderId);
+          router.refresh();
+        } else {
+          showNotification(getErrorNotification(res.errorHeader, res.errorMessage, res.requestId));
+        }
+      });
+  }, [selectedToolset, etag, showNotification, t, router, fetchFiles]);
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0 w-full bg-layer-2 rounded p-4 pb-14 lg:pb-4 relative">
+      <SimpleEntityHeader
+        view={ApplicationRoute.AssetsToolsets}
+        entity={selectedToolset}
+        etag={etag}
+        isChanged={isChanged}
+        onDiscard={onDiscard}
+        onSave={onSave}
+        tabs={tabs}
+        jsonConfiguration={jsonConfiguration}
+        activeTab={activeTab}
+        onChangeActiveTab={setActiveTab}
+        onRemove={removePlatformToolset}
+        getAssetContext={useToolsetFolder}
+      >
+        <ResourceAuthButtons
+          view={ApplicationRoute.AssetsToolsets}
+          selectedToolset={selectedToolset as DialToolsetResource}
+          signInToolset={signInToolset}
+          signOutToolset={signOutToolset}
+          oAuthCode={oAuthCode}
+        />
+      </SimpleEntityHeader>
+
+      <div className="flex-1 overflow-auto min-h-0">
+        {isEditorEnabled ? (
+          <EntityJsonEditor
+            key={discardKey}
+            entity={selectedToolset}
+            setSelectedEntity={setSelectedToolset}
+            setIsChanged={setIsChanged}
+          />
+        ) : (
+          <TabsContent
+            key={discardKey}
+            activeTab={activeTab}
+            selectedToolset={selectedToolset}
+            originalToolset={originalToolset}
+            onChange={setSelectedToolset}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default PlatformToolsetView;

--- a/apps/ai-dial-admin/src/components/Assets/Platform/Toolsets/tests/View.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Platform/Toolsets/tests/View.spec.tsx
@@ -1,0 +1,51 @@
+import { useToolsetFolder } from '@/src/context/assets/ToolsetsFolderContext';
+import { AssetToolset } from '@/src/models/dial/deployment-asset';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, Mock, test, vi } from 'vitest';
+import PlatformToolsetView from '../View';
+
+vi.mock('@/src/context/assets/ToolsetsFolderContext', () => ({
+  useToolsetFolder: vi.fn(),
+}));
+
+vi.mock('@/src/app/[lang]/assets-toolsets/actions', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/src/app/[lang]/assets-toolsets/actions')>()),
+  removePlatformToolset: vi.fn(),
+  updatePlatformToolset: vi.fn(),
+  signInToolset: vi.fn(),
+  signOutToolset: vi.fn(),
+}));
+
+/**
+ * Matches `Assets/Platform/Applications/tests/View.spec.tsx`'s scope: a render smoke test, not deep
+ * interaction coverage — the component's real dependency surface (`TabsContent`, `SimpleEntityHeader`,
+ * `ResourceAuthButtons`) is exercised at the shared-component level, since this view reuses them
+ * unmodified (design.md's Context — Core gives platform-bucket toolsets full field/tab/auth parity).
+ */
+describe('PlatformToolsetView', () => {
+  const mockFetchFiles = vi.fn();
+
+  const mockOriginalToolset: AssetToolset = {
+    name: 'platform-toolset',
+    version: '',
+    folderId: 'platform/',
+    path: 'platform/platform-toolset',
+    displayName: 'Platform Toolset',
+  } as AssetToolset;
+
+  const mockEtag = 'etag-123';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    (useToolsetFolder as Mock).mockReturnValue({
+      fetchFiles: mockFetchFiles,
+    });
+  });
+
+  test('renders the platform toolset detail view without crashing', () => {
+    render(<PlatformToolsetView etag={mockEtag} originalToolset={mockOriginalToolset} />);
+
+    expect(screen.getByText('platform-toolset')).toBeTruthy();
+  });
+});

--- a/apps/ai-dial-admin/src/components/Assets/Toolsets/View/Properties.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Toolsets/View/Properties.tsx
@@ -28,6 +28,7 @@ import { DialToolsetResource, ToolsetAuthType } from '@/src/models/dial/resource
 import { TOOLSET_AUTH_REDIRECT_URL } from '@/src/components/Assets/Resources/Auth/ResourceAuthButtons';
 import { Toolset } from '@/src/models/dial/toolset';
 import { ApplicationRoute } from '@/src/types/routes';
+import { isPlatformBucketPath } from '@/src/utils/files/root-folder';
 
 interface Props {
   selectedToolset: DialToolsetResource;
@@ -95,7 +96,9 @@ const ToolsetAssetProperties: FC<Props> = ({ selectedToolset, onChange, isPublic
         />
         <TopicsControl entity={selectedToolset} onChange={onChange} view={ApplicationRoute.AssetsToolsets} />
 
-        {!isPublication && (
+        {/* The platform bucket is flat — no folder tree to move into (design.md's `platform-toolsets`
+            capability) — so this control is meaningless there and is hidden rather than shown-but-inert. */}
+        {!isPublication && !isPlatformBucketPath(selectedToolset.folderId) && (
           <FilePath
             value={selectedToolset.folderId}
             label={t(EntitiesI18nKey.FolderStorage)}

--- a/apps/ai-dial-admin/src/components/Assets/Toolsets/View/tests/Properties.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Toolsets/View/tests/Properties.spec.tsx
@@ -51,4 +51,16 @@ describe('ToolsetAssetProperties', () => {
 
     expect(onChange).toHaveBeenCalledWith({ ...baseToolset, vendor_website: 'h' });
   });
+
+  test('renders the folder-move control for a public-bucket toolset', () => {
+    render(<ToolsetAssetProperties selectedToolset={{ ...baseToolset, folderId: 'public/' }} onChange={vi.fn()} />);
+
+    expect(screen.getByText('file-path')).toBeInTheDocument();
+  });
+
+  test('hides the folder-move control for a platform-bucket toolset — the bucket has no folders', () => {
+    render(<ToolsetAssetProperties selectedToolset={{ ...baseToolset, folderId: 'platform/' }} onChange={vi.fn()} />);
+
+    expect(screen.queryByText('file-path')).not.toBeInTheDocument();
+  });
 });

--- a/apps/ai-dial-admin/src/components/Assets/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/Assets/tests/utils.spec.ts
@@ -18,7 +18,6 @@ import {
   getToolbarOptionLabels,
   getTreeActionLabels,
   getVersionsPerName,
-  isPlatformApplicationsBucket,
 } from '../utils';
 
 describe('getToolbarOptionLabels', () => {
@@ -36,76 +35,80 @@ describe('getToolbarOptionLabels', () => {
   });
 });
 
-describe('isPlatformApplicationsBucket', () => {
-  test('is true only for AssetsApplications when the current path is platform-prefixed', () => {
-    expect(isPlatformApplicationsBucket(ApplicationRoute.AssetsApplications, 'platform/')).toBe(true);
-    expect(isPlatformApplicationsBucket(ApplicationRoute.AssetsApplications, 'platform/my-app')).toBe(true);
-  });
-
-  test('is false for a public-prefixed path on AssetsApplications', () => {
-    expect(isPlatformApplicationsBucket(ApplicationRoute.AssetsApplications, 'public/')).toBe(false);
-  });
-
-  test('is false for an undefined path, and for other views even with a platform-prefixed path', () => {
-    expect(isPlatformApplicationsBucket(ApplicationRoute.AssetsApplications, undefined)).toBe(false);
-    expect(isPlatformApplicationsBucket(ApplicationRoute.PlatformKeys, 'platform/')).toBe(false);
-    expect(isPlatformApplicationsBucket(ApplicationRoute.AssetsToolsets, 'platform/')).toBe(false);
-  });
-});
-
 describe('getGridActionLabels', () => {
-  test('AssetsApplications on the platform bucket offers only duplicate, delete, and openInNewTab', () => {
-    const keys = getGridActionLabels(ApplicationRoute.AssetsApplications, false, 'platform/').map((item) => item.key);
+  test.each([ApplicationRoute.AssetsApplications, ApplicationRoute.AssetsToolsets])(
+    '%s on the platform bucket offers only duplicate, delete, and openInNewTab',
+    (view) => {
+      const keys = getGridActionLabels(view, false, 'platform/').map((item) => item.key);
 
-    expect(keys).toEqual(expect.arrayContaining(['duplicate', 'delete', 'openInNewTab']));
-    expect(keys).not.toContain('preview');
-    expect(keys).not.toContain('move');
-    expect(keys).not.toContain('rename');
-  });
+      expect(keys).toEqual(expect.arrayContaining(['duplicate', 'delete', 'openInNewTab']));
+      expect(keys).not.toContain('preview');
+      expect(keys).not.toContain('move');
+      expect(keys).not.toContain('rename');
+    },
+  );
 
-  test('AssetsApplications on the public bucket keeps the existing full action set', () => {
-    const withPublicPath = getGridActionLabels(ApplicationRoute.AssetsApplications, false, 'public/').map(
-      (item) => item.key,
-    );
-    const withoutPath = getGridActionLabels(ApplicationRoute.AssetsApplications, false).map((item) => item.key);
+  test.each([ApplicationRoute.AssetsApplications, ApplicationRoute.AssetsToolsets])(
+    '%s on the public bucket keeps the existing full action set',
+    (view) => {
+      const withPublicPath = getGridActionLabels(view, false, 'public/').map((item) => item.key);
+      const withoutPath = getGridActionLabels(view, false).map((item) => item.key);
 
-    expect(withPublicPath).toEqual(withoutPath);
-    // The public bucket keeps folder/versioning actions the platform bucket's restricted set lacks.
-    expect(withPublicPath).toContain('move');
-    expect(withPublicPath).toContain('rename');
-  });
+      expect(withPublicPath).toEqual(withoutPath);
+      // The public bucket keeps folder/versioning actions the platform bucket's restricted set lacks.
+      expect(withPublicPath).toContain('move');
+      expect(withPublicPath).toContain('rename');
+    },
+  );
 
-  test('AssetsApplications on the platform bucket still returns no options for a read-only admin', () => {
-    expect(getGridActionLabels(ApplicationRoute.AssetsApplications, true, 'platform/')).toEqual([]);
-  });
+  test.each([ApplicationRoute.AssetsApplications, ApplicationRoute.AssetsToolsets])(
+    '%s on the platform bucket still returns no options for a read-only admin',
+    (view) => {
+      expect(getGridActionLabels(view, true, 'platform/')).toEqual([]);
+    },
+  );
 });
 
 describe('getTreeActionLabels', () => {
-  test('AssetsApplications offers no tree actions while browsing the platform bucket', () => {
-    expect(getTreeActionLabels(false, ApplicationRoute.AssetsApplications, 'platform/')).toEqual([]);
-  });
+  test.each([ApplicationRoute.AssetsApplications, ApplicationRoute.AssetsToolsets])(
+    '%s offers no tree actions while browsing the platform bucket',
+    (view) => {
+      expect(getTreeActionLabels(false, view, 'platform/')).toEqual([]);
+    },
+  );
 
-  test('AssetsApplications keeps folder-tree actions while browsing the public bucket', () => {
-    const keys = getTreeActionLabels(false, ApplicationRoute.AssetsApplications, 'public/').map((item) => item.key);
+  test.each([ApplicationRoute.AssetsApplications, ApplicationRoute.AssetsToolsets])(
+    '%s keeps folder-tree actions while browsing the public bucket',
+    (view) => {
+      const keys = getTreeActionLabels(false, view, 'public/').map((item) => item.key);
 
-    expect(keys.length).toBeGreaterThan(0);
-  });
+      expect(keys.length).toBeGreaterThan(0);
+    },
+  );
 });
 
-describe('getToolbarOptionLabels — Assets Applications bucket switch', () => {
-  test('offers a single "New Application" entry (same label as the public bucket) while browsing the platform bucket', () => {
+describe('getToolbarOptionLabels — dual-bucket views', () => {
+  test('AssetsApplications offers a single "New Application" entry (same label as the public bucket) while browsing the platform bucket', () => {
     const labels = getToolbarOptionLabels(ApplicationRoute.AssetsApplications, false, 'platform/');
 
     expect(labels).toEqual([{ key: 'newItem', label: FileManagerI18nKey.Application, icon: null }]);
   });
 
-  test('keeps the existing toolbar entries while browsing the public bucket', () => {
-    const withPublicPath = getToolbarOptionLabels(ApplicationRoute.AssetsApplications, false, 'public/');
-    const withoutPath = getToolbarOptionLabels(ApplicationRoute.AssetsApplications, false);
+  test('AssetsToolsets offers a single "New Toolset" entry (same label as the public bucket) while browsing the platform bucket', () => {
+    const labels = getToolbarOptionLabels(ApplicationRoute.AssetsToolsets, false, 'platform/');
 
-    expect(withPublicPath).toEqual(withoutPath);
-    expect(withPublicPath.some((item) => item.label === FileManagerI18nKey.Application)).toBe(true);
+    expect(labels).toEqual([{ key: 'newItem', label: FileManagerI18nKey.Toolset, icon: null }]);
   });
+
+  test.each([ApplicationRoute.AssetsApplications, ApplicationRoute.AssetsToolsets])(
+    '%s keeps the existing toolbar entries while browsing the public bucket',
+    (view) => {
+      const withPublicPath = getToolbarOptionLabels(view, false, 'public/');
+      const withoutPath = getToolbarOptionLabels(view, false);
+
+      expect(withPublicPath).toEqual(withoutPath);
+    },
+  );
 });
 
 describe('getGridActionLabels', () => {
@@ -347,6 +350,19 @@ describe('getDeleteNotificationContent', () => {
     expect(result.description).toContain('2');
   });
 
+  // Regression: a platform-bucket application has no version, so the notification must show the
+  // bare name, not a `folderId+name__` path with a dangling separator.
+  test('should return the bare name, not a folderId+name__ path, for a platform-bucket application delete', () => {
+    const fileNodes = [{ name: 'pl_Ts', folderId: 'platform/' }] as any[];
+    const result = getDeleteNotificationContent(ApplicationRoute.AssetsApplications, fileNodes, mockT) as {
+      title: string;
+      description: string;
+    };
+
+    expect(result.title).toBe('Delete Application Success');
+    expect(result.description).toBe('Successfully deleted Application pl_Ts');
+  });
+
   test('should return correct notification for single toolset delete in Toolsets view', () => {
     const fileNodes = [{ name: 'My Toolset' }] as any[];
     const result = getDeleteNotificationContent(ApplicationRoute.AssetsToolsets, fileNodes, mockT) as {
@@ -367,6 +383,19 @@ describe('getDeleteNotificationContent', () => {
 
     expect(result.title).toBe('Delete Items Success');
     expect(result.description).toContain('2');
+  });
+
+  // Regression: a platform-bucket toolset has no version, so the notification must show the bare
+  // name, not a `folderId+name__` path with a dangling separator (e.g. "platform/pl_Ts__").
+  test('should return the bare name, not a folderId+name__ path, for a platform-bucket toolset delete', () => {
+    const fileNodes = [{ name: 'pl_Ts', folderId: 'platform/' }] as any[];
+    const result = getDeleteNotificationContent(ApplicationRoute.AssetsToolsets, fileNodes, mockT) as {
+      title: string;
+      description: string;
+    };
+
+    expect(result.title).toBe('Delete Toolset Success');
+    expect(result.description).toBe('Successfully deleted Toolset pl_Ts');
   });
 });
 

--- a/apps/ai-dial-admin/src/components/Assets/utils.ts
+++ b/apps/ai-dial-admin/src/components/Assets/utils.ts
@@ -3,7 +3,7 @@ import { AssetApp, AssetWithVersion } from '@/src/models/dial/deployment-asset';
 import { compareVersions, modifyNameVersionInAsset } from '@/src/utils/entities/versions';
 import { resolveCatalogDeploymentNavigation } from '@/src/utils/deployment-navigation';
 import { getUrnForEntity } from '@/src/utils/open-in-new-tab';
-import { isFlatPlatformView, isPlatformBucketPath } from '@/src/utils/files/root-folder';
+import { isFlatPlatformView, isPlatformBucketPath, isPlatformDualBucketView } from '@/src/utils/files/root-folder';
 import { ApplicationRoute } from '@/src/types/routes';
 import { allActionLabels, baseToolbarOptionLabels } from './constants';
 import { ButtonsI18nKey, FileManagerI18nKey } from '@/src/constants/i18n';
@@ -82,16 +82,6 @@ export const getParentPathByFullPath = (fullPath: string) => {
   return normalized.slice(0, lastSlash + 1);
 };
 
-/**
- * Applications is the one view whose resources live in both the flat `platform` bucket and the
- * hierarchical `public` one (see design.md D2, `platform-applications` capability). The grid never
- * shows rows from both at once — browsing into `platform/` renders only its flat row set, browsing
- * into `public/...` renders the public tree — so which action set applies is a property of the
- * current path being browsed, not of an individual row.
- */
-export const isPlatformApplicationsBucket = (view: ApplicationRoute, currentPath?: string): boolean =>
-  view === ApplicationRoute.AssetsApplications && isPlatformBucketPath(currentPath);
-
 export const getGridActionLabels = (view: ApplicationRoute, isReadOnlyAdmin: boolean, currentPath?: string) => {
   switch (view) {
     case ApplicationRoute.Files:
@@ -110,7 +100,8 @@ export const getGridActionLabels = (view: ApplicationRoute, isReadOnlyAdmin: boo
             (item) => item.key === 'duplicate' || item.key === 'delete' || item.key === 'openInNewTab',
           );
     case ApplicationRoute.AssetsApplications:
-      if (isPlatformApplicationsBucket(view, currentPath)) {
+    case ApplicationRoute.AssetsToolsets:
+      if (isPlatformDualBucketView(view, currentPath)) {
         return isReadOnlyAdmin
           ? []
           : allActionLabels.filter(
@@ -118,7 +109,6 @@ export const getGridActionLabels = (view: ApplicationRoute, isReadOnlyAdmin: boo
             );
       }
       return isReadOnlyAdmin ? [] : allActionLabels.filter((item) => item.key !== 'preview');
-    case ApplicationRoute.AssetsToolsets:
     case ApplicationRoute.Prompts:
       return isReadOnlyAdmin ? [] : allActionLabels.filter((item) => item.key !== 'preview');
     case ApplicationRoute.Conversations:
@@ -132,7 +122,7 @@ export const getGridActionLabels = (view: ApplicationRoute, isReadOnlyAdmin: boo
 };
 
 export const getTreeActionLabels = (isReadOnlyAdmin: boolean, view: ApplicationRoute, currentPath?: string) => {
-  if (isFlatPlatformView(view) || isPlatformApplicationsBucket(view, currentPath)) {
+  if (isFlatPlatformView(view) || isPlatformDualBucketView(view, currentPath)) {
     return [];
   }
 
@@ -158,8 +148,10 @@ export const getTreeActionLabels = (isReadOnlyAdmin: boolean, view: ApplicationR
 export const getToolbarOptionLabels = (view: ApplicationRoute, isReadOnlyAdmin: boolean, currentPath?: string) => {
   if (isReadOnlyAdmin) return [];
 
-  if (isPlatformApplicationsBucket(view, currentPath)) {
-    return [{ key: 'newItem', label: FileManagerI18nKey.Application, icon: null }];
+  if (isPlatformDualBucketView(view, currentPath)) {
+    const label =
+      view === ApplicationRoute.AssetsToolsets ? FileManagerI18nKey.Toolset : FileManagerI18nKey.Application;
+    return [{ key: 'newItem', label, icon: null }];
   }
 
   switch (view) {
@@ -388,6 +380,22 @@ export const getDeleteNotificationContent = (
       return { title, description };
     }
     case ApplicationRoute.AssetsApplications: {
+      // A platform-bucket row has no version to select or append — `isMultipleVersionsDelete`
+      // never applies there, and the description shows the bare name rather than a
+      // `folderId+name__version` path that carries no meaning for a flat, unversioned resource.
+      if (isPlatformBucketPath((fileNodes as DialFile[])?.[0]?.folderId)) {
+        const title = isDeleteSeveralFiles
+          ? t(FileManagerI18nKey.DeleteSuccessTitle, { item: t(FileManagerI18nKey.Items) })
+          : t(FileManagerI18nKey.DeleteSuccessTitle, { item: t(FileManagerI18nKey.Application) });
+        const description = isDeleteSeveralFiles
+          ? t(FileManagerI18nKey.DeleteSuccessDescriptionForMany, { count: deletedItemsCount })
+          : t(FileManagerI18nKey.DeleteSuccessDescriptionForOne, {
+              item: t(FileManagerI18nKey.Application),
+              name: (fileNodes as DialFile[])?.[0]?.name || '',
+            });
+        return { title, description };
+      }
+
       if (isMultipleVersionsDelete) {
         const title = t(FileManagerI18nKey.DeleteSuccessTitle, { item: t(FileManagerI18nKey.Application) });
         const descriptions = (fileNodes as AssetWithVersion[])[0].selectedVersions?.map((version) =>
@@ -414,6 +422,20 @@ export const getDeleteNotificationContent = (
       return { title, description };
     }
     case ApplicationRoute.AssetsToolsets: {
+      // Same platform-bucket carve-out as AssetsApplications above.
+      if (isPlatformBucketPath((fileNodes as DialFile[])?.[0]?.folderId)) {
+        const title = isDeleteSeveralFiles
+          ? t(FileManagerI18nKey.DeleteSuccessTitle, { item: t(FileManagerI18nKey.Items) })
+          : t(FileManagerI18nKey.DeleteSuccessTitle, { item: t(FileManagerI18nKey.Toolset) });
+        const description = isDeleteSeveralFiles
+          ? t(FileManagerI18nKey.DeleteSuccessDescriptionForMany, { count: deletedItemsCount })
+          : t(FileManagerI18nKey.DeleteSuccessDescriptionForOne, {
+              item: t(FileManagerI18nKey.Toolset),
+              name: (fileNodes as DialFile[])?.[0]?.name || '',
+            });
+        return { title, description };
+      }
+
       if (isMultipleVersionsDelete) {
         const title = t(FileManagerI18nKey.DeleteSuccessTitle, { item: t(FileManagerI18nKey.Toolset) });
         const descriptions = (fileNodes as AssetWithVersion[])[0].selectedVersions?.map((version) =>

--- a/apps/ai-dial-admin/src/components/Common/FileManager/FileManager.tsx
+++ b/apps/ai-dial-admin/src/components/Common/FileManager/FileManager.tsx
@@ -397,9 +397,9 @@ const FileManager: FC<Props> = ({
         onFilterChanged: handleGridFilterChanged,
       },
     };
-    // Applications is the only view whose action set depends on `filePath` (which bucket is being
-    // browsed — see `isPlatformApplicationsBucket`); every other view keeps the same options
-    // regardless of path, so this dependency is a no-op for them.
+    // Applications and Toolsets are the only views whose action set depends on `filePath` (which
+    // bucket is being browsed — see `isPlatformDualBucketView`); every other view keeps the same
+    // options regardless of path, so this dependency is a no-op for them.
   }, [view, isReadOnlyAdmin, columnDefs, t, handleGridFilterChanged, filePath]);
 
   return (

--- a/apps/ai-dial-admin/src/components/Common/FileManager/utils.ts
+++ b/apps/ai-dial-admin/src/components/Common/FileManager/utils.ts
@@ -4,12 +4,7 @@ import { DialFile, DialUploadFileItem, GridOptions, GridSelectionMode } from '@e
 import { ColDef, ITextFilterParams } from 'ag-grid-community';
 
 import { bulkActionLabels } from '@/src/components/Assets/constants';
-import {
-  getGridActionLabels,
-  getToolbarOptionLabels,
-  getTreeActionLabels,
-  isPlatformApplicationsBucket,
-} from '@/src/components/Assets/utils';
+import { getGridActionLabels, getToolbarOptionLabels, getTreeActionLabels } from '@/src/components/Assets/utils';
 import { baseColumnComparator } from '@/src/components/Grid/comparators/base-column-comparator';
 import FloatingFilter from '@/src/components/Grid/FloatingFilter/FloatingFilter';
 import { TEMP_FOLDER } from '@/src/constants/file';
@@ -22,7 +17,7 @@ import {
   MAX_FOLDER_NESTING_DEPTH,
 } from './constants';
 import { FORBIDDEN_NAME_SYMBOLS } from '@/src/constants/validation';
-import { getRootFolder } from '@/src/utils/files/root-folder';
+import { getRootFolder, isPlatformDualBucketView } from '@/src/utils/files/root-folder';
 import { addTrailingSlash } from '@/src/utils/url';
 
 export const findFolderByPath = (items: DialFile[], targetPath: string): DialFile | undefined => {
@@ -225,7 +220,7 @@ export const getBulkActionsToolbarOptions = (
     view === ApplicationRoute.PlatformRoles ||
     view === ApplicationRoute.PlatformKeys ||
     view === ApplicationRoute.Skills ||
-    isPlatformApplicationsBucket(view, currentPath);
+    isPlatformDualBucketView(view, currentPath);
 
   const actionLabels = isFlatBulkView ? bulkActionLabels.filter((action) => action.key === 'delete') : bulkActionLabels;
 

--- a/apps/ai-dial-admin/src/components/EntityListView/CreateEntity/CreateEntity.tsx
+++ b/apps/ai-dial-admin/src/components/EntityListView/CreateEntity/CreateEntity.tsx
@@ -27,7 +27,7 @@ import { isAssetView, isAssetWithVersion } from '@/src/utils/is-view';
 import { getErrorNotification, getSuccessNotification } from '@/src/utils/notification';
 import { getEntityPath } from '@/src/utils/open-in-new-tab';
 import { addTrailingSlash } from '@/src/utils/url';
-import { isPlatformBucketPath } from '@/src/utils/files/root-folder';
+import { DUAL_BUCKET_VIEWS, isPlatformBucketPath } from '@/src/utils/files/root-folder';
 import { RoutesForCheckingUniqueName } from './constants';
 
 interface CreateEntityBase extends BaseEntity {
@@ -68,14 +68,14 @@ const CreateEntity = <T extends CreateEntityBase>({
   const getReqRef = useRef(useProtectedRequest());
   const { showNotification } = useNotification();
 
-  // Applications is the one asset-with-version route that also has a flat, unversioned bucket
-  // (`platform/`) — the current folder (where "New Application" was invoked from) is the only signal
-  // available at create time to tell the two apart (design.md's `platform-applications` capability).
-  const isPlatformApplicationCreate =
-    route === ApplicationRoute.AssetsApplications && isPlatformBucketPath(folderContext?.filePath);
+  // Applications and Toolsets are the asset-with-version routes that also have a flat, unversioned
+  // bucket (`platform/`) — the current folder (where "New Application"/"New Toolset" was invoked
+  // from) is the only signal available at create time to tell the two apart (design.md's
+  // `platform-applications`/`platform-toolsets` capabilities).
+  const isPlatformDualBucketCreate = DUAL_BUCKET_VIEWS.includes(route) && isPlatformBucketPath(folderContext?.filePath);
 
   const [currentEntity, setEntity] = useState<T>(() => {
-    if (isAssetWithVersion(route) && !isPlatformApplicationCreate) {
+    if (isAssetWithVersion(route) && !isPlatformDualBucketCreate) {
       return { name: '', description: '', version: DEFAULT_NEW_ENTITY_VERSION } as T;
     }
 
@@ -169,7 +169,7 @@ const CreateEntity = <T extends CreateEntityBase>({
       });
     }
 
-    if (isAssetWithVersion(route) && !isPlatformApplicationCreate) {
+    if (isAssetWithVersion(route) && !isPlatformDualBucketCreate) {
       dispatch({
         type: ValidationActionType.SetField,
         field: 'version',
@@ -210,7 +210,7 @@ const CreateEntity = <T extends CreateEntityBase>({
           onChangeEntity={(entity) => setEntity(entity as T)}
           initialValues={initialValues}
           isModal={isModal}
-          hideVersionField={isPlatformApplicationCreate}
+          hideVersionField={isPlatformDualBucketCreate}
         />
       </div>
     </DialFormPopup>

--- a/apps/ai-dial-admin/src/components/EntityListView/CreateEntity/tests/CreateEntity.spec.tsx
+++ b/apps/ai-dial-admin/src/components/EntityListView/CreateEntity/tests/CreateEntity.spec.tsx
@@ -84,6 +84,32 @@ describe('CreateEntity', () => {
     expect(createApp.mock.calls[0][0]).not.toHaveProperty('version');
   });
 
+  test('omits the version field and does not require it when creating a toolset into the platform bucket', async () => {
+    (useRouter as Mock).mockReturnValue({ push: vi.fn() });
+
+    const createToolset = vi.fn().mockResolvedValue({ success: true, response: { name: 'platform-toolset' } });
+    const context = () => ({ filePath: 'platform/', fetchFiles: vi.fn() });
+
+    render(
+      <CreateEntity
+        route={ApplicationRoute.AssetsToolsets}
+        isModalOpen={true}
+        onClose={vi.fn()}
+        names={[]}
+        versionsMap={{}}
+        createEntity={createToolset}
+        context={context as any}
+      />,
+    );
+
+    expect(screen.queryByDisplayValue('1.0.0')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText(ButtonsI18nKey.Create));
+
+    await waitFor(() => expect(createToolset).toHaveBeenCalled());
+    expect(createToolset.mock.calls[0][0]).not.toHaveProperty('version');
+  });
+
   test('seeds the default display version for AssetsModels', async () => {
     (useRouter as Mock).mockReturnValue({ push: vi.fn() });
 

--- a/apps/ai-dial-admin/src/components/EntityView/Modals/Delete/Delete.tsx
+++ b/apps/ai-dial-admin/src/components/EntityView/Modals/Delete/Delete.tsx
@@ -22,6 +22,7 @@ import { useI18n } from '@/src/locales/client';
 import { ServerActionResponse } from '@/src/models/server-action';
 import { ApplicationRoute } from '@/src/types/routes';
 import { getNameVersionFromAsset } from '@/src/utils/entities/versions';
+import { DUAL_BUCKET_VIEWS, isPlatformBucketPath } from '@/src/utils/files/root-folder';
 import { hasRelatedArtefacts, isAssetView } from '@/src/utils/is-view';
 import { getErrorNotification, getSuccessNotification } from '@/src/utils/notification';
 import { getEntityPath } from '@/src/utils/open-in-new-tab';
@@ -86,11 +87,17 @@ const DeleteConfirmationModal = <T extends Artefact>({
 
   const showSuccessNotification = useCallback(
     (entityKey: string) => {
+      // For a platform-bucket application/toolset, `entityKey` is the full storage path
+      // (`platform/{name}`) the server action needs — Core has no lookup by bare name for these —
+      // but the notification should show the plain name, matching every other platform entity's
+      // flat, unversioned display (design.md's `platform-applications`/`platform-toolsets`).
+      const displayKey =
+        DUAL_BUCKET_VIEWS.includes(view) && isPlatformBucketPath(entityKey) ? entity?.name || entityKey : entityKey;
       showNotification(
-        getSuccessNotification(getNotificationTitle(view, t), getNotificationDescription(view, entityKey, t)),
+        getSuccessNotification(getNotificationTitle(view, t), getNotificationDescription(view, displayKey, t)),
       );
     },
-    [showNotification, t, view],
+    [showNotification, t, view, entity],
   );
 
   const existingVersionOptions = useMemo(() => {

--- a/apps/ai-dial-admin/src/components/EntityView/Modals/Delete/tests/Delete.spec.tsx
+++ b/apps/ai-dial-admin/src/components/EntityView/Modals/Delete/tests/Delete.spec.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useRouter } from 'next/navigation';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { ApplicationRoute } from '@/src/types/routes';
+import DeleteConfirmationModal from '../Delete';
+
+const showNotification = vi.fn();
+vi.mock('@/src/context/NotificationContext', () => ({
+  useNotification: () => ({ showNotification, removeNotification: vi.fn() }),
+}));
+
+// The global `t()` mock returns the key as-is and drops interpolation params — override it here so
+// the notification description embeds `entityId`, the only way to assert which key was passed.
+vi.mock('@/src/locales/client', () => ({
+  useI18n: () => (key: string, options?: Record<string, string>) => (options ? `${key}:${options.entityId}` : key),
+  useCurrentLocale: () => 'en',
+}));
+
+describe('DeleteConfirmationModal :: platform-bucket notification', () => {
+  beforeEach(() => {
+    showNotification.mockClear();
+  });
+
+  const confirmDelete = () => fireEvent.click(screen.getByRole('button', { name: 'Buttons.Delete' }));
+
+  test.each([ApplicationRoute.AssetsApplications, ApplicationRoute.AssetsToolsets])(
+    'shows the plain name, not the full platform/ path, when a platform-bucket %s entity is removed',
+    async (view) => {
+      vi.mocked(useRouter).mockReturnValue({ push: vi.fn() } as unknown as ReturnType<typeof useRouter>);
+      const onRemoveEntity = vi.fn().mockResolvedValue({ success: true });
+
+      render(
+        <DeleteConfirmationModal
+          view={view}
+          entity={{ name: 'pl_Ts', folderId: 'platform/', path: 'platform/pl_Ts' } as never}
+          onRemoveEntity={onRemoveEntity}
+          onCloseModal={vi.fn()}
+        />,
+      );
+
+      confirmDelete();
+
+      await waitFor(() => expect(onRemoveEntity).toHaveBeenCalledWith('platform/pl_Ts', undefined));
+      await waitFor(() => expect(showNotification).toHaveBeenCalled());
+      const notification = showNotification.mock.calls[0][0];
+      expect(notification.description).not.toContain('platform/pl_Ts');
+      expect(notification.description).toContain('pl_Ts');
+    },
+  );
+
+  test('shows the full versioned path, unchanged, for a public-bucket application entity', async () => {
+    vi.mocked(useRouter).mockReturnValue({ push: vi.fn() } as unknown as ReturnType<typeof useRouter>);
+    const onRemoveEntity = vi.fn().mockResolvedValue({ success: true });
+
+    render(
+      <DeleteConfirmationModal
+        view={ApplicationRoute.AssetsApplications}
+        entity={{ name: 'MyApp', folderId: 'public/', path: 'public/MyApp__1.0', version: '1.0' } as never}
+        onRemoveEntity={onRemoveEntity}
+        onCloseModal={vi.fn()}
+      />,
+    );
+
+    confirmDelete();
+
+    await waitFor(() => expect(showNotification).toHaveBeenCalled());
+    const notification = showNotification.mock.calls[0][0];
+    expect(notification.description).toContain('public/MyApp__1.0');
+  });
+});

--- a/apps/ai-dial-admin/src/models/dial/resource.ts
+++ b/apps/ai-dial-admin/src/models/dial/resource.ts
@@ -274,6 +274,26 @@ export interface DialPlatformApplicationResource
   validationWarnings?: CoreValidationWarning[];
 }
 
+/**
+ * A platform-bucket toolset resource (`toolsets/platform/{name}`), as returned by Core. Core reuses
+ * the same `ToolSet` entity class for both the `public` and `platform` buckets — the bucket segment
+ * alone distinguishes them — so this carries the same snake_case content fields as
+ * `DialToolsetResource`, minus the fields that only make sense for the versioned, folder-nested
+ * `public` bucket (`version`, `nodeType`, `updatedAt` in favor of `ModifiedEntity`'s
+ * `createdAt`/`updatedAt`, `etag`). Flat and unversioned like `DialPlatformApplicationResource`.
+ */
+export interface DialPlatformToolsetResource
+  extends
+    Omit<DialToolsetResource, 'path' | 'folderId' | 'version' | 'nodeType' | 'updatedAt' | 'etag'>,
+    ModifiedEntity {
+  name: string;
+  path: string;
+  folderId: string;
+  author?: string;
+  status?: DialModelResourceStatus;
+  validationWarnings?: CoreValidationWarning[];
+}
+
 /** The resource types DIAL Core keeps in its flat `platform` bucket — see `isFlatPlatformView`. */
 export type PlatformAsset =
   | DialModelResource
@@ -282,7 +302,8 @@ export type PlatformAsset =
   | DialRouteResource
   | DialRoleResource
   | DialKeyResource
-  | DialPlatformApplicationResource;
+  | DialPlatformApplicationResource
+  | DialPlatformToolsetResource;
 
 export enum DialModelResourceType {
   Chat = 'CHAT',

--- a/apps/ai-dial-admin/src/utils/files/root-folder.ts
+++ b/apps/ai-dial-admin/src/utils/files/root-folder.ts
@@ -25,15 +25,35 @@ export const getRootFolder = (view: ApplicationRoute): string =>
   isFlatPlatformView(view) ? PLATFORM_ROOT_FOLDER : ROOT_FOLDER;
 
 /**
- * Applications is the one view whose resources DIAL Core stores in *both* buckets — a flat
- * `platform` set (config-managed, same as the six `FLAT_PLATFORM_VIEWS`) and the hierarchical,
- * versioned `public` tree. Every other view has exactly one root; this returns that view's single
- * root as a one-element array, and for Applications returns both roots with `platform` first, so a
- * caller can fetch/order them without special-casing the view itself.
+ * Views whose resources DIAL Core stores in *both* buckets — a flat `platform` set (config-managed,
+ * same as `FLAT_PLATFORM_VIEWS`) and the hierarchical, versioned `public` tree: Applications and
+ * Toolsets (see `platform-applications`/`platform-toolsets` capabilities). Kept as its own small,
+ * explicit set rather than inferred from anything else, so a third dual-bucket entity is a one-line
+ * addition here and nowhere else.
+ */
+export const DUAL_BUCKET_VIEWS: readonly ApplicationRoute[] = [
+  ApplicationRoute.AssetsApplications,
+  ApplicationRoute.AssetsToolsets,
+];
+
+/**
+ * Every other view has exactly one root; this returns that view's single root as a one-element
+ * array, and for a `DUAL_BUCKET_VIEWS` member returns both roots with `platform` first, so a caller
+ * can fetch/order them without special-casing the view itself.
  */
 export const getRootFolders = (view: ApplicationRoute): string[] =>
-  view === ApplicationRoute.AssetsApplications ? [PLATFORM_ROOT_FOLDER, ROOT_FOLDER] : [getRootFolder(view)];
+  DUAL_BUCKET_VIEWS.includes(view) ? [PLATFORM_ROOT_FOLDER, ROOT_FOLDER] : [getRootFolder(view)];
 
 /** The bucket segment a path/folderId begins with, for views whose resources can live in either. */
 export const isPlatformBucketPath = (path?: string | null): boolean =>
   !!path && path.startsWith(`${PLATFORM_ROOT_FOLDER}/`);
+
+/**
+ * True when `view` is one of `DUAL_BUCKET_VIEWS` *and* the current path is inside its `platform`
+ * bucket. The dual-bucket grid never shows platform rows and public rows at the same time — browsing
+ * into `platform/` renders only the flat platform row set, browsing into `public/...` renders the
+ * foldered tree — so "which bucket" is a property of the current path being browsed, not a per-row
+ * concern (design.md D2, `platform-applications`/`platform-toolsets`).
+ */
+export const isPlatformDualBucketView = (view: ApplicationRoute, currentPath?: string): boolean =>
+  DUAL_BUCKET_VIEWS.includes(view) && isPlatformBucketPath(currentPath);

--- a/apps/ai-dial-admin/src/utils/files/tests/root-folder.spec.ts
+++ b/apps/ai-dial-admin/src/utils/files/tests/root-folder.spec.ts
@@ -5,6 +5,7 @@ import {
   getRootFolders,
   isFlatPlatformView,
   isPlatformBucketPath,
+  isPlatformDualBucketView,
   PLATFORM_ROOT_FOLDER,
 } from '../root-folder';
 
@@ -62,18 +63,42 @@ describe('Root Folder Utils :: isFlatPlatformView', () => {
 });
 
 describe('Root Folder Utils :: getRootFolders', () => {
-  test('Should return both buckets, platform first, for Assets Applications', () => {
-    expect(getRootFolders(ApplicationRoute.AssetsApplications)).toEqual(['platform', 'public']);
-  });
+  test.each([ApplicationRoute.AssetsApplications, ApplicationRoute.AssetsToolsets])(
+    'Should return both buckets, platform first, for %s',
+    (view) => {
+      expect(getRootFolders(view)).toEqual(['platform', 'public']);
+    },
+  );
 
   test.each([
-    ApplicationRoute.AssetsToolsets,
     ApplicationRoute.Prompts,
     ApplicationRoute.Conversations,
     ApplicationRoute.Files,
     ApplicationRoute.PlatformKeys,
   ])('Should return a single-element array matching getRootFolder for %s', (view) => {
     expect(getRootFolders(view)).toEqual([getRootFolder(view)]);
+  });
+});
+
+describe('Root Folder Utils :: isPlatformDualBucketView', () => {
+  test.each([ApplicationRoute.AssetsApplications, ApplicationRoute.AssetsToolsets])(
+    'is true for %s when the current path is platform-prefixed',
+    (view) => {
+      expect(isPlatformDualBucketView(view, 'platform/')).toBe(true);
+      expect(isPlatformDualBucketView(view, 'platform/my-item')).toBe(true);
+    },
+  );
+
+  test.each([ApplicationRoute.AssetsApplications, ApplicationRoute.AssetsToolsets])(
+    'is false for %s for a public-prefixed path',
+    (view) => {
+      expect(isPlatformDualBucketView(view, 'public/')).toBe(false);
+    },
+  );
+
+  test('is false for an undefined path, and for a non-dual-bucket view even with a platform-prefixed path', () => {
+    expect(isPlatformDualBucketView(ApplicationRoute.AssetsApplications, undefined)).toBe(false);
+    expect(isPlatformDualBucketView(ApplicationRoute.PlatformKeys, 'platform/')).toBe(false);
   });
 });
 

--- a/apps/ai-dial-admin/src/utils/open-in-new-tab.ts
+++ b/apps/ai-dial-admin/src/utils/open-in-new-tab.ts
@@ -5,7 +5,7 @@ import { DialApplicationScheme } from '@/src/models/dial/application';
 import { BaseEntity } from '@/src/models/dial/base-entity';
 import { DialPrompt } from '@/src/models/dial/prompt';
 import { Publication } from '@/src/models/dial/publications';
-import { isPlatformBucketPath } from '@/src/utils/files/root-folder';
+import { isPlatformBucketPath, PLATFORM_ROOT_FOLDER } from '@/src/utils/files/root-folder';
 
 export const escapePercentSign = (str: string): string => {
   return str.replace(/%/g, '%25');
@@ -35,7 +35,6 @@ export const getEntityPath = (
     case ApplicationRoute.Conversations:
     case ApplicationRoute.Prompts:
     case ApplicationRoute.Files:
-    case ApplicationRoute.AssetsToolsets:
     case ApplicationRoute.Skills: {
       const path = version
         ? `${(data as DialPrompt).folderId}${(data as DialPrompt).name}__${version}`
@@ -47,17 +46,22 @@ export const getEntityPath = (
         : `${encodeURIComponent((data as DialPrompt).name as string)}?path=${encodeURIComponent(path)}`;
     }
 
-    // Applications is the one view whose resources live in both buckets (design.md's
-    // `platform-applications` capability). Both share the same `/assets-applications/[id]` detail
-    // route — a platform-bucket row has no version and no folder tree, so it gets the flat
-    // `PlatformModels`-style segment below (bare name, no `?path=`); the query param's presence is
-    // exactly what the detail page uses to tell the two buckets apart.
-    case ApplicationRoute.AssetsApplications: {
+    // Applications and Toolsets are the views whose resources live in both buckets (design.md's
+    // `platform-applications`/`platform-toolsets` capabilities). Both share their existing
+    // `/assets-applications/[id]`/`/assets-toolsets/[id]` detail route — a platform-bucket row has no
+    // version and no folder tree, so it gets the flat `PlatformModels`-style segment below (bare
+    // name, no `?path=`); the query param's presence is exactly what the detail page uses to tell the
+    // two buckets apart.
+    case ApplicationRoute.AssetsApplications:
+    case ApplicationRoute.AssetsToolsets: {
       const entity = data as DialPrompt & { folderId?: string; path?: string };
 
       if (isPlatformBucketPath(entity.path || entity.folderId)) {
-        const resolvedName = entity.name || '';
-        return forRemove ? decodeURIComponent(escapePercentSign(resolvedName)) : encodeURIComponent(resolvedName);
+        // `forRemove` must still resolve to the resource's storage path (`platform/{name}`) — Core
+        // has no route for a bare name — unlike the URL-segment case just below, where the bucket
+        // prefix is deliberately dropped for a readable URL (design.md D5).
+        const resolvedPath = entity.path || `${PLATFORM_ROOT_FOLDER}/${entity.name || ''}`;
+        return forRemove ? decodeURIComponent(escapePercentSign(resolvedPath)) : encodeURIComponent(entity.name || '');
       }
 
       const path = version

--- a/apps/ai-dial-admin/src/utils/tests/open-in-new-tab.spec.ts
+++ b/apps/ai-dial-admin/src/utils/tests/open-in-new-tab.spec.ts
@@ -48,6 +48,23 @@ describe('getUrnForEntity', () => {
     );
   });
 
+  test('returns the bare-name URN, with no ?path=, for a platform-bucket toolset', () => {
+    const entity = { name: 'my-toolset', path: 'platform/my-toolset' };
+    const urn = getUrnForEntity(ApplicationRoute.AssetsToolsets, entity);
+
+    expect(urn).toBe('/assets-toolsets/my-toolset');
+    expect(urn).not.toContain('?path=');
+  });
+
+  test('returns the versioned ?path= URN, unchanged, for a public-bucket toolset', () => {
+    const entity = { name: 'MyToolset', path: 'public/MyToolset__1.0', folderId: 'public/', version: '1.0' };
+    const urn = getUrnForEntity(ApplicationRoute.AssetsToolsets, entity);
+
+    expect(urn).toBe(
+      `/assets-toolsets/${encodeURIComponent('MyToolset')}?path=${encodeURIComponent('public/MyToolset__1.0')}`,
+    );
+  });
+
   test('returns correct URN for ActivityAudit', () => {
     const entity = { activityId: 'act123' };
     const urn = getUrnForEntity(ApplicationRoute.ActivityAudit, entity);
@@ -235,6 +252,42 @@ describe('Entity list view :: getEntityPath', () => {
     });
     expect(result).toEqual('my-route');
   });
+
+  // Regression: forRemove must still resolve to the resource's full storage path for a
+  // platform-bucket application/toolset — Core has no route for the bare name alone, unlike the
+  // URL-segment case (no forRemove) where the bucket prefix is deliberately dropped.
+  test.each([ApplicationRoute.AssetsApplications, ApplicationRoute.AssetsToolsets])(
+    'Should return the platform-prefixed path for %s when forRemove is true',
+    (route) => {
+      const result = getEntityPath(route, { name: 'my-item', path: 'platform/my-item' }, true);
+      expect(result).toEqual('platform/my-item');
+    },
+  );
+
+  test.each([ApplicationRoute.AssetsApplications, ApplicationRoute.AssetsToolsets])(
+    'Should fall back to a built platform path for %s when forRemove is true and no path field is present',
+    (route) => {
+      const result = getEntityPath(route, { name: 'my-item', folderId: 'platform/' }, true);
+      expect(result).toEqual('platform/my-item');
+    },
+  );
+
+  test.each([ApplicationRoute.AssetsApplications, ApplicationRoute.AssetsToolsets])(
+    'Should return the bare encoded name for %s (no ?path=) when forRemove is false',
+    (route) => {
+      const result = getEntityPath(route, { name: 'my-item', path: 'platform/my-item' });
+      expect(result).toEqual('my-item');
+    },
+  );
+
+  test.each([ApplicationRoute.AssetsApplications, ApplicationRoute.AssetsToolsets])(
+    'Should keep the versioned ?path= for %s when forRemove is true on a public-bucket entity',
+    (route) => {
+      const entity = { name: 'MyEntity', path: 'public/MyEntity__1.0', folderId: 'public/', version: '1.0' };
+      const result = getEntityPath(route, entity, true);
+      expect(result).toEqual('public/MyEntity__1.0');
+    },
+  );
 });
 
 describe('onOpenInNewTab', () => {

--- a/openspec/changes/archive/2026-09-03-add-platform-toolsets/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-03-add-platform-toolsets/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-03

--- a/openspec/changes/archive/2026-09-03-add-platform-toolsets/design.md
+++ b/openspec/changes/archive/2026-09-03-add-platform-toolsets/design.md
@@ -1,0 +1,194 @@
+## Context
+
+`ai-dial-core` gives `toolsets` the identical `public`/`platform` duality already given to
+`applications` (see archived change `add-platform-applications`, capability `platform-applications`):
+`RouteTemplate.PLATFORM_APP_TOOLSET_RESOURCE` (`^/v1/(applications|toolsets)/(?<bucket>platform)/(?<path>.*)$`)
+routes both entity types to `ConfigResourceController` ahead of the generic resource route, which
+delegates PUT/DELETE business logic to `ToolSetService.putToolSet`/`deleteToolset`/
+`getToolSetWithDecryptedAuthSettings` — the same pattern `ApplicationService` gets.
+
+Unlike Applications, this is the *second* dual-bucket view, not the first. The Applications change
+built two things that need to generalize rather than duplicate:
+
+1. **The multi-root fetch mechanism** (`getRootFolders`, `createFolderContext`'s `fetchFiles`/
+   `fetchRoots`) — already written generically (`fetchFiles(path: string | string[], ...)`,
+   `getRootFolders(view): string[]`). Only `getRootFolders`'s own body special-cases
+   `AssetsApplications`; the mechanism underneath needs no change at all.
+2. **The bucket-detection/action-label branching** (`isPlatformApplicationsBucket`,
+   `getGridActionLabels`/`getTreeActionLabels`/`getToolbarOptionLabels` in `Assets/utils.ts`,
+   `getGridColumns` in `BaseAssetList/utils.tsx`) — written as a named, Applications-specific helper
+   with its own `switch` arm. This one **does** need generalizing per the user's decision below,
+   rather than adding a second near-identical arm for Toolsets.
+
+Confirmed against `ai-dial-core`'s `ToolSetService`: `ToolSet extends SecuredResource` has no
+platform-incompatible field the way `function`-type `Application`s were rejected outright for the
+platform bucket — so Toolsets need no equivalent of that carve-out. `ToolSetService`'s auth-secret
+encrypt/decrypt (`resourceAuthSettingsEncryptionService.encrypt/decrypt`) and credential-locator scope
+(`CredentialsLocatorFactory.fromAnyUrl`) both derive from the resource descriptor's own bucket, and
+`ToolsetOpsApi`'s discovered-tools/sign-in/sign-out client calls resolve a toolset by its path/name
+generically — none of this is public-bucket-specific. Toolsets do have one restriction Applications
+never had: `ConfigResourceController` additionally rejects a toolset PUT/DELETE up front when the name
+fails `ConfigPostProcessor.isValidToolSetKey` (a stricter pattern than the generic `ENTITY_NAME_PATTERN`
+Applications uses), returning 400 with a message naming the required pattern.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Show `platform/` as a bucket above `public/` in the existing `Assets ▸ Toolsets` grid
+  (`/assets-toolsets`), with no new menu entry and no new top-level list route — mirroring
+  `platform-applications` exactly.
+- Generalize `isPlatformApplicationsBucket` and the four functions that branch on it into a
+  view-agnostic dual-bucket check, so a third future dual-bucket entity needs no new arm either.
+- Add server actions and a detail view for platform-bucket toolsets, following the
+  `Assets/Platform/Applications/` precedent (reuse the existing `Assets/Toolsets/View/TabsContent`
+  and `ResourceAuthButtons` unmodified — confirmed full field/tab/auth parity against Core, see
+  Context) rather than writing new tab components.
+- Land this without changing the single-root behavior of any other view and without any
+  `ai-dial-core` change.
+
+**Non-Goals:**
+- Any other entity gaining dual-bucket status. Applications and Toolsets are the two entities Core
+  gives this duality to; the generalized helper is sized for "a small, explicit set of dual-bucket
+  views," not an open-ended mechanism.
+- Client-side toolset-name validation before submit. Core's `isValidToolSetKey` rejection surfaces
+  through the existing error-notification path, the same way Applications' "Code" source gap and
+  `FilePath`-for-a-flat-bucket gap already do — not a silent failure, just not pre-validated.
+- Folders or versioning inside the `platform` bucket for toolsets. Confirmed flat, matching
+  `platform-applications` and every other platform entity.
+- Any change to `ai-dial-core`.
+
+## Decisions
+
+### D1 — Multi-root fetch needs no new code; only `getRootFolders`'s condition grows
+
+`getRootFolders(view)` already returns `[PLATFORM_ROOT_FOLDER, ROOT_FOLDER]` for one view and
+`[getRootFolder(view)]` for every other. The mechanism consuming it (`FileManager.tsx`'s
+`getRootFolders(view).map(...)`, `isMultiRootView`, `createFolderContext`'s `fetchRoots`) is already
+keyed purely off the returned array's length/order, not off which view produced it. Adding Toolsets
+is exactly:
+
+```ts
+export const getRootFolders = (view: ApplicationRoute): string[] =>
+  DUAL_BUCKET_VIEWS.includes(view) ? [PLATFORM_ROOT_FOLDER, ROOT_FOLDER] : [getRootFolder(view)];
+```
+
+where `DUAL_BUCKET_VIEWS` is the same small array D2 introduces (kept in `root-folder.ts`, imported by
+`Assets/utils.ts` and `BaseAssetList/utils.tsx` rather than redeclared). No test in
+`root-folder.spec.ts` beyond adding a Toolsets case to the existing Applications-shaped assertions.
+
+### D2 — Generalize `isPlatformApplicationsBucket` into a view-agnostic `isPlatformDualBucketView` (per user decision)
+
+Confirmed with the user: generalize rather than duplicate. Today's helper:
+
+```ts
+export const isPlatformApplicationsBucket = (view: ApplicationRoute, currentPath?: string): boolean =>
+  view === ApplicationRoute.AssetsApplications && isPlatformBucketPath(currentPath);
+```
+
+becomes:
+
+```ts
+// root-folder.ts — lives next to isFlatPlatformView/isPlatformBucketPath, the other bucket predicates
+export const DUAL_BUCKET_VIEWS: readonly ApplicationRoute[] = [
+  ApplicationRoute.AssetsApplications,
+  ApplicationRoute.AssetsToolsets,
+];
+
+export const isPlatformDualBucketView = (view: ApplicationRoute, currentPath?: string): boolean =>
+  DUAL_BUCKET_VIEWS.includes(view) && isPlatformBucketPath(currentPath);
+```
+
+`Assets/utils.ts`'s `getGridActionLabels`/`getTreeActionLabels`/`getToolbarOptionLabels` and
+`BaseAssetList/utils.tsx`'s `getGridColumns` each replace their `isPlatformApplicationsBucket(view,
+currentPath)` check with `isPlatformDualBucketView(view, currentPath)` — no new `switch` arm, since
+the check is already view-agnostic once renamed. `getToolbarOptionLabels`'s single-entry-menu branch
+(`{ key: 'newItem', label: FileManagerI18nKey.Application, icon: null }`) needs to become
+per-view — replace the hardcoded `FileManagerI18nKey.Application` with a small
+`view === ApplicationRoute.AssetsToolsets ? FileManagerI18nKey.Toolset : FileManagerI18nKey.Application`
+lookup, since that's the one place the old helper's caller assumed "the dual-bucket view" meant
+Applications specifically.
+
+Every other call site of the old name (tests, `BaseAssetList/utils.tsx`'s imports) is mechanically
+renamed. `isPlatformApplicationsBucket` is deleted, not kept as a deprecated alias — it has no
+external consumers outside this codebase.
+
+Rejected alternative: keep `isPlatformApplicationsBucket` and add a sibling
+`isPlatformToolsetsBucket`, then OR them at each call site. Rejected per the user's explicit
+instruction to generalize; it would also mean every future dual-bucket entity adds another OR clause
+at four call sites instead of one array entry.
+
+### D3 — Platform-bucket toolset writes reuse `createToolset`/`updateToolset`'s existing conditional path, with their own field-stripping helper
+
+Mirrors `application-resources-core-api`'s D3 exactly. New server actions in
+`assets-toolsets/actions.ts` — `getPlatformToolset`, `createPlatformToolset`, `updatePlatformToolset`,
+`removePlatformToolset`, `bulkDeletePlatformToolsets` — call `assetApi` directly with
+`ResourceType.TOOLSET` against a `platform/`-prefixed path, never setting `version` and never
+computing a folder-prefixed path. A `toPlatformToolsetPayload` helper strips `status`/
+`validationWarnings`/`author`/`createdAt`/`updatedAt`/`reference` before write, matching
+`toPlatformApplicationPayload` — `ConfigResourceController`'s strict deserialization
+(`FAIL_ON_UNKNOWN_PROPERTIES`) rejects these the same way it did for Applications.
+
+### D4 — `Assets/Platform/Toolsets/View.tsx` reuses `Assets/Toolsets/View/TabsContent` and `ResourceAuthButtons` directly
+
+Per the user's decision to check reuse feasibility first: confirmed above (Context) that
+`ToolSetService`'s secret encryption and `ToolsetOpsApi`'s sign-in/out/discovered-tools calls are
+bucket-agnostic — nothing in Core gates auth or MCP tool discovery to the `public` bucket. So
+`Assets/Platform/Toolsets/View.tsx` reuses `Assets/Toolsets/View/TabsContent` (Properties, Tools,
+Audit) and `ResourceAuthButtons` (sign-in/out) exactly as written, passing
+`view={ApplicationRoute.AssetsToolsets}` through — the same shape `Assets/Platform/Applications/
+View.tsx` uses for the public Apps `TabsContent`. Only a new `View.tsx` wrapper (`SimpleEntityHeader`
+instead of `AssetHeader`; the new platform server actions instead of `updateToolset`/`removeToolset`;
+no move/version logic) and the detail route/page are new — no new `Properties.tsx`/`TabsContent.tsx`.
+
+`Assets/Toolsets/View/Properties.tsx`'s `FilePath` control gets the same guard
+`Assets/Apps/Properties.tsx` already has: wrap it in `!isPlatformBucketPath(selectedToolset.folderId)`
+so a platform-bucket toolset (no folders to move into) doesn't show an inert move control.
+
+`CreateEntity.tsx`'s `isPlatformApplicationCreate` (skips seeding/requiring `version` when creating
+into a platform bucket) generalizes the same way D2 does — rename to
+`isPlatformDualBucketCreate` and drop the `route === ApplicationRoute.AssetsApplications` check in
+favor of `DUAL_BUCKET_VIEWS.includes(route)`, since the underlying reason (no version field, no
+folder placement in the platform bucket) applies identically to Toolsets.
+
+### D5 — Detail route is the existing `/assets-toolsets/[id]` route, told apart the same way as Applications
+
+Both buckets share the existing `/assets-toolsets/[id]/page.tsx`: a `?path=` query param present means
+public bucket (`getToolset(path, etag)` + public `ToolsetView`); absent means platform bucket
+(`platform/{id}` + `getPlatformToolset`, rendering `PlatformToolsetView`). This sidesteps the
+breadcrumbs crash the Applications change hit and reverted away from (a nested route indexes a
+`configSegment` `Breadcrumbs.getBreadcrumbs` doesn't have) by construction — no nested route is
+introduced here in the first place.
+
+`getEntityPath`'s `AssetsToolsets` case (`utils/open-in-new-tab.ts`) needs the same platform-bucket
+branch Applications' case already has: a platform-bucket toolset resolves to the bare
+`{encodedName}` segment with no `?path=`, landing on this same shared route.
+
+## Risks / Trade-offs
+
+- **[Risk]** Renaming `isPlatformApplicationsBucket` touches every existing call site
+  (`Assets/utils.ts`, `BaseAssetList/utils.tsx`, and their tests) even though none of their
+  *behavior* changes for the Applications view.
+  → **Mitigation**: mechanical rename plus a `DUAL_BUCKET_VIEWS` array; existing Applications-bucket
+  tests keep asserting the same outcomes under the new name, and new tests add only the Toolsets
+  case rather than re-testing Applications from scratch.
+- **[Risk]** `getToolbarOptionLabels`'s dual-bucket branch was hardcoded to the "Application" label;
+  generalizing it to pick a label per view is a second small branch inside what was previously a
+  single-line return.
+  → **Mitigation**: a one-line ternary (or a `Record<ApplicationRoute, FileManagerI18nKey>` lookup if
+  a third dual-bucket view ever appears) — no structural change to the function's control flow.
+- **[Risk]** Toolsets' stricter name-key validation (`isValidToolSetKey`) means a platform-bucket
+  toolset create can fail for a reason (invalid characters in the key) Applications' platform bucket
+  never surfaces, and the 400's message is Core-specific wording ("must match ...").
+  → **Mitigation**: accepted per Non-Goals — surfaced through the existing error-notification path,
+  same as every other accepted Core-side rejection in this surface (e.g. Applications' "Code" source
+  gap). No new client-side pattern check added; revisit only if this proves confusing in practice.
+
+## Open Questions
+
+None outstanding. The three questions raised during exploration were resolved before this design was
+written:
+1. Generalize the bucket-detection/action-label helpers rather than duplicate them for Toolsets (D2).
+2. Handle Core's stricter toolset-name rejection the same way Applications' accepted gaps are handled
+   — surfaced via the existing error path, no new client-side validation (Non-Goals, Risks).
+3. Reuse `Assets/Toolsets/View/TabsContent` and `ResourceAuthButtons` unmodified — confirmed against
+   `ToolSetService`/`ToolsetOpsApi` that auth and MCP tool discovery are bucket-agnostic (D4).

--- a/openspec/changes/archive/2026-09-03-add-platform-toolsets/proposal.md
+++ b/openspec/changes/archive/2026-09-03-add-platform-toolsets/proposal.md
@@ -1,0 +1,92 @@
+## Why
+
+`ai-dial-core` lets `toolsets` live in a `platform` bucket — API-managed, config-equivalent toolsets
+served through `ConfigResourceController`, the exact duality already given to `applications` (see
+archived change `add-platform-applications`) and to the six platform-only entities. The admin
+frontend has no way to reach `platform/toolsets/*` yet: `Assets ▸ Toolsets` (`/assets-toolsets`) only
+ever opens the `public/` root. Applications already validated the pattern for a dual-bucket asset
+list; this change applies the same pattern to Toolsets, which the Applications change explicitly
+deferred ("toolsets can follow the same pattern as a separate change once this one is validated").
+
+## What Changes
+
+- Add a `platform` bucket to the existing `Assets ▸ Toolsets` grid (`/assets-toolsets`), fetched and
+  shown as a top-level sibling of `public`, ordered above it — same `BaseAssetList` instance, no new
+  menu entry, no new list route. `getRootFolders` (already generalized past a single Apps-specific
+  case) gains `AssetsToolsets` as a second dual-bucket view.
+- **Generalize the bucket-detection and action-label helpers from Applications-only to any dual-bucket
+  view**: `isPlatformApplicationsBucket` is renamed/reshaped into a view-agnostic helper (e.g.
+  `isPlatformAssetBucket`) checked against a small `DUAL_BUCKET_VIEWS` set containing both
+  `AssetsApplications` and `AssetsToolsets`, rather than adding a second Toolsets-specific copy of the
+  same branch. `getGridActionLabels`, `getTreeActionLabels`, `getToolbarOptionLabels`, and
+  `getGridColumns` switch on that shared helper.
+- Make the Toolsets action surface (row actions, folder-tree actions, toolbar "New" menu, bulk-actions
+  toolbar) branch on bucket exactly as Applications' does: platform-bucket toolset rows get the
+  restricted action set (duplicate, delete, openInNewTab; no folders, no versioning, no publish);
+  public-bucket rows and the folder tree keep their current full action set unchanged.
+- Add `getPlatformToolset`/`createPlatformToolset`/`updatePlatformToolset`/`removePlatformToolset`/
+  `bulkDeletePlatformToolsets` server actions for `platform/toolsets/*`, parallel to
+  `assets-applications/actions.ts`'s platform functions and `platform-keys/actions.ts`'s direct-Core
+  pattern, reusing `ResourceType.TOOLSET` and the existing `assetApi` client — Core already routes the
+  `platform` bucket segment for toolsets to `ConfigResourceController` ahead of the generic toolsets
+  route, so no Core change is required. Platform toolset writes omit `version`/folder placement, like
+  platform applications.
+- Add `src/components/Assets/Platform/Toolsets/` (`View.tsx` + create modal) as the detail view for a
+  platform-bucket toolset row — mirrors the `Assets/Platform/Applications/` precedent: reuse the
+  existing `Assets/Toolsets/View/TabsContent` (Properties, Tools, Audit) and `ResourceAuthButtons`
+  (sign-in/out) unmodified, since Core's `ToolSetService` derives auth-secret encryption and
+  credential-locator scope from the resource's own bucket already — no platform-specific auth
+  behavior to special-case. Only the header chrome (`SimpleEntityHeader` instead of the versioning-aware
+  `AssetHeader`) and the platform server actions are new.
+- Add its detail route nested under the existing `/assets-toolsets/[id]` route, told apart from the
+  public route by the same `?path=` presence/absence signal Applications uses (present → public
+  bucket; absent → platform bucket) — not a new route.
+- Strip fields the merge reader adds but that aren't part of Core's `ToolSet` entity (`status`,
+  `validationWarnings`, `author`, `createdAt`, `updatedAt`, `reference`) before a platform toolset
+  write, mirroring `toPlatformApplicationPayload`.
+- Surface Core's toolset-name key-pattern rejection (`ConfigPostProcessor.isValidToolSetKey` — stricter
+  than the generic entity-name pattern applications use) through the existing error-notification path,
+  the same way the Applications change let Core's own 400s surface for its accepted gaps — no new
+  client-side name validation added.
+- **BREAKING**: none — this only adds a new bucket and new detail route; existing `/assets-toolsets`
+  behavior for `public/` is unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+- `platform-toolsets`: platform-bucket toolsets — server actions, detail view/components under
+  `Assets/Platform/Toolsets/`, and the (now view-agnostic) bucket-aware action-label branching applied
+  to the Toolsets view.
+
+### Modified Capabilities
+
+- `toolset-resources-core-api`: the existing spec assumes a single `public/`-bucket contract for
+  `getToolsets`/`createToolset`/`getToolset`/`updateToolset`/`removeToolset`/`bulkDeleteToolsets`; this
+  change adds the platform-bucket variant of list/get/create/update/delete/bulk-delete alongside it,
+  and states that platform-bucket writes never carry a version suffix or folder placement.
+
+Note: `isPlatformApplicationsBucket` being generalized into a view-agnostic helper (design.md D2) is
+an implementation detail, not a requirement change — `platform-applications`'s spec never names the
+helper, so it needs no delta here.
+
+## Impact
+
+- `src/utils/files/root-folder.ts` — `getRootFolders` gains `AssetsToolsets` as a second dual-bucket
+  view.
+- `src/components/Assets/utils.ts` — `isPlatformApplicationsBucket` generalized to a view-agnostic
+  helper; `getGridActionLabels`/`getTreeActionLabels`/`getToolbarOptionLabels` gain a Toolsets branch
+  keyed off that helper instead of a second copy of the Applications branch.
+- `src/components/Assets/BaseAssetList/utils.tsx` — `getGridColumns`'s bucket check generalized the
+  same way; `AssetFolderContextMap`/`GetAssetActionMap`/`CreateAssetActionMap`/
+  `BulkDeleteAssetActionMap` gain platform-toolset entries.
+- `src/components/EntityListView/CreateEntity/CreateEntity.tsx` — `isPlatformApplicationCreate`
+  generalized to cover Toolsets (no version field when creating into either view's platform bucket).
+- `src/components/Assets/Toolsets/View/Properties.tsx` — hide the `FilePath` folder-move control for a
+  platform-bucket toolset, mirroring `Assets/Apps/Properties.tsx`.
+- `src/app/[lang]/assets-toolsets/actions.ts` — new platform server actions; `src/models/dial/resource.ts`
+  (a `DialPlatformToolsetResource`-shaped type, added to the `PlatformAsset` union).
+- New: `src/components/Assets/Platform/Toolsets/**`, a new detail route nested under
+  `/assets-toolsets/[id]`.
+- No backend change — `ai-dial-core` already serves `platform/toolsets/{path}` through
+  `ConfigResourceController`.

--- a/openspec/changes/archive/2026-09-03-add-platform-toolsets/specs/platform-toolsets/spec.md
+++ b/openspec/changes/archive/2026-09-03-add-platform-toolsets/specs/platform-toolsets/spec.md
@@ -1,0 +1,147 @@
+## ADDED Requirements
+
+### Requirement: Platform bucket shown above public in the Assets Toolsets grid
+The system SHALL display a `platform` bucket as a top-level node in the existing
+`Assets ▸ Toolsets` grid (`/assets-toolsets`), positioned above the `public` bucket, using the same
+`BaseAssetList` instance the public toolsets list already uses. No new menu entry and no new
+top-level list route SHALL be introduced for this bucket.
+
+#### Scenario: Platform bucket appears above public on first load
+- **WHEN** the user navigates to `/assets-toolsets`
+- **THEN** the grid shows a `platform` top-level node above the `public` top-level node, both fetched
+  and rendered in the same tree
+
+#### Scenario: No separate platform toolsets list page exists
+- **WHEN** the user looks for a platform toolsets entry in the sidebar navigation
+- **THEN** no such entry exists — platform toolsets are reachable only through the existing
+  `/assets-toolsets` grid
+
+### Requirement: Platform bucket toolsets are flat
+The system SHALL NOT offer folder creation, nested navigation, or versioning for toolsets under the
+`platform` bucket, matching the flat treatment already given to platform applications and the six
+existing platform-only entities.
+
+#### Scenario: No folder actions on the platform node
+- **WHEN** the user opens the context menu on the `platform` top-level node or any toolset under it
+- **THEN** no folder-create, move, or nested-navigation actions are offered
+
+#### Scenario: No versioning on a platform toolset
+- **WHEN** the user opens a platform-bucket toolset's detail view
+- **THEN** no version history, publish, or version-switcher UI is shown
+
+### Requirement: Platform bucket toolset rows use the restricted action set
+The system SHALL restrict row and multi-select actions on `platform`-bucket toolset rows to
+duplicate, delete, and open-in-new-tab — the same set already used by platform applications and the
+six existing flat platform views — while `public`-bucket rows and the folder tree keep their current,
+unrestricted action set.
+
+#### Scenario: Platform row actions are restricted
+- **WHEN** the user opens the row action menu for a toolset under the `platform` bucket
+- **THEN** only duplicate, delete, and open-in-new-tab are offered
+
+#### Scenario: Public row actions are unchanged
+- **WHEN** the user opens the row action menu for a toolset under the `public` bucket
+- **THEN** the full existing action set is offered, unchanged from current behavior
+
+#### Scenario: Toolbar "New" menu offers a create action while browsing the platform bucket
+- **WHEN** the user opens the "New" toolbar menu while the `platform` bucket or an item under it is
+  the current context in the Toolsets view
+- **THEN** the menu offers a single "Toolset" entry (the same label the `public` bucket's create
+  entry uses), with no folder-create or import entries alongside it
+
+### Requirement: Platform bucket toolset rows use the same column set as other platform entities
+The system SHALL display the same flat column set platform applications and the six existing
+platform-only views use — Name, Author, Created time, Updated time — for `platform`-bucket toolset
+rows, instead of the `public` bucket's Name/Version/Author/Updated time set.
+
+#### Scenario: Platform-bucket rows show no Version column
+- **WHEN** the user browses the `platform` bucket in the Assets Toolsets grid
+- **THEN** the grid shows Name, Author, Created time, and Updated time columns, with no Version
+  column
+
+#### Scenario: Public-bucket rows are unaffected
+- **WHEN** the user browses the `public` bucket in the Assets Toolsets grid
+- **THEN** the grid keeps its existing Name, Version, Author, and Updated time columns
+
+### Requirement: Creating a platform toolset has no version field
+The system SHALL NOT display or require a version field when creating a new toolset while browsing
+the `platform` bucket, since the bucket has no versioning concept. Creating into the `public` bucket
+is unaffected and keeps requiring a version.
+
+#### Scenario: No version field when creating into the platform bucket
+- **WHEN** the user opens the create form while browsing the `platform` bucket in the Toolsets view
+- **THEN** no version field is shown, and the form can be submitted without one
+
+#### Scenario: Version field unchanged when creating into the public bucket
+- **WHEN** the user opens the create form while browsing the `public` bucket in the Toolsets view
+- **THEN** the version field is shown and required, unchanged from current behavior
+
+### Requirement: Platform toolset server actions
+The system SHALL provide server actions to list, get, create, update, delete, and bulk-delete
+toolsets in the `platform` bucket, calling the shared Core asset client with `ResourceType.TOOLSET`
+against `platform/`-prefixed paths — no `ai-dial-core` change is required, since Core already routes
+the `platform` bucket segment for toolsets to `ConfigResourceController` ahead of the generic
+toolsets route.
+
+#### Scenario: Listing platform toolsets
+- **WHEN** the platform bucket node is expanded in the Toolsets view
+- **THEN** the system fetches toolsets via the asset client with a `platform/`-prefixed path and
+  displays them in the grid
+
+#### Scenario: Creating a platform toolset omits version and folder placement
+- **WHEN** the user creates a new platform toolset
+- **THEN** the write payload sent to Core carries no `version` and no folder-derived path segment,
+  unlike a public-bucket toolset create
+
+#### Scenario: Deleting a platform toolset
+- **WHEN** the user deletes a platform toolset
+- **THEN** the system sends a delete request against its `platform/`-prefixed path, conditional on
+  the caller's etag when supplied
+
+### Requirement: Platform toolset writes strip read-only and derived fields
+The system SHALL strip fields the merge reader adds but that are not part of Core's `ToolSet` entity
+— `status`, `validationWarnings`, `author`, `createdAt`, `updatedAt`, and `reference` — before sending
+a create or update write for a platform-bucket toolset. Unlike the `public` bucket's generic write
+path, the `platform` bucket's write path deserializes strictly and rejects any unrecognized field.
+
+#### Scenario: A platform toolset save round-trips without a parse failure
+- **WHEN** the user edits and saves a platform-bucket toolset whose fetched entity carries `status`,
+  `author`, `createdAt`, `updatedAt`, and `reference`
+- **THEN** the write succeeds, with none of those fields present in the request body sent to Core
+
+### Requirement: A rejected platform toolset name surfaces through the existing error path
+The system SHALL NOT pre-validate a toolset name against Core's stricter platform-bucket key pattern
+before submitting a create or update. When Core rejects the write because the name fails that
+pattern, the system SHALL surface the rejection through the existing error-notification path rather
+than failing silently.
+
+#### Scenario: An invalid platform toolset name is rejected with a visible error
+- **WHEN** the user creates or renames a platform-bucket toolset with a name Core's key-pattern
+  validation rejects
+- **THEN** the write fails, and an error notification carrying Core's rejection message is shown
+
+### Requirement: Platform toolset detail view
+The system SHALL provide a detail view for a platform-bucket toolset under
+`src/components/Assets/Platform/Toolsets/`, distinct from the public Toolsets detail view, reusing
+the public Toolsets `TabsContent` (Properties, Tools, Audit) and its authentication controls
+(sign-in/sign-out) for full field/tab/auth parity, but showing no versioning/publish UI and no
+folder-move control. Both buckets share the existing `/assets-toolsets/[id]` detail route — a `?path=`
+query param present means public bucket; its absence means platform bucket.
+
+#### Scenario: Opening a platform toolset shows the platform detail view
+- **WHEN** the user clicks a platform-bucket toolset row
+- **THEN** the system navigates to `/assets-toolsets/[id]` with no `?path=` query param, and renders
+  the platform Toolsets view, not the public Toolsets view
+
+#### Scenario: Platform toolset detail has no version tab
+- **WHEN** the user views a platform-bucket toolset's detail
+- **THEN** no version-history or publish tab is present
+
+#### Scenario: Platform toolset detail has no folder-move control
+- **WHEN** the user views a platform-bucket toolset's Properties tab
+- **THEN** no folder-move control is shown, since the platform bucket has no folders to move into
+
+#### Scenario: Platform toolset sign-in and sign-out work the same as public
+- **WHEN** the user signs in to or out of a platform-bucket toolset's external service
+- **THEN** the sign-in/sign-out flow behaves identically to a public-bucket toolset, since Core scopes
+  authentication credentials and secret encryption to the resource's own bucket

--- a/openspec/changes/archive/2026-09-03-add-platform-toolsets/specs/toolset-resources-core-api/spec.md
+++ b/openspec/changes/archive/2026-09-03-add-platform-toolsets/specs/toolset-resources-core-api/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Platform-bucket toolset resources served directly by DIAL Core
+The system SHALL route platform-bucket toolset list, get, create, update, delete, and bulk-delete
+operations to DIAL Core via the same shared Core asset client used for public-bucket toolsets,
+targeting `platform/`-prefixed paths instead of `public/`-prefixed ones. This is additive to the
+existing public-bucket contract — `getToolsets`/`createToolset`/`getToolset`/`updateToolset`/
+`removeToolset`/`bulkDeleteToolsets` and their `public/`-bucket behavior are unchanged.
+
+#### Scenario: Platform-bucket CRUD operations call Core with a platform-prefixed path
+- **WHEN** a platform-bucket toolset list, get, create, update, delete, or bulk-delete action runs
+- **THEN** the request path passed to the shared Core asset client is prefixed with `platform/`
+  instead of `public/`
+
+#### Scenario: Public-bucket behavior is unaffected
+- **WHEN** any existing public-bucket toolset action (`getToolsets`, `createToolset`, `getToolset`,
+  `updateToolset`, `removeToolset`, `bulkDeleteToolsets`) runs with a `public/`-prefixed path
+- **THEN** its request and response shape are unchanged from current behavior
+
+### Requirement: Platform-bucket toolset writes omit version and folder placement
+The system SHALL NOT include a `version` suffix or a folder-derived path segment when creating or
+updating a platform-bucket toolset, since Core has no folder or versioning concept for the `platform`
+bucket. Public-bucket writes are unaffected and keep computing a versioned, folder-prefixed path as
+they do today.
+
+#### Scenario: Platform-bucket create path has no version suffix
+- **WHEN** a platform-bucket toolset is created
+- **THEN** the path written to Core is the bare toolset name under `platform/`, with no `__version`
+  suffix
+
+#### Scenario: Platform-bucket update path has no folder segment
+- **WHEN** a platform-bucket toolset is updated
+- **THEN** the path written to Core carries no folder-derived prefix beyond the fixed `platform/`
+  bucket segment
+
+### Requirement: Platform-bucket toolset discovered-tools, sign-in, and sign-out are unaffected
+The system SHALL route discovered-tools, sign-in, and sign-out for a platform-bucket toolset through
+the same `ToolsetOpsApi` calls used for a public-bucket toolset, since Core resolves these by the
+toolset's resource path/name regardless of bucket.
+
+#### Scenario: Discovered-tools works for a platform-bucket toolset
+- **WHEN** the discovered-tools list is fetched for a platform-bucket toolset
+- **THEN** the request resolves by that toolset's `platform/`-prefixed path, the same way a
+  public-bucket toolset's request resolves by its `public/`-prefixed path
+
+#### Scenario: Sign-in and sign-out work for a platform-bucket toolset
+- **WHEN** the user signs in to or out of a platform-bucket toolset
+- **THEN** the request succeeds identically to a public-bucket toolset's sign-in/sign-out

--- a/openspec/changes/archive/2026-09-03-add-platform-toolsets/tasks.md
+++ b/openspec/changes/archive/2026-09-03-add-platform-toolsets/tasks.md
@@ -1,0 +1,75 @@
+## 1. Generalize the dual-bucket helpers (Applications-only → view-agnostic)
+
+- [x] 1.1 In `src/utils/files/root-folder.ts`: add `DUAL_BUCKET_VIEWS` (`AssetsApplications`,
+  `AssetsToolsets`); change `getRootFolders` to check membership in that array instead of
+  `view === ApplicationRoute.AssetsApplications`.
+- [x] 1.2 In `src/components/Assets/utils.ts`: rename `isPlatformApplicationsBucket` →
+  `isPlatformDualBucketView` (moved to/re-exported from `root-folder.ts` alongside
+  `isFlatPlatformView`/`isPlatformBucketPath`, checking `DUAL_BUCKET_VIEWS`), update its call sites in
+  `getGridActionLabels`/`getTreeActionLabels`/`getToolbarOptionLabels`. Replace
+  `getToolbarOptionLabels`'s hardcoded `FileManagerI18nKey.Application` dual-bucket entry with a
+  per-view label (`FileManagerI18nKey.Toolset` for `AssetsToolsets`, `FileManagerI18nKey.Application`
+  otherwise).
+- [x] 1.3 In `src/components/Assets/BaseAssetList/utils.tsx`: update `getGridColumns`'s bucket check
+  to use `isPlatformDualBucketView`.
+- [x] 1.4 In `src/components/EntityListView/CreateEntity/CreateEntity.tsx`: rename
+  `isPlatformApplicationCreate` → `isPlatformDualBucketCreate`, switching its condition from
+  `route === ApplicationRoute.AssetsApplications` to `DUAL_BUCKET_VIEWS.includes(route)`.
+- [x] 1.5 Update every existing test referencing the renamed symbols
+  (`Assets/tests/utils.spec.ts`, `BaseAssetList/tests/utils.spec.ts`,
+  `BaseAssetList/tests/platform-applications-bucket.spec.tsx`,
+  `CreateEntity/tests/CreateEntity.spec.tsx`, `utils/files/tests/root-folder.spec.ts`) so existing
+  Applications-bucket assertions keep passing under the new names.
+
+## 2. Models and server actions for platform-bucket toolsets
+
+- [x] 2.1 In `src/models/dial/resource.ts`: add `DialPlatformToolsetResource` (mirrors
+  `DialPlatformApplicationResource`'s shape relative to `DialApplicationResource`: omit
+  `version`/`nodeType`/`created_at`/`updated_at`/`etag` from `DialToolsetResource`, add
+  `ModifiedEntity`, `author`, `status`, `validationWarnings`); add it to the `PlatformAsset` union.
+- [x] 2.2 In `src/app/[lang]/assets-toolsets/actions.ts`: add `getPlatformToolset`,
+  `createPlatformToolset`, `updatePlatformToolset`, `removePlatformToolset`,
+  `bulkDeletePlatformToolsets`, calling `assetApi` directly with `ResourceType.TOOLSET` against a
+  `platform/`-prefixed path, never setting `version` or a folder-derived path segment (mirroring
+  `assets-applications/actions.ts`'s platform functions and `platform-keys/actions.ts`'s direct-Core
+  pattern).
+- [x] 2.3 Add `toPlatformToolsetPayload` (mirroring `toPlatformApplicationPayload`), stripping
+  `status`/`validationWarnings`/`author`/`createdAt`/`updatedAt`/`reference` before
+  `createPlatformToolset`/`updatePlatformToolset` write.
+- [x] 2.4 Unit tests for the new server actions and the payload-stripping helper in
+  `assets-toolsets/actions.spec.ts` — platform-prefixed path construction, no version/folder segment,
+  field stripping, conditional etag on update/delete.
+
+## 3. Platform bucket action-map wiring
+
+- [x] 3.1 In `src/components/Assets/BaseAssetList/utils.tsx`: add platform-bucket entries to
+  `GetAssetActionMap`/`CreateAssetActionMap`/`BulkDeleteAssetActionMap` (or the equivalent
+  bucket-aware dispatch Applications' platform entries use) so `AssetsToolsets` rows resolve to
+  `getPlatformToolset`/`createPlatformToolset`/`bulkDeletePlatformToolsets` while browsing the
+  `platform` bucket, and to the existing public functions otherwise.
+- [x] 3.2 Unit tests covering the bucket-aware dispatch for Toolsets (mirroring the equivalent
+  Applications test in `platform-applications-bucket.spec.tsx`).
+
+## 4. Platform toolset detail view
+
+- [x] 4.1 Create `src/components/Assets/Platform/Toolsets/View.tsx`: header chrome
+  (`SimpleEntityHeader`) + save/discard/remove wired to the new platform server actions, reusing
+  `Assets/Toolsets/View/TabsContent` and `ResourceAuthButtons` (sign-in/out) unmodified — mirrors
+  `Assets/Platform/Applications/View.tsx`'s structure.
+- [x] 4.2 In `src/app/[lang]/assets-toolsets/[id]/page.tsx`: branch on `searchParams.path` presence —
+  absent → build `platform/{id}`, fetch via `getPlatformToolset`, render the new platform View;
+  present → existing `getToolset` flow, render the existing public `ToolsetView` unchanged.
+- [x] 4.3 In `src/utils/open-in-new-tab.ts`: update `getEntityPath`'s `AssetsToolsets` case to resolve
+  a platform-bucket toolset to the bare `{encodedName}` segment with no `?path=`, matching the
+  Applications precedent.
+- [x] 4.4 In `src/components/Assets/Toolsets/View/Properties.tsx`: guard the `FilePath` folder-move
+  control with `!isPlatformBucketPath(selectedToolset.folderId)`, mirroring
+  `Assets/Apps/Properties.tsx`.
+- [x] 4.5 Unit tests for the new `View.tsx` (mirroring
+  `Assets/Platform/Applications/tests/View.spec.tsx`) and for the updated `Properties.tsx`/
+  `page.tsx`/`open-in-new-tab.ts` branches.
+
+## 5. Final quality checks
+
+- [x] 5.1 Run `npm run lint`, `npm run format`, and the full `npm run test` suite from
+  `apps/ai-dial-admin/`; fix any failures.

--- a/openspec/specs/platform-toolsets/spec.md
+++ b/openspec/specs/platform-toolsets/spec.md
@@ -1,0 +1,159 @@
+# platform-toolsets Specification
+
+## Purpose
+Platform-bucket toolsets shown as a second, flat bucket in the existing `Assets ▸ Toolsets` grid
+(`/assets-toolsets`), above the hierarchical, versioned `public` bucket. DIAL Core already gives
+platform-bucket toolsets full field/tab/auth parity with public-bucket ones (auth-secret encryption
+and credential-locator scope both derive from the resource's own bucket in `ToolSetService`,
+discovered-tools/sign-in/sign-out all resolve by the toolset's path regardless of bucket — see
+`toolset-resources-core-api`'s platform requirements for the write-path details); the differences
+this capability covers are structural (flat, no folders, no versioning) and surface-level (a
+restricted action set, a dedicated detail view). Created by archiving change `add-platform-toolsets`.
+
+## Requirements
+
+### Requirement: Platform bucket shown above public in the Assets Toolsets grid
+The system SHALL display a `platform` bucket as a top-level node in the existing
+`Assets ▸ Toolsets` grid (`/assets-toolsets`), positioned above the `public` bucket, using the same
+`BaseAssetList` instance the public toolsets list already uses. No new menu entry and no new
+top-level list route SHALL be introduced for this bucket.
+
+#### Scenario: Platform bucket appears above public on first load
+- **WHEN** the user navigates to `/assets-toolsets`
+- **THEN** the grid shows a `platform` top-level node above the `public` top-level node, both fetched
+  and rendered in the same tree
+
+#### Scenario: No separate platform toolsets list page exists
+- **WHEN** the user looks for a platform toolsets entry in the sidebar navigation
+- **THEN** no such entry exists — platform toolsets are reachable only through the existing
+  `/assets-toolsets` grid
+
+### Requirement: Platform bucket toolsets are flat
+The system SHALL NOT offer folder creation, nested navigation, or versioning for toolsets under the
+`platform` bucket, matching the flat treatment already given to platform applications and the six
+existing platform-only entities.
+
+#### Scenario: No folder actions on the platform node
+- **WHEN** the user opens the context menu on the `platform` top-level node or any toolset under it
+- **THEN** no folder-create, move, or nested-navigation actions are offered
+
+#### Scenario: No versioning on a platform toolset
+- **WHEN** the user opens a platform-bucket toolset's detail view
+- **THEN** no version history, publish, or version-switcher UI is shown
+
+### Requirement: Platform bucket toolset rows use the restricted action set
+The system SHALL restrict row and multi-select actions on `platform`-bucket toolset rows to
+duplicate, delete, and open-in-new-tab — the same set already used by platform applications and the
+six existing flat platform views — while `public`-bucket rows and the folder tree keep their current,
+unrestricted action set.
+
+#### Scenario: Platform row actions are restricted
+- **WHEN** the user opens the row action menu for a toolset under the `platform` bucket
+- **THEN** only duplicate, delete, and open-in-new-tab are offered
+
+#### Scenario: Public row actions are unchanged
+- **WHEN** the user opens the row action menu for a toolset under the `public` bucket
+- **THEN** the full existing action set is offered, unchanged from current behavior
+
+#### Scenario: Toolbar "New" menu offers a create action while browsing the platform bucket
+- **WHEN** the user opens the "New" toolbar menu while the `platform` bucket or an item under it is
+  the current context in the Toolsets view
+- **THEN** the menu offers a single "Toolset" entry (the same label the `public` bucket's create
+  entry uses), with no folder-create or import entries alongside it
+
+### Requirement: Platform bucket toolset rows use the same column set as other platform entities
+The system SHALL display the same flat column set platform applications and the six existing
+platform-only views use — Name, Author, Created time, Updated time — for `platform`-bucket toolset
+rows, instead of the `public` bucket's Name/Version/Author/Updated time set.
+
+#### Scenario: Platform-bucket rows show no Version column
+- **WHEN** the user browses the `platform` bucket in the Assets Toolsets grid
+- **THEN** the grid shows Name, Author, Created time, and Updated time columns, with no Version
+  column
+
+#### Scenario: Public-bucket rows are unaffected
+- **WHEN** the user browses the `public` bucket in the Assets Toolsets grid
+- **THEN** the grid keeps its existing Name, Version, Author, and Updated time columns
+
+### Requirement: Creating a platform toolset has no version field
+The system SHALL NOT display or require a version field when creating a new toolset while browsing
+the `platform` bucket, since the bucket has no versioning concept. Creating into the `public` bucket
+is unaffected and keeps requiring a version.
+
+#### Scenario: No version field when creating into the platform bucket
+- **WHEN** the user opens the create form while browsing the `platform` bucket in the Toolsets view
+- **THEN** no version field is shown, and the form can be submitted without one
+
+#### Scenario: Version field unchanged when creating into the public bucket
+- **WHEN** the user opens the create form while browsing the `public` bucket in the Toolsets view
+- **THEN** the version field is shown and required, unchanged from current behavior
+
+### Requirement: Platform toolset server actions
+The system SHALL provide server actions to list, get, create, update, delete, and bulk-delete
+toolsets in the `platform` bucket, calling the shared Core asset client with `ResourceType.TOOLSET`
+against `platform/`-prefixed paths — no `ai-dial-core` change is required, since Core already routes
+the `platform` bucket segment for toolsets to `ConfigResourceController` ahead of the generic
+toolsets route.
+
+#### Scenario: Listing platform toolsets
+- **WHEN** the platform bucket node is expanded in the Toolsets view
+- **THEN** the system fetches toolsets via the asset client with a `platform/`-prefixed path and
+  displays them in the grid
+
+#### Scenario: Creating a platform toolset omits version and folder placement
+- **WHEN** the user creates a new platform toolset
+- **THEN** the write payload sent to Core carries no `version` and no folder-derived path segment,
+  unlike a public-bucket toolset create
+
+#### Scenario: Deleting a platform toolset
+- **WHEN** the user deletes a platform toolset
+- **THEN** the system sends a delete request against its `platform/`-prefixed path, conditional on
+  the caller's etag when supplied
+
+### Requirement: Platform toolset writes strip read-only and derived fields
+The system SHALL strip fields the merge reader adds but that are not part of Core's `ToolSet` entity
+— `status`, `validationWarnings`, `author`, `createdAt`, `updatedAt`, and `reference` — before sending
+a create or update write for a platform-bucket toolset. Unlike the `public` bucket's generic write
+path, the `platform` bucket's write path deserializes strictly and rejects any unrecognized field.
+
+#### Scenario: A platform toolset save round-trips without a parse failure
+- **WHEN** the user edits and saves a platform-bucket toolset whose fetched entity carries `status`,
+  `author`, `createdAt`, `updatedAt`, and `reference`
+- **THEN** the write succeeds, with none of those fields present in the request body sent to Core
+
+### Requirement: A rejected platform toolset name surfaces through the existing error path
+The system SHALL NOT pre-validate a toolset name against Core's stricter platform-bucket key pattern
+before submitting a create or update. When Core rejects the write because the name fails that
+pattern, the system SHALL surface the rejection through the existing error-notification path rather
+than failing silently.
+
+#### Scenario: An invalid platform toolset name is rejected with a visible error
+- **WHEN** the user creates or renames a platform-bucket toolset with a name Core's key-pattern
+  validation rejects
+- **THEN** the write fails, and an error notification carrying Core's rejection message is shown
+
+### Requirement: Platform toolset detail view
+The system SHALL provide a detail view for a platform-bucket toolset under
+`src/components/Assets/Platform/Toolsets/`, distinct from the public Toolsets detail view, reusing
+the public Toolsets `TabsContent` (Properties, Tools, Audit) and its authentication controls
+(sign-in/sign-out) for full field/tab/auth parity, but showing no versioning/publish UI and no
+folder-move control. Both buckets share the existing `/assets-toolsets/[id]` detail route — a `?path=`
+query param present means public bucket; its absence means platform bucket.
+
+#### Scenario: Opening a platform toolset shows the platform detail view
+- **WHEN** the user clicks a platform-bucket toolset row
+- **THEN** the system navigates to `/assets-toolsets/[id]` with no `?path=` query param, and renders
+  the platform Toolsets view, not the public Toolsets view
+
+#### Scenario: Platform toolset detail has no version tab
+- **WHEN** the user views a platform-bucket toolset's detail
+- **THEN** no version-history or publish tab is present
+
+#### Scenario: Platform toolset detail has no folder-move control
+- **WHEN** the user views a platform-bucket toolset's Properties tab
+- **THEN** no folder-move control is shown, since the platform bucket has no folders to move into
+
+#### Scenario: Platform toolset sign-in and sign-out work the same as public
+- **WHEN** the user signs in to or out of a platform-bucket toolset's external service
+- **THEN** the sign-in/sign-out flow behaves identically to a public-bucket toolset, since Core scopes
+  authentication credentials and secret encryption to the resource's own bucket

--- a/openspec/specs/toolset-resources-core-api/spec.md
+++ b/openspec/specs/toolset-resources-core-api/spec.md
@@ -1,7 +1,7 @@
 # toolset-resources-core-api Specification
 
 ## Purpose
-Toolset-resource list, get, create, update, delete, bulk-delete, move, JSON/zip export, JSON/zip import, discovered-tools, sign-in/sign-out, and try-out-tool executed directly against DIAL Core via the shared `core-asset-client` (or, for try-out-tool, a direct MCP client session), replacing the admin-BE proxy for these operations, while the FE-facing `Toolset`/`AssetToolset` contract, routes, and server-action signatures stay identical — CRUD/move created by archiving change `migrate-toolset-resources-to-core`, import/export/discovery/auth completed by archiving change `migrate-toolset-auth-discovery-import-to-core`, try-out-tool completed by archiving change `migrate-toolset-tryout-tool-to-core`. Toolsets have zero remaining admin-BE dependency: `tryOutAssetTool` for `ResourceType.APPLICATION` now routes through Core too, completed by archiving change `finalize-assets-core-migration` alongside the prior toolset try-out-tool migration.
+Toolset-resource list, get, create, update, delete, bulk-delete, move, JSON/zip export, JSON/zip import, discovered-tools, sign-in/sign-out, and try-out-tool executed directly against DIAL Core via the shared `core-asset-client` (or, for try-out-tool, a direct MCP client session), replacing the admin-BE proxy for these operations, while the FE-facing `Toolset`/`AssetToolset` contract, routes, and server-action signatures stay identical — CRUD/move created by archiving change `migrate-toolset-resources-to-core`, import/export/discovery/auth completed by archiving change `migrate-toolset-auth-discovery-import-to-core`, try-out-tool completed by archiving change `migrate-toolset-tryout-tool-to-core`. Toolsets have zero remaining admin-BE dependency: `tryOutAssetTool` for `ResourceType.APPLICATION` now routes through Core too, completed by archiving change `finalize-assets-core-migration` alongside the prior toolset try-out-tool migration. Platform-bucket toolset CRUD, write, and discovered-tools/sign-in/sign-out parity added by archiving change `add-platform-toolsets` (see `platform-toolsets` for the surface-level requirements).
 
 ## Requirements
 
@@ -183,3 +183,50 @@ route rather than the toolset-scoped one.
 #### Scenario: Request and response shapes are unchanged
 - **WHEN** `tryOutAssetTool` is called for `ResourceType.APPLICATION` with a path and a `callToolRequest`
 - **THEN** the response shape matches what the admin-BE-backed implementation previously returned
+
+### Requirement: Platform-bucket toolset resources served directly by DIAL Core
+The system SHALL route platform-bucket toolset list, get, create, update, delete, and bulk-delete
+operations to DIAL Core via the same shared Core asset client used for public-bucket toolsets,
+targeting `platform/`-prefixed paths instead of `public/`-prefixed ones. This is additive to the
+existing public-bucket contract — `getToolsets`/`createToolset`/`getToolset`/`updateToolset`/
+`removeToolset`/`bulkDeleteToolsets` and their `public/`-bucket behavior are unchanged.
+
+#### Scenario: Platform-bucket CRUD operations call Core with a platform-prefixed path
+- **WHEN** a platform-bucket toolset list, get, create, update, delete, or bulk-delete action runs
+- **THEN** the request path passed to the shared Core asset client is prefixed with `platform/`
+  instead of `public/`
+
+#### Scenario: Public-bucket behavior is unaffected
+- **WHEN** any existing public-bucket toolset action (`getToolsets`, `createToolset`, `getToolset`,
+  `updateToolset`, `removeToolset`, `bulkDeleteToolsets`) runs with a `public/`-prefixed path
+- **THEN** its request and response shape are unchanged from current behavior
+
+### Requirement: Platform-bucket toolset writes omit version and folder placement
+The system SHALL NOT include a `version` suffix or a folder-derived path segment when creating or
+updating a platform-bucket toolset, since Core has no folder or versioning concept for the `platform`
+bucket. Public-bucket writes are unaffected and keep computing a versioned, folder-prefixed path as
+they do today.
+
+#### Scenario: Platform-bucket create path has no version suffix
+- **WHEN** a platform-bucket toolset is created
+- **THEN** the path written to Core is the bare toolset name under `platform/`, with no `__version`
+  suffix
+
+#### Scenario: Platform-bucket update path has no folder segment
+- **WHEN** a platform-bucket toolset is updated
+- **THEN** the path written to Core carries no folder-derived prefix beyond the fixed `platform/`
+  bucket segment
+
+### Requirement: Platform-bucket toolset discovered-tools, sign-in, and sign-out are unaffected
+The system SHALL route discovered-tools, sign-in, and sign-out for a platform-bucket toolset through
+the same `ToolsetOpsApi` calls used for a public-bucket toolset, since Core resolves these by the
+toolset's resource path/name regardless of bucket.
+
+#### Scenario: Discovered-tools works for a platform-bucket toolset
+- **WHEN** the discovered-tools list is fetched for a platform-bucket toolset
+- **THEN** the request resolves by that toolset's `platform/`-prefixed path, the same way a
+  public-bucket toolset's request resolves by its `public/`-prefixed path
+
+#### Scenario: Sign-in and sign-out work for a platform-bucket toolset
+- **WHEN** the user signs in to or out of a platform-bucket toolset
+- **THEN** the request succeeds identically to a public-bucket toolset's sign-in/sign-out


### PR DESCRIPTION
**Description:**

Adds platform-bucket toolsets support to the admin console, mirroring the existing platform-applications feature. Platform toolsets now appear in the Assets ▸ Toolsets grid alongside public-bucket toolsets, with a dedicated detail view and restricted action set (no versioning, no publish). Generalizes bucket-detection helpers so future dual-bucket entities don't require new branching logic.

Core gives toolsets the same public/platform duality as applications; this change makes the admin UI reflect that parity, reusing existing TabsContent and ResourceAuthButtons from the public toolsets view for full field/tab/auth compatibility.

Issues:

- Issue #4389

**Key Changes:**

- [src/components/Assets/Platform/Toolsets/View.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/feat/add-platform-toolsets-support/apps/ai-dial-admin/src/components/Assets/Platform/Toolsets/View.tsx) — new platform toolsets detail view, reusing TabsContent and auth components
- [src/app/[lang]/assets-toolsets/actions.ts](https://github.com/epam/ai-dial-admin-frontend/blob/feat/add-platform-toolsets-support/apps/ai-dial-admin/src/app/[lang]/assets-toolsets/actions.ts) — server actions for platform toolsets (remove, update, sign in/out)
- [src/components/Assets/BaseAssetList/BaseAssetList.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/feat/add-platform-toolsets-support/apps/ai-dial-admin/src/components/Assets/BaseAssetList/BaseAssetList.tsx) — unified handling for dual-bucket assets
- [src/utils/files/root-folder.ts](https://github.com/epam/ai-dial-admin-frontend/blob/feat/add-platform-toolsets-support/apps/ai-dial-admin/src/utils/files/root-folder.ts) — generalized dual-bucket root folder detection
- [src/components/Assets/utils.ts](https://github.com/epam/ai-dial-admin-frontend/blob/feat/add-platform-toolsets-support/apps/ai-dial-admin/src/components/Assets/utils.ts) — generalized bucket-detection and action-label branching helpers
- [openspec/specs/platform-toolsets/spec.md](https://github.com/epam/ai-dial-admin-frontend/blob/feat/add-platform-toolsets-support/openspec/specs/platform-toolsets/spec.md) — feature specification

**New Components:**

- Platform Toolsets View — detail view for platform-bucket toolsets with resource authentication buttons and tab navigation

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #4389)`