### PR TITLE
feat(analytics/Tables): read table roles from DIAL Core catalog (Issue #3847)

### DIFF
--- a/apps/ai-dial-admin/src/app/[lang]/tables/actions.ts
+++ b/apps/ai-dial-admin/src/app/[lang]/tables/actions.ts
@@ -2,8 +2,10 @@
 
 import { cookies, headers } from 'next/headers';
 
-import { analyticsDataApi, rolesApi } from '@/src/app/api/api';
+import { analyticsDataApi } from '@/src/app/api/api';
+import { EntitiesI18nKey } from '@/src/constants/i18n';
 import {
+  AnalyticsRoleCatalog,
   AnalyticsSchemaPatch,
   AnalyticsTable,
   CreateTableDto,
@@ -12,8 +14,10 @@ import {
   UpdateTableDto,
   WriteRowsDto,
 } from '@/src/models/analytics/table';
-import { DialRole } from '@/src/models/dial/role';
+import { ConfigEntityRow } from '@/src/models/dial/config-file';
 import { ServerActionResponse } from '@/src/models/server-action';
+import { readConfigEntities } from '@/src/server/config-entities/read-page-options';
+import { ConfigFileEntityType } from '@/src/types/config-file-entity';
 import { getUserToken } from '@/src/utils/auth/auth-request';
 import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
 
@@ -59,7 +63,9 @@ export async function replaceTableAccess(name: string, access: TableAccess): Pro
   return analyticsDataApi.replaceTableAccess(name, access, await token());
 }
 
-// The catalog of DIAL-configured roles offered as checkboxes in the Manage table access panel.
-export async function getRoles(): Promise<DialRole[] | null> {
-  return rolesApi.getRolesList(await token());
+export async function getRoles(): Promise<AnalyticsRoleCatalog> {
+  const warnings: EntitiesI18nKey[] = [];
+  const roles = await readConfigEntities<ConfigEntityRow>(await token(), ConfigFileEntityType.Roles, warnings);
+
+  return { roles, warnings };
 }

--- a/apps/ai-dial-admin/src/app/[lang]/tables/tests/actions.spec.ts
+++ b/apps/ai-dial-admin/src/app/[lang]/tables/tests/actions.spec.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { analyticsDataApi, rolesApi } from '@/src/app/api/api';
+import { EntitiesI18nKey } from '@/src/constants/i18n';
 import { AnalyticsTableType, CreateTableDto } from '@/src/models/analytics/table';
+import { readConfigEntities } from '@/src/server/config-entities/read-page-options';
+import { ConfigEntityOrigin, ConfigFileEntityType } from '@/src/types/config-file-entity';
 import { getUserToken } from '@/src/utils/auth/auth-request';
 import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
 import { TOKEN_MOCK } from '@/src/utils/tests/mock/api.mock';
@@ -22,6 +25,7 @@ import {
 vi.mock('@/src/utils/auth/auth-request');
 vi.mock('@/src/utils/env/get-auth-toggle');
 vi.mock('@/src/app/api/api');
+vi.mock('@/src/server/config-entities/read-page-options');
 
 describe('Tables server actions', () => {
   beforeEach(() => {
@@ -117,11 +121,30 @@ describe('Tables server actions', () => {
     expect(analyticsDataApi.replaceTableAccess).toHaveBeenCalledWith('events', access, TOKEN_MOCK);
   });
 
-  test('getRoles passes the token to the roles client', async () => {
-    (rolesApi.getRolesList as any).mockResolvedValue([{ name: 'Admin' }]);
+  test('getRoles reads the role catalog from Core, not from the admin backend', async () => {
+    (readConfigEntities as any).mockResolvedValue([
+      { name: 'analytics-writer', displayName: 'analytics-writer', origin: ConfigEntityOrigin.Api },
+    ]);
 
-    await getRoles();
+    const catalog = await getRoles();
 
-    expect(rolesApi.getRolesList).toHaveBeenCalledWith(TOKEN_MOCK);
+    expect(readConfigEntities).toHaveBeenCalledWith(TOKEN_MOCK, ConfigFileEntityType.Roles, []);
+    expect(rolesApi.getRolesList).not.toHaveBeenCalled();
+    expect(catalog.roles).toEqual([
+      { name: 'analytics-writer', displayName: 'analytics-writer', origin: ConfigEntityOrigin.Api },
+    ]);
+  });
+
+  test('getRoles returns the warnings the Core read reported', async () => {
+    (readConfigEntities as any).mockImplementation(
+      async (_token: unknown, _type: unknown, warnings: EntitiesI18nKey[]) => {
+        warnings.push(EntitiesI18nKey.OptionListPartial);
+        return [];
+      },
+    );
+
+    const catalog = await getRoles();
+
+    expect(catalog).toEqual({ roles: [], warnings: [EntitiesI18nKey.OptionListPartial] });
   });
 });

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/TableAccessPanel.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/TableAccessPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FC, useEffect, useState } from 'react';
+import { FC, useEffect, useMemo, useState } from 'react';
 
 import { DialFormPopup, DialLoader, DialSelectField, PopupSize, SelectOption } from '@epam/ai-dial-ui-kit';
 
@@ -15,39 +15,39 @@ interface Props {
   onClose: () => void;
 }
 
-// FULL_ADMIN-only panel to view and full-replace a table's write/modify provider-role lists. Rendered
-// only when the caller can manage roles (the backend access endpoint is admin-only). Role names are
-// picked from the DIAL Roles catalog (each role's `name` is what the backend matches against the
-// caller's provider roles) rather than typed free-form.
 const TableAccessPanel: FC<Props> = ({ name, onClose }) => {
   const t = useI18n();
   const { showNotification } = useNotification();
 
   const [write, setWrite] = useState<string[]>([]);
   const [modify, setModify] = useState<string[]>([]);
-  const [roleOptions, setRoleOptions] = useState<SelectOption[]>([]);
+  const [catalogRoles, setCatalogRoles] = useState<string[]>([]);
+  const [grantedOnLoad, setGrantedOnLoad] = useState<string[]>([]);
   const [saving, setSaving] = useState(false);
-  // Whether the initial fetch is still in flight — gates the spinner. Distinct from `loaded` (below):
-  // a failed fetch still stops `fetching` (falls through to the empty, Save-disabled form) rather than
-  // spinning forever.
   const [fetching, setFetching] = useState(true);
-  // Gate Save until the current lists are loaded — otherwise a save could full-replace the table's real
-  // roles with empty state (before the fetch resolves, or if it failed).
   const [loaded, setLoaded] = useState(false);
+
+  const roleOptions: SelectOption[] = useMemo(
+    () =>
+      Array.from(new Set([...catalogRoles, ...grantedOnLoad]))
+        .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
+        .map((role) => ({ value: role, label: role })),
+    [catalogRoles, grantedOnLoad],
+  );
 
   useEffect(() => {
     let active = true;
-    void Promise.all([getTableAccess(name), getRoles()]).then(([access, roles]) => {
+    void Promise.all([getTableAccess(name), getRoles()]).then(([access, catalog]) => {
       if (!active) return;
       setFetching(false);
-      if (roles) {
-        setRoleOptions(roles.map((role) => ({ value: role.name ?? '', label: role.name ?? '' })));
-      } else {
-        showNotification(getErrorNotification(t(AnalyticsTablesI18nKey.RolesLoadFailed)));
-      }
+      setCatalogRoles(catalog.roles.map((role) => role.displayName ?? '').filter(Boolean));
+      catalog.warnings.forEach((warning) =>
+        showNotification(getErrorNotification(t(AnalyticsTablesI18nKey.RolesLoadFailed), t(warning))),
+      );
       if (access) {
         setWrite(access.write ?? []);
         setModify(access.modify ?? []);
+        setGrantedOnLoad([...(access.write ?? []), ...(access.modify ?? [])]);
         setLoaded(true);
       } else {
         showNotification(getErrorNotification(t(AnalyticsTablesI18nKey.AccessLoadFailed)));

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/tests/TableAccessPanel.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/tests/TableAccessPanel.spec.tsx
@@ -4,7 +4,9 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { getRoles, getTableAccess, replaceTableAccess } from '@/src/app/[lang]/tables/actions';
 import TableAccessPanel from '@/src/components/Analytics/Tables/TableAccessPanel';
-import { AnalyticsTablesI18nKey, ButtonsI18nKey } from '@/src/constants/i18n';
+import { AnalyticsTablesI18nKey, ButtonsI18nKey, EntitiesI18nKey } from '@/src/constants/i18n';
+import { ConfigEntityRow } from '@/src/models/dial/config-file';
+import { ConfigEntityOrigin } from '@/src/types/config-file-entity';
 
 vi.mock('@/src/app/[lang]/tables/actions');
 
@@ -43,55 +45,62 @@ vi.mock('@epam/ai-dial-ui-kit', async (importOriginal) => {
   };
 });
 
-const roles = [{ name: 'analytics-writer' }, { name: 'analytics-editor' }, { name: 'analytics-viewer' }];
-
-// The role groups only render once the initial fetch (access + roles catalog) resolves — before that,
-// a spinner is shown in their place. Await this once per test before using the sync `*RolesGroup`
-// helpers below.
+const toRow = (name: string): ConfigEntityRow => ({ name, displayName: name, origin: ConfigEntityOrigin.Api });
+const catalog = [toRow('analytics-writer'), toRow('analytics-editor'), toRow('analytics-viewer')];
+const renderPanel = (onClose = vi.fn()) => render(<TableAccessPanel name="events" onClose={onClose} />);
 const waitForLoaded = () => screen.findByRole('group', { name: AnalyticsTablesI18nKey.WriteRoles });
 const writeRolesGroup = () => screen.getByRole('group', { name: AnalyticsTablesI18nKey.WriteRoles });
 const modifyRolesGroup = () => screen.getByRole('group', { name: AnalyticsTablesI18nKey.ModifyRoles });
+const offeredRoles = (group: HTMLElement) =>
+  within(group)
+    .getAllByRole('checkbox')
+    .map((option) => option.parentElement?.textContent);
+
+const save = (user: ReturnType<typeof userEvent.setup>) =>
+  user.click(screen.getByRole('button', { name: ButtonsI18nKey.Save }));
 
 beforeEach(() => {
   vi.clearAllMocks();
   (getTableAccess as any).mockResolvedValue({ write: ['analytics-writer'], modify: [] });
   (replaceTableAccess as any).mockResolvedValue({ success: true });
-  (getRoles as any).mockResolvedValue(roles);
+  (getRoles as any).mockResolvedValue({ roles: catalog, warnings: [] });
 });
 
 describe('TableAccessPanel', () => {
   test('shows a loading spinner while the initial fetch is in flight', () => {
-    render(<TableAccessPanel name="events" onClose={vi.fn()} />);
+    renderPanel();
 
     expect(screen.getByRole('status')).toBeInTheDocument();
     expect(screen.queryByRole('group')).not.toBeInTheDocument();
   });
 
-  test('loads and checks the roles already granted', async () => {
-    render(<TableAccessPanel name="events" onClose={vi.fn()} />);
+  test('checks the roles already granted in the list that granted them', async () => {
+    (getTableAccess as any).mockResolvedValue({ write: ['analytics-writer'], modify: ['analytics-editor'] });
+    renderPanel();
     await waitForLoaded();
 
     expect(within(writeRolesGroup()).getByRole('checkbox', { name: 'analytics-writer' })).toBeChecked();
     expect(within(writeRolesGroup()).getByRole('checkbox', { name: 'analytics-editor' })).not.toBeChecked();
+    expect(within(modifyRolesGroup()).getByRole('checkbox', { name: 'analytics-editor' })).toBeChecked();
     expect(getTableAccess).toHaveBeenCalledWith('events');
-    expect(getRoles).toHaveBeenCalled();
+    expect(getRoles).toHaveBeenCalledOnce();
   });
 
-  test('offers every catalog role as a checkbox, not just the granted ones', async () => {
-    render(<TableAccessPanel name="events" onClose={vi.fn()} />);
+  test('offers every catalog role, not just the granted ones, in alphabetical order', async () => {
+    renderPanel();
     await waitForLoaded();
 
-    expect(within(writeRolesGroup()).getAllByRole('checkbox')).toHaveLength(roles.length);
-    expect(within(modifyRolesGroup()).getAllByRole('checkbox')).toHaveLength(roles.length);
+    expect(offeredRoles(writeRolesGroup())).toEqual(['analytics-editor', 'analytics-viewer', 'analytics-writer']);
+    expect(offeredRoles(modifyRolesGroup())).toEqual(['analytics-editor', 'analytics-viewer', 'analytics-writer']);
   });
 
   test('checking a new role includes it in the saved list', async () => {
     const user = userEvent.setup();
-    render(<TableAccessPanel name="events" onClose={vi.fn()} />);
+    renderPanel();
     await waitForLoaded();
 
     await user.click(within(writeRolesGroup()).getByRole('checkbox', { name: 'analytics-viewer' }));
-    await user.click(screen.getByRole('button', { name: ButtonsI18nKey.Save }));
+    await save(user);
 
     await waitFor(() =>
       expect(replaceTableAccess).toHaveBeenCalledWith('events', {
@@ -104,19 +113,39 @@ describe('TableAccessPanel', () => {
   test('unchecking a granted role removes it from the saved list', async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
-    render(<TableAccessPanel name="events" onClose={onClose} />);
+    renderPanel(onClose);
     await waitForLoaded();
 
     await user.click(within(writeRolesGroup()).getByRole('checkbox', { name: 'analytics-writer' }));
-    await user.click(screen.getByRole('button', { name: ButtonsI18nKey.Save }));
+    await save(user);
 
     await waitFor(() => expect(replaceTableAccess).toHaveBeenCalledWith('events', { write: [], modify: [] }));
     await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
 
-  test('keeps Save disabled and does not replace when the initial load fails', async () => {
+  test('offers a granted role the catalog does not contain, and sends it back unchanged', async () => {
+    (getTableAccess as any).mockResolvedValue({ write: ['config-file-only-role'], modify: [] });
+    const user = userEvent.setup();
+    renderPanel();
+    await waitForLoaded();
+
+    expect(within(writeRolesGroup()).getByRole('checkbox', { name: 'config-file-only-role' })).toBeChecked();
+    expect(within(modifyRolesGroup()).getByRole('checkbox', { name: 'config-file-only-role' })).not.toBeChecked();
+
+    await user.click(within(modifyRolesGroup()).getByRole('checkbox', { name: 'analytics-editor' }));
+    await save(user);
+
+    await waitFor(() =>
+      expect(replaceTableAccess).toHaveBeenCalledWith('events', {
+        write: ['config-file-only-role'],
+        modify: ['analytics-editor'],
+      }),
+    );
+  });
+
+  test('keeps Save disabled and does not replace when the access load fails', async () => {
     (getTableAccess as any).mockResolvedValue(null);
-    render(<TableAccessPanel name="events" onClose={vi.fn()} />);
+    renderPanel();
 
     await waitFor(() => expect(getTableAccess).toHaveBeenCalledWith('events'));
 
@@ -127,27 +156,30 @@ describe('TableAccessPanel', () => {
     );
   });
 
-  test('notifies when the roles catalog fails to load, even though access loaded fine', async () => {
-    (getRoles as any).mockResolvedValue(null);
-    render(<TableAccessPanel name="events" onClose={vi.fn()} />);
-
-    await waitFor(() =>
-      expect(showNotificationSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ title: AnalyticsTablesI18nKey.RolesLoadFailed }),
-      ),
-    );
-  });
-
-  test('shows both role lists and round-trips them on save', async () => {
-    (getTableAccess as any).mockResolvedValue({ write: ['analytics-writer'], modify: ['analytics-editor'] });
-    const user = userEvent.setup();
-    render(<TableAccessPanel name="events" onClose={vi.fn()} />);
+  test('reports a role-catalog failure separately and still offers the granted roles', async () => {
+    (getRoles as any).mockResolvedValue({ roles: [], warnings: [EntitiesI18nKey.OptionListUnavailable] });
+    renderPanel();
     await waitForLoaded();
 
-    expect(within(writeRolesGroup()).getByRole('checkbox', { name: 'analytics-writer' })).toBeChecked();
-    expect(within(modifyRolesGroup()).getByRole('checkbox', { name: 'analytics-editor' })).toBeChecked();
+    expect(showNotificationSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: AnalyticsTablesI18nKey.RolesLoadFailed,
+        description: EntitiesI18nKey.OptionListUnavailable,
+      }),
+    );
+    expect(showNotificationSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({ title: AnalyticsTablesI18nKey.AccessLoadFailed }),
+    );
+    expect(offeredRoles(writeRolesGroup())).toEqual(['analytics-writer']);
+  });
 
-    await user.click(screen.getByRole('button', { name: ButtonsI18nKey.Save }));
+  test('round-trips both lists on save when nothing is edited', async () => {
+    (getTableAccess as any).mockResolvedValue({ write: ['analytics-writer'], modify: ['analytics-editor'] });
+    const user = userEvent.setup();
+    renderPanel();
+    await waitForLoaded();
+
+    await save(user);
 
     await waitFor(() =>
       expect(replaceTableAccess).toHaveBeenCalledWith('events', {

--- a/apps/ai-dial-admin/src/models/analytics/table.ts
+++ b/apps/ai-dial-admin/src/models/analytics/table.ts
@@ -1,4 +1,6 @@
+import { EntitiesI18nKey } from '@/src/constants/i18n';
 import { AnalyticsFieldType } from '@/src/models/analytics/entity';
+import { ConfigEntityRow } from '@/src/models/dial/config-file';
 
 export enum AnalyticsTableType {
   Source = 'source',
@@ -85,8 +87,11 @@ export interface TableAccess {
   modify: string[];
 }
 
-// POST /v1/tables is identity-only: no columns, no physical keys. The physical schema is defined
-// afterwards via the draft-schema resource (see DraftSchemaDto below).
+export interface AnalyticsRoleCatalog {
+  roles: ConfigEntityRow[];
+  warnings: EntitiesI18nKey[];
+}
+
 export interface CreateSourceTableDto {
   name: string;
   type: AnalyticsTableType.Source;

--- a/openspec/changes/archive/2026-09-04-analytics-table-access-core-roles/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-04-analytics-table-access-core-roles/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-04

--- a/openspec/changes/archive/2026-09-04-analytics-table-access-core-roles/design.md
+++ b/openspec/changes/archive/2026-09-04-analytics-table-access-core-roles/design.md
@@ -1,0 +1,70 @@
+## Context
+
+See `proposal.md` — Why. The design-relevant state:
+
+- `TableAccessPanel` opens as a form popup, and on open issues one `Promise.all([getTableAccess(name), getRoles()])`. `getRoles()` (`app/[lang]/tables/actions.ts`) wraps `rolesApi.getRolesList` and returns `DialRole[] | null`; the panel treats `null` as "catalog failed" and shows one notification.
+- The reader this change moves to, `readConfigEntities(token, ConfigFileEntityType.Roles, warnings)`, has a different failure contract: it **never returns null**. A total failure returns `[]` and pushes `EntitiesI18nKey.OptionListUnavailable` into the caller's `warnings` array; a partial failure returns the population it could read and pushes `OptionListPartial`. Callers today are server components that render those keys as page banners.
+- It returns `ConfigEntityRow { name, displayName, origin }`. For roles both fields carry the bare name — `toConfigEntityRows` fills them from the same `option.name`, and `getConfigEntityReference` returns the bare name for the short-name-keyed types, roles among them — so no adaptation is needed either way.
+- The two pickers are `DialSelectField multiple`. A closed select renders only the `value` entries that match an `option`, and its `onChange` reports the selection built from the options — so a stored value with no matching option is invisible and is dropped by the next edit.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- The panel's option source and the panel's failure reporting move together: adopting a reader with a different failure contract must not silently drop the "catalog failed" notification the current panel shows.
+- No new prop, branch, or behavior on any shared control, and no new UI shape invented for this surface.
+- A grant the catalog does not contain is preserved structurally, not by a guard that a future refactor can drop.
+
+**Non-Goals:**
+
+- Reworking how `readConfigEntities` reports failure. Its warnings-array contract serves five existing callers; this change adapts to it at the action boundary.
+- Adopting the `GridView` + `AddEntitiesGrid` shape the other role surfaces use (see D3).
+
+## Decisions
+
+### D1 — Re-point `getRoles()` in place rather than add a second action
+
+`getRoles()` has exactly one caller. Adding a `getTableRoleOptions()` beside it would leave two names for one read and an unused legacy path pointing at a backend being retired. The body is replaced; the name stays, so the panel's `Promise.all` is untouched.
+
+Its return type changes from `DialRole[] | null` to a named shape carrying both halves of the reader's contract (see D2). `actions.spec.ts`'s `getRoles` test moves from asserting the token reached `rolesApi.getRolesList` to asserting it reached the config-entities reader.
+
+### D2 — Carry the reader's warnings out of the action, rather than collapsing them to `null`
+
+The panel needs to know a catalog read failed; the reader says so through a mutable `warnings` array, not a return value. Three shapes were considered:
+
+- **Return `[]` and drop the signal.** Rejected — it turns a Core outage into "no roles are configured", which is exactly the silent option loss the reader was built to prevent.
+- **Return `null` when any warning was pushed.** Rejected — it discards the partial read's usable half, and conflates "unreadable" with "incomplete".
+- **Return `{ roles, warnings }` (chosen).** `warnings: EntitiesI18nKey[]` is the reader's own vocabulary, already translated, and already how every other caller consumes it. The panel keeps `AnalyticsTablesI18nKey.RolesLoadFailed` as the notification title — it names *which* list failed, which a toast has no page context to supply — and uses the reader's key as the message body, so a total failure and a partial one read differently. The type is declared in `models/analytics/table.ts` beside the other table models rather than inline in the action, per the project's type-placement rule.
+
+A partial read therefore also notifies. That is deliberate: an incomplete option list and an absent one have the same consequence for the user (a role they expect may not be offered) and the same remedy.
+
+### D3 — Keep the closed select; do not adopt the grid-plus-modal role shape
+
+The other role surfaces (`RouteRoles`, `KeyRoles`, `AssetRoles`) render grants in a `GridView` and add through the `AddEntitiesGrid` modal. That shape was considered and rejected here for one concrete reason: this panel *is* a `DialFormPopup`, and `AddEntitiesGrid` opens its own — a modal inside a modal, with two focus traps competing, on a surface whose entire content is two role lists. The grid shape earns its weight on a full tab with descriptions, a Source column and per-row navigation; here it would cost more than the select it replaces and read as a heavier answer to a smaller question.
+
+What that shape gets right is not the grid — it is that what the user sees is derived from the grants, not from the catalog (both files carry a comment saying so). D4 takes that property into the select.
+
+Typed entry was also considered, since the analytics service matches provider role names the identity provider issues and this application cannot enumerate them. Rejected: on a permissions surface a free-text field turns a typo into a grant that looks made and does nothing, and the roles in use are expected to exist in Core. Selection stays closed.
+
+### D4 — Options are the catalog unioned with the grants loaded at open
+
+The preservation requirement is met by what the options are, not by a guard: the option list is `catalog ∪ grantedOnLoad`, so a role the catalog does not offer still has an option, renders as selected, and round-trips. `grantedOnLoad` is captured once from the access response rather than derived from the live `write`/`modify` state, so unchecking such a role leaves its option in place and it can be re-checked within the session — deriving from live state would make an accidental uncheck unrecoverable without reopening the panel.
+
+### D5 — Alphabetical ordering lives in the panel, not in the reader
+
+`unionConfigEntityOptions` orders API-written options first, and its de-duplication depends on that order. Sorting there would touch five other pickers and entangle a presentational concern with the merge semantics. The panel sorts its own options, case-insensitively via `localeCompare`, after the union — the only place where ordering is a presentation decision.
+
+### D6 — Keep the existing `DialSelectField` test double
+
+The spec already mocks `DialSelectField` as a checkbox list, because the real control is a heavy floating dropdown. The rendered control does not change in this update, so the mock still describes it and is kept; the new cases (ordering, out-of-catalog grant) are expressed through it. The union and de-duplication of Core's two populations are **not** re-asserted here — they belong to `utils/config-entities/tests/options.spec.ts`, which already covers them at the reader level, and asserting them through a mocked action would only test the mock.
+
+## Risks / Trade-offs
+
+- **A provider role that exists only in the identity provider cannot be granted from this panel.** → Accepted per D3; the roles in use are expected to be configured in Core, and a free-text field would trade this for silently ineffective grants. If it turns out to be needed, it is an additive change to the same panel.
+- **Two Core requests per panel open, where there was one admin-backend request.** → Both are small listings issued concurrently, and the panel is a rarely-opened admin surface. The metadata half paginates, but role populations are small.
+- **`grantedOnLoad` keeps an option alive for the session after it is unchecked.** → Intentional (D4); the alternative loses it on a misclick. It disappears on the next open, once it is no longer granted.
+- **`AnalyticsTablesI18nKey.RolesLoadFailed` keeps its wording while its meaning narrows** (title, not whole message). → No other caller uses it; the message body now carries the detail.
+
+## Migration Plan
+
+None. No stored data, wire contract, or backend endpoint changes: the access lists hold the same bare role names before and after, so a table's existing grants are unaffected and the change is reversible by reverting the two files.

--- a/openspec/changes/archive/2026-09-04-analytics-table-access-core-roles/proposal.md
+++ b/openspec/changes/archive/2026-09-04-analytics-table-access-core-roles/proposal.md
@@ -1,0 +1,68 @@
+## Why
+
+The analytics table access panel picks its role names from the admin backend's `/roles` list — a
+source that is both wrong and closing. It is wrong because DIAL Core keeps roles in **two**
+populations (API-written resources under `roles/platform/`, and roles declared in Core's
+configuration file) and the admin backend serves neither directly; a role that exists only as an
+`Assets > Roles` resource, or only in Core's config file, cannot be granted on a table at all today.
+It is closing because that backend is being retired, and this is the last role picker in the app
+still sitting on it — every Platform/Assets picker already reads Core.
+
+The picker also drops what it cannot match. Its options come from one catalog, and a closed select
+renders only the values that match an option — so a grant naming a role outside that catalog is
+invisible in the panel and is dropped by the next unrelated edit, silently revoking access that is
+still in effect. Every other role surface in this application guards against exactly that by deriving
+what it shows from the grants themselves.
+
+## What Changes
+
+- `getRoles()` in `app/[lang]/tables/actions.ts` stops calling `rolesApi.getRolesList` and reads
+  Core's two role populations through the existing `readConfigEntities` reader, which issues both
+  requests concurrently, merges them by bare name with an API-written role superseding a
+  config-file role of the same name, and degrades to whichever population it could read.
+- `TableAccessPanel` keeps its two `DialSelectField multiple` controls — selection stays closed, with
+  no typed entry — but builds their options as the union of the Core catalog and the names the table
+  already grants, so a grant outside the catalog is shown as selected and survives a save.
+- Options are sorted alphabetically, independently of the order Core's two populations were read in.
+- **BREAKING**: none. The wire contract (`TableAccess { write: string[]; modify: string[] }`) and the
+  stored values (bare role names) are unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `analytics`: the "Full-admin per-table role management panel" requirement currently names
+  `RolesApi.getRolesList` as the option source and says nothing about ordering or about a grant the
+  catalog does not contain. It changes to Core's merged role catalog as the source, alphabetical
+  option order, and options that always include the roles the table already grants.
+
+## Impact
+
+- `apps/ai-dial-admin/src/app/[lang]/tables/actions.ts` — `getRoles()` re-pointed at
+  `readConfigEntities`; its return type becomes the `ConfigEntityRow` shape the reader produces.
+- `apps/ai-dial-admin/src/components/Analytics/Tables/TableAccessPanel.tsx` — option source, the
+  union with the loaded grants, and sorting.
+- `apps/ai-dial-admin/src/components/Analytics/Tables/tests/TableAccessPanel.spec.tsx` — new cases for
+  ordering and for the out-of-catalog grant; the existing `DialSelectField` checkbox mock still
+  describes the rendered control and is kept.
+- `openspec/specs/analytics/spec.md` — one modified requirement.
+- No change to `RolesApi`, to `readConfigEntities`, to any shared control, or to any other surface
+  that reads roles.
+
+## Non-goals
+
+- Migrating the remaining `rolesApi.getRolesList` callers (Entities pages: models, applications,
+  routes, toolsets, keys, app runners, roles, export-config). Those move with the admin backend's own
+  retirement; bundling them here would spread one change across eight unrelated surfaces.
+- Hand-typed role entry. The analytics service matches provider role names as the identity provider
+  issues them, so a role with no DIAL role resource behind it would in principle be a valid grant —
+  but offering free text on a permissions surface trades a typo for a silently ineffective grant, and
+  the roles in use are expected to be configured in Core. Selection stays closed.
+- Showing which population a suggested role came from. The reader carries `origin`, but the panel
+  writes a bare name either way, so the distinction has no consequence a user could act on here.
+- Any change to how the analytics service evaluates access, or to the Connect panel's rendering of
+  the `write` list.

--- a/openspec/changes/archive/2026-09-04-analytics-table-access-core-roles/specs/analytics/spec.md
+++ b/openspec/changes/archive/2026-09-04-analytics-table-access-core-roles/specs/analytics/spec.md
@@ -1,0 +1,60 @@
+## MODIFIED Requirements
+
+### Requirement: Full-admin per-table role management panel
+
+The table detail view SHALL provide a panel to view and manage the table's `write` / `modify` provider-role lists, backed by `AnalyticsDataApi.getTableAccess` / `replaceTableAccess` (`GET` / `PUT /v1/tables/{name}/access`) and a `TableAccess { write: string[]; modify: string[] }` model. Because the backend restricts `GET /access` to `FULL_ADMIN` and system tables carry no per-table roles to manage, the panel SHALL be shown only when `canManageRoles` (`FULL_ADMIN` and non-system); a save SHALL full-replace the lists via `replaceTableAccess`.
+
+Role names SHALL be picked from a closed option list rather than typed. The catalog behind that list SHALL be DIAL Core's own merged role population — the union of the roles written through Core's API and the roles declared in Core's configuration file, merged by bare name with an API-written entry superseding a configuration-file entry of the same name, and degrading to whichever population could be read rather than to an empty catalog. The admin backend's roles list SHALL NOT be requested: it is a third copy that is neither population, it can hold a role Core does not, and it is being retired — every other role picker in the application already reads Core. Each option's value SHALL be the role's bare name, which is the raw provider-role string the backend matches against; there is no separate role id, and no resource reference is ever stored.
+
+The options SHALL be presented in alphabetical order, independently of the order the two populations were read in, so a role can be found by name.
+
+The options SHALL additionally include every role name the table already grants, even when the catalog does not offer it. A closed select renders only the values that match an option, so without this a grant naming a role outside the catalog — one declared only in Core's configuration file, or any of them when the catalog read failed — would be invisible and would be dropped by the next unrelated edit, silently revoking access that is still in effect.
+
+While the initial fetch (the table's current access and the role catalog, requested together) is in flight the panel SHALL show a loading spinner in place of the role pickers. A failed access fetch and a failed role-catalog fetch SHALL each surface their own error notification (the two requests can fail independently); Save SHALL stay disabled until the access fetch succeeds. A failed role-catalog fetch SHALL still leave the table's existing grants selected and selectable rather than emptying the lists.
+
+#### Scenario: Full admin edits the role lists
+
+- **WHEN** a `FULL_ADMIN` opens the role panel, checks a role in the `write` list, and saves
+- **THEN** `replaceTableAccess` is called with the full updated `{write, modify}` lists
+
+#### Scenario: Panel hidden for non-admins
+
+- **WHEN** the detail view renders for a user who is not `FULL_ADMIN`
+- **THEN** the role-management panel is not shown
+
+#### Scenario: Panel hidden for system tables even for a full admin
+
+- **WHEN** a `FULL_ADMIN` opens a system table's detail view
+- **THEN** the role-management panel is not shown
+
+#### Scenario: Loading spinner while fetching
+
+- **WHEN** the panel opens
+- **THEN** a loading spinner is shown until both the table's current access and the role catalog have been fetched
+
+#### Scenario: Every catalog role is offered, not just the granted ones
+
+- **WHEN** the role catalog loads
+- **THEN** each write/modify picker offers every catalog role as an option, with already-granted roles selected
+
+#### Scenario: Options are ordered alphabetically
+
+- **WHEN** the catalog resolves in an order other than alphabetical
+- **THEN** each picker presents its options sorted by name
+
+#### Scenario: The admin backend's roles list is not requested
+
+- **WHEN** the panel opens
+- **THEN** no request is made to the admin backend's roles endpoint
+
+#### Scenario: A granted role outside the catalog stays offered and survives a save
+
+- **WHEN** the panel opens for a table whose stored `write` list contains a role the catalog does not offer
+- **THEN** that role is offered as a selected option in the `write` picker
+- **AND** a save made after editing only the `modify` list sends the `write` list back unchanged
+
+#### Scenario: Roles-catalog fetch failure is surfaced independently
+
+- **WHEN** the role catalog fails to load even though the table's current access loads successfully
+- **THEN** an error notification distinct from the access-load-failure notification is shown
+- **AND** the roles the table already grants remain offered and selected

--- a/openspec/changes/archive/2026-09-04-analytics-table-access-core-roles/tasks.md
+++ b/openspec/changes/archive/2026-09-04-analytics-table-access-core-roles/tasks.md
@@ -1,0 +1,22 @@
+## 1. Role options come from DIAL Core
+
+- [x] 1.1 Add the action's return shape to `apps/ai-dial-admin/src/models/analytics/table.ts`: an interface carrying the `ConfigEntityRow[]` the reader produced and the `EntitiesI18nKey[]` warnings it reported (per design D2 — types live in a model file, not inline in the action).
+- [x] 1.2 Re-point `getRoles()` in `apps/ai-dial-admin/src/app/[lang]/tables/actions.ts` at `readConfigEntities(await token(), ConfigFileEntityType.Roles, warnings)` with a locally-declared warnings array, returning that shape. Drop the now-unused `rolesApi` and `DialRole` imports.
+
+## 2. Panel options: the catalog unioned with the grants, sorted
+
+- [x] 2.1 In `apps/ai-dial-admin/src/components/Analytics/Tables/TableAccessPanel.tsx`, build the `DialSelectField` options from the fetched rows' bare names. The two controls themselves are unchanged — selection stays closed, with no typed entry (design D3).
+- [x] 2.2 Capture the names granted when the panel opened and union them into the option list, so a grant the catalog does not offer renders as selected and survives a save (design D4).
+- [x] 2.3 Sort the options case-insensitively by name in the panel, after the union — not in the shared reader, whose de-duplication depends on its own ordering (design D5).
+- [x] 2.4 Report a catalog failure from the returned warnings instead of a null check: keep `AnalyticsTablesI18nKey.RolesLoadFailed` as the notification title and pass the reported warning key as its message, so an unreadable catalog and a partial one read differently. Leave the granted roles selected either way.
+
+## 3. Tests
+
+- [x] 3.1 Extend `apps/ai-dial-admin/src/components/Analytics/Tables/tests/TableAccessPanel.spec.tsx` for the new behaviour, keeping the existing `DialSelectField` checkbox double (design D6): alphabetical option order from an unsorted catalog, a stored out-of-catalog grant shown as selected and round-tripped unchanged, and the catalog-failure notification leaving the granted roles offered. The union and de-duplication of Core's two populations stay covered by `apps/ai-dial-admin/src/utils/config-entities/tests/options.spec.ts`, which asserts them at the reader level.
+- [x] 3.2 Update the `getRoles` test in `apps/ai-dial-admin/src/app/[lang]/tables/tests/actions.spec.ts` to assert the token and `ConfigFileEntityType.Roles` reach the config-entities reader, that the admin-backend roles client is not called, and that reported warnings are returned alongside the rows.
+
+## 4. Quality checks
+
+- [x] 4.1 Run lint, format check, and the full test suite; fix anything they report.
+
+No browser-verification task: the user was asked and chose to rely on the component and action tests above.

--- a/openspec/specs/analytics/spec.md
+++ b/openspec/specs/analytics/spec.md
@@ -1897,7 +1897,15 @@ Every delete-table confirmation dialog — the catalog list's row delete action 
 
 ### Requirement: Full-admin per-table role management panel
 
-The table detail view SHALL provide a panel to view and manage the table's `write` / `modify` provider-role lists, backed by `AnalyticsDataApi.getTableAccess` / `replaceTableAccess` (`GET` / `PUT /v1/tables/{name}/access`) and a `TableAccess { write: string[]; modify: string[] }` model. Because the backend restricts `GET /access` to `FULL_ADMIN` and system tables carry no per-table roles to manage, the panel SHALL be shown only when `canManageRoles` (`FULL_ADMIN` and non-system); a save SHALL full-replace the lists via `replaceTableAccess`. Role names SHALL be picked as checkboxes from the DIAL Roles catalog (fetched via `RolesApi.getRolesList`, the same source other admin surfaces such as App Routes already use for role selection) rather than typed free text — each option's value is the `DialRole.name`, which is also the raw provider-role string the backend matches against; there is no separate role id. While the initial fetch (the table's current access and the roles catalog, requested together) is in flight the panel SHALL show a loading spinner in place of the role pickers. A failed access fetch and a failed roles-catalog fetch SHALL each surface their own error notification (the two requests can fail independently); Save SHALL stay disabled until the access fetch succeeds.
+The table detail view SHALL provide a panel to view and manage the table's `write` / `modify` provider-role lists, backed by `AnalyticsDataApi.getTableAccess` / `replaceTableAccess` (`GET` / `PUT /v1/tables/{name}/access`) and a `TableAccess { write: string[]; modify: string[] }` model. Because the backend restricts `GET /access` to `FULL_ADMIN` and system tables carry no per-table roles to manage, the panel SHALL be shown only when `canManageRoles` (`FULL_ADMIN` and non-system); a save SHALL full-replace the lists via `replaceTableAccess`.
+
+Role names SHALL be picked from a closed option list rather than typed. The catalog behind that list SHALL be DIAL Core's own merged role population — the union of the roles written through Core's API and the roles declared in Core's configuration file, merged by bare name with an API-written entry superseding a configuration-file entry of the same name, and degrading to whichever population could be read rather than to an empty catalog. The admin backend's roles list SHALL NOT be requested: it is a third copy that is neither population, it can hold a role Core does not, and it is being retired — every other role picker in the application already reads Core. Each option's value SHALL be the role's bare name, which is the raw provider-role string the backend matches against; there is no separate role id, and no resource reference is ever stored.
+
+The options SHALL be presented in alphabetical order, independently of the order the two populations were read in, so a role can be found by name.
+
+The options SHALL additionally include every role name the table already grants, even when the catalog does not offer it. A closed select renders only the values that match an option, so without this a grant naming a role outside the catalog — one declared only in Core's configuration file, or any of them when the catalog read failed — would be invisible and would be dropped by the next unrelated edit, silently revoking access that is still in effect.
+
+While the initial fetch (the table's current access and the role catalog, requested together) is in flight the panel SHALL show a loading spinner in place of the role pickers. A failed access fetch and a failed role-catalog fetch SHALL each surface their own error notification (the two requests can fail independently); Save SHALL stay disabled until the access fetch succeeds. A failed role-catalog fetch SHALL still leave the table's existing grants selected and selectable rather than emptying the lists.
 
 #### Scenario: Full admin edits the role lists
 
@@ -1917,17 +1925,34 @@ The table detail view SHALL provide a panel to view and manage the table's `writ
 #### Scenario: Loading spinner while fetching
 
 - **WHEN** the panel opens
-- **THEN** a loading spinner is shown until both the table's current access and the roles catalog have been fetched
+- **THEN** a loading spinner is shown until both the table's current access and the role catalog have been fetched
 
 #### Scenario: Every catalog role is offered, not just the granted ones
 
-- **WHEN** the roles catalog loads
-- **THEN** each write/modify picker offers every catalog role as a checkbox, with already-granted roles checked
+- **WHEN** the role catalog loads
+- **THEN** each write/modify picker offers every catalog role as an option, with already-granted roles selected
+
+#### Scenario: Options are ordered alphabetically
+
+- **WHEN** the catalog resolves in an order other than alphabetical
+- **THEN** each picker presents its options sorted by name
+
+#### Scenario: The admin backend's roles list is not requested
+
+- **WHEN** the panel opens
+- **THEN** no request is made to the admin backend's roles endpoint
+
+#### Scenario: A granted role outside the catalog stays offered and survives a save
+
+- **WHEN** the panel opens for a table whose stored `write` list contains a role the catalog does not offer
+- **THEN** that role is offered as a selected option in the `write` picker
+- **AND** a save made after editing only the `modify` list sends the `write` list back unchanged
 
 #### Scenario: Roles-catalog fetch failure is surfaced independently
 
-- **WHEN** the roles catalog fails to load even though the table's current access loads successfully
+- **WHEN** the role catalog fails to load even though the table's current access loads successfully
 - **THEN** an error notification distinct from the access-load-failure notification is shown
+- **AND** the roles the table already grants remain offered and selected
 
 ### Requirement: System-owned tables are read-only
 


### PR DESCRIPTION
**Description:**

The Manage-table-access role picker now reads DIAL Core's merged role population (API-written and configuration-file roles) instead of the admin backend's roles list. This aligns with other role pickers in the console and enables retiring the admin backend's `/roles` endpoint. Options are presented alphabetically, and role grants outside the catalog are preserved across saves.

**Issues:**

- Issue #3847

**Key Changes:**

- [apps/ai-dial-admin/src/app/\[lang\]/tables/actions.ts](https://github.com/epam/ai-dial-admin-frontend/blob/feat/read-table-roles-from-core/apps/ai-dial-admin/src/app/%5Blang%5D/tables/actions.ts) — `getTableAccessOptions` now calls `readConfigEntities` to merge Core's role populations
- [apps/ai-dial-admin/src/components/Analytics/Tables/TableAccessPanel.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/feat/read-table-roles-from-core/apps/ai-dial-admin/src/components/Analytics/Tables/TableAccessPanel.tsx) — refactored to use `readConfigEntities` and sort options alphabetically
- [apps/ai-dial-admin/src/models/analytics/table.ts](https://github.com/epam/ai-dial-admin-frontend/blob/feat/read-table-roles-from-core/apps/ai-dial-admin/src/models/analytics/table.ts) — added role option model
- [openspec/specs/analytics/spec.md](https://github.com/epam/ai-dial-admin-frontend/blob/feat/read-table-roles-from-core/openspec/specs/analytics/spec.md) — updated requirement and scenarios

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with \`(Issue #3847)\`