### PR TITLE
fix(Assets/Folders): normalize folder path trailing slash before publication create (Issue #4396)

### DIFF
--- a/apps/ai-dial-admin/src/server/folders/folders-core.ts
+++ b/apps/ai-dial-admin/src/server/folders/folders-core.ts
@@ -259,21 +259,29 @@ export async function changeFolderCore(
   resourceTypes: ResourceType[],
   overwrite = false,
 ): Promise<ServerActionResponse> {
+  // The ui-kit's DialCopiedItem.destinationUrl is built as `${destinationFolder}/${name}`
+  // with no trailing slash, while sourceUrl (from DialFile.path) carries one. Core's
+  // create-publication endpoint validates targetFolder with isFolder() (must end with /),
+  // so normalize both before any Core call — addTrailingSlash is idempotent for paths
+  // that already end with /.
+  const normalizedOldPath = addTrailingSlash(oldPath);
+  const normalizedNewPath = addTrailingSlash(newPath);
+
   for (const type of resourceTypes) {
-    if (!(await folderExists(token, type, oldPath))) {
+    if (!(await folderExists(token, type, normalizedOldPath))) {
       return {
         success: false,
         errorHeader: 'Not Found',
-        errorMessage: `Folder "${oldPath}" does not exist for resource type ${type}`,
+        errorMessage: `Folder "${normalizedOldPath}" does not exist for resource type ${type}`,
       };
     }
   }
 
-  const rulesResult = await getRulesCore(token, oldPath);
+  const rulesResult = await getRulesCore(token, normalizedOldPath);
   if (rulesResult.success && rulesResult.response) {
     const flatRules = Object.values(rulesResult.response).flat();
     if (flatRules.length > 0) {
-      const copyResult = await updateRulesCore(token, newPath, flatRules);
+      const copyResult = await updateRulesCore(token, normalizedNewPath, flatRules);
       if (!copyResult.success) {
         return copyResult;
       }
@@ -282,12 +290,12 @@ export async function changeFolderCore(
 
   for (const type of resourceTypes) {
     const prefix = RESOURCE_TYPE_PREFIX[type];
-    const urls = await gatherResourceUrls(readRecursiveMetadata(token, type), oldPath);
+    const urls = await gatherResourceUrls(readRecursiveMetadata(token, type), normalizedOldPath);
     for (const url of urls) {
       const barePath = decodeCorePath(stripPrefix(url, prefix));
       let destinationPath: string;
       try {
-        destinationPath = replacePathPrefix(barePath, oldPath, newPath);
+        destinationPath = replacePathPrefix(barePath, normalizedOldPath, normalizedNewPath);
       } catch (error) {
         return {
           success: false,

--- a/apps/ai-dial-admin/src/server/folders/tests/folders-core.spec.ts
+++ b/apps/ai-dial-admin/src/server/folders/tests/folders-core.spec.ts
@@ -214,6 +214,37 @@ describe('Server :: Folders :: folders-core :: changeFolderCore', () => {
     expect(result.success).toBe(true);
   });
 
+  test('normalizes a destination path without a trailing slash before copying rules', async () => {
+    (assetApi.getMetadata as any).mockImplementation(
+      (_t: unknown, _type: unknown, path: string, options: { recursive?: boolean }) =>
+        options?.recursive
+          ? Promise.resolve(folderNode('prompts/old/', [itemNode('prompts/old/a__1')]))
+          : Promise.resolve(folderNode('prompts/old/')),
+    );
+    (publicationsApi.ruleList as any).mockResolvedValue({
+      success: true,
+      response: { rules: { 'old/': [{ source: 'title', function: 'equal', targets: ['x'] }] } },
+    });
+    (publicationsApi.createPublication as any).mockResolvedValue({
+      success: true,
+      response: { url: 'publications/new/' },
+    });
+    (publicationsApi.approvePublication as any).mockResolvedValue({ success: true });
+    (assetApi.move as any).mockResolvedValue({ success: true });
+
+    // Simulate the ui-kit's DialCopiedItem.destinationUrl which has no trailing slash
+    const result = await changeFolderCore(TOKEN_MOCK, 'old/', 'new', [ResourceType.PROMPT]);
+
+    expect(publicationsApi.createPublication).toHaveBeenCalledWith(
+      TOKEN_MOCK,
+      'new/',
+      [],
+      [{ source: 'title', function: 'equal', targets: ['x'] }],
+    );
+    expect(assetApi.move).toHaveBeenCalledWith(TOKEN_MOCK, ResourceType.PROMPT, 'old/a__1', 'new/a__1', false);
+    expect(result.success).toBe(true);
+  });
+
   test('stops at the first per-type move failure without rolling back', async () => {
     (assetApi.getMetadata as any).mockImplementation(
       (_t: unknown, _type: unknown, path: string, options: { recursive?: boolean }) =>


### PR DESCRIPTION
**Description:**

Moving a folder that has rules/permissions set failed with Core's `Publication "targetUrl" must start with: public and ends with: /` because the ui-kit's `DialCopiedItem.destinationUrl` is built as `${destinationFolder}/${folderName}` — without a trailing slash for folders. `changeFolderCore` passed this directly to `updateRulesCore` → `createPublication`, where Core rejected it because `targetFolder.isFolder()` was false. Only folders with rules triggered the publication path; folders without rules skipped it and moved via `assetApi.move`, which worked regardless — explaining why the issue appeared correlated with folder names containing spaces (those happened to be the ones with rules).

The fix normalizes `oldPath` and `newPath` with `addTrailingSlash` at the top of `changeFolderCore`, before any Core call. `addTrailingSlash` is idempotent for paths that already end with `/`, so existing callers are unaffected.

Issues:

- Issue #4396

**Key Changes:**

- [apps/ai-dial-admin/src/server/folders/folders-core.ts](https://github.com/epam/ai-dial-admin-frontend/blob/fix/4396-folder-move-trailing-slash/apps/ai-dial-admin/src/server/folders/folders-core.ts) — normalize `oldPath`/`newPath` with `addTrailingSlash` before any Core call; removed debug `console.log` statements
- [apps/ai-dial-admin/src/server/folders/tests/folders-core.spec.ts](https://github.com/epam/ai-dial-admin-frontend/blob/fix/4396-folder-move-trailing-slash/apps/ai-dial-admin/src/server/folders/tests/folders-core.spec.ts) — new test: `changeFolderCore` with trailing-slash-less `newPath` + rules on source folder asserts `createPublication` receives a `targetFolder` ending with `/`


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<ticket>)` (comma-separated list of issues)