### PR TITLE
fix(Assets): restore platform folderId and restrict Move-to (Issue #4416, #4417, #4418, #4420)

### DIFF
--- a/apps/ai-dial-admin/src/components/Assets/BaseAssetList/BaseAssetList.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/BaseAssetList/BaseAssetList.tsx
@@ -338,12 +338,12 @@ const BaseAssetList: FC<Props> = ({ view, runners }) => {
       const platformAsset = asset as unknown as PlatformAsset;
       // A platform-bucket application/toolset row duplicates the same flat, unversioned way the six
       // other flat platform views already do (design.md D2/`platform-applications`/
-      // `platform-toolsets`) — the row's own path decides it, since neither dual-bucket view is
-      // itself flagged `isFlatPlatformView`.
-      const isPlatformDualBucketDuplicate = isPlatformDualBucketView(
-        view,
-        platformAsset.path || platformAsset.folderId,
-      );
+      // `platform-toolsets`) — the row's own `folderId` decides it (reliably `'platform/'` for a
+      // platform-bucket row since `fix-platform-bucket-folder-storage`; a `.path` fallback used to be
+      // needed here and was the cause of Issue #4420's `Modals.tsx` counterpart — `.path` never
+      // carries the bucket prefix, so it always won the `||` and made this check false for a
+      // platform-bucket row).
+      const isPlatformDualBucketDuplicate = isPlatformDualBucketView(view, platformAsset.folderId);
       if (isFlatPlatformView(view) || isPlatformDualBucketDuplicate) {
         const duplicate = getPlatformAssetDuplicate(view, platformAsset);
         // `getRootFolder(view)`'s fallback (used when the second argument is omitted) resolves to

--- a/apps/ai-dial-admin/src/components/Assets/BaseAssetList/Modals.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/BaseAssetList/Modals.tsx
@@ -111,10 +111,11 @@ const Modals: FC<Props> = ({
         view !== ApplicationRoute.PlatformKeys &&
         // A platform-bucket application/toolset row duplicates the same flat, unversioned way the
         // six other flat platform views already do (design.md D2/`platform-applications`/
-        // `platform-toolsets`) — the row's own path decides it, since neither dual-bucket view is
-        // itself flagged `isFlatPlatformView`.
-        (isFlatPlatformView(view) ||
-        isPlatformDualBucketView(view, (duplicateItem as PlatformAsset)?.path || duplicateItem?.folderId) ? (
+        // `platform-toolsets`) — the row's own `folderId` decides it (reliably `'platform/'` for a
+        // platform-bucket row since `fix-platform-bucket-folder-storage`; a `.path` fallback used to
+        // be needed here and was the cause of Issue #4420 — `.path` never carries the bucket prefix,
+        // so it always won the `||` and made this check false for a platform-bucket row).
+        (isFlatPlatformView(view) || isPlatformDualBucketView(view, duplicateItem?.folderId) ? (
           <DuplicatePlatformAsset
             view={view}
             isModalOpen={isModalOpen}

--- a/apps/ai-dial-admin/src/components/Assets/BaseAssetList/tests/platform-applications-bucket.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/BaseAssetList/tests/platform-applications-bucket.spec.tsx
@@ -103,7 +103,7 @@ vi.mock('../Modals', () => ({
           bucket-branch decision from `handleDuplicateModalOpen`'s async fetch, tested separately above. */}
       <button
         onClick={() =>
-          props.onDuplicate({ name: 'copy-of-platform-app', path: 'platform/platform-app', folderId: undefined })
+          props.onDuplicate({ name: 'copy-of-platform-app', path: 'platform/platform-app', folderId: 'platform/' })
         }
       >
         confirm-duplicate-platform

--- a/apps/ai-dial-admin/src/components/Assets/BaseAssetList/tests/platform-toolsets-bucket.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/BaseAssetList/tests/platform-toolsets-bucket.spec.tsx
@@ -110,7 +110,7 @@ vi.mock('../Modals', () => ({
           props.onDuplicate({
             name: 'copy-of-platform-toolset',
             path: 'platform/platform-toolset',
-            folderId: undefined,
+            folderId: 'platform/',
           })
         }
       >

--- a/apps/ai-dial-admin/src/components/Assets/Header/FolderStorage.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Header/FolderStorage.tsx
@@ -12,6 +12,7 @@ import { AssetWithVersion } from '@/src/models/dial/deployment-asset';
 import { DialFile } from '@/src/models/dial/file';
 import { Publication } from '@/src/models/dial/publications';
 import { ApplicationRoute } from '@/src/types/routes';
+import { isPlatformBucketPath } from '@/src/utils/files/root-folder';
 import { removeTrailingSlash } from '@/src/utils/files/path';
 
 interface Props {
@@ -28,6 +29,10 @@ const FoldersStorageLabel: FC<Props> = ({ asset }) => {
     },
     [currentLocale],
   );
+
+  if (isPlatformBucketPath(asset.folderId)) {
+    return <DialLabelledText label={t(EntitiesI18nKey.FolderStorage)} text={removeTrailingSlash(asset.folderId)} />;
+  }
 
   return (
     asset.folderId && (

--- a/apps/ai-dial-admin/src/components/Assets/Header/tests/FolderStorage.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Header/tests/FolderStorage.spec.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import FoldersStorageLabel from '../FolderStorage';
+import { EntitiesI18nKey } from '@/src/constants/i18n';
+import { DialResource } from '@/src/models/dial/resource';
+
+const baseAsset = { name: 'asset-1' } as DialResource;
+
+describe('FoldersStorageLabel', () => {
+  test('renders the platform bucket name with no open-in-new-tab button for a platform-bucket asset', () => {
+    render(<FoldersStorageLabel asset={{ ...baseAsset, folderId: 'platform/' }} />);
+
+    expect(screen.getByText(EntitiesI18nKey.FolderStorage)).toBeInTheDocument();
+    expect(screen.getByText('platform')).toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  test('renders the folder path with an open-in-new-tab button for a public-bucket asset', () => {
+    render(<FoldersStorageLabel asset={{ ...baseAsset, folderId: 'public/sub/' }} />);
+
+    expect(screen.getByText('public/sub')).toBeInTheDocument();
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  test('renders nothing for an asset with no folderId', () => {
+    render(<FoldersStorageLabel asset={{ ...baseAsset, folderId: '' }} />);
+
+    expect(screen.queryByText(EntitiesI18nKey.FolderStorage)).not.toBeInTheDocument();
+  });
+});

--- a/apps/ai-dial-admin/src/components/Common/FilePath/FilePath.tsx
+++ b/apps/ai-dial-admin/src/components/Common/FilePath/FilePath.tsx
@@ -17,7 +17,7 @@ import { useI18n } from '@/src/locales/client';
 import { ROOT_FOLDER } from '@/src/constants/file';
 import { ServerActionResponse } from '@/src/models/server-action';
 import { getParentPathByFullPath } from '@/src/components/Assets/utils';
-import { getFilePathGridOptions, processAssetsData } from './utils';
+import { excludePlatformRoot, getFilePathGridOptions, processAssetsData } from './utils';
 import { ApplicationRoute } from '@/src/types/routes';
 
 interface Props {
@@ -47,7 +47,8 @@ const FilePath: FC<Props> = ({
 }) => {
   const t = useI18n();
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const { files, fetchFiles } = context?.() || {};
+  const { files: rawFiles, fetchFiles } = context?.() || {};
+  const files = excludePlatformRoot(rawFiles, view);
   const [loadedPaths, setLoadedPaths] = useState(new Set(['']));
   const [path, setPath] = useState(`${ROOT_FOLDER}/`);
 

--- a/apps/ai-dial-admin/src/components/Common/FilePath/tests/FilePath.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Common/FilePath/tests/FilePath.spec.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test, vi } from 'vitest';
+
+import FilePath from '../FilePath';
+import { AssetsFolderContext } from '@/src/context/assets/AssetsFolderContext';
+import { Asset } from '@/src/models/dial/deployment-asset';
+import { ApplicationRoute } from '@/src/types/routes';
+
+vi.mock('@epam/ai-dial-ui-kit', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@epam/ai-dial-ui-kit')>();
+  return {
+    ...actual,
+    DialDestinationFolderPopup: ({ open, rootItem, items }: { open: boolean; rootItem?: Asset; items: Asset[] }) =>
+      open ? (
+        <div>
+          <span>root:{rootItem?.name}</span>
+          {items.map((item) => (
+            <span key={item.path}>item:{item.name}</span>
+          ))}
+        </div>
+      ) : null,
+  };
+});
+
+const platformRoot = { name: 'platform', path: 'platform/', nodeType: 'FOLDER', items: [] } as unknown as Asset;
+const publicRoot = { name: 'public', path: 'public/', nodeType: 'FOLDER', items: [] } as unknown as Asset;
+
+const renderFilePath = (files: Asset[], view = ApplicationRoute.AssetsApplications) => {
+  const context = () => ({ files, fetchFiles: vi.fn() }) as unknown as AssetsFolderContext;
+
+  return render(
+    <FilePath
+      label="label"
+      placeholder="placeholder"
+      modalTitle="modalTitle"
+      value=""
+      onChange={vi.fn()}
+      context={context}
+      view={view}
+    />,
+  );
+};
+
+describe('FilePath', () => {
+  test('does not offer the platform bucket as a Move-to destination for a dual-bucket view', async () => {
+    const user = userEvent.setup();
+    renderFilePath([platformRoot, publicRoot]);
+
+    await user.click(screen.getByRole('button', { name: 'ActionMenuOperation.Move_to' }));
+
+    expect(screen.getByText('root:public')).toBeInTheDocument();
+    expect(screen.queryByText('root:platform')).not.toBeInTheDocument();
+    expect(screen.queryByText('item:platform')).not.toBeInTheDocument();
+  });
+
+  test('offers every root as a Move-to destination for a non-dual-bucket view', async () => {
+    const user = userEvent.setup();
+    renderFilePath([publicRoot], ApplicationRoute.Prompts);
+
+    await user.click(screen.getByRole('button', { name: 'ActionMenuOperation.Move_to' }));
+
+    expect(screen.getByText('root:public')).toBeInTheDocument();
+  });
+});

--- a/apps/ai-dial-admin/src/components/Common/FilePath/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/Common/FilePath/tests/utils.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ApplicationRoute } from '@/src/types/routes';
 import { DialFileNodeType } from '@epam/ai-dial-ui-kit';
-import { processAssetsData, getFilePathGridOptions } from '../utils';
+import { processAssetsData, getFilePathGridOptions, excludePlatformRoot } from '../utils';
 import * as fileManagerUtils from '@/src/components/Common/FileManager/utils';
 import * as baseAssetListUtils from '@/src/components/Assets/BaseAssetList/utils';
 import { Asset, AssetWithVersion } from '@/src/models/dial/deployment-asset';
@@ -186,6 +186,41 @@ describe('FilePath utils', () => {
 
       expect(result).toHaveLength(1);
       expect((result[0] as AssetWithVersion).versions).toEqual(['1.0']);
+    });
+  });
+
+  describe('excludePlatformRoot', () => {
+    const platformRoot = { name: 'platform', path: 'platform/', nodeType: DialFileNodeType.FOLDER, items: [] };
+    const publicRoot = { name: 'public', path: 'public/', nodeType: DialFileNodeType.FOLDER, items: [] };
+
+    it('drops the platform root for a dual-bucket view', () => {
+      const result = excludePlatformRoot([platformRoot, publicRoot] as Asset[], ApplicationRoute.AssetsApplications);
+
+      expect(result).toEqual([publicRoot]);
+    });
+
+    it('drops the platform root for the AssetsToolsets dual-bucket view', () => {
+      const result = excludePlatformRoot([platformRoot, publicRoot] as Asset[], ApplicationRoute.AssetsToolsets);
+
+      expect(result).toEqual([publicRoot]);
+    });
+
+    it('returns files unchanged for a non-dual-bucket view', () => {
+      const result = excludePlatformRoot([platformRoot, publicRoot] as Asset[], ApplicationRoute.Prompts);
+
+      expect(result).toEqual([platformRoot, publicRoot]);
+    });
+
+    it('returns files unchanged when view is undefined', () => {
+      const result = excludePlatformRoot([platformRoot, publicRoot] as Asset[]);
+
+      expect(result).toEqual([platformRoot, publicRoot]);
+    });
+
+    it('returns an empty array when no files are given', () => {
+      const result = excludePlatformRoot(undefined, ApplicationRoute.AssetsApplications);
+
+      expect(result).toEqual([]);
     });
   });
 

--- a/apps/ai-dial-admin/src/components/Common/FilePath/utils.ts
+++ b/apps/ai-dial-admin/src/components/Common/FilePath/utils.ts
@@ -3,6 +3,23 @@ import { ApplicationRoute } from '@/src/types/routes';
 import { DialFileNodeType } from '@epam/ai-dial-ui-kit';
 import { getGridOptions } from '@/src/components/Common/FileManager/utils';
 import { getGridColumns } from '@/src/components/Assets/BaseAssetList/utils';
+import { DUAL_BUCKET_VIEWS, isPlatformBucketPath } from '@/src/utils/files/root-folder';
+
+/**
+ * The Move-to popup only ever offers `public` destinations (the `platform` bucket is flat, see
+ * `platform-applications`/`platform-toolsets`), so its source tree drops the `platform` root that
+ * `AssetsFolderContext.files` otherwise carries for `DUAL_BUCKET_VIEWS`. Views outside that set never
+ * have a `platform` root in `files` to begin with, so this is a no-op for them.
+ */
+export const excludePlatformRoot = (
+  files: (Asset | AssetWithVersion)[] = [],
+  view?: ApplicationRoute,
+): (Asset | AssetWithVersion)[] => {
+  if (!view || !DUAL_BUCKET_VIEWS.includes(view)) {
+    return files;
+  }
+  return files.filter((file) => !isPlatformBucketPath(file.path));
+};
 
 export const processAssetsData = (
   assets: (Asset | AssetWithVersion)[] = [],

--- a/apps/ai-dial-admin/src/server/core/asset-metadata.ts
+++ b/apps/ai-dial-admin/src/server/core/asset-metadata.ts
@@ -113,12 +113,22 @@ const metadataFields = (metadata: CoreResourceMetadataNode, prefix: string) => {
   };
 };
 
-const flatMetadataFields = (metadata: CoreResourceMetadataNode, prefix: string) => {
+/**
+ * `parseEncodedFlatPath`'s own `folderId` is always `''` (flat resources have no folder concept), which
+ * is correct for platform-only flat entities (models, roles, routes, interceptors, keys, schemas —
+ * see `DuplicatePlatformKeyModal.tsx`'s comment for why `''` matters there). The dual-bucket platform
+ * branch (see `dualBucketMetadataFields`) is the one exception: it needs `folderId: 'platform/'` so
+ * `isPlatformBucketPath(asset.folderId)` works on a freshly-fetched resource, matching what the write
+ * path already sets on create/update — hence the explicit `isDualBucketPlatform` flag rather than
+ * inferring it from `prefix`, which flat platform-only prefixes (`MODELS_PREFIX` et al.) already bake
+ * their fixed `platform/` segment into and would otherwise match too.
+ */
+const flatMetadataFields = (metadata: CoreResourceMetadataNode, prefix: string, isDualBucketPlatform = false) => {
   const { path, folderId, name } = parseEncodedFlatPath(metadata.url, prefix);
   return {
     name,
     path,
-    folderId,
+    folderId: isDualBucketPlatform ? `${PLATFORM_ROOT_FOLDER}/` : folderId,
     author: metadata.author ?? '',
     createdAt: metadata.createdAt !== undefined ? String(metadata.createdAt) : undefined,
     updatedAt: metadata.updatedAt !== undefined ? String(metadata.updatedAt) : undefined,
@@ -130,14 +140,15 @@ const flatMetadataFields = (metadata: CoreResourceMetadataNode, prefix: string) 
  * and versioned, `platform/…` is flat like the other platform-only entities. Which bucket a given
  * resource lives in is a property of its own metadata `url`, not its `ResourceType` — the same type
  * serves both — so it's read off the URL here rather than threaded through as a caller flag. The
- * `platform` segment is folded into the prefix for the flat case, matching how `MODELS_PREFIX` et al.
- * already bake their fixed bucket segment in.
+ * `platform` segment is folded into the prefix for the flat case (matching how `MODELS_PREFIX` et al.
+ * already bake their fixed bucket segment in), so `name` parses correctly.
  */
 const dualBucketMetadataFields = (metadata: CoreResourceMetadataNode, prefix: string) => {
   const remainder = decodeCorePath(stripPrefix(metadata.url, prefix));
-  return isPlatformBucketPath(remainder)
-    ? flatMetadataFields(metadata, `${prefix}${PLATFORM_ROOT_FOLDER}/`)
-    : metadataFields(metadata, prefix);
+  if (isPlatformBucketPath(remainder)) {
+    return flatMetadataFields(metadata, `${prefix}${PLATFORM_ROOT_FOLDER}/`, true);
+  }
+  return metadataFields(metadata, prefix);
 };
 
 /**

--- a/apps/ai-dial-admin/src/server/core/tests/asset-metadata.spec.ts
+++ b/apps/ai-dial-admin/src/server/core/tests/asset-metadata.spec.ts
@@ -44,7 +44,7 @@ describe('Server :: Core :: asset-metadata', () => {
     });
   });
 
-  test('mergeApplicationResource sources flat name/path/author/createdAt/updatedAt from metadata for a platform-bucket resource', () => {
+  test('mergeApplicationResource sources flat name/path/author/createdAt/updatedAt from metadata for a platform-bucket resource, with folderId identifying the bucket', () => {
     const content = { endpoint: 'https://app' };
     const meta = metadata({ url: 'applications/platform/my-app', author: 'alice', createdAt: 100, updatedAt: 111 });
 
@@ -52,7 +52,7 @@ describe('Server :: Core :: asset-metadata', () => {
       endpoint: 'https://app',
       name: 'my-app',
       path: 'my-app',
-      folderId: '',
+      folderId: 'platform/',
       author: 'alice',
       createdAt: '100',
       updatedAt: '111',
@@ -75,7 +75,7 @@ describe('Server :: Core :: asset-metadata', () => {
     });
   });
 
-  test('mergeToolsetResource sources flat name/path/author/createdAt/updatedAt from metadata for a platform-bucket resource', () => {
+  test('mergeToolsetResource sources flat name/path/author/createdAt/updatedAt from metadata for a platform-bucket resource, with folderId identifying the bucket', () => {
     const content = { endpoint: 'https://ts' };
     const meta = metadata({ url: 'toolsets/platform/my-toolset', author: 'bob', createdAt: 200, updatedAt: 222 });
 
@@ -83,7 +83,7 @@ describe('Server :: Core :: asset-metadata', () => {
       endpoint: 'https://ts',
       name: 'my-toolset',
       path: 'my-toolset',
-      folderId: '',
+      folderId: 'platform/',
       author: 'bob',
       createdAt: '200',
       updatedAt: '222',

--- a/openspec/changes/archive/2026-09-07-fix-platform-bucket-folder-storage/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-07-fix-platform-bucket-folder-storage/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-07

--- a/openspec/changes/archive/2026-09-07-fix-platform-bucket-folder-storage/design.md
+++ b/openspec/changes/archive/2026-09-07-fix-platform-bucket-folder-storage/design.md
@@ -1,0 +1,112 @@
+## Context
+
+Applications and toolsets are dual-bucket: DIAL Core stores them under both a flat `platform/` bucket
+and the hierarchical, versioned `public/` bucket (`DUAL_BUCKET_VIEWS` in `utils/files/root-folder.ts`).
+Three surfaces need to treat the two buckets differently but currently can't, all because of one shared
+gap: a platform-bucket resource's `folderId` comes back as `''` on every GET.
+
+- **Write path** (`createPlatformApplication`/`updatePlatformApplication` and the toolset equivalents)
+  already sets `folderId: 'platform/'` explicitly.
+- **Read path** (`dualBucketMetadataFields` in `server/core/asset-metadata.ts`) folds the `platform`
+  segment into the *prefix* it strips before calling `flatMetadataFields`, so the remainder handed to
+  `flatMetadataFields` never contains `platform/` and `folderId` always comes back `''`.
+
+Both `ApplicationAssetProperties` and `ToolsetAssetProperties` already guard their Move-to control with
+`!isPlatformBucketPath(asset.folderId)` — that guard is dead code today because `folderId` never carries
+the `platform/` prefix it's checking for. `FoldersStorageLabel` gates the whole Folder Storage field on
+`asset.folderId &&`, so a platform asset's `''` folderId hides the field entirely instead of showing
+`platform`. And `FilePath`'s Move-to popup reads its `items`/`rootItem` straight from the shared
+`AssetsFolderContext`'s `files` array, which holds both the `platform` and `public` root nodes for
+dual-bucket views (`AppsFolderProvider`/`ToolsetsFolderProvider` are singletons mounted once in
+`app/[lang]/layout.tsx`, shared between the grid and every entity's Move-to control) — nothing filters
+that array down to just `public` before it reaches the popup.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make a platform-bucket application/toolset's `folderId` read back as `'platform/'`, so
+  `isPlatformBucketPath` gives a correct answer wherever it's already checked.
+- Show `platform` (no link) in the header Folder Storage field for platform-bucket assets.
+- Stop the Move-to popup from offering `platform` as a destination for public-bucket
+  applications/toolsets.
+
+**Non-Goals:**
+- No folder or versioning support for the `platform` bucket.
+- No change to `public`-bucket read/write behavior, or to any other consumer of
+  `flatMetadataFields`/`AssetsFolderContext` (models, app runners, interceptors, routes, roles, keys,
+  Prompts, Conversations, Files).
+
+## Decisions
+
+**D1 — Fix `folderId` at the merge layer, not by threading a new flag.**
+`dualBucketMetadataFields` already knows which bucket a resource is in (it branches on
+`isPlatformBucketPath(remainder)` to pick `flatMetadataFields` vs `metadataFields`). Keep folding
+`platform/` into the prefix passed to `flatMetadataFields` (that's still required for `name` to parse
+correctly — `parseEncodedFlatPath` treats its whole remainder as `name` with no `/` splitting), but
+override the `folderId` field it returns: `flatMetadataFields`'s underlying `parseEncodedFlatPath`
+hardcodes `folderId: ''` unconditionally (flat resources have no folder concept), so the platform
+branch spreads that result and sets `folderId: 'platform/'` explicitly. This fixes the read path at
+its one source of truth — every downstream consumer (`isPlatformBucketPath` checks in
+`ApplicationAssetProperties`, `ToolsetAssetProperties`, `FoldersStorageLabel`) starts working with no
+changes of its own, instead of adding a second, parallel way to detect "is this platform" that could
+drift from the first.
+*Alternative considered*: have each consuming component independently detect "platform" from
+`asset.path` or `asset.id` instead of `folderId`. Rejected — `folderId` is the field
+`isPlatformBucketPath` already targets everywhere else; fixing it once keeps that single existing
+convention intact rather than introducing a second one.
+
+**D2 — `FoldersStorageLabel` gets an explicit platform branch, not a generic "no link" prop.**
+Add an `isPlatformBucketPath(asset.folderId)` check inside `FoldersStorageLabel` that renders the
+literal `platform` bucket name with no `IconExternalLink` postfix, alongside the existing
+folder-path-and-link rendering. Keep the existing `asset.folderId &&` gate for the no-folder case (a
+public-bucket asset with a genuinely empty `folderId`, if that occurs) — the new branch takes priority
+over it, since a fixed `folderId` of `'platform/'` is now truthy anyway.
+*Alternative considered*: pass an `isPlatformBucket` boolean prop down from each caller instead of
+checking `folderId` inside the component. Rejected — every current caller already has `asset` in scope
+and no caller currently needs to override the derivation, so a prop would be pure duplication of what
+`isPlatformBucketPath(asset.folderId)` already tells the component directly.
+
+**D3 — Filter the Move-to popup's source tree at the `FilePath` call site, not inside the shared
+context.**
+`AssetsFolderContext`'s `files` array is intentionally shared (grid + Move-to both need the same fetched
+tree) and intentionally holds both roots for dual-bucket views — that's correct for the grid. The fix
+belongs where the tree is *consumed for the popup*: in `FilePath.tsx`, drop the `platform` root node
+before computing `items`/`rootItem`, scoped to `DUAL_BUCKET_VIEWS` so Prompts/Files/Conversations (which
+never have a `platform` root in their `files` array to begin with) are structurally unaffected even
+without an explicit view check. This also resolves the secondary `rootItem={files?.[0]}` observation
+from explore mode for free: once `platform` is filtered out, `files[0]` is the `public` root, which is
+what `rootItem` should be for a Move-to popup that only ever offers `public` destinations.
+*Alternative considered*: give `AppsFolderProvider`/`ToolsetsFolderProvider` a second, filtered `files`
+selector and have `FilePath` request that instead. Rejected — no other consumer needs a
+platform-filtered view of `files`, so adding one to the shared context is speculative surface area for
+a need that exists at exactly one call site.
+
+## Risks / Trade-offs
+
+- **[Risk]** Fixing `folderId` centrally in `dualBucketMetadataFields` affects every place that reads a
+  platform-bucket application/toolset's `folderId`, not just the three surfaces in scope — a caller
+  relying on the old (incorrect) `''` value would silently change behavior.
+  → **Mitigation**: grep every read of `.folderId` on `DialApplicationResource`/`DialToolsetResource`
+  before landing the fix (tasks.md will enumerate them) and confirm each either already expects
+  `'platform/'` (the create/update write path does) or is one of the three surfaces this change
+  targets.
+  → **Materialized (inverse case)**: the initial audit (tasks.md 1.2) missed that
+  `Modals.tsx`/`BaseAssetList.tsx` had a `platformAsset.path || platformAsset.folderId` fallback that
+  predated this fix (needed back when `folderId` was always `''`). Once landed, `folderId` became the
+  correct signal but the stale `.path ||` fallback still won the `||` and was never the correct one —
+  this shipped as Issue #4420 (wrong duplicate modal for a platform-bucket row) and was fixed in
+  `Modals.tsx` by dropping the fallback. The equivalent read in `BaseAssetList.tsx`'s `handleDuplicate`
+  carried the same bug and was fixed the same way; its two bucket-branch spec files' fixtures were
+  updated from a stale `folderId: undefined` to `folderId: 'platform/'` to match.
+- **[Risk]** Scoping the `FilePath` fix to `DUAL_BUCKET_VIEWS` only, rather than "always drop a
+  `platform`-named root if present," could miss a future view that legitimately has both a `platform`
+  and `public` root added without updating `DUAL_BUCKET_VIEWS`.
+  → **Mitigation**: `DUAL_BUCKET_VIEWS` is already the single explicit source of truth this exact
+  scenario is designed around (see its own doc comment: "a third dual-bucket entity is a one-line
+  addition here and nowhere else") — a new dual-bucket view registers there, and `FilePath`'s filter
+  keys off the same list, so the two can't drift independently.
+
+## Open Questions
+
+None — all three fixes are localized to the files listed in the proposal's Impact section, with no
+external dependency or backend change involved.

--- a/openspec/changes/archive/2026-09-07-fix-platform-bucket-folder-storage/proposal.md
+++ b/openspec/changes/archive/2026-09-07-fix-platform-bucket-folder-storage/proposal.md
@@ -1,0 +1,66 @@
+## Why
+
+Platform-bucket applications and toolsets are flat, unversioned, and unmoveable, but three surfaces
+still treat them as if they had a `public`-bucket folder location: the Properties tab tries to show a
+Move-to control, the header's Folder Storage field is blank instead of naming the `platform` bucket,
+and the shared Move-to popup used by public-bucket entities lists `platform` as a valid drop
+destination. All three trace back to the same read-path gap — a platform-bucket resource's `folderId`
+is hardcoded to `''` on every GET (see `dualBucketMetadataFields`/`flatMetadataFields` in
+`server/core/asset-metadata.ts`), so nothing downstream can tell a platform-bucket asset apart from a
+public-bucket one with no folder.
+
+## What Changes
+
+- Fix the read-path asymmetry: a platform-bucket application/toolset's `folderId` on GET SHALL be
+  `'platform/'`, matching what the write path already sets on create/update, so `isPlatformBucketPath`
+  can reliably distinguish the two buckets everywhere it's checked.
+- `FoldersStorageLabel` (header Folder Storage field): render the `platform` bucket name for a
+  platform-bucket asset, without the existing `IconExternalLink` open-in-new-tab affordance (there is
+  no folder to link to).
+- `ApplicationAssetProperties`/`ToolsetAssetProperties`: the existing
+  `!isPublication && !isPlatformBucketPath(asset.folderId)` guard around the Move-to (`FilePath`)
+  control starts working once `folderId` is correct, hiding Move-to for platform-bucket entities as
+  already intended (already-specified behavior in `platform-applications`/`platform-toolsets` — this
+  closes the gap, no new requirement needed).
+- `FilePath`'s Move-to destination popup (used by public-bucket applications/toolsets, and shared with
+  Prompts): filter the injected `AssetsFolderContext`'s shared `files` tree down to the `public` root
+  before building `items`/`rootItem`, so the `platform` bucket never appears as a selectable move
+  destination for a `public`-bucket entity.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `platform-applications`: add a requirement that a platform-bucket application's `folderId` reads
+  back as `'platform/'` (not `''`), and that its header Folder Storage field shows the `platform`
+  bucket name with no link — the existing "no folder-move control" requirement already covers hiding
+  Move-to once `folderId` is correct.
+- `platform-toolsets`: same two additions as `platform-applications`, mirrored for toolsets.
+
+## Impact
+
+- `apps/ai-dial-admin/src/server/core/asset-metadata.ts` — `dualBucketMetadataFields`/
+  `flatMetadataFields` read path (also used by models/interceptors/routes/roles/keys via
+  `flatMetadataFields`; only the dual-bucket branch changes).
+- `apps/ai-dial-admin/src/components/Assets/Header/FolderStorage.tsx` — add a platform-bucket,
+  no-link rendering branch.
+- `apps/ai-dial-admin/src/components/Common/FilePath/FilePath.tsx` and
+  `apps/ai-dial-admin/src/components/Common/FilePath/utils.ts` — filter the `platform` root out of
+  the Move-to popup's `items`/`rootItem` for dual-bucket views; Prompts (non-dual-bucket) is
+  unaffected since it has no `platform` root in its `files` tree to begin with.
+- No `ai-dial-core` change, no server-action signature change, no admin-BE involvement.
+
+## Non-goals
+
+- Not adding folder/versioning support to the `platform` bucket — it stays structurally flat, per
+  `platform-applications`/`platform-toolsets`.
+- Not changing behavior for `public`-bucket applications/toolsets, or for any other dual-bucket-adjacent
+  view (Prompts, Conversations, Files) beyond the Move-to popup's platform-root filtering, which is a
+  no-op for them today.
+- Not touching the six existing flat platform-only views (models, app runners, interceptors, routes,
+  roles, keys) — they have no `public` counterpart and are already fully flat/unmoveable with no
+  Folder Storage field.

--- a/openspec/changes/archive/2026-09-07-fix-platform-bucket-folder-storage/specs/platform-applications/spec.md
+++ b/openspec/changes/archive/2026-09-07-fix-platform-bucket-folder-storage/specs/platform-applications/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Platform application folderId identifies the platform bucket
+The system SHALL return `'platform/'` as `folderId` when reading a platform-bucket application from
+DIAL Core, matching the value the write path already sets on create and update, so that any check of
+`isPlatformBucketPath(asset.folderId)` correctly identifies a platform-bucket application on a
+freshly-fetched resource, not only on one just created or updated in the current session.
+
+#### Scenario: A freshly-fetched platform application's folderId identifies its bucket
+- **WHEN** the user opens a platform-bucket application that was not created or updated in the current
+  session
+- **THEN** the fetched resource's `folderId` is `'platform/'`, and `isPlatformBucketPath` on that value
+  returns `true`
+
+### Requirement: Platform application header shows the platform bucket with no link
+The system SHALL show `platform` as the value of the header's Folder Storage field for a
+platform-bucket application, without the open-in-new-tab link shown for a `public`-bucket folder
+path, since the platform bucket has no folder location to link to.
+
+#### Scenario: Header Folder Storage names the platform bucket
+- **WHEN** the user views a platform-bucket application's detail header
+- **THEN** the Folder Storage field shows `platform`, with no open-in-new-tab affordance
+
+#### Scenario: Public-bucket header Folder Storage is unaffected
+- **WHEN** the user views a public-bucket application's detail header
+- **THEN** the Folder Storage field shows the folder path with its existing open-in-new-tab link,
+  unchanged from current behavior

--- a/openspec/changes/archive/2026-09-07-fix-platform-bucket-folder-storage/specs/platform-toolsets/spec.md
+++ b/openspec/changes/archive/2026-09-07-fix-platform-bucket-folder-storage/specs/platform-toolsets/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Platform toolset folderId identifies the platform bucket
+The system SHALL return `'platform/'` as `folderId` when reading a platform-bucket toolset from DIAL
+Core, matching the value the write path already sets on create and update, so that any check of
+`isPlatformBucketPath(asset.folderId)` correctly identifies a platform-bucket toolset on a
+freshly-fetched resource, not only on one just created or updated in the current session.
+
+#### Scenario: A freshly-fetched platform toolset's folderId identifies its bucket
+- **WHEN** the user opens a platform-bucket toolset that was not created or updated in the current
+  session
+- **THEN** the fetched resource's `folderId` is `'platform/'`, and `isPlatformBucketPath` on that value
+  returns `true`
+
+### Requirement: Platform toolset header shows the platform bucket with no link
+The system SHALL show `platform` as the value of the header's Folder Storage field for a
+platform-bucket toolset, without the open-in-new-tab link shown for a `public`-bucket folder path,
+since the platform bucket has no folder location to link to.
+
+#### Scenario: Header Folder Storage names the platform bucket
+- **WHEN** the user views a platform-bucket toolset's detail header
+- **THEN** the Folder Storage field shows `platform`, with no open-in-new-tab affordance
+
+#### Scenario: Public-bucket header Folder Storage is unaffected
+- **WHEN** the user views a public-bucket toolset's detail header
+- **THEN** the Folder Storage field shows the folder path with its existing open-in-new-tab link,
+  unchanged from current behavior

--- a/openspec/changes/archive/2026-09-07-fix-platform-bucket-folder-storage/tasks.md
+++ b/openspec/changes/archive/2026-09-07-fix-platform-bucket-folder-storage/tasks.md
@@ -1,0 +1,100 @@
+## 1. Fix the platform-bucket folderId read path
+
+- [x] 1.1 In `apps/ai-dial-admin/src/server/core/asset-metadata.ts`, change `dualBucketMetadataFields`'s
+      platform branch to spread `flatMetadataFields`'s result and override `folderId: 'platform/'`
+      explicitly (`flatMetadataFields`'s underlying `parseEncodedFlatPath` hardcodes `folderId: ''`
+      unconditionally, since flat resources have no folder concept).
+- [x] 1.2 Grep every read of `.folderId` on `DialApplicationResource`/`DialToolsetResource` (both
+      platform and public consumers, including `ApplicationAssetProperties`, `ToolsetAssetProperties`,
+      `FoldersStorageLabel`, `updatePlatformApplication`/`updatePlatformToolset`'s `fetchFiles` calls,
+      and any grid/list code reading a merged application/toolset's `folderId`) and confirm each either
+      already expects `'platform/'` or is one of the three surfaces this change targets — fix or note
+      any caller that assumed the old `''` value.
+      Audit result: `ApplicationAssetProperties`/`ToolsetAssetProperties`/`FoldersStorageLabel` are the
+      three targeted surfaces (tasks 2-3). `isPlatformBucketDelete` in `Assets/Modals/utils.tsx` was
+      silently dead before this fix and now correctly activates, matching its own comment's stated
+      intent — a behavior improvement, not a regression, and out of this change's scope to test.
+      **Correction (post-landing):** the `platformAsset.path || platformAsset.folderId` fallback in
+      `Modals.tsx`'s duplicate-modal-selection check was *not* unaffected — `path` always won the `||`
+      and never carried the bucket prefix, so `isPlatformDualBucketView` came back `false` for a
+      platform-bucket row and the wrong duplicate modal (versioned `DuplicateAsset`, with its
+      "Duplication type" selector) rendered. This surfaced as Issue #4420 and was fixed by dropping the
+      `.path` fallback now that this change makes `folderId` itself reliably `'platform/'`.
+      `BaseAssetList.tsx`'s `handleDuplicate` had the identical `platformAsset.path || platformAsset.folderId`
+      pattern at its own `isPlatformDualBucketView` call (deciding which duplicate *action* to run, after
+      the modal closes) — same latent bug, now also fixed by dropping the `.path` fallback there too.
+      The two related bucket-branch spec files' `confirm-duplicate-platform` fixtures hardcoded
+      `folderId: undefined` (correct back when `folderId` was always unreliable pre-fix) and were updated
+      to `folderId: 'platform/'` to match what a real post-fix platform-bucket resource now carries.
+      `fetchFiles(selectedApp.folderId)` in the platform detail views now refreshes the correct root
+      instead of a no-op `fetchFiles('')`. The only caller assuming the old `''` value is the existing
+      unit test in `asset-metadata.spec.ts` (fixed in 1.3).
+- [x] 1.3 Add/update unit tests for `dualBucketMetadataFields`/`mergeApplicationResource`/
+      `mergeToolsetResource` in `asset-metadata`'s test file covering: a platform-bucket resource's
+      `folderId` is `'platform/'`, and a public-bucket resource's `folderId`/`path`/`version` are
+      unchanged.
+
+## 2. Hide the Move-to control for platform-bucket entities
+
+- [x] 2.1 Verify (with a component test, adding one if missing) that `ApplicationAssetProperties`'s
+      existing `!isPublication && !isPlatformBucketPath(asset.folderId)` guard now hides the `FilePath`
+      Move-to control for a platform-bucket application, given the Task 1 fix, and still shows it for a
+      public-bucket application with a real `folderId`.
+      Verified: `Apps/tests/Properties.spec.tsx` already had both cases (public-bucket shows, platform
+      shows-hidden) — no new test needed. Both pass against the fixed read path (3/3).
+- [x] 2.2 Do the same for `ToolsetAssetProperties`.
+      Verified: `Toolsets/View/tests/Properties.spec.tsx` already had both cases too — no new test
+      needed. Both pass (4/4).
+
+## 3. Show the platform bucket in the header Folder Storage field
+
+- [x] 3.1 In `apps/ai-dial-admin/src/components/Assets/Header/FolderStorage.tsx`, add an
+      `isPlatformBucketPath(asset.folderId)` branch in `FoldersStorageLabel` that renders the literal
+      `platform` bucket name with no `IconExternalLink` postfix button, ahead of the existing
+      folder-path-and-link rendering; keep the existing `asset.folderId &&` gate for the public,
+      no-folder case.
+- [x] 3.2 Add/update `FoldersStorageLabel`'s component tests: a platform-bucket asset renders `platform`
+      with no link button (query by role/accessible name per `.claude/rules/a11y.md` and
+      `testing.md` §4); a public-bucket asset with a folder path is unaffected.
+      Added `Header/tests/FolderStorage.spec.tsx` (no prior test file existed): platform-bucket renders
+      `platform` with no button; public-bucket renders the path with a button; no-folderId renders
+      nothing. 3/3 passing.
+
+## 4. Filter the platform root out of the Move-to popup's destination tree
+
+- [x] 4.1 In `apps/ai-dial-admin/src/components/Common/FilePath/utils.ts`, add a pure helper that,
+      given the shared `AssetsFolderContext` `files` array and the current `view`, drops the `platform`
+      root node when `view` is in `DUAL_BUCKET_VIEWS` and returns the array unchanged otherwise.
+      Added `excludePlatformRoot`: for `DUAL_BUCKET_VIEWS`, filters out any root whose `path` satisfies
+      `isPlatformBucketPath` (confirmed via `AssetsFolderContext`'s `fetchRoots` that dual-bucket root
+      nodes carry a trailing-slash path, e.g. `'platform/'`/`'public/'` — `FileManager.tsx` appends the
+      slash before calling `fetchFiles`); returns `files` unchanged for every other view.
+- [x] 4.2 In `apps/ai-dial-admin/src/components/Common/FilePath/FilePath.tsx`, apply that helper to
+      `files` before computing `items={processAssetsData(...)}` and `rootItem`, so `rootItem` resolves
+      to the `public` root for dual-bucket views instead of `files?.[0]`.
+      Wired in: context's raw `files` is renamed `rawFiles` and passed through `excludePlatformRoot`
+      before use, so both `rootItem={files?.[0]}` and `items={processAssetsData(files, view)}` already
+      exclude `platform` with no further change to those two lines.
+- [x] 4.3 Add/update unit tests for the new filtering helper (drops `platform` for a dual-bucket view's
+      `files`, passes non-dual-bucket `files` through unchanged) and a `FilePath`/`DialDestinationFolderPopup`
+      component test confirming `platform` is not offered as a Move-to destination for a public-bucket
+      application/toolset.
+      Extended `Common/FilePath/tests/utils.spec.ts` with an `excludePlatformRoot` describe block (5
+      cases: dual-bucket Applications/Toolsets drop `platform`, non-dual-bucket view and undefined view
+      pass through unchanged, no-files input). Added `Common/FilePath/tests/FilePath.spec.tsx` (no prior
+      test file existed), mocking `DialDestinationFolderPopup` to render `rootItem`/`items` and asserting
+      `platform` is absent from both for a dual-bucket view, present for a non-dual-bucket view. 23/23
+      passing across both files.
+
+## 5. Final quality checks
+
+- [x] 5.1 Run `npm run lint`, `npm run format`, and `npm run test` (full coverage run) from the repo
+      root and fix any failures.
+      `npm run lint`: clean (0 errors, 113 pre-existing unrelated warnings). `npm run format`: found
+      one file (`Common/FilePath/tests/utils.spec.ts`) needing reformatting, fixed via
+      `prettier --write`. `npm run test` (full coverage, 957 files/10958 tests): 14 tests failed, all
+      "Test timed out in 5000ms" in `Analytics/QueryBuilder/tests/QueryBuilder.spec.tsx` and
+      `EntityListView/CreateEntity/tests/CreateEntity.spec.tsx` — neither file touches
+      `FilePath`/`AssetsFolderContext`/`root-folder`. Re-ran `CreateEntity.spec.tsx` in isolation: 8/8
+      passed in 3s, confirming full-suite resource contention flakiness, not a regression from this
+      change. All 23 tests added/extended by this change pass.

--- a/openspec/specs/platform-applications/spec.md
+++ b/openspec/specs/platform-applications/spec.md
@@ -119,6 +119,32 @@ unrecognized field.
   `status`, `author`, `createdAt`, `updatedAt`, and `reference`
 - **THEN** the write succeeds, with none of those fields present in the request body sent to Core
 
+### Requirement: Platform application folderId identifies the platform bucket
+The system SHALL return `'platform/'` as `folderId` when reading a platform-bucket application from
+DIAL Core, matching the value the write path already sets on create and update, so that any check of
+`isPlatformBucketPath(asset.folderId)` correctly identifies a platform-bucket application on a
+freshly-fetched resource, not only on one just created or updated in the current session.
+
+#### Scenario: A freshly-fetched platform application's folderId identifies its bucket
+- **WHEN** the user opens a platform-bucket application that was not created or updated in the current
+  session
+- **THEN** the fetched resource's `folderId` is `'platform/'`, and `isPlatformBucketPath` on that value
+  returns `true`
+
+### Requirement: Platform application header shows the platform bucket with no link
+The system SHALL show `platform` as the value of the header's Folder Storage field for a
+platform-bucket application, without the open-in-new-tab link shown for a `public`-bucket folder
+path, since the platform bucket has no folder location to link to.
+
+#### Scenario: Header Folder Storage names the platform bucket
+- **WHEN** the user views a platform-bucket application's detail header
+- **THEN** the Folder Storage field shows `platform`, with no open-in-new-tab affordance
+
+#### Scenario: Public-bucket header Folder Storage is unaffected
+- **WHEN** the user views a public-bucket application's detail header
+- **THEN** the Folder Storage field shows the folder path with its existing open-in-new-tab link,
+  unchanged from current behavior
+
 ### Requirement: Platform application detail view
 The system SHALL provide a detail view for a platform-bucket application under
 `src/components/Assets/Platform/Applications/`, distinct from the public Apps detail view, reusing the

--- a/openspec/specs/platform-toolsets/spec.md
+++ b/openspec/specs/platform-toolsets/spec.md
@@ -132,6 +132,32 @@ than failing silently.
   validation rejects
 - **THEN** the write fails, and an error notification carrying Core's rejection message is shown
 
+### Requirement: Platform toolset folderId identifies the platform bucket
+The system SHALL return `'platform/'` as `folderId` when reading a platform-bucket toolset from DIAL
+Core, matching the value the write path already sets on create and update, so that any check of
+`isPlatformBucketPath(asset.folderId)` correctly identifies a platform-bucket toolset on a
+freshly-fetched resource, not only on one just created or updated in the current session.
+
+#### Scenario: A freshly-fetched platform toolset's folderId identifies its bucket
+- **WHEN** the user opens a platform-bucket toolset that was not created or updated in the current
+  session
+- **THEN** the fetched resource's `folderId` is `'platform/'`, and `isPlatformBucketPath` on that value
+  returns `true`
+
+### Requirement: Platform toolset header shows the platform bucket with no link
+The system SHALL show `platform` as the value of the header's Folder Storage field for a
+platform-bucket toolset, without the open-in-new-tab link shown for a `public`-bucket folder path,
+since the platform bucket has no folder location to link to.
+
+#### Scenario: Header Folder Storage names the platform bucket
+- **WHEN** the user views a platform-bucket toolset's detail header
+- **THEN** the Folder Storage field shows `platform`, with no open-in-new-tab affordance
+
+#### Scenario: Public-bucket header Folder Storage is unaffected
+- **WHEN** the user views a public-bucket toolset's detail header
+- **THEN** the Folder Storage field shows the folder path with its existing open-in-new-tab link,
+  unchanged from current behavior
+
 ### Requirement: Platform toolset detail view
 The system SHALL provide a detail view for a platform-bucket toolset under
 `src/components/Assets/Platform/Toolsets/`, distinct from the public Toolsets detail view, reusing


### PR DESCRIPTION
**Description:**

Platform-bucket applications and toolsets were treated as if they had a `public`-bucket folder location because GET always returned `folderId: ''`. That hid Folder Storage in the header, showed a Move-to control that should never apply to a flat bucket, offered `platform` as a Move-to destination for public entities, and selected the versioned duplicate modal for platform rows. The read path now returns `folderId: 'platform/'`, matching the write path, so those surfaces can tell the two buckets apart.

Issues:

- Issue #4416
- Issue #4417
- Issue #4418
- Issue #4420

**Key Changes:**

- [apps/ai-dial-admin/src/server/core/asset-metadata.ts](https://github.com/epam/ai-dial-admin-frontend/blob/fix/platform-bucket-folder-storage/apps/ai-dial-admin/src/server/core/asset-metadata.ts) — platform-bucket GET now returns `folderId: 'platform/'`
- [apps/ai-dial-admin/src/components/Assets/Header/FolderStorage.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/fix/platform-bucket-folder-storage/apps/ai-dial-admin/src/components/Assets/Header/FolderStorage.tsx) — show the `platform` bucket name with no open-in-new-tab link
- [apps/ai-dial-admin/src/components/Common/FilePath/utils.ts](https://github.com/epam/ai-dial-admin-frontend/blob/fix/platform-bucket-folder-storage/apps/ai-dial-admin/src/components/Common/FilePath/utils.ts) — drop the `platform` root from Move-to destinations for dual-bucket views
- [apps/ai-dial-admin/src/components/Common/FilePath/FilePath.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/fix/platform-bucket-folder-storage/apps/ai-dial-admin/src/components/Common/FilePath/FilePath.tsx) — apply that filter before building the popup tree
- [apps/ai-dial-admin/src/components/Assets/BaseAssetList/Modals.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/fix/platform-bucket-folder-storage/apps/ai-dial-admin/src/components/Assets/BaseAssetList/Modals.tsx) — detect platform rows from `folderId` so Duplicate uses the unversioned modal
- [apps/ai-dial-admin/src/components/Assets/BaseAssetList/BaseAssetList.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/fix/platform-bucket-folder-storage/apps/ai-dial-admin/src/components/Assets/BaseAssetList/BaseAssetList.tsx) — same `folderId` check when running the duplicate action
- [openspec/specs/platform-applications/spec.md](https://github.com/epam/ai-dial-admin-frontend/blob/fix/platform-bucket-folder-storage/openspec/specs/platform-applications/spec.md) — require `'platform/'` folderId and header Folder Storage without a link
- [openspec/specs/platform-toolsets/spec.md](https://github.com/epam/ai-dial-admin-frontend/blob/fix/platform-bucket-folder-storage/openspec/specs/platform-toolsets/spec.md) — same requirements for toolsets

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<ticket>)` (comma-separated list of issues)

Made with [Cursor](https://cursor.com)