### PR TITLE
fix(Assets/Toolsets): recompute platform toolset update path (Issue #4419)

### DIFF
--- a/apps/ai-dial-admin/src/app/[lang]/assets-toolsets/actions.spec.ts
+++ b/apps/ai-dial-admin/src/app/[lang]/assets-toolsets/actions.spec.ts
@@ -71,6 +71,7 @@ describe('Assets Toolset :: server actions', () => {
 
     const result = await updateToolset(
       {
+        name: 'my-toolset',
         folderId: 'public',
         nodeType: DialFileNodeType.FOLDER,
         path: 'test',
@@ -82,8 +83,9 @@ describe('Assets Toolset :: server actions', () => {
     expect(assetApi.put).toHaveBeenCalledWith(
       TOKEN_MOCK,
       ResourceType.TOOLSET,
-      'test',
+      'publicmy-toolset__1.0',
       {
+        name: 'my-toolset',
         folderId: undefined,
         nodeType: DialFileNodeType.FOLDER,
         path: undefined,
@@ -93,6 +95,45 @@ describe('Assets Toolset :: server actions', () => {
       { etag: 'etag' },
     );
     expect(result).toBe(RESPONSE_MOCK);
+  });
+
+  test('updateToolset recomputes a folder-qualified path from folderId + versioned name, matching createToolset', async () => {
+    (assetApi.put as any).mockResolvedValue(RESPONSE_MOCK);
+
+    await updateToolset(
+      {
+        name: 'my-toolset',
+        folderId: 'public/',
+        nodeType: DialFileNodeType.FOLDER,
+        path: 'stale-path',
+        version: '2.0',
+      },
+      'etag',
+    );
+
+    const [, , path] = (assetApi.put as any).mock.calls[0];
+    expect(path).toBe('public/my-toolset__2.0');
+  });
+
+  test('updateToolset writes to the platform-prefixed path when folderId is the platform bucket', async () => {
+    (assetApi.put as any).mockResolvedValue(RESPONSE_MOCK);
+
+    await updateToolset(
+      {
+        name: 'my-toolset',
+        folderId: 'platform/',
+        nodeType: DialFileNodeType.FOLDER,
+        path: 'my-toolset',
+        version: undefined,
+      },
+      'etag-1',
+    );
+
+    const [, type, path, , options] = (assetApi.put as any).mock.calls[0];
+    expect(type).toBe(ResourceType.TOOLSET);
+    expect(path).toBe('platform/my-toolset');
+    expect(path).not.toContain('__');
+    expect(options).toEqual({ etag: 'etag-1' });
   });
 
   test('updateToolset without a concrete etag still passes it through', async () => {

--- a/apps/ai-dial-admin/src/app/[lang]/assets-toolsets/actions.ts
+++ b/apps/ai-dial-admin/src/app/[lang]/assets-toolsets/actions.ts
@@ -61,10 +61,12 @@ export async function getToolset(path: string, etag: string) {
 
 export async function updateToolset(toolset: AssetToolset, etag: string) {
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
+  const folderId = toolset.folderId || ROOT_FOLDER;
+  const path = `${folderId}${getVersionedName(toolset.name || '', toolset.version)}`;
   return assetApi.put(
     token,
     ResourceType.TOOLSET,
-    toolset.path,
+    path,
     { ...toolset, displayVersion: toolset.version, folderId: undefined, version: undefined, path: undefined },
     { etag },
   );

--- a/openspec/changes/archive/2026-09-07-fix-platform-toolset-update-path/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-07-fix-platform-toolset-update-path/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-07

--- a/openspec/changes/archive/2026-09-07-fix-platform-toolset-update-path/design.md
+++ b/openspec/changes/archive/2026-09-07-fix-platform-toolset-update-path/design.md
@@ -1,0 +1,40 @@
+## Context
+
+`updateToolset` (`assets-toolsets/actions.ts:62-71`) writes to `assetApi.put(token, ResourceType.TOOLSET, toolset.path, ...)`, trusting the caller-supplied `path` as-is. For a public-bucket toolset, `path` comes from `metadataFields`/`parseEncodedVersionedPath`, which already returns a folder-qualified, versioned path — so this happens to work today. For a platform-bucket toolset, `path` comes from `flatMetadataFields`, which deliberately returns the bare resource name (`"yo"`); the `platform/` bucket segment lives only on `toolset.folderId`, which `updatePlatformToolset` sets to `'platform/'` but `updateToolset` never reads. The write lands at `v1/toolsets/yo` instead of `v1/toolsets/platform/yo`, 404s (issue #4419).
+
+`createToolset` (`:33-46`) already avoids this: it recomputes `path` from `folderId` + `getVersionedName(name, version)`, so `createPlatformToolset`'s `folderId: 'platform/'` override actually reaches the write path. Applications' `updateApp` (`assets-applications/actions.ts:109-110`) does the identical recomputation for its update path, which is why `updatePlatformApplication` works correctly today — confirmed by the user, who reports Applications has no equivalent bug.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `updateToolset` compute its write path from `folderId` + versioned name, matching `createToolset` and `updateApp`, so `updatePlatformToolset`'s `folderId` override takes effect.
+- Fix scoped to toolsets only — Applications is not touched.
+
+**Non-Goals:**
+
+- Changing how platform-bucket writes strip fields, validate names, or anything else already covered by the `platform-toolsets` spec.
+- Introducing a new path-construction pattern — this reuses the one `createToolset`/`updateApp` already establish.
+
+## Decisions
+
+### Recompute the path in `updateToolset`, not in `updatePlatformToolset`
+
+Two shapes were considered:
+
+- **A — recompute in `updateToolset`** (chosen): add the same `folderId`/`getVersionedName` computation `createToolset` already has. `updatePlatformToolset`'s existing `folderId: 'platform/'` override then flows through unchanged.
+- **B — special-case in `updatePlatformToolset`**: set `path: \`${PLATFORM_ROOT_FOLDER}/${name}\`` only in the platform wrapper, leaving `updateToolset` untouched.
+
+A is chosen because:
+- It matches the sibling implementation (`updateApp`) exactly, which this codebase's patterned-entity convention favors over a locally-invented shape.
+- It fulfills the doc comment already sitting on `getPlatformToolsets`/`createPlatformToolset` (`actions.ts:83-91`), which claims `updateToolset` already does this recomputation — the comment describes the intended design, and A makes the code match it instead of leaving the comment wrong.
+- It satisfies the `toolset-resources-core-api` spec's existing "Platform-bucket update path has no folder segment" scenario directly, rather than working around a gap in `updateToolset`.
+
+B was rejected because it fixes only the platform case while leaving `updateToolset` inconsistent with `createToolset`, and does nothing to reconcile the misleading doc comment.
+
+**Consequence for public-bucket toolsets:** today, editing a public toolset's *name* and saving writes to the *old* `toolset.path` (the rename only lands in the request body, since `path` is trusted verbatim). After A, the write path is recomputed from `folderId` + the new name, so a name-edit save now targets the new path — matching how `updateApp` already behaves for applications. This is a behavior change beyond the 404 fix, but it aligns toolsets with the established Applications pattern rather than introducing a new inconsistency.
+
+## Risks / Trade-offs
+
+- **[Risk] Public-bucket rename-on-save behavior shifts to target the new path instead of the old one.** → Mitigation: this matches `updateApp`'s existing behavior for Applications, so it is not a new pattern in this codebase; confirm during implementation whether the Toolset view's name field is editable independently of a version bump (if the UI always creates a new version on rename rather than allowing an in-place rename, this risk doesn't materialize in practice).
+- **[Risk] Any other caller of `updateToolset` might rely on `toolset.path` being honored verbatim.** → Mitigation: grep call sites of `updateToolset`/`updatePlatformToolset` before implementing; the only two callers are the toolset view's save action and `updatePlatformToolset`, both of which already supply the fields the recomputation needs (`name`, `version`/`folderId`).

--- a/openspec/changes/archive/2026-09-07-fix-platform-toolset-update-path/proposal.md
+++ b/openspec/changes/archive/2026-09-07-fix-platform-toolset-update-path/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+Saving an existing platform-bucket toolset 404s: the UI sends `PUT /v1/toolsets/yo` instead of
+`PUT /v1/toolsets/platform/yo` (GitHub issue #4419). `updateToolset` builds its write path from
+`toolset.path`, which for a platform toolset is the bare resource name — the `platform/` bucket
+segment only lives on `toolset.folderId`, which `updateToolset` never reads. This already violates
+the existing `toolset-resources-core-api` spec ("Platform-bucket update path has no folder segment"),
+so this is a bug fix, not a new requirement.
+
+## What Changes
+
+- `updateToolset` (`assets-toolsets/actions.ts`) recomputes its write path from `folderId` +
+  versioned name — the same shape `createToolset` and Applications' `updateApp` already use —
+  instead of trusting the caller-supplied `path` verbatim.
+- This lets `updatePlatformToolset`'s existing `folderId: 'platform/'` override actually reach the
+  write path, producing `platform/{name}` instead of the bare name.
+- Public-bucket toolset updates keep the same computed path they get today (folder-qualified,
+  versioned) — no behavior change there, confirmed by tracing `metadataFields`/
+  `parseEncodedVersionedPath`, which already returns a folder-qualified `folderId` for public
+  toolsets.
+- Scoped to toolsets only. Applications' `updateApp`/`updatePlatformApplication` already do this
+  recomputation correctly and are not touched.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+None — the fix brings `updateToolset` in line with the `toolset-resources-core-api` spec's existing
+"Platform-bucket update path has no folder segment" scenario, which the current code violates. No
+spec-level behavior is changing.
+
+## Impact
+
+- `apps/ai-dial-admin/src/app/[lang]/assets-toolsets/actions.ts` — `updateToolset` gains path
+  recomputation; `updatePlatformToolset` needs no change (its `folderId` override starts working).
+- No API surface, route, or component signature changes.
+- Existing toolset unit tests around `updateToolset`/`updatePlatformToolset` need updating/adding to
+  cover the platform-bucket path.

--- a/openspec/changes/archive/2026-09-07-fix-platform-toolset-update-path/tasks.md
+++ b/openspec/changes/archive/2026-09-07-fix-platform-toolset-update-path/tasks.md
@@ -1,0 +1,13 @@
+## 1. Fix
+
+- [x] 1.1 Grep all call sites of `updateToolset` and `updatePlatformToolset` in `apps/ai-dial-admin/src/app/[lang]/assets-toolsets/actions.ts` and the components that call them, to confirm `name`, `version`, and `folderId` are always populated on the object passed in (per design.md's "Risks" section).
+- [x] 1.2 In `updateToolset` (`assets-toolsets/actions.ts`), recompute the write path from `folderId` + `getVersionedName(name, version)` — mirroring `createToolset` in the same file and `updateApp` in `assets-applications/actions.ts` — instead of trusting `toolset.path` verbatim.
+
+## 2. Tests
+
+- [x] 2.1 Add/update unit tests for `updateToolset` covering: a public-bucket toolset (path recomputed from `folderId` + versioned name, unchanged outcome from today) and a platform-bucket toolset (`folderId: 'platform/'` produces a `platform/{name}` write path, no `__version` suffix).
+- [x] 2.2 Add/update a unit test for `updatePlatformToolset` confirming it delegates through `updateToolset` and the resulting write path is `platform/{name}`, reproducing the fix for issue #4419.
+
+## 3. Quality gate
+
+- [x] 3.1 Run lint, format check, and the full test suite (`npm run test`) from the repo root.


### PR DESCRIPTION
**Description:**

Saving an existing platform-bucket toolset 404s because `updateToolset` sent `PUT /v1/toolsets/{name}` instead of `PUT /v1/toolsets/platform/{name}`. The write path was taken from `toolset.path`, which is the bare resource name; the `platform/` bucket segment only lives on `folderId`. The action now recomputes the path from `folderId` + versioned name, matching `createToolset` and Applications' `updateApp`, so `updatePlatformToolset`'s `folderId: 'platform/'` override actually reaches Core.

Issues:

- Issue #4419

**Key Changes:**

- [apps/ai-dial-admin/src/app/[lang]/assets-toolsets/actions.ts](https://github.com/epam/ai-dial-admin-frontend/blob/fix/recompute-platform-toolset-update-path/apps/ai-dial-admin/src/app/%5Blang%5D/assets-toolsets/actions.ts) — recompute the update write path from `folderId` + versioned name instead of using `toolset.path` verbatim
- [apps/ai-dial-admin/src/app/[lang]/assets-toolsets/actions.spec.ts](https://github.com/epam/ai-dial-admin-frontend/blob/fix/recompute-platform-toolset-update-path/apps/ai-dial-admin/src/app/%5Blang%5D/assets-toolsets/actions.spec.ts) — cover platform-bucket and folder-qualified public paths, and align the existing public update assertion with the recomputed path
- [openspec/changes/archive/2026-09-07-fix-platform-toolset-update-path/](https://github.com/epam/ai-dial-admin-frontend/tree/fix/recompute-platform-toolset-update-path/openspec/changes/archive/2026-09-07-fix-platform-toolset-update-path) — archived OpenSpec change for the bug fix

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<ticket>)` (comma-separated list of issues)

Made with [Cursor](https://cursor.com)