### PR TITLE
fix(Assets): reset OAuth on duplicate and fix app-runner params (Issue #4390, #4407, #4225, #4394, #4413)

### DIFF
--- a/.cursor/skills/git-commit/SKILL.md
+++ b/.cursor/skills/git-commit/SKILL.md
@@ -1,0 +1,248 @@
+---
+name: git-commit
+model: claude-haiku-4-5-20251001
+context: fork
+effort: low
+allowed-tools: Bash(git:*), Bash(gh:*), Bash(grep:*), Edit(.claude/reference/areas.md)
+arguments: ticket area
+argument-hint: "[ticket] [area]"
+description: >
+  Use this skill whenever the user wants to commit, push, or ship changes in a git repository.
+  Triggers include: "commit changes", "push my changes", "ship it", "commit and push", "create a branch and commit",
+  "make a PR", "open a pull request", "create draft PR", or any variation of committing/pushing work.
+  Always use this skill when the user mentions committing — even casually — as it handles the full cycle:
+  branch → add → commit → push → (optionally) PR, with Conventional Commits format and automatic area detection.
+---
+
+# Git Commit Skill
+
+Full cycle: checkout new branch from `development` → stage → commit (Conventional Commits) → push → optional PR.
+
+---
+
+## Step 0 — Detect mode (new branch vs. update existing)
+
+First figure out which mode you're in. This decides whether you create a branch/PR or just push to what already exists.
+
+```bash
+git rev-parse --abbrev-ref HEAD          # current branch
+gh pr view --json number,url,state 2>/dev/null   # open PR for current branch (if any)
+```
+
+- **New-branch mode** — current branch is `development` (or another base branch), or there's no PR for it.
+  Run the full cycle: Steps 1–6 as written (create branch → commit → push → optional PR).
+- **Update-existing mode** — you're already on a feature branch **and** it has an open PR (or the user
+  says "push to the existing PR" / "update my PR"). **Do not** create a new branch and **do not** run
+  `gh pr create`. Stay on the current branch, then:
+  1. Step 2 — review the changes.
+  2. Step 4 — generate the commit message (reuse the existing PR's ticket; keep the same `area`/type style).
+  3. Step 5 — **skip the `git checkout` lines**; just `git add` → `git commit` → `git push` to the current branch.
+  4. Skip Step 6's `gh pr create`. Pushing updates the open PR automatically. Only refresh the PR body
+     (`gh pr edit --body`) if the user asks or the description is now stale/missing.
+  5. Step 7 — report the existing PR link, not a new one.
+
+---
+
+## Step 1 — Gather required context
+
+Before doing anything, ensure you have:
+
+- **Ticket number** — use the `ticket` argument if passed. Else look in conversation context (e.g. from
+  OpenSpec explore, recent messages). If still not found, ask: _"What is the ticket number?"_
+- **Area** — if the `area` argument is passed, use it directly in Step 3 (skip detection).
+- **Draft PR?** — if the user said "draft" or "draft PR", note it for Step 5.
+
+> This skill runs in a forked context (`context: fork`), so it does **not** see the main conversation.
+> Prefer passing `ticket` (and optionally `area`) as arguments: `/git-commit 3642 Deployments/Images`.
+
+---
+
+## Step 2 — Understand the changes
+
+```bash
+git status
+git diff HEAD
+```
+
+If there are no changes at all — report and stop.
+
+---
+
+## Step 3 — Determine `area`
+
+Resolve the `area` with this 3-tier fallback (project-agnostic — works in any repo):
+
+1. **`area` argument given** → use it verbatim. Done.
+2. **Project defines an area taxonomy** → if `.claude/reference/areas.md` exists, read it and map the changed
+   files to an area using the rules in that file (`Parent/Child` for one leaf, `Parent` for several
+   under one parent, most-changed parent across many, technical area for infra/config).
+3. **Neither** → infer a sensible area from the **top-level directory** of the changed files
+   (e.g. most changes under `src/auth/**` → `auth`). For pure tooling/config with no feature home, use a
+   technical area: `infra`, `config`, `api`.
+
+### Step 3a — Self-extend `.claude/reference/areas.md` (only if the file exists)
+
+If the resolved area is **not already listed** in `.claude/reference/areas.md`, append it so the taxonomy grows
+over time. Do this for both a new arg-supplied area and a tier-3 inferred area.
+
+Rules — be conservative, append-only, never rewrite or reorder existing rows:
+
+1. **Confirm it's new** — `grep -F "<area>" .claude/reference/areas.md`. If the exact area string is already
+   present, skip; do nothing.
+2. **Pick the right section:**
+   - New leaf under an existing parent (e.g. `Deployments/Foo`) → add a row to that parent's table.
+   - New top-level feature with a route/component but no parent → add a row under
+     **Cross-cutting feature areas**.
+   - New non-UI concern → add a row under **Technical areas** with a short "Covers" note.
+3. **Fill the evidence columns** from the actual change — the route slug (`app/[lang]/<slug>`) and/or
+   the component folder (`src/components/<Folder>`) the change touched. Leave a cell as `—` only if it
+   genuinely has none.
+4. **Only one new row per run**, matching the single resolved area. Don't bulk-invent areas.
+5. The edit is staged by `git add` in Step 5, so the taxonomy update ships **in the same commit** as the
+   change that introduced it. Mention the added area in the Step 7 summary.
+
+If `.claude/reference/areas.md` does **not** exist, skip 3a entirely (don't create it — that's a deliberate
+project-setup choice, not something this skill bootstraps).
+
+---
+
+## Step 4 — Generate commit message
+
+Format:
+```
+<type>(<area>): <short description> (Issue #<ticket>)
+```
+
+**Type selection** — pick the most accurate:
+
+| Type | When to use |
+|------|-------------|
+| `feat` | New feature or capability |
+| `fix` | Bug fix |
+| `chore` | Maintenance, deps, config, tooling |
+| `refactor` | Restructuring without behavior change |
+| `docs` | Documentation only |
+| `test` | Tests only |
+| `style` | Formatting, no logic change |
+
+**Message rules:**
+- Analyze the diff to understand *what* changed and *why*
+- Keep the description concise and imperative (add, fix, update, remove, extract...)
+- If ticket context is available (e.g. from OpenSpec), use it to improve accuracy
+
+**Branch name** is derived from the commit message slug:
+`feat/<short-slug>` — lowercase, hyphens only, no ticket number.
+
+Example:
+- Commit: `feat(Deployments/Images): add image version selector (Issue #42)`
+- Branch: `feat/add-image-version-selector`
+
+---
+
+## Step 5 — Execute
+
+```bash
+# 1. Create branch from development
+git checkout development
+git checkout -b feat/<short-slug>
+
+# 2. Stage all changes
+git add .
+
+# 3. Commit
+git commit -m "<type>(<area>): <description> (Issue #<ticket>)"
+
+# 4. Push
+git push origin feat/<short-slug>
+```
+
+If push fails for any reason (no permissions, rejected, conflict) — **report the error with the full output and stop**. Do not attempt force push or rebase automatically.
+
+---
+
+## Step 6 — Pull Request (if requested)
+
+If the user requested a PR or draft PR **Always follow that template** — fill every placeholder,
+never leave `<SHORT_DESCRIPTION>` or `<TICKET_ID>` unreplaced.
+
+```markdown
+**Description:**
+
+<2-4 sentences: what changed and why. Use the diff + ticket context. Explain the *why*, not just the *what*.>
+
+Issues:
+
+- Issue #<ticket>
+
+**Key Changes:**
+
+- [path/to/file.tsx](<github-file-link>) — short description
+- [path/to/file.tsx](<github-file-link>) — short description
+
+**New Components:**
+
+<List of newly created React components or reusable modules with a one-line description each.>
+<Omit this section entirely if no new components were added.>
+
+**Breaking Changes:**
+
+<Describe any breaking changes to APIs, props, or component interfaces.>
+<Omit this section entirely if there are no breaking changes.>
+
+
+**Checklist:**
+
+- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+- [x] the pull request name ends with `(Issue #<ticket>)` (comma-separated list of issues)
+```
+
+Rules for filling the template:
+- **Description**: required — always write a real summary, even for small chores. Explain the *why*,
+  not just the *what*; use ticket title/description for context.
+- **Issues**: one `- Issue #<ticket>` line per ticket. If there is genuinely no ticket, **remove the
+  whole `Issues:` block** and leave the second checklist item **unchecked** (`[ ]`), since the title
+  can't end with `(Issue #…)`.
+- **Summary**: explain the *why*, not just the *what*; use ticket description for context.
+- **Key Changes**: most impactful files only (max ~10); skip trivial files like formatting-only changes.
+- **New Components**: newly created React components or shared modules only. Omit the section if none.
+- **Breaking Changes**: only if interfaces, props, or contracts changed non-backward-compatibly;
+  otherwise omit the section.
+- **Checklist**: tick `[x]` the boxes this skill actually satisfies — the title is Conventional Commits
+  (always checked) and ends with `(Issue #<ticket>)` (checked only when a ticket exists).
+
+Then create the PR:
+
+```bash
+# Regular PR
+gh pr create \
+  --base development \
+  --head feat/<short-slug> \
+  --title "<type>(<area>): <description> (Issue #<ticket>)" \
+  --body "<generated body>"
+
+# Draft PR (if user said "draft")
+gh pr create \
+  --base development \
+  --head feat/<short-slug> \
+  --title "<type>(<area>): <description> (Issue #<ticket>)" \
+  --body "<generated body>" \
+  --draft
+```
+
+If `gh` CLI is not available — provide the GitHub compare URL for manual PR creation:
+```
+https://github.com/<org>/<repo>/compare/development...feat/<short-slug>
+```
+
+---
+
+## Step 7 — Summary
+
+Finish with a concise confirmation:
+
+```
+Branch:  feat/<short-slug>
+Commit:  <type>(<area>): <description> (Issue #<ticket>)
+Push:    ✅ succeeded  /  ❌ failed — <reason>
+PR:      <link> (created)  /  <link> (updated existing)  /  skipped
+```

--- a/apps/ai-dial-admin/src/components/Applications/ParametersTab/ParametersTab.tsx
+++ b/apps/ai-dial-admin/src/components/Applications/ParametersTab/ParametersTab.tsx
@@ -5,6 +5,11 @@ import { Dispatch, FC, SetStateAction, useCallback, useEffect, useMemo, useState
 
 import { DialLoader, DialNoDataContent, DialPrimaryButton, JsonSchema, SelectOption } from '@epam/ai-dial-ui-kit';
 import { IconPlus } from '@tabler/icons-react';
+
+import { getResolvedApplicationScheme } from '@/src/app/[lang]/application-runners/actions';
+import { getResolvedRunnerSchema } from '@/src/app/[lang]/platform-app-runners/actions';
+import { AppRunnerOrigin } from '@/src/components//SourceField/Application/models';
+import { getRunnerOrigin } from '@/src/components//SourceField/Application/utils';
 import {
   convertJsonSchema,
   generateViewItems,
@@ -13,7 +18,6 @@ import {
   getInitialParamsView,
   getTargetUrl,
 } from '@/src/components/Applications/ParametersTab/utils';
-import { getResolvedApplicationScheme } from '@/src/app/[lang]/application-runners/actions';
 import SchemaUiRenderer from '@/src/components/Common/SchemaUIRenderer/SchemaUIRenderer';
 import EntityJsonEditor from '@/src/components/EntityTabs/JsonEditor/JsonEditor';
 import FrameRenderer from '@/src/components/FrameRenderer/FrameRenderer';
@@ -25,13 +29,13 @@ import { useIsReadOnlyAdmin } from '@/src/hooks/use-is-read-only-admin';
 import { useI18n } from '@/src/locales/client';
 import { UserSession } from '@/src/models/auth';
 import { DialApplication, DialApplicationScheme } from '@/src/models/dial/application';
-import { DialApplicationResource } from '@/src/models/dial/resource';
 import { BaseEntity } from '@/src/models/dial/base-entity';
+import { AssetApp } from '@/src/models/dial/deployment-asset';
+import { DialApplicationResource } from '@/src/models/dial/resource';
 import { ParamsView } from '@/src/types/parameters';
 import { ApplicationRoute } from '@/src/types/routes';
 import TableView from './TableView';
 import ViewControl from './ViewControl';
-import { AssetApp } from '@/src/models/dial/deployment-asset';
 
 interface Props {
   application?: DialApplication | DialApplicationResource;
@@ -73,10 +77,17 @@ const ParametersTab: FC<Props> = ({
   useEffect(() => {
     let scheme = undefined;
     const foundRunner = getAppRunner(application as DialApplication, applicationSchemes, view);
+    const isAsset = !!foundRunner && getRunnerOrigin(foundRunner) === AppRunnerOrigin.Asset;
+    const resolve = isAsset
+      ? getResolvedRunnerSchema(foundRunner.$id ?? '')
+      : getResolvedApplicationScheme(foundRunner?.$id ?? '');
     setIsSchemeLoading(true);
-    getResolvedApplicationScheme(foundRunner?.$id ?? '').then((res) => {
-      if (res.success && (res.response as { schema?: DialApplicationScheme })?.schema) {
-        scheme = (res.response as { schema: DialApplicationScheme }).schema;
+    resolve.then((res) => {
+      const resolved = isAsset
+        ? (res.response as DialApplicationScheme | undefined)
+        : (res.response as { schema?: DialApplicationScheme })?.schema;
+      if (res.success) {
+        scheme = resolved;
       } else {
         scheme = foundRunner ?? undefined;
       }

--- a/apps/ai-dial-admin/src/components/Assets/Deployments/DuplicateAsset.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Deployments/DuplicateAsset.tsx
@@ -32,7 +32,7 @@ import { duplicateEntityMap, getClonedEntityName, getCloneTitle } from '@/src/ut
 import { checkNameVersionCombination, getInitialVersion } from '@/src/utils/entities/versions';
 import { isDeploymentAsset } from '@/src/utils/is-view';
 import { addTrailingSlash } from '@/src/utils/url';
-import { DialToolsetResource, ToolsetAuthType } from '@/src/models/dial/resource';
+import { DialApplicationResource, DialToolsetResource, ToolsetAuthType } from '@/src/models/dial/resource';
 
 interface Props {
   view: ApplicationRoute;
@@ -109,6 +109,20 @@ const DuplicateAsset: FC<Props> = ({
         field: 'authSettings.apiKeyHeader',
         isValid: !!toolset.auth_settings?.api_key_header,
       });
+    }
+
+    // Core never returns a real client_secret on read, so an OAuth external service copied
+    // verbatim fails Core's write-time validation with a missing-CLIENT_SECRET error.
+    const externalServices = (entity as DialApplicationResource).external_services;
+    if (externalServices) {
+      (clonedAsset as DialApplicationResource).external_services = Object.fromEntries(
+        Object.entries(externalServices).map(([key, service]) => [
+          key,
+          service.auth_settings?.authentication_type === ToolsetAuthType.OAUTH
+            ? { ...service, auth_settings: { authentication_type: ToolsetAuthType.NONE } }
+            : service,
+        ]),
+      );
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/apps/ai-dial-admin/src/components/Assets/Deployments/tests/DuplicateAsset.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Deployments/tests/DuplicateAsset.spec.tsx
@@ -1,0 +1,128 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test, vi } from 'vitest';
+
+import { ButtonsI18nKey } from '@/src/constants/i18n';
+import { AssetWithVersion } from '@/src/models/dial/deployment-asset';
+import { ToolsetAuthType } from '@/src/models/dial/resource';
+import { ApplicationRoute } from '@/src/types/routes';
+import DuplicateAsset from '../DuplicateAsset';
+
+// A non-numeric last version segment makes `getInitialVersion` fall back to `DEFAULT_NEW_ENTITY_VERSION`
+// ('1.0.0'), so the clone's derived version is deterministic without affecting the external-services walk.
+const versionsMapFor = (name: string) => ({ [name]: ['1.0.x'] });
+
+const renderModal = (entity: AssetWithVersion, onDuplicate = vi.fn()) => {
+  render(
+    <DuplicateAsset
+      view={ApplicationRoute.AssetsApplications}
+      isModalOpen
+      entity={entity}
+      versionsMap={versionsMapFor(entity.name)}
+      onDuplicate={onDuplicate}
+      onClose={vi.fn()}
+    />,
+  );
+
+  return { onDuplicate };
+};
+
+describe('DuplicateAsset', () => {
+  test('resets an OAuth external service to NONE on duplicate', async () => {
+    const user = userEvent.setup();
+    const entity = {
+      name: 'app',
+      folderId: 'public/',
+      external_services: {
+        svc: {
+          display_name: 'Service',
+          description: 'A service',
+          auth_settings: { authentication_type: ToolsetAuthType.OAUTH, client_id: 'id' },
+        },
+      },
+    } as unknown as AssetWithVersion;
+    const { onDuplicate } = renderModal(entity);
+
+    await user.click(screen.getByRole('button', { name: ButtonsI18nKey.Duplicate }));
+
+    expect(onDuplicate).toHaveBeenCalledWith({
+      ...entity,
+      version: '1.0.0',
+      external_services: {
+        svc: {
+          display_name: 'Service',
+          description: 'A service',
+          auth_settings: { authentication_type: ToolsetAuthType.NONE },
+        },
+      },
+    });
+  });
+
+  test('leaves a non-OAuth external service unchanged on duplicate', async () => {
+    const user = userEvent.setup();
+    const entity = {
+      name: 'app',
+      folderId: 'public/',
+      external_services: {
+        svc: { auth_settings: { authentication_type: ToolsetAuthType.API_KEY } },
+      },
+    } as unknown as AssetWithVersion;
+    const { onDuplicate } = renderModal(entity);
+
+    await user.click(screen.getByRole('button', { name: ButtonsI18nKey.Duplicate }));
+
+    expect(onDuplicate).toHaveBeenCalledWith({ ...entity, version: '1.0.0' });
+  });
+
+  test('resets only the OAuth entry in a mix of OAuth and non-OAuth external services', async () => {
+    const user = userEvent.setup();
+    const entity = {
+      name: 'app',
+      folderId: 'public/',
+      external_services: {
+        oauthSvc: { auth_settings: { authentication_type: ToolsetAuthType.OAUTH } },
+        apiKeySvc: { auth_settings: { authentication_type: ToolsetAuthType.API_KEY } },
+      },
+    } as unknown as AssetWithVersion;
+    const { onDuplicate } = renderModal(entity);
+
+    await user.click(screen.getByRole('button', { name: ButtonsI18nKey.Duplicate }));
+
+    expect(onDuplicate).toHaveBeenCalledWith({
+      ...entity,
+      version: '1.0.0',
+      external_services: {
+        oauthSvc: { auth_settings: { authentication_type: ToolsetAuthType.NONE } },
+        apiKeySvc: { auth_settings: { authentication_type: ToolsetAuthType.API_KEY } },
+      },
+    });
+  });
+
+  test('is unaffected when the application has no external services', async () => {
+    const user = userEvent.setup();
+    const entity = { name: 'app', folderId: 'public/' } as unknown as AssetWithVersion;
+    const { onDuplicate } = renderModal(entity);
+
+    await user.click(screen.getByRole('button', { name: ButtonsI18nKey.Duplicate }));
+
+    expect(onDuplicate).toHaveBeenCalledWith({ ...entity, version: '1.0.0' });
+  });
+
+  test('still resets a toolset auth_settings OAuth entry to NONE, unaffected by the external-services walk', async () => {
+    const user = userEvent.setup();
+    const entity = {
+      name: 'toolset',
+      folderId: 'public/',
+      auth_settings: { authentication_type: ToolsetAuthType.OAUTH, client_id: 'id' },
+    } as unknown as AssetWithVersion;
+    const { onDuplicate } = renderModal(entity);
+
+    await user.click(screen.getByRole('button', { name: ButtonsI18nKey.Duplicate }));
+
+    expect(onDuplicate).toHaveBeenCalledWith({
+      ...entity,
+      version: '1.0.0',
+      auth_settings: { authentication_type: ToolsetAuthType.NONE },
+    });
+  });
+});

--- a/apps/ai-dial-admin/src/components/Assets/Modals/DuplicatePlatformAsset.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Modals/DuplicatePlatformAsset.tsx
@@ -12,6 +12,7 @@ import {
   DialPlatformApplicationResource,
   DialPlatformToolsetResource,
   PlatformAsset,
+  ToolsetAuthType,
 } from '@/src/models/dial/resource';
 import { ApplicationRoute } from '@/src/types/routes';
 import { CORE_UNENCODABLE_ID_CHARS } from '@/src/utils/app-runners/constants';
@@ -41,11 +42,39 @@ const DuplicatePlatformAsset: FC<Props> = ({ view, isModalOpen, names, entity, o
     view === ApplicationRoute.PlatformInterceptors ||
     isDualBucketAsset;
 
-  const [clonedAsset, setClonedAsset] = useState<PlatformAsset>(() =>
-    isRunner
-      ? ({ ...entity, $id: getClonedEntityName((entity as DialAppRunnerResource).$id, true) } as DialAppRunnerResource)
-      : ({ ...entity, name: getClonedEntityName(entity.name, true) } as DialModelResource),
-  );
+  const [clonedAsset, setClonedAsset] = useState<PlatformAsset>(() => {
+    if (isRunner) {
+      return {
+        ...entity,
+        $id: getClonedEntityName((entity as DialAppRunnerResource).$id, true),
+      } as DialAppRunnerResource;
+    }
+
+    const clone = { ...entity, name: getClonedEntityName(entity.name, true) } as PlatformAsset;
+
+    // Core never returns a real client_secret/api_key on read, so an OAuth toolset or external
+    // service copied verbatim fails Core's write-time validation with a missing-secret error.
+    if (view === ApplicationRoute.AssetsToolsets) {
+      const toolset = entity as DialPlatformToolsetResource;
+      if (toolset.auth_settings?.authentication_type === ToolsetAuthType.OAUTH) {
+        (clone as DialPlatformToolsetResource).auth_settings = { authentication_type: ToolsetAuthType.NONE };
+      }
+    } else if (view === ApplicationRoute.AssetsApplications) {
+      const externalServices = (entity as DialPlatformApplicationResource).external_services;
+      if (externalServices) {
+        (clone as DialPlatformApplicationResource).external_services = Object.fromEntries(
+          Object.entries(externalServices).map(([key, service]) => [
+            key,
+            service.auth_settings?.authentication_type === ToolsetAuthType.OAUTH
+              ? { ...service, auth_settings: { authentication_type: ToolsetAuthType.NONE } }
+              : service,
+          ]),
+        );
+      }
+    }
+
+    return clone;
+  });
 
   const onChangeId = useCallback(
     ({ name }: { name?: string }) => {

--- a/apps/ai-dial-admin/src/components/Assets/Modals/tests/DuplicatePlatformAsset.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Modals/tests/DuplicatePlatformAsset.spec.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { describe, expect, test, vi } from 'vitest';
 
 import { ButtonsI18nKey } from '@/src/constants/i18n';
-import { PlatformAsset } from '@/src/models/dial/resource';
+import { PlatformAsset, ToolsetAuthType } from '@/src/models/dial/resource';
 import { ApplicationRoute } from '@/src/types/routes';
 import DuplicatePlatformAsset from '../DuplicatePlatformAsset';
 
@@ -117,6 +117,107 @@ describe('DuplicatePlatformAsset', () => {
       await user.click(screen.getByRole('button', { name: ButtonsI18nKey.Duplicate }));
 
       expect(onDuplicate).toHaveBeenCalledWith({ ...platformEntity, name: 'pl_Ts-copy' });
+    });
+  });
+
+  // Regression: Core never returns a real client_secret on read, so an OAuth toolset or external
+  // service copied verbatim onto the clone fails Core's write-time validation.
+  describe('a platform-bucket toolset with OAuth auth settings', () => {
+    const toolset = {
+      name: 'pl_Ts',
+      display_name: 'Platform Toolset',
+      auth_settings: { authentication_type: ToolsetAuthType.OAUTH, client_id: 'id' },
+    } as unknown as PlatformAsset;
+
+    test('resets auth_settings to NONE on duplicate', async () => {
+      const user = userEvent.setup();
+      const { onDuplicate } = renderModal(ApplicationRoute.AssetsToolsets, toolset);
+
+      await user.click(screen.getByRole('button', { name: ButtonsI18nKey.Duplicate }));
+
+      expect(onDuplicate).toHaveBeenCalledWith({
+        ...toolset,
+        name: 'pl_Ts-copy',
+        auth_settings: { authentication_type: ToolsetAuthType.NONE },
+      });
+    });
+  });
+
+  test('leaves a platform-bucket toolset with non-OAuth auth settings unchanged on duplicate', async () => {
+    const user = userEvent.setup();
+    const toolset = {
+      name: 'pl_Ts',
+      display_name: 'Platform Toolset',
+      auth_settings: { authentication_type: ToolsetAuthType.API_KEY, api_key_header: 'X-Key' },
+    } as unknown as PlatformAsset;
+    const { onDuplicate } = renderModal(ApplicationRoute.AssetsToolsets, toolset);
+
+    await user.click(screen.getByRole('button', { name: ButtonsI18nKey.Duplicate }));
+
+    expect(onDuplicate).toHaveBeenCalledWith({ ...toolset, name: 'pl_Ts-copy' });
+  });
+
+  describe('a platform-bucket application with external services', () => {
+    test('resets an OAuth external service to NONE on duplicate', async () => {
+      const user = userEvent.setup();
+      const application = {
+        name: 'pl_App',
+        display_name: 'Platform Application',
+        external_services: {
+          svc: {
+            display_name: 'Service',
+            auth_settings: { authentication_type: ToolsetAuthType.OAUTH, client_id: 'id' },
+          },
+        },
+      } as unknown as PlatformAsset;
+      const { onDuplicate } = renderModal(ApplicationRoute.AssetsApplications, application);
+
+      await user.click(screen.getByRole('button', { name: ButtonsI18nKey.Duplicate }));
+
+      expect(onDuplicate).toHaveBeenCalledWith({
+        ...application,
+        name: 'pl_App-copy',
+        external_services: {
+          svc: {
+            display_name: 'Service',
+            auth_settings: { authentication_type: ToolsetAuthType.NONE },
+          },
+        },
+      });
+    });
+
+    test('resets only the OAuth entry in a mix of OAuth and non-OAuth external services', async () => {
+      const user = userEvent.setup();
+      const application = {
+        name: 'pl_App',
+        display_name: 'Platform Application',
+        external_services: {
+          oauthSvc: { auth_settings: { authentication_type: ToolsetAuthType.OAUTH } },
+          apiKeySvc: { auth_settings: { authentication_type: ToolsetAuthType.API_KEY } },
+        },
+      } as unknown as PlatformAsset;
+      const { onDuplicate } = renderModal(ApplicationRoute.AssetsApplications, application);
+
+      await user.click(screen.getByRole('button', { name: ButtonsI18nKey.Duplicate }));
+
+      expect(onDuplicate).toHaveBeenCalledWith({
+        ...application,
+        name: 'pl_App-copy',
+        external_services: {
+          oauthSvc: { auth_settings: { authentication_type: ToolsetAuthType.NONE } },
+          apiKeySvc: { auth_settings: { authentication_type: ToolsetAuthType.API_KEY } },
+        },
+      });
+    });
+
+    test('is unaffected when the application has no external services', async () => {
+      const user = userEvent.setup();
+      const application = { name: 'pl_App', display_name: 'Platform Application' } as unknown as PlatformAsset;
+      const { onDuplicate } = renderModal(ApplicationRoute.AssetsApplications, application);
+
+      await user.click(screen.getByRole('button', { name: ButtonsI18nKey.Duplicate }));
+
+      expect(onDuplicate).toHaveBeenCalledWith({ ...application, name: 'pl_App-copy' });
     });
   });
 });

--- a/apps/ai-dial-admin/src/components/Assets/Resources/ResourceSourceField.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Resources/ResourceSourceField.tsx
@@ -128,7 +128,7 @@ const ResourceSourceField: FC<Props> = ({
             onChangeEntity({
               ...entity,
               application_type_schema_id: value,
-              applicationProperties: application_properties,
+              applicationProperties: { ...application_properties, ...entity.application_properties },
             } as DialApplication)
           }
           runners={runners}

--- a/apps/ai-dial-admin/src/locales/en.ts
+++ b/apps/ai-dial-admin/src/locales/en.ts
@@ -1529,8 +1529,8 @@ export default {
     DockerImage: 'Docker Image',
     NgcRegistry: 'NGC Registry',
     HuggingFace: 'Hugging Face',
-    EntityRunner: 'Entity',
-    AssetRunner: 'Asset',
+    EntityRunner: 'Configuration file',
+    AssetRunner: 'API',
   },
   Toolset: {
     Tools: 'Tools',

--- a/openspec/changes/archive/2026-09-06-fix-app-runner-picker-source-labels/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-06-fix-app-runner-picker-source-labels/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-06

--- a/openspec/changes/archive/2026-09-06-fix-app-runner-picker-source-labels/proposal.md
+++ b/openspec/changes/archive/2026-09-06-fix-app-runner-picker-source-labels/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+GitHub issue #4407: in the App Runner picker (Application → Source Type = App Runner → "Select
+application runner", on `Assets > Applications`), the `Source` column reads `Entity`/`Asset`. Every
+other Core-backed picker in this codebase (Roles, Interceptors, Keys, Models, Applications, Toolsets,
+Routes) labels the same two populations `Configuration file`/`API` via `ConfigEntityOrigin`. The App
+Runner picker predates that convention and never picked it up, so it reads as a bug rather than a
+different, intentional labeling.
+
+## What Changes
+
+- Relabel the App Runner picker's `Source` column: `Entity Runner` → `Configuration file`,
+  `Asset Runner` → `API` — matching `ConfigEntityOrigin`'s existing `ORIGIN_LABEL` wording
+  (`src/utils/config-entities/source-column.ts`) instead of the picker's own `SourceI18nKey`
+  strings.
+- No column added for display name: confirmed `assetApi.list`'s underlying Core metadata read
+  (`CoreResourceMetadataNode`) never carries `dial:applicationTypeDisplayName` — that field lives only
+  in a runner's content body, one per-runner `GET` away. Adding the column would mean adding that
+  fetch for every asset-origin row in the picker, which is out of scope for a label fix.
+- `AppRunnerOrigin` (`Entity`/`Asset`) stays as the internal discriminator — it still drives real
+  behavior differences (schema-resolution source, open-in-new-tab target) documented in
+  `platform-app-runners`'s "Runner origin drives schema resolution and navigation" requirement. Only
+  the column's rendered text changes.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `platform-app-runners`: the "app runners created through `Assets > App Runners`... offered as source
+  options" requirement currently pins the column text to `Entity`/`Asset`; it changes to
+  `Configuration file`/`API`.
+
+## Impact
+
+- `apps/ai-dial-admin/src/constants/grid-columns/grid-columns.tsx` — `PICKER_RUNNER_COLUMNS`'s
+  `valueFormatter`.
+- `apps/ai-dial-admin/src/constants/i18n.ts` / `src/locales/en.ts` — `SourceI18nKey.AssetRunner`/
+  `.EntityRunner` values (or their replacement).
+- `apps/ai-dial-admin/src/components/SourceField/Application/tests/runner-options.spec.ts` — asserts
+  the current label strings, needs updating.
+- No change to `AppRunnerOrigin`, `buildAppRunnerOptions`, or the schema-resolution/navigation logic
+  in `AppRunners.tsx` — those keys off the enum value, not the label.
+
+## Non-goals
+
+- Unifying `AppRunnerOrigin` with `ConfigEntityOrigin` as a single type, or routing the picker's data
+  through `getConfigEntityOptions`/`readConfigEntities`. The two populations here come from a
+  different merge (`buildAppRunnerOptions`, entity-vs-raw-resource-listing) than the Api/ConfigFile
+  union those helpers implement; only the label convention is being matched.
+- Adding a display-name column (see above — no data available without a new per-row fetch).
+- Changing the interceptor attach-picker's separate `AssetInterceptorOrigin` (`Entity`/`Asset`)
+  labels — a different component, not part of this issue.

--- a/openspec/changes/archive/2026-09-06-fix-app-runner-picker-source-labels/specs/platform-app-runners/spec.md
+++ b/openspec/changes/archive/2026-09-06-fix-app-runner-picker-source-labels/specs/platform-app-runners/spec.md
@@ -1,0 +1,61 @@
+## MODIFIED Requirements
+
+### Requirement: Asset runners are selectable from asset applications
+
+The system SHALL offer app runners created through `Assets > App Runners` as source options in the App Runner picker on `Assets > Applications`, alongside the admin-BE-backed runners already offered there. The two populations SHALL be presented in a single flat grid distinguished by a `Source` column reading `Configuration file` or `API`, and each option SHALL carry an explicit origin discriminator rather than one inferred from the shape of its value.
+
+The asset half SHALL be read through the Core app-runner resource path, and its rows SHALL be identified by the runner's `$id`, matching the `Assets > App Runners` list.
+
+The picker's columns SHALL be limited to `ID`, `Source`, `Author`, and `Updated time` — a set both populations can fill from data already loaded. Columns whose values live in the runner's content body (`Display Name`, `Description`, `Topics`) SHALL NOT appear, since populating them for asset rows would require one Core content read per runner on every render. This column set is specific to the picker; the standalone `Entities > Application Runners` list and the config import/export, audit-rollback, and import-preview grids keep their own unchanged column sets.
+
+A runner SHALL be labelled by its `$id` consistently across the picker — the grid's `ID` column, the dropdown options, and the collapsed field showing the current selection — so the name a user selects by is the name they see afterwards. The runner's display name SHALL NOT be surfaced in the merged picker, because an asset runner has none without a content read and a label absent from the grid would not be recognizable.
+
+The picker component and its grid are shared with other surfaces, so this column set and labelling SHALL apply only where both populations are offered. Every other consumer — `Entities > Applications` included — SHALL keep the display-name label and the standalone runner column set unchanged, since all of its runners are admin-BE-backed and carry a display name.
+
+A failure to read the asset runner list SHALL degrade to the admin-BE-only list rather than failing the page.
+
+#### Scenario: Both populations appear in the picker
+
+- **WHEN** a user opens the App Runner picker on an asset application and runners exist in both `Entities > Application Runners` and `Assets > App Runners`
+- **THEN** both are listed in one grid
+- **AND** each row's `Source` column reads `Configuration file` or `API` accordingly
+
+#### Scenario: Asset rows are identified by `$id`
+
+- **WHEN** an asset runner with `$id` `http://asdqwe` appears in the picker
+- **THEN** its `ID` cell reads `http://asdqwe`
+
+#### Scenario: The picker shows no content-backed columns
+
+- **WHEN** the picker grid renders
+- **THEN** its columns are exactly `ID`, `Source`, `Author`, and `Updated time`
+- **AND** no `Display Name`, `Description`, or `Topics` column is present
+
+#### Scenario: The selected runner reads the same as the row that was picked
+
+- **WHEN** a user selects any runner, of either origin
+- **THEN** the collapsed field shows that runner's `$id`, the same value its grid row showed
+- **AND** no display name is shown in its place
+
+#### Scenario: Entities > Applications keeps its own presentation and source
+
+- **WHEN** the runner picker renders on `Entities > Applications`
+- **THEN** it labels runners by their display name and shows the standalone runner column set
+- **AND** it offers admin-BE runners only
+
+#### Scenario: Asset rows show their metadata
+
+- **WHEN** an asset runner appears in the picker
+- **THEN** its author and updated time cells are populated from the Core metadata node
+- **AND** the updated time renders as a localized date, not raw epoch milliseconds
+
+#### Scenario: Every runner in the bucket is offered
+
+- **WHEN** the picker is opened and the `platform` bucket holds more runners than one metadata page
+- **THEN** all of them appear in the grid
+
+#### Scenario: Core read failure leaves the entity list usable
+
+- **WHEN** the asset runner list cannot be read
+- **THEN** the picker still lists the admin-BE runners
+- **AND** the page renders rather than erroring

--- a/openspec/changes/archive/2026-09-06-fix-app-runner-picker-source-labels/tasks.md
+++ b/openspec/changes/archive/2026-09-06-fix-app-runner-picker-source-labels/tasks.md
@@ -1,0 +1,33 @@
+## 1. Relabel the Source column
+
+- [x] 1.1 In `apps/ai-dial-admin/src/locales/en.ts`, change the `SourceI18nKey.EntityRunner` value from
+      `'Entity'` to `'Configuration file'` and `SourceI18nKey.AssetRunner` from `'Asset'` to `'API'` —
+      matching `ConfigEntityOrigin`'s `ORIGIN_LABEL` wording in
+      `src/utils/config-entities/source-column.ts`. `PICKER_RUNNER_COLUMNS`'s `valueFormatter` in
+      `apps/ai-dial-admin/src/constants/grid-columns/grid-columns.tsx` already renders these keys through
+      `t()`, so no code change is needed there — the enum members, `AppRunnerOrigin`, and
+      `buildAppRunnerOptions` are untouched.
+
+## 2. Tests
+
+- [x] 2.1 Confirm `apps/ai-dial-admin/src/components/SourceField/Application/tests/runner-options.spec.ts`
+      still passes unchanged: its `'renders the Source cell per origin'` test asserts the i18n **keys**
+      (`SourceI18nKey.AssetRunner`/`.EntityRunner`), which are not renamed, so it needs no edit — run it to
+      verify rather than assuming.
+
+## 3. Quality checks
+
+- [x] 3.1 Run lint, format check, and the full test suite (`npm run lint`, `npm run format`,
+      `npm run test` from `apps/ai-dial-admin/`) and fix any failures.
+
+Note: no dedicated browser-verification task is included. The spec's "Both populations appear in the
+picker" scenario is browser-observable (its THEN describes rendered text), so the user was asked
+whether to add one; they declined, opting to rely on the existing `PICKER_RUNNER_COLUMNS` unit test
+(asserting the origin→i18n-key mapping) plus the `en.ts` locale-value change, consistent with the same
+choice made for `fix-duplicate-app-oauth-external-service`.
+
+Note: the full-suite run (task 3.1) showed 38 failures across 11 unrelated files (Analytics/Pipelines,
+QueryBuilder, Grid/Filter, Runs/Compare). Confirmed via `git stash` + isolated rerun of those exact
+files both with and without this change's diff: all 113 tests in them pass cleanly either way. The
+failures are full-suite flakiness (parallel-run contention/timeouts), not a regression from this
+change or the other uncommitted work in the branch.

--- a/openspec/changes/document-app-runner-property-fixes/.openspec.yaml
+++ b/openspec/changes/document-app-runner-property-fixes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-06

--- a/openspec/changes/document-app-runner-property-fixes/proposal.md
+++ b/openspec/changes/document-app-runner-property-fixes/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+Three already-implemented fixes to Asset Applications' App-Runner-driven parameters have no spec
+coverage: switching an App Runner used to discard already-set `applicationProperties` (#4225), the
+Parameters tab's "Generated form" view showed "No Configuration Scheme" for Asset-origin (e.g.
+QuickApp 2.0) App Runners because it always resolved schema through the admin-BE path (#4394), and
+preset/schema parameters for those same Asset-origin runners were removable in the Parameters Table
+view because they never landed in the schema-derived row set (#4413). The code for all three is
+already merged into this branch; this change documents the resulting behavior as spec requirements.
+
+## What Changes
+
+- `ResourceSourceField.tsx` (`Assets` resource source editor, used by platform/asset Applications):
+  switching the selected App Runner now merges the new runner's default `applicationProperties` under
+  the entity's existing values, so already-set values for keys the new runner also defines survive
+  the switch instead of being overwritten.
+- `ParametersTab.tsx`: scheme resolution for an already-selected App Runner now branches on the
+  runner's origin — Asset-origin runners resolve via `getResolvedRunnerSchema` (Core), other runners
+  via `getResolvedApplicationScheme` (admin-BE) — matching the branching `AppRunners.tsx` already used
+  at selection time. This fixes the Generated form view for Asset-origin runners.
+- No code change for the Parameters Table view's Remove-hiding: fixing scheme resolution above means
+  an Asset-origin runner's preset parameters now populate `schemeProperties`, so `TableView.tsx`'s
+  existing `isFromScheme`/`isRemoveHidden` logic (unchanged) now correctly marks and locks them.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `platform-applications`: switching the App Runner on a platform/asset Application preserves
+  already-set `applicationProperties` for keys the new runner also defines.
+- `platform-app-runners`: viewing an existing application's Parameters tab resolves an Asset-origin
+  runner's scheme through Core, not just at selection time.
+- `app-properties-table-editing`: schema-derived rows now include an Asset-origin runner's resolved
+  preset parameters, so Remove stays hidden for them.
+
+## Impact
+
+- `apps/ai-dial-admin/src/components/Assets/Resources/ResourceSourceField.tsx`
+- `apps/ai-dial-admin/src/components/Applications/ParametersTab/ParametersTab.tsx`
+- No test or task work is proposed here — the code is already implemented and merged; this change
+  only adds spec coverage for it.
+
+## Non-goals
+
+- Not re-implementing or altering the existing fixes — this change is documentation-only.
+- Not adding a browser-verification or unit-test task — the user explicitly asked only for specs,
+  with no code or test changes.

--- a/openspec/changes/document-app-runner-property-fixes/specs/app-properties-table-editing/spec.md
+++ b/openspec/changes/document-app-runner-property-fixes/specs/app-properties-table-editing/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Asset-origin runner preset parameters are treated as schema rows
+The table's schema-derived rows SHALL be built from an Asset-origin App Runner's Core-resolved
+schema, the same way they are built from the admin-BE-resolved schema for other runners, when the
+application's currently-selected App Runner is Asset-origin (see the Parameters-tab
+scheme-resolution requirement in `platform-app-runners`). A parameter contributed by an Asset-origin
+runner's resolved schema is therefore a schema row, not a user-added row: it renders read-only
+key/type and hides the Remove action, per the existing "Schema rows are read-only for key and type"
+requirement.
+
+#### Scenario: Preset parameter from an Asset-origin runner cannot be removed
+- **WHEN** a user opens the Parameters Table view of an application whose selected App Runner was
+  created through `Assets > App Runners` and defines a configuration schema
+- **THEN** each parameter contributed by that schema appears as a schema row
+- **AND** its row's Remove action is hidden, matching schema rows from admin-BE-origin runners
+
+#### Scenario: A user-added parameter on the same application remains removable
+- **WHEN** the same application also has a user-added parameter not defined by the runner's schema
+- **THEN** that row's Remove action remains available
+

--- a/openspec/changes/document-app-runner-property-fixes/specs/platform-app-runners/spec.md
+++ b/openspec/changes/document-app-runner-property-fixes/specs/platform-app-runners/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Viewing an application's Parameters tab resolves an Asset-origin runner's scheme through Core
+The Parameters tab SHALL resolve the currently-selected App Runner's scheme by the runner's origin,
+matching the branching the App Runner picker already applies at selection time: an Asset-origin
+runner (one created through `Assets > App Runners`) SHALL resolve via `getResolvedRunnerSchema`
+(Core's resolved-schema read), while any other runner SHALL resolve via `getResolvedApplicationScheme`
+(the admin-BE's resolved-schema read). This applies whenever the Parameters tab loads or reloads its
+scheme for the application's currently-selected runner, not only at selection time.
+
+#### Scenario: Generated form renders for an Asset-origin runner's application
+- **WHEN** a user opens the Parameters tab of an application whose selected App Runner was created
+  through `Assets > App Runners` and declares a configuration schema
+- **AND** selects the "Generated form" view
+- **THEN** the configuration form renders using that runner's resolved schema, instead of showing
+  "No Configuration Scheme"
+
+#### Scenario: Admin-BE-origin runners are unaffected
+- **WHEN** a user opens the Parameters tab of an application whose selected App Runner comes from
+  `Entities > Application Runners`
+- **THEN** the scheme is resolved via the admin-BE's resolved-schema read, unchanged from current
+  behavior
+

--- a/openspec/changes/document-app-runner-property-fixes/specs/platform-applications/spec.md
+++ b/openspec/changes/document-app-runner-property-fixes/specs/platform-applications/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Switching App Runner preserves already-set applicationProperties
+The `Assets` resource source editor SHALL, when the user switches the selected App Runner on a
+platform/asset Application, merge the new runner's default `applicationProperties` under the
+entity's existing `applicationProperties` rather than replacing them outright. For any key present
+in both the entity's current `applicationProperties` and the new runner's defaults, the entity's
+existing value SHALL win. A key present only in the new runner's defaults SHALL be added; a key
+present only in the entity's existing values and not in the new runner's schema SHALL be preserved
+unchanged.
+
+#### Scenario: Switching to a runner with the same schema preserves a set value
+- **WHEN** the user has set a value for a parameter (e.g. `openapi`) on an Application, then switches
+  the selected App Runner to a different runner that defines the same parameter
+- **THEN** the parameter's value on the Application is unchanged after the switch
+
+#### Scenario: Switching runner still applies defaults for parameters not already set
+- **WHEN** the user switches the selected App Runner to one that defines a parameter the Application
+  does not already have a value for
+- **THEN** that parameter is added with the new runner's default value
+

--- a/openspec/changes/fix-duplicate-app-oauth-external-service/.openspec.yaml
+++ b/openspec/changes/fix-duplicate-app-oauth-external-service/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-06

--- a/openspec/changes/fix-duplicate-app-oauth-external-service/proposal.md
+++ b/openspec/changes/fix-duplicate-app-oauth-external-service/proposal.md
@@ -1,0 +1,55 @@
+## Why
+
+Duplicating an Application whose `external_services` includes an OAuth-authenticated entry fails with
+`Bad Request: CLIENT_SECRET is required for OAUTH authentication` (GitHub #4390). Core never returns
+the real `client_secret` on read, so the duplicated payload carries an OAuth `auth_settings` block
+missing the one field Core requires for that type. Toolsets hit the identical problem for their own
+(single, top-level) `auth_settings` and already fix it — on duplicate, an OAuth `auth_settings` is
+reset to `{ authentication_type: NONE }` — in `DuplicateAsset.tsx` and `DuplicateToolset.tsx`. That
+reset never runs for Applications because it only inspects a toolset-shaped `auth_settings` field;
+Applications carry their auth per-entry under `external_services`, a shape the check never looks at.
+
+`DuplicatePlatformAsset.tsx` (the platform-bucket duplicate modal for both Applications and Toolsets)
+has no such reset at all, so a platform-bucket OAuth Toolset hits the same failure today too, via the
+same root cause, just undetected until now.
+
+## What Changes
+
+- `DuplicateAsset.tsx` (public-bucket Applications/Toolsets): extend the existing OAuth-reset check to
+  also walk `external_services`, resetting any service whose `auth_settings.authentication_type ===
+  OAUTH` to `{ authentication_type: NONE }`. Non-OAuth services (`API_KEY`, `DIAL_NATIVE`, `NONE`) are
+  untouched — their real credentials live behind a separate sign-in/consent flow, not in this field.
+  Service `display_name`/`description` are preserved; only that service's `auth_settings` is replaced.
+- `DuplicatePlatformAsset.tsx` (platform-bucket Applications/Toolsets): port the same two resets —
+  the existing toolset `auth_settings` reset (currently only in `DuplicateAsset.tsx`) and the new
+  `external_services` walk — so platform-bucket duplication gets the same protection.
+- No change to the toolset-only `DuplicateToolset.tsx` path (legacy `Toolsets` view) — it already
+  resets OAuth `auth_settings` and has no `external_services` field to walk.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `app-external-services-auth`: duplicating an Application with an OAuth external service now resets
+  that service's `auth_settings` to `NONE` instead of carrying over an incomplete OAuth block, for both
+  public- and platform-bucket duplication.
+- `platform-toolsets`: duplicating a platform-bucket Toolset with OAuth `auth_settings` now resets it
+  to `NONE`, matching the existing public-bucket behavior.
+
+## Impact
+
+- `apps/ai-dial-admin/src/components/Assets/Deployments/DuplicateAsset.tsx`
+- `apps/ai-dial-admin/src/components/Assets/Modals/DuplicatePlatformAsset.tsx`
+- Their existing test files (`DuplicateAsset` currently has no dedicated spec file — check before
+  writing tests; `DuplicatePlatformAsset.spec.tsx` exists and needs new cases)
+- No API/backend change — client-only, avoids ever sending an incomplete OAuth block instead of relying
+  on Core's rejection.
+
+## Non-goals
+
+- Not implementing the issue's alternative ("prompt the user to re-enter the secret before
+  finalizing") — clearing to `NONE` and letting the user re-configure auth after duplicating is the
+  chosen approach, consistent with the existing Toolset behavior.
+- Not touching `API_KEY`/`DIAL_NATIVE` external services or toolset auth — those don't carry a
+  duplicable secret in `auth_settings` today.
+- Not changing `DuplicateToolset.tsx` (legacy `Toolsets` view) — already correct.

--- a/openspec/changes/fix-duplicate-app-oauth-external-service/specs/app-external-services-auth/spec.md
+++ b/openspec/changes/fix-duplicate-app-oauth-external-service/specs/app-external-services-auth/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Duplicating an application resets OAuth external services to NONE
+The duplicate modal SHALL replace, for every entry in `external_services` whose
+`auth_settings.authentication_type === OAUTH`, that entry's `auth_settings` with
+`{ authentication_type: NONE }` before the duplicate is created. This applies
+in both the `public`-bucket duplicate modal and the `platform`-bucket duplicate modal. An entry whose
+`authentication_type` is `API_KEY`, `DIAL_NATIVE`, `NONE`, or unrecognised SHALL be carried over
+unchanged — Core never returns a real `client_secret` on read, so an OAuth entry copied verbatim
+fails Core's write-time validation with a missing-`CLIENT_SECRET` error; the other types carry no
+secret in `auth_settings` and are unaffected by that validation. A service's `display_name` and
+`description` are preserved; only its `auth_settings` is replaced.
+
+#### Scenario: Duplicating a public-bucket application with an OAuth external service
+- **WHEN** the user duplicates a `public`-bucket application whose `external_services` map contains
+  an entry with `auth_settings.authentication_type === OAUTH`
+- **THEN** the created duplicate's entry for that service has `auth_settings` equal to
+  `{ authentication_type: NONE }`
+- **AND** the duplicate is created successfully, with no `CLIENT_SECRET`-required error from Core
+
+#### Scenario: Duplicating a platform-bucket application with an OAuth external service
+- **WHEN** the user duplicates a `platform`-bucket application whose `external_services` map contains
+  an entry with `auth_settings.authentication_type === OAUTH`
+- **THEN** the created duplicate's entry for that service has `auth_settings` equal to
+  `{ authentication_type: NONE }`
+- **AND** the duplicate is created successfully, with no `CLIENT_SECRET`-required error from Core
+
+#### Scenario: Duplicating an application with a non-OAuth external service
+- **WHEN** the user duplicates an application whose `external_services` map contains an entry with
+  `auth_settings.authentication_type` set to `API_KEY`, `DIAL_NATIVE`, `NONE`, or a value the
+  frontend does not recognise
+- **THEN** that entry's `auth_settings` is carried over to the duplicate unchanged
+
+#### Scenario: Duplicating an application with multiple external services
+- **WHEN** the user duplicates an application whose `external_services` map contains both an `OAUTH`
+  entry and a non-`OAUTH` entry
+- **THEN** only the `OAUTH` entry's `auth_settings` is reset to `{ authentication_type: NONE }`
+- **AND** the non-`OAUTH` entry is unchanged
+- **AND** each entry's `display_name` and `description` are preserved
+
+#### Scenario: Duplicating an application with no external services
+- **WHEN** the user duplicates an application whose `external_services` map is empty or absent
+- **THEN** the duplicate is created with no `external_services` changes

--- a/openspec/changes/fix-duplicate-app-oauth-external-service/specs/platform-toolsets/spec.md
+++ b/openspec/changes/fix-duplicate-app-oauth-external-service/specs/platform-toolsets/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Duplicating a platform-bucket toolset resets OAuth auth settings to NONE
+The platform-bucket duplicate modal SHALL replace, when a `platform`-bucket toolset's
+`auth_settings.authentication_type === OAUTH` is duplicated, that `auth_settings` with
+`{ authentication_type: NONE }` before the duplicate is created, matching the existing
+`public`-bucket toolset duplicate behavior. Core never returns a real `client_secret` on read, so an
+OAuth `auth_settings` copied verbatim fails Core's write-time validation with a
+missing-`CLIENT_SECRET` error. A toolset whose `authentication_type` is `API_KEY`, `NONE`,
+`DIAL_NATIVE`, or unrecognised SHALL be carried over unchanged.
+
+#### Scenario: Duplicating a platform toolset with OAuth auth settings
+- **WHEN** the user duplicates a `platform`-bucket toolset with `auth_settings.authentication_type
+  === OAUTH`
+- **THEN** the created duplicate has `auth_settings` equal to `{ authentication_type: NONE }`
+- **AND** the duplicate is created successfully, with no `CLIENT_SECRET`-required error from Core
+
+#### Scenario: Duplicating a platform toolset with non-OAuth auth settings
+- **WHEN** the user duplicates a `platform`-bucket toolset whose `authentication_type` is `API_KEY`,
+  `NONE`, `DIAL_NATIVE`, or a value the frontend does not recognise
+- **THEN** `auth_settings` is carried over to the duplicate unchanged

--- a/openspec/changes/fix-duplicate-app-oauth-external-service/tasks.md
+++ b/openspec/changes/fix-duplicate-app-oauth-external-service/tasks.md
@@ -1,0 +1,41 @@
+## 1. `DuplicateAsset.tsx` (public bucket)
+
+- [x] 1.1 In `apps/ai-dial-admin/src/components/Assets/Deployments/DuplicateAsset.tsx`, extend the
+      existing OAuth-reset `useEffect` with a walk over `(entity as DialApplicationResource).external_services`:
+      for each entry whose `auth_settings?.authentication_type === ToolsetAuthType.OAUTH`, set that
+      entry's `auth_settings` on `clonedAsset.external_services` to `{ authentication_type: ToolsetAuthType.NONE }`,
+      preserving `display_name`/`description` and leaving non-OAUTH entries untouched.
+- [x] 1.2 Guard the new walk so it only runs when `entity.external_services` is present (Toolsets have
+      no such field) and does not affect the existing top-level `auth_settings` OAuth/API_KEY handling
+      already in this component.
+
+## 2. `DuplicatePlatformAsset.tsx` (platform bucket)
+
+- [x] 2.1 In `apps/ai-dial-admin/src/components/Assets/Modals/DuplicatePlatformAsset.tsx`, port the
+      existing toolset OAuth-reset check from `DuplicateAsset.tsx`: when the entity is a
+      `DialPlatformToolsetResource` with `auth_settings?.authentication_type === ToolsetAuthType.OAUTH`,
+      reset the clone's `auth_settings` to `{ authentication_type: ToolsetAuthType.NONE }`.
+- [x] 2.2 In the same component, port the `external_services` walk from task 1.1: when the entity is a
+      `DialPlatformApplicationResource`, reset every `OAUTH` entry's `auth_settings` to
+      `{ authentication_type: ToolsetAuthType.NONE }`, leaving other entries untouched.
+
+## 3. Tests
+
+- [x] 3.1 Add/extend unit tests for `DuplicateAsset.tsx` covering: an OAuth external service is reset
+      to NONE on duplicate; a non-OAuth external service (API_KEY/DIAL_NATIVE/NONE/unrecognised) is
+      unchanged; a mix of OAuth and non-OAuth services in the same map only resets the OAuth one and
+      preserves `display_name`/`description`; an application with no `external_services` is unaffected;
+      the existing toolset `auth_settings` OAuth/API_KEY behavior in this file still passes unchanged.
+- [x] 3.2 Extend `DuplicatePlatformAsset.spec.tsx` with the equivalent cases for the platform bucket:
+      platform toolset OAuth `auth_settings` reset to NONE, platform toolset non-OAuth unaffected,
+      platform application external-services OAuth reset (single, mixed, and none-present cases), and
+      existing display-name/id behavior for runners/models/dual-bucket assets still passes unchanged.
+
+## 4. Quality checks
+
+- [x] 4.1 Run lint, format check, and the full test suite (`npm run lint`, `npm run format`,
+      `npm run test` from `apps/ai-dial-admin/`) and fix any failures.
+
+Note: no dedicated browser-verification task is included — the user explicitly declined one for this
+change, opting to rely on the unit/component tests in section 3 despite some scenarios (success vs.
+error notification on duplicate) being browser-observable.

--- a/openspec/specs/platform-app-runners/spec.md
+++ b/openspec/specs/platform-app-runners/spec.md
@@ -282,7 +282,7 @@ Reference-data consumers of the admin-BE runner list SHALL continue to read it. 
 
 ### Requirement: Asset runners are selectable from asset applications
 
-The system SHALL offer app runners created through `Assets > App Runners` as source options in the App Runner picker on `Assets > Applications`, alongside the admin-BE-backed runners already offered there. The two populations SHALL be presented in a single flat grid distinguished by a `Source` column reading `Entity` or `Asset`, and each option SHALL carry an explicit origin discriminator rather than one inferred from the shape of its value.
+The system SHALL offer app runners created through `Assets > App Runners` as source options in the App Runner picker on `Assets > Applications`, alongside the admin-BE-backed runners already offered there. The two populations SHALL be presented in a single flat grid distinguished by a `Source` column reading `Configuration file` or `API`, and each option SHALL carry an explicit origin discriminator rather than one inferred from the shape of its value.
 
 The asset half SHALL be read through the Core app-runner resource path, and its rows SHALL be identified by the runner's `$id`, matching the `Assets > App Runners` list.
 
@@ -298,7 +298,7 @@ A failure to read the asset runner list SHALL degrade to the admin-BE-only list 
 
 - **WHEN** a user opens the App Runner picker on an asset application and runners exist in both `Entities > Application Runners` and `Assets > App Runners`
 - **THEN** both are listed in one grid
-- **AND** each row's `Source` column reads `Entity` or `Asset` accordingly
+- **AND** each row's `Source` column reads `Configuration file` or `API` accordingly
 
 #### Scenario: Asset rows are identified by `$id`
 


### PR DESCRIPTION
**Description:**

Duplicating Applications/Toolsets with OAuth auth failed because Core never returns real secrets on read, so the clone carried incomplete OAuth blocks. This also fixes App Runner parameter handling: Asset-origin scheme resolution on the Parameters tab, preserving existing `applicationProperties` when switching runners, and aligning App Runner picker Source labels with the rest of the catalog (`Configuration file`/`API`).

Issues:

- Issue #4390
- Issue #4407
- Issue #4225
- Issue #4394
- Issue #4413

**Key Changes:**

- [apps/ai-dial-admin/src/components/Assets/Deployments/DuplicateAsset.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/fix/oauth-duplicate-and-app-runner-params/apps/ai-dial-admin/src/components/Assets/Deployments/DuplicateAsset.tsx) — reset OAuth `external_services` auth to `NONE` on public-bucket duplicate
- [apps/ai-dial-admin/src/components/Assets/Modals/DuplicatePlatformAsset.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/fix/oauth-duplicate-and-app-runner-params/apps/ai-dial-admin/src/components/Assets/Modals/DuplicatePlatformAsset.tsx) — same OAuth resets for platform-bucket Applications and Toolsets
- [apps/ai-dial-admin/src/components/Applications/ParametersTab/ParametersTab.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/fix/oauth-duplicate-and-app-runner-params/apps/ai-dial-admin/src/components/Applications/ParametersTab/ParametersTab.tsx) — resolve Asset-origin runner schemas via Core
- [apps/ai-dial-admin/src/components/Assets/Resources/ResourceSourceField.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/fix/oauth-duplicate-and-app-runner-params/apps/ai-dial-admin/src/components/Assets/Resources/ResourceSourceField.tsx) — merge existing applicationProperties when switching App Runner
- [apps/ai-dial-admin/src/locales/en.ts](https://github.com/epam/ai-dial-admin-frontend/blob/fix/oauth-duplicate-and-app-runner-params/apps/ai-dial-admin/src/locales/en.ts) — relabel Entity/Asset runner sources to Configuration file/API
- [openspec/specs/platform-app-runners/spec.md](https://github.com/epam/ai-dial-admin-frontend/blob/fix/oauth-duplicate-and-app-runner-params/openspec/specs/platform-app-runners/spec.md) — sync consolidated app-runner source label wording

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #4390, #4407, #4225, #4394, #4413)` (comma-separated list of issues)

Made with [Cursor](https://cursor.com)