### PR TITLE
fix(Catalog/PlatformKeys): refresh correct folder path after key duplication (Issue #4392)

### DIFF
--- a/apps/ai-dial-admin/src/components/Assets/Platform/Keys/CreateKeyModal.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Platform/Keys/CreateKeyModal.tsx
@@ -26,6 +26,7 @@ import { DialRole } from '@/src/models/dial/role';
 import { ApplicationRoute } from '@/src/types/routes';
 import { withSourceColumn } from '@/src/utils/config-entities/source-column';
 import { getCreateEntityTitle } from '@/src/utils/entities/create-entity';
+import { getRootFolder } from '@/src/utils/files/root-folder';
 import { generateKey } from '@/src/utils/keys/generate-key';
 import { getUrnForEntity } from '@/src/utils/open-in-new-tab';
 
@@ -138,7 +139,9 @@ const CreateKeyModal: FC<Props> = ({ isOpen, names, onClose }) => {
         if (res.success) {
           setCreatedKeyValue(generated);
           setStep(CreateStep.Reveal);
-          fetchFiles(asset.folderId);
+          // `asset` is seeded as `{ name, project }` with no `folderId` — the list displays
+          // `fetchedFoldersData['platform/']`, so refresh the view's root folder, not `undefined`.
+          fetchFiles(`${getRootFolder(ApplicationRoute.PlatformKeys)}/`);
         }
       });
       return;

--- a/apps/ai-dial-admin/src/components/Assets/Platform/Keys/DuplicatePlatformKeyModal.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Platform/Keys/DuplicatePlatformKeyModal.tsx
@@ -14,6 +14,7 @@ import { useI18n } from '@/src/locales/client';
 import { DialKeyResource } from '@/src/models/dial/resource';
 import { ApplicationRoute } from '@/src/types/routes';
 import { getClonedEntityName, getCloneTitle } from '@/src/utils/entities/duplicate-entity';
+import { getRootFolder } from '@/src/utils/files/root-folder';
 import { generateKey } from '@/src/utils/keys/generate-key';
 import { getUrnForEntity } from '@/src/utils/open-in-new-tab';
 
@@ -63,7 +64,12 @@ const DuplicatePlatformKeyModal: FC<Props> = ({ isOpen, names, entity, onClose }
       if (res.success) {
         setCreatedKeyValue(generated);
         setStep(DuplicateStep.Reveal);
-        fetchFiles(entity.folderId);
+        // Flat platform resources (keys, models, roles…) have `folderId: ''` on the
+        // individually-fetched entity — the `keys/platform/` prefix consumes the `platform`
+        // segment during path parsing. The list displays `fetchedFoldersData['platform/']`,
+        // so refreshing with `entity.folderId` (`''`) updates the wrong path and the new key
+        // never appears. Mirror `handleCreateAsset`'s fallback to the view's root folder.
+        fetchFiles(`${getRootFolder(ApplicationRoute.PlatformKeys)}/`);
       }
     });
   }, [entity, name, fetchFiles]);


### PR DESCRIPTION
**Description:**

After duplicating a platform key, the Keys list did not refresh to show the new key — it only appeared after a manual page refresh. The root cause was that `DuplicatePlatformKeyModal` (and `CreateKeyModal`) called `fetchFiles(entity.folderId)` to refresh the list, but for flat platform resources `folderId` is `''` (the `keys/platform/` prefix consumes the `platform` segment during path parsing). This fetched from the wrong path, so `fetchedFoldersData['platform/']` — what the grid displays — was never updated. Both modals now use `fetchFiles(`${getRootFolder(ApplicationRoute.PlatformKeys)}/`)`, mirroring the fallback that `handleCreateAsset` already uses for every other flat platform view.

Issues:

- Issue #4392

**Key Changes:**

- [apps/ai-dial-admin/src/components/Assets/Platform/Keys/DuplicatePlatformKeyModal.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/fix/keys-duplicate-list-refresh/apps/ai-dial-admin/src/components/Assets/Platform/Keys/DuplicatePlatformKeyModal.tsx) — replace `fetchFiles(entity.folderId)` with `fetchFiles(`${getRootFolder(ApplicationRoute.PlatformKeys)}/`)` so the list refreshes from `platform/` instead of the empty root path
- [apps/ai-dial-admin/src/components/Assets/Platform/Keys/CreateKeyModal.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/fix/keys-duplicate-list-refresh/apps/ai-dial-admin/src/components/Assets/Platform/Keys/CreateKeyModal.tsx) — same latent bug (`asset.folderId` is `undefined` on the seeded object); same fix applied


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #4392)` (comma-separated list of issues)