### PR TITLE
fix: name and focus the shared grid row-actions trigger

### DIFF
--- a/apps/ai-dial-admin/src/components/Common/ActionsDropdown/ActionsDropdown.tsx
+++ b/apps/ai-dial-admin/src/components/Common/ActionsDropdown/ActionsDropdown.tsx
@@ -1,8 +1,9 @@
-import { FC, ReactNode } from 'react';
+import { FC, ReactNode, useState } from 'react';
 import classNames from 'classnames';
 import { DialDropdown, DropdownItem } from '@epam/ai-dial-ui-kit';
 
 import { ActionMenuOperationDeclaration } from '@/src/models/action-menu-operations';
+import { ButtonsI18nKey } from '@/src/constants/i18n';
 import { useI18n } from '@/src/locales/client';
 
 interface ActionsProps<T> {
@@ -15,6 +16,7 @@ interface ActionsProps<T> {
 
 const ActionsDropdown = <T extends object>({ items, data, rowIndex, ...props }: ActionsProps<T>) => {
   const t = useI18n();
+  const [isOpen, setIsOpen] = useState(false);
   const dropdownItems: DropdownItem[] = items.map((item) => ({
     key: item.id,
     disabled: item.disabled as boolean,
@@ -33,15 +35,33 @@ const ActionsDropdown = <T extends object>({ items, data, rowIndex, ...props }: 
 
   return (
     <div>
-      <DialDropdown items={dropdownItems}>
-        <ActionTrigger {...props} />
+      <DialDropdown items={dropdownItems} open={isOpen} onOpenChange={setIsOpen}>
+        <ActionTrigger {...props} isOpen={isOpen} />
       </DialDropdown>
     </div>
   );
 };
 
-const ActionTrigger: FC<{ icon: ReactNode; actionTriggerClassName?: string }> = ({ icon, actionTriggerClassName }) => {
-  return <div className={classNames('cursor-pointer', actionTriggerClassName)}>{icon}</div>;
+interface TriggerProps {
+  icon: ReactNode;
+  actionTriggerClassName?: string;
+  isOpen: boolean;
+}
+
+const ActionTrigger: FC<TriggerProps> = ({ icon, actionTriggerClassName, isOpen }) => {
+  const t = useI18n();
+
+  return (
+    <button
+      type="button"
+      aria-label={t(ButtonsI18nKey.Actions)}
+      aria-haspopup="menu"
+      aria-expanded={isOpen}
+      className={classNames('cursor-pointer', actionTriggerClassName)}
+    >
+      <span aria-hidden>{icon}</span>
+    </button>
+  );
 };
 
 export default ActionsDropdown;

--- a/apps/ai-dial-admin/src/components/EntityView/AppRoute/AppRouteList.tsx
+++ b/apps/ai-dial-admin/src/components/EntityView/AppRoute/AppRouteList.tsx
@@ -31,14 +31,21 @@ const AppRouteList: FC<Props> = ({ disabled, routes, activeRouteIndex, onRemove,
   };
 
   return (
-    <div className="flex-1 min-h-0 flex flex-col relative gap-y-4 overflow-auto">
+    <div className="flex-1 min-h-0 flex flex-col relative gap-y-4 overflow-auto" role="tablist">
       {activeRouteIndex == null && <DialNoDataContent title={t(EntitiesI18nKey.NoAppRoutes)} />}
       {activeRouteIndex != null && !!routes?.length
         ? routes.map((route, index) => {
             return (
-              <button
+              <div
                 key={route.name}
                 role="tab"
+                tabIndex={0}
+                aria-selected={activeRouteIndex === index}
+                onKeyDown={(e) => {
+                  if (e.key !== 'Enter' && e.key !== ' ') return;
+                  e.preventDefault();
+                  onClick(index);
+                }}
                 className={classNames(
                   'rounded group pl-3 py-2 flex flex-row gap-2 h-[32px] w-full small cursor-pointer hover:text-accent-primary',
                   activeRouteIndex === index
@@ -50,14 +57,14 @@ const AppRouteList: FC<Props> = ({ disabled, routes, activeRouteIndex, onRemove,
                   <DialEllipsisTooltip text={route.name} />
                 </span>
                 {!disabled && (
-                  <div className="invisible group-hover:visible text-primary mx-2 flex flex-row gap-2">
+                  <div className="invisible group-hover:visible focus-within:visible text-primary mx-2 flex flex-row gap-2">
                     <ActionsDropdown
                       items={[getOperation(() => onRemove(route.name))]}
                       icon={<IconDotsVertical {...BASE_BUTTON_ICON_PROPS} />}
                     />
                   </div>
                 )}
-              </button>
+              </div>
             );
           })
         : null}

--- a/apps/ai-dial-admin/src/components/Grid/ActionColumn/ActionCellRenderer.tsx
+++ b/apps/ai-dial-admin/src/components/Grid/ActionColumn/ActionCellRenderer.tsx
@@ -1,4 +1,5 @@
 import { ActionMenuOperationDeclaration } from '@/src/models/action-menu-operations';
+import { useI18n } from '@/src/locales/client';
 import { CustomCellRendererProps } from 'ag-grid-react';
 
 interface Props<T> extends CustomCellRendererProps<T> {
@@ -6,17 +7,21 @@ interface Props<T> extends CustomCellRendererProps<T> {
 }
 
 const ActionCellRenderer = <T extends object>({ item, data, api, node }: Props<T>) => {
+  const t = useI18n();
+
   if (!data || item.hidden?.(api, node)) {
     return null;
   }
 
   return (
-    <div
+    <button
+      type="button"
+      aria-label={t(item.label)}
       className="w-full justify-items-center cursor-pointer"
       onClick={() => item.onClick(data, node.rowIndex as number)}
     >
-      {item?.icon}
-    </div>
+      <span aria-hidden>{item?.icon}</span>
+    </button>
   );
 };
 

--- a/apps/ai-dial-admin/src/components/Grid/ActionColumn/tests/ActionCellRenderer.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Grid/ActionColumn/tests/ActionCellRenderer.spec.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, test, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { CustomCellRendererProps } from 'ag-grid-react';
 
 import ActionCellRenderer from '../ActionCellRenderer';
@@ -22,20 +23,44 @@ const renderCell = (item: ActionMenuOperationDeclaration<Row>, data: Row | undef
   );
 
 describe('ActionCellRenderer', () => {
-  test('renders the icon when data is present and not hidden', () => {
+  test('renders the operation as a button named after it', () => {
     renderCell({
       icon,
       id: 'try',
+      label: 'Try_out',
       onClick: vi.fn(),
     });
 
+    expect(screen.getByRole('button', { name: 'Try_out' })).toBeInTheDocument();
     expect(screen.getByText('icon')).toBeInTheDocument();
+  });
+
+  test('invokes the operation on click with the row data and index', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    renderCell({ icon, id: 'try', label: 'Try_out', onClick });
+
+    await user.click(screen.getByRole('button', { name: 'Try_out' }));
+
+    expect(onClick).toHaveBeenCalledWith({ id: '1' }, 0);
+  });
+
+  test('invokes the operation from the keyboard', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    renderCell({ icon, id: 'try', label: 'Try_out', onClick });
+
+    await user.tab();
+    await user.keyboard('{Enter}');
+
+    expect(onClick).toHaveBeenCalledWith({ id: '1' }, 0);
   });
 
   test('returns null when hidden is true', () => {
     const { container } = renderCell({
       icon,
       id: 'try',
+      label: 'Try_out',
       onClick: vi.fn(),
       hidden: () => true,
     });

--- a/apps/ai-dial-admin/src/components/Grid/ActionColumn/tests/ActionColumn.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Grid/ActionColumn/tests/ActionColumn.spec.tsx
@@ -1,28 +1,67 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, test } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test, vi } from 'vitest';
+import { ButtonsI18nKey } from '@/src/constants/i18n';
 import ActionColumn from '../ActionColumn';
 
 describe('ActionColumn', () => {
   const baseProps = {
     items: [
-      { id: 'edit', hidden: undefined },
-      { id: 'delete', hidden: () => false },
-      { id: 'hidden', hidden: () => true },
+      { id: 'edit', label: 'edit-label', hidden: undefined },
+      { id: 'delete', label: 'delete-label', hidden: () => false },
+      { id: 'hidden', label: 'hidden-label', hidden: () => true },
     ],
     data: { name: 'entity1' },
     api: {},
     node: { rowIndex: 2 },
   };
 
-  test('renders dropdown with visible items and ActionTrigger', () => {
-    const { container } = render(<ActionColumn {...baseProps} />);
+  test('renders the action menu trigger as a named button', () => {
+    render(<ActionColumn {...baseProps} />);
 
-    expect(container.querySelector('.tabler-icon-dots-vertical')).toBeInTheDocument();
+    const trigger = screen.getByRole('button', { name: ButtonsI18nKey.Actions });
+    expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  test('opens the menu with the visible items and marks the trigger expanded', async () => {
+    const user = userEvent.setup();
+    render(<ActionColumn {...baseProps} />);
+
+    await user.click(screen.getByRole('button', { name: ButtonsI18nKey.Actions }));
+
+    expect(screen.getByRole('button', { name: ButtonsI18nKey.Actions })).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('menuitem', { name: 'edit-label' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'delete-label' })).toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'hidden-label' })).not.toBeInTheDocument();
+  });
+
+  test('opens the menu from the keyboard', async () => {
+    const user = userEvent.setup();
+    render(<ActionColumn {...baseProps} />);
+
+    await user.tab();
+    expect(screen.getByRole('button', { name: ButtonsI18nKey.Actions })).toHaveFocus();
+
+    await user.keyboard('{Enter}');
+
+    expect(screen.getByRole('menuitem', { name: 'edit-label' })).toBeInTheDocument();
+  });
+
+  test('invokes the chosen operation with the row data and index', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(<ActionColumn {...baseProps} items={[{ id: 'edit', label: 'edit-label', hidden: undefined, onClick }]} />);
+
+    await user.click(screen.getByRole('button', { name: ButtonsI18nKey.Actions }));
+    await user.click(screen.getByRole('menuitem', { name: 'edit-label' }));
+
+    expect(onClick).toHaveBeenCalledWith(baseProps.data, baseProps.node.rowIndex);
   });
 
   test('renders nothing if data is null', () => {
-    const { container } = render(<ActionColumn {...baseProps} data={null} />);
+    render(<ActionColumn {...baseProps} data={null} />);
 
-    expect(container.querySelector('.tabler-icon-dots-vertical')).toBeNull();
+    expect(screen.queryByRole('button', { name: ButtonsI18nKey.Actions })).not.toBeInTheDocument();
   });
 });

--- a/apps/ai-dial-admin/src/components/Menu/MenuContent/MenuActions.tsx
+++ b/apps/ai-dial-admin/src/components/Menu/MenuContent/MenuActions.tsx
@@ -1,8 +1,8 @@
-import { DialDropdown, DropdownItem } from '@epam/ai-dial-ui-kit';
+import { DialDropdown, DialIconButton, DropdownItem } from '@epam/ai-dial-ui-kit';
 import { FC } from 'react';
 import { IconDotsVertical, IconDownload, IconUpload, IconWorldCog } from '@tabler/icons-react';
 
-import { MenuI18nKey } from '@/src/constants/i18n';
+import { ButtonsI18nKey, MenuI18nKey } from '@/src/constants/i18n';
 import { BASE_BUTTON_ICON_PROPS } from '@/src/constants/main-layout';
 import { useI18n } from '@/src/locales/client';
 
@@ -45,7 +45,11 @@ const MenuActions: FC<Props> = ({ onExport, onImport, onOpenProperties, showImpo
   return (
     <div>
       <DialDropdown items={dropdownItems} listClassName="w-[150px]">
-        <IconDotsVertical className="cursor-pointer" />
+        <DialIconButton
+          aria-label={t(ButtonsI18nKey.Actions)}
+          icon={<IconDotsVertical {...BASE_BUTTON_ICON_PROPS} />}
+          className="cursor-pointer"
+        />
       </DialDropdown>
     </div>
   );

--- a/apps/ai-dial-admin/src/constants/i18n.ts
+++ b/apps/ai-dial-admin/src/constants/i18n.ts
@@ -417,6 +417,7 @@ export enum ButtonsI18nKey {
   Open = 'Buttons.Open',
   None = 'Buttons.None',
   BulkActions = 'Buttons.BulkActions',
+  Actions = 'Buttons.Actions',
   AddAdditionalProperties = 'Buttons.AddAdditionalProperties',
   Build = 'Buttons.Build',
   Deploy = 'Buttons.Deploy',

--- a/apps/ai-dial-admin/src/locales/en.ts
+++ b/apps/ai-dial-admin/src/locales/en.ts
@@ -515,6 +515,7 @@ export default {
     Open: 'Open',
     None: 'None',
     BulkActions: 'Bulk actions',
+    Actions: 'Actions',
     AddAdditionalProperties: 'Add additional properties',
     Build: 'Build',
     Deploy: 'Deploy',


### PR DESCRIPTION
**Description:**

The row-actions kebab that every grid in the app uses was a role-less `div` holding an icon, wrapped in the ui-kit dropdown's own reference `span`. That span carries `aria-haspopup`/`aria-expanded` but has no role for them to apply to and no `tabindex`, so the control had **no accessible name, could not be reached with the keyboard at all**, and could not be located by `getByRole` in tests or by the browser-verification agent. The menu it opens was fine — `role="menu"` with named `menuitem` entries — the defect was entirely in the trigger.

- `ActionsDropdown` now renders a real `<button>` carrying the name (`Buttons.Actions`), `aria-haspopup="menu"` and `aria-expanded`, with the icon marked `aria-hidden`. The expanded state comes from ui-kit's documented `open`/`onOpenChange` controlled mode, since every internal close path (item click, outside press, scroll out of view) routes through it.
- Two sibling triggers with the same defect follow suit: the single-action grid cell (`ActionCellRenderer`, named after its own operation) and the app menu's kebab, which was a bare SVG and now uses `DialIconButton` the way `AdaptiveHeaderActions` already did.
- `AppRouteList` needed the follow-on fix: its row was a `<button role="tab">` and would now nest a button, so it becomes a `div role="tab"` that is still a tab stop (`tabIndex`, Enter/Space) and now reports `aria-selected` — which the button never did. Its hover-only action container also gains `focus-within:visible`, or the newly focusable kebab would be invisible while focused.

The two grid specs move off `container.querySelector('.tabler-icon-dots-vertical')` onto role queries, and cover opening the menu by mouse and by keyboard plus the `aria-expanded` round trip.

Verified against the running app on two grids (Tables and Models): the trigger is `role=button` named "Actions", Tab reaches it, Enter opens the menu with named items, Escape closes it and returns `aria-expanded` to false, and mouse behaviour is unchanged.

Scope note: `.claude/reference/areas.md` has no area for shared UI components, so the title carries no scope rather than an invented one. No ticket — reported and fixed in passing while verifying another change.

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues) — no ticket for this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)