### PR TITLE
feat(Entities/Assets): add per-interface endpoint overrides for upstream endpoints (Issue #4433)

### DIFF
--- a/apps/ai-dial-admin/src/components/Applications/View/Properties/Properties.tsx
+++ b/apps/ai-dial-admin/src/components/Applications/View/Properties/Properties.tsx
@@ -35,6 +35,7 @@ const EntityProperties: FC<Props> = ({ runners, view, ...props }) => {
   const { codeAppEditorUrl } = useAppContext();
 
   const application = props.entity as DialApplication;
+  const onChangeApplication = props.onChangeEntity as (entity: DialApplication) => void;
 
   const appRunner = useMemo(() => getAppRunner(application, runners), [application, runners]);
 
@@ -63,15 +64,15 @@ const EntityProperties: FC<Props> = ({ runners, view, ...props }) => {
         label={t(EntitiesI18nKey.SourceType)}
         sourceItems={APPLICATION_SOURCE_ITEMS}
         entity={application}
-        onChange={props.onChangeEntity as (entity: DialApplication) => void}
+        onChange={onChangeApplication}
         runners={runners}
         getContainers={getApplicationContainers}
         isEntityImmutable={true}
         codeAppEditorUrl={codeAppEditorUrl}
       />
       <InterfacesField
-        entity={application}
-        onChangeEntity={props.onChangeEntity as (entity: DialApplication) => void}
+        interfaces={application.interfaces}
+        onChangeInterfaces={(interfaces) => onChangeApplication({ ...application, interfaces })}
         allowedTypes={APPLICATION_INTERFACE_TYPES}
       />
       <OverrideNameControl entity={props.entity as any} onChangeEntity={props.onChangeEntity} />

--- a/apps/ai-dial-admin/src/components/Assets/Apps/Properties.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Apps/Properties.tsx
@@ -120,8 +120,8 @@ const ApplicationAssetProperties: FC<Props> = ({ asset, runners, onChange, isPub
           codeAppEditorUrl={codeAppEditorUrl}
         />
         <InterfacesField
-          entity={asset}
-          onChangeEntity={onChange}
+          interfaces={asset.interfaces}
+          onChangeInterfaces={(interfaces) => onChange({ ...asset, interfaces })}
           allowedTypes={ASSET_APPLICATION_INTERFACE_TYPES}
           isAsset
         />

--- a/apps/ai-dial-admin/src/components/Assets/Platform/Interceptors/Properties.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Platform/Interceptors/Properties.tsx
@@ -36,7 +36,12 @@ const InterceptorAssetProperties: FC<Props> = ({ asset, onChange }) => {
         />
         <DescriptionControl entity={asset} onChangeEntity={onChange} isFullWidth={false} />
         <OverrideNameControl entity={asset} onChangeEntity={onChange} />
-        <InterfacesField entity={asset} onChangeEntity={onChange} allowedTypes={INTERCEPTOR_INTERFACE_TYPES} isAsset />
+        <InterfacesField
+          interfaces={asset.interfaces}
+          onChangeInterfaces={(interfaces) => onChange({ ...asset, interfaces })}
+          allowedTypes={INTERCEPTOR_INTERFACE_TYPES}
+          isAsset
+        />
         <EndpointControl
           id="endpoint"
           label={t(EntityFieldsI18nKey.endpoint)}

--- a/apps/ai-dial-admin/src/components/Assets/Platform/Models/Properties.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Platform/Models/Properties.tsx
@@ -82,7 +82,12 @@ const ModelAssetProperties: FC<Props> = ({ asset, onChange }) => {
         />
         <OverrideNameControl entity={asset} onChangeEntity={onChange} />
 
-        <InterfacesField entity={asset} onChangeEntity={onChange} allowedTypes={MODEL_INTERFACE_TYPES} isAsset />
+        <InterfacesField
+          interfaces={asset.interfaces}
+          onChangeInterfaces={(interfaces) => onChange({ ...asset, interfaces })}
+          allowedTypes={MODEL_INTERFACE_TYPES}
+          isAsset
+        />
         <EndpointControl
           id="endpoint"
           label={t(EntityFieldsI18nKey.endpoint)}

--- a/apps/ai-dial-admin/src/components/BaseControls/InterfacesField/InterfaceEndpointRow.tsx
+++ b/apps/ai-dial-admin/src/components/BaseControls/InterfacesField/InterfaceEndpointRow.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { DialInput, DialPasswordInput, DialRemoveButton } from '@epam/ai-dial-ui-kit';
+
+import ExtraDataField from '@/src/components/UpstreamEndpoints/ExtraData/ExtraDataField';
+import {
+  ButtonsI18nKey,
+  EntityFieldsI18nKey,
+  EntityPlaceholdersI18nKey,
+  UpstreamEndpointsI18nKey,
+} from '@/src/constants/i18n';
+import { STANDARD_CONTROL_WIDTH } from '@/src/constants/main-layout';
+import { useSaveValidationContext, ValidationActionType } from '@/src/context/SaveValidationContext';
+import { useI18n } from '@/src/locales/client';
+import { DialUpstreamInterface } from '@/src/models/dial/model';
+import { FieldError } from '@/src/models/error';
+import { getUrlError } from '@/src/utils/validation/url-error';
+
+interface Props {
+  fieldId: string;
+  typeLabel: string;
+  value: DialUpstreamInterface;
+  disabled?: boolean;
+  onChange: (value: DialUpstreamInterface) => void;
+  onDelete: () => void;
+}
+
+// Peer of InterfaceRow for InterfaceFieldVariant.Endpoint: an upstream overrides an interface with its
+// own endpoint/key/extraData rather than one base_url. `endpoint` is optional here — absent, DIAL Core
+// falls back to the upstream's own baseUrl for this interface — so it validates only when non-empty.
+const InterfaceEndpointRow = ({ fieldId, typeLabel, value, disabled, onChange, onDelete }: Props) => {
+  const t = useI18n();
+  const { dispatch, resetCounter } = useSaveValidationContext();
+  const [error, setError] = useState<FieldError | null>(null);
+
+  const validate = useCallback(
+    (endpoint?: string, shouldShowError = true) => {
+      const urlError = getUrlError(endpoint, t, false);
+      dispatch({ type: ValidationActionType.SetField, field: fieldId, isValid: !urlError });
+      if (shouldShowError) {
+        setError(urlError);
+      }
+    },
+    [dispatch, fieldId, t],
+  );
+
+  useEffect(() => {
+    validate(value.endpoint, false);
+
+    return () => {
+      dispatch({ type: ValidationActionType.RemoveField, field: fieldId });
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (resetCounter) {
+      validate(value.endpoint);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [resetCounter]);
+
+  const onChangeEndpoint = useCallback(
+    (newValue?: string) => {
+      const trimmedValue = newValue?.trimStart() || '';
+      validate(trimmedValue);
+      onChange({ ...value, endpoint: trimmedValue });
+    },
+    [value, onChange, validate],
+  );
+
+  return (
+    <div className="flex flex-col gap-y-2">
+      <p className="dial-body-text font-semibold text-primary">{typeLabel}</p>
+      <div className="flex items-start gap-x-2">
+        <DialInput
+          id={fieldId}
+          labelProps={{ label: t(EntityFieldsI18nKey.endpoint) }}
+          placeholder={t(EntityPlaceholdersI18nKey.UpstreamEndpoint)}
+          value={value.endpoint || ''}
+          onChange={onChangeEndpoint}
+          disabled={disabled}
+          error={error?.text}
+          invalid={!!error}
+          containerClassName={STANDARD_CONTROL_WIDTH}
+        />
+        <DialPasswordInput
+          id={`${fieldId}-key`}
+          labelProps={{ label: t(UpstreamEndpointsI18nKey.Keys) }}
+          placeholder={t(EntityPlaceholdersI18nKey.UpstreamKey)}
+          value={value.key}
+          onChange={(key?: string) => onChange({ ...value, key })}
+          disabled={disabled}
+          containerClassName="flex-1"
+        />
+        {!disabled && <DialRemoveButton aria-label={t(ButtonsI18nKey.Delete)} onClick={onDelete} className="mt-7" />}
+      </div>
+      <div className="flex flex-row gap-x-2 w-full">
+        <ExtraDataField
+          label={t(EntityFieldsI18nKey.extraData)}
+          value={value.extraData}
+          disabled={disabled}
+          containerClassName="flex-1 min-w-0"
+          onChange={(extraData) => onChange({ ...value, extraData })}
+        />
+        <ExtraDataField
+          label={t(EntityFieldsI18nKey.secretExtraData)}
+          value={value.secretExtraData}
+          disabled={disabled}
+          isSecret
+          containerClassName="flex-1 min-w-0"
+          onChange={(secretExtraData) => onChange({ ...value, secretExtraData })}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default InterfaceEndpointRow;

--- a/apps/ai-dial-admin/src/components/BaseControls/InterfacesField/InterfacesField.tsx
+++ b/apps/ai-dial-admin/src/components/BaseControls/InterfacesField/InterfacesField.tsx
@@ -10,17 +10,22 @@ import { ButtonsI18nKey, InterfacesI18nKey } from '@/src/constants/i18n';
 import { BASE_BUTTON_ICON_PROPS, STANDARD_CONTROL_WIDTH } from '@/src/constants/main-layout';
 import { useIsReadOnlyAdmin } from '@/src/hooks/use-is-read-only-admin';
 import { useI18n } from '@/src/locales/client';
-import { DeploymentInterfaceType } from '@/src/models/dial/interfaces';
+import { DeploymentInterfaceType, InterfaceFieldVariant } from '@/src/models/dial/interfaces';
+import { DialUpstreamInterface } from '@/src/models/dial/model';
+import InterfaceEndpointRow from './InterfaceEndpointRow';
 import InterfaceRow from './InterfaceRow';
 
-type InterfaceValueMap = Record<string, { baseUrl?: string; base_url?: string }>;
+type BaseUrlInterfaceValue = { baseUrl?: string; base_url?: string };
+type InterfaceValue = BaseUrlInterfaceValue | DialUpstreamInterface;
 
-interface Props<T extends { interfaces?: InterfaceValueMap }> {
-  entity: T;
-  onChangeEntity: (entity: T) => void;
+interface Props<V extends InterfaceValue> {
+  interfaces?: Record<string, V>;
+  onChangeInterfaces: (interfaces: Record<string, V>) => void;
   allowedTypes: DeploymentInterfaceType[];
+  variant?: InterfaceFieldVariant;
   isAsset?: boolean;
   disabled?: boolean;
+  className?: string;
 }
 
 const getInterfaceTypeLabel = (t: ReturnType<typeof useI18n>, type: DeploymentInterfaceType): string => {
@@ -36,33 +41,38 @@ const getInterfaceTypeLabel = (t: ReturnType<typeof useI18n>, type: DeploymentIn
   }
 };
 
-const InterfacesField = <T extends { interfaces?: InterfaceValueMap }>({
-  entity,
-  onChangeEntity,
+const InterfacesField = <V extends InterfaceValue>({
+  interfaces: interfacesProp,
+  onChangeInterfaces,
   allowedTypes,
+  variant = InterfaceFieldVariant.BaseUrl,
   isAsset,
   disabled,
-}: Props<T>) => {
+  className,
+}: Props<V>) => {
   const t = useI18n();
   const isReadOnlyAdmin = useIsReadOnlyAdmin();
   const isReadonly = disabled || isReadOnlyAdmin;
+  const isEndpointVariant = variant === InterfaceFieldVariant.Endpoint;
   const baseUrlKey = isAsset ? 'base_url' : 'baseUrl';
 
   const [isSelectingType, setIsSelectingType] = useState(false);
 
-  const interfaces = useMemo(() => entity.interfaces || {}, [entity.interfaces]);
+  const interfaces = useMemo(() => interfacesProp || {}, [interfacesProp]);
   const usedTypes = Object.keys(interfaces) as DeploymentInterfaceType[];
   const availableTypes = allowedTypes.filter((type) => !usedTypes.includes(type));
 
+  const createEmptyValue = useCallback(
+    (): V => (isEndpointVariant ? { endpoint: '' } : { [baseUrlKey]: '' }) as V,
+    [isEndpointVariant, baseUrlKey],
+  );
+
   const onAddType = useCallback(
     (type: DeploymentInterfaceType) => {
-      onChangeEntity({
-        ...entity,
-        interfaces: { ...interfaces, [type]: { [baseUrlKey]: '' } },
-      });
+      onChangeInterfaces({ ...interfaces, [type]: createEmptyValue() });
       setIsSelectingType(false);
     },
-    [entity, interfaces, baseUrlKey, onChangeEntity],
+    [interfaces, createEmptyValue, onChangeInterfaces],
   );
 
   const onAddClick = useCallback(() => {
@@ -73,23 +83,20 @@ const InterfacesField = <T extends { interfaces?: InterfaceValueMap }>({
     }
   }, [allowedTypes, onAddType]);
 
-  const onChangeField = useCallback(
-    (type: string, field: string, value: string) => {
-      onChangeEntity({
-        ...entity,
-        interfaces: { ...interfaces, [type]: { ...interfaces[type], [field]: value } },
-      });
+  const onChangeValue = useCallback(
+    (type: string, value: V) => {
+      onChangeInterfaces({ ...interfaces, [type]: value });
     },
-    [entity, interfaces, onChangeEntity],
+    [interfaces, onChangeInterfaces],
   );
 
   const onDeleteType = useCallback(
     (type: string) => {
       const updated = { ...interfaces };
       delete updated[type];
-      onChangeEntity({ ...entity, interfaces: updated });
+      onChangeInterfaces(updated);
     },
-    [entity, interfaces, onChangeEntity],
+    [interfaces, onChangeInterfaces],
   );
 
   const showAddButton = availableTypes.length > 0 && !isSelectingType;
@@ -101,7 +108,7 @@ const InterfacesField = <T extends { interfaces?: InterfaceValueMap }>({
         <DialTooltip
           tooltip={
             <div className="flex flex-col gap-1">
-              <div>{t(InterfacesI18nKey.InfoBaseUrl)}</div>
+              <div>{isEndpointVariant ? t(InterfacesI18nKey.InfoEndpoint) : t(InterfacesI18nKey.InfoBaseUrl)}</div>
             </div>
           }
         >
@@ -109,18 +116,35 @@ const InterfacesField = <T extends { interfaces?: InterfaceValueMap }>({
         </DialTooltip>
       </div>
 
-      <div className={classNames('flex flex-col gap-y-2 rounded border border-primary p-4', STANDARD_CONTROL_WIDTH)}>
-        {usedTypes.map((type) => (
-          <InterfaceRow
-            key={type}
-            fieldId={`interface-${type}`}
-            typeLabel={getInterfaceTypeLabel(t, type)}
-            baseUrl={interfaces[type]?.[baseUrlKey] || ''}
-            disabled={isReadonly}
-            onChangeBaseUrl={(value) => onChangeField(type, baseUrlKey, value)}
-            onDelete={() => onDeleteType(type)}
-          />
-        ))}
+      <div
+        className={classNames(
+          'flex flex-col gap-y-2 rounded border border-primary p-4',
+          className ?? STANDARD_CONTROL_WIDTH,
+        )}
+      >
+        {usedTypes.map((type) =>
+          isEndpointVariant ? (
+            <InterfaceEndpointRow
+              key={type}
+              fieldId={`interface-${type}`}
+              typeLabel={getInterfaceTypeLabel(t, type)}
+              value={(interfaces[type] as DialUpstreamInterface) || {}}
+              disabled={isReadonly}
+              onChange={(value) => onChangeValue(type, value as V)}
+              onDelete={() => onDeleteType(type)}
+            />
+          ) : (
+            <InterfaceRow
+              key={type}
+              fieldId={`interface-${type}`}
+              typeLabel={getInterfaceTypeLabel(t, type)}
+              baseUrl={(interfaces[type] as BaseUrlInterfaceValue)?.[baseUrlKey] || ''}
+              disabled={isReadonly}
+              onChangeBaseUrl={(value) => onChangeValue(type, { ...interfaces[type], [baseUrlKey]: value } as V)}
+              onDelete={() => onDeleteType(type)}
+            />
+          ),
+        )}
 
         {!isReadonly && isSelectingType && (
           <DialSelectField

--- a/apps/ai-dial-admin/src/components/BaseControls/InterfacesField/tests/InterfacesField.spec.tsx
+++ b/apps/ai-dial-admin/src/components/BaseControls/InterfacesField/tests/InterfacesField.spec.tsx
@@ -8,11 +8,11 @@ import InterfacesField from '@/src/components/BaseControls/InterfacesField/Inter
 import { ErrorI18nKey, InterfacesI18nKey } from '@/src/constants/i18n';
 import { DeploymentInterfaceType } from '@/src/models/dial/interfaces';
 
-type Entity = { interfaces?: Record<string, { baseUrl?: string }> };
+type InterfaceValue = { baseUrl?: string; base_url?: string };
 
-const ControlledInterfacesField = ({ initialEntity }: { initialEntity: Entity }) => {
-  const [entity, setEntity] = useState(initialEntity);
-  return <InterfacesField entity={entity} onChangeEntity={setEntity} allowedTypes={SINGLE_TYPE} />;
+const ControlledInterfacesField = ({ initialInterfaces }: { initialInterfaces: Record<string, InterfaceValue> }) => {
+  const [interfaces, setInterfaces] = useState(initialInterfaces);
+  return <InterfacesField interfaces={interfaces} onChangeInterfaces={setInterfaces} allowedTypes={SINGLE_TYPE} />;
 };
 
 vi.mock('@epam/ai-dial-ui-kit', async () => {
@@ -47,22 +47,22 @@ const getBaseUrlInput = () => screen.getByRole('textbox', { name: new RegExp(`^$
 describe('InterfacesField', () => {
   test('single allowed type: clicking Add creates the inputs directly, no dropdown', async () => {
     const user = userEvent.setup();
-    const onChangeEntity = vi.fn();
-    render(<InterfacesField entity={{ interfaces: {} }} onChangeEntity={onChangeEntity} allowedTypes={SINGLE_TYPE} />);
+    const onChangeInterfaces = vi.fn();
+    render(<InterfacesField interfaces={{}} onChangeInterfaces={onChangeInterfaces} allowedTypes={SINGLE_TYPE} />);
 
     await user.click(screen.getByRole('button', { name: 'Buttons.AddInterface' }));
 
     expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
-    expect(onChangeEntity).toHaveBeenCalledWith({
-      interfaces: { [DeploymentInterfaceType.OpenAIChatCompletions]: { baseUrl: '' } },
+    expect(onChangeInterfaces).toHaveBeenCalledWith({
+      [DeploymentInterfaceType.OpenAIChatCompletions]: { baseUrl: '' },
     });
   });
 
   test('single allowed type: add button hides once the type is configured', () => {
     render(
       <InterfacesField
-        entity={{ interfaces: { [DeploymentInterfaceType.OpenAIChatCompletions]: { baseUrl: '' } } }}
-        onChangeEntity={vi.fn()}
+        interfaces={{ [DeploymentInterfaceType.OpenAIChatCompletions]: { baseUrl: '' } }}
+        onChangeInterfaces={vi.fn()}
         allowedTypes={SINGLE_TYPE}
       />,
     );
@@ -74,8 +74,8 @@ describe('InterfacesField', () => {
     const user = userEvent.setup();
     render(
       <InterfacesField
-        entity={{ interfaces: { [DeploymentInterfaceType.OpenAIChatCompletions]: { baseUrl: 'https://x' } } }}
-        onChangeEntity={vi.fn()}
+        interfaces={{ [DeploymentInterfaceType.OpenAIChatCompletions]: { baseUrl: 'https://x' } }}
+        onChangeInterfaces={vi.fn()}
         allowedTypes={MULTI_TYPES}
       />,
     );
@@ -92,28 +92,26 @@ describe('InterfacesField', () => {
 
   test('multiple allowed types: selecting a type from the dropdown reveals its inputs and hides the dropdown', async () => {
     const user = userEvent.setup();
-    const onChangeEntity = vi.fn();
-    render(<InterfacesField entity={{ interfaces: {} }} onChangeEntity={onChangeEntity} allowedTypes={MULTI_TYPES} />);
+    const onChangeInterfaces = vi.fn();
+    render(<InterfacesField interfaces={{}} onChangeInterfaces={onChangeInterfaces} allowedTypes={MULTI_TYPES} />);
 
     await user.click(screen.getByRole('button', { name: 'Buttons.AddInterface' }));
     await user.selectOptions(screen.getByRole('combobox'), DeploymentInterfaceType.AnthropicMessages);
 
-    expect(onChangeEntity).toHaveBeenCalledWith({
-      interfaces: { [DeploymentInterfaceType.AnthropicMessages]: { baseUrl: '' } },
+    expect(onChangeInterfaces).toHaveBeenCalledWith({
+      [DeploymentInterfaceType.AnthropicMessages]: { baseUrl: '' },
     });
   });
 
   test('multiple allowed types: add button hides once all types are configured', () => {
     render(
       <InterfacesField
-        entity={{
-          interfaces: {
-            [DeploymentInterfaceType.OpenAIChatCompletions]: { baseUrl: 'a' },
-            [DeploymentInterfaceType.OpenAIResponses]: { baseUrl: 'b' },
-            [DeploymentInterfaceType.AnthropicMessages]: { baseUrl: 'c' },
-          },
+        interfaces={{
+          [DeploymentInterfaceType.OpenAIChatCompletions]: { baseUrl: 'a' },
+          [DeploymentInterfaceType.OpenAIResponses]: { baseUrl: 'b' },
+          [DeploymentInterfaceType.AnthropicMessages]: { baseUrl: 'c' },
         }}
-        onChangeEntity={vi.fn()}
+        onChangeInterfaces={vi.fn()}
         allowedTypes={MULTI_TYPES}
       />,
     );
@@ -123,45 +121,45 @@ describe('InterfacesField', () => {
 
   test('deleting a row removes it and restores add availability', async () => {
     const user = userEvent.setup();
-    const onChangeEntity = vi.fn();
+    const onChangeInterfaces = vi.fn();
     render(
       <InterfacesField
-        entity={{ interfaces: { [DeploymentInterfaceType.OpenAIChatCompletions]: { baseUrl: 'https://x' } } }}
-        onChangeEntity={onChangeEntity}
+        interfaces={{ [DeploymentInterfaceType.OpenAIChatCompletions]: { baseUrl: 'https://x' } }}
+        onChangeInterfaces={onChangeInterfaces}
         allowedTypes={SINGLE_TYPE}
       />,
     );
 
     await user.click(screen.getByRole('button', { name: 'Buttons.Delete' }));
 
-    expect(onChangeEntity).toHaveBeenCalledWith({ interfaces: {} });
+    expect(onChangeInterfaces).toHaveBeenCalledWith({});
   });
 
-  test('editing the base URL input calls onChangeEntity with the entity-backed camelCase baseUrl field', async () => {
+  test('editing the base URL input calls onChangeInterfaces with the entity-backed camelCase baseUrl field', async () => {
     const user = userEvent.setup();
-    const onChangeEntity = vi.fn();
+    const onChangeInterfaces = vi.fn();
     render(
       <InterfacesField
-        entity={{ interfaces: { [DeploymentInterfaceType.OpenAIChatCompletions]: { baseUrl: '' } } }}
-        onChangeEntity={onChangeEntity}
+        interfaces={{ [DeploymentInterfaceType.OpenAIChatCompletions]: { baseUrl: '' } }}
+        onChangeInterfaces={onChangeInterfaces}
         allowedTypes={SINGLE_TYPE}
       />,
     );
 
     await user.type(getBaseUrlInput(), 'x');
 
-    expect(onChangeEntity).toHaveBeenCalledWith({
-      interfaces: { [DeploymentInterfaceType.OpenAIChatCompletions]: { baseUrl: 'x' } },
+    expect(onChangeInterfaces).toHaveBeenCalledWith({
+      [DeploymentInterfaceType.OpenAIChatCompletions]: { baseUrl: 'x' },
     });
   });
 
-  test('editing an input value calls onChangeEntity with the core-backed snake_case base_url field when isAsset', async () => {
+  test('editing an input value calls onChangeInterfaces with the core-backed snake_case base_url field when isAsset', async () => {
     const user = userEvent.setup();
-    const onChangeEntity = vi.fn();
+    const onChangeInterfaces = vi.fn();
     render(
       <InterfacesField
-        entity={{ interfaces: { [DeploymentInterfaceType.OpenAIChatCompletions]: { base_url: '' } } }}
-        onChangeEntity={onChangeEntity}
+        interfaces={{ [DeploymentInterfaceType.OpenAIChatCompletions]: { base_url: '' } }}
+        onChangeInterfaces={onChangeInterfaces}
         allowedTypes={SINGLE_TYPE}
         isAsset
       />,
@@ -169,8 +167,8 @@ describe('InterfacesField', () => {
 
     await user.type(getBaseUrlInput(), 'x');
 
-    expect(onChangeEntity).toHaveBeenCalledWith({
-      interfaces: { [DeploymentInterfaceType.OpenAIChatCompletions]: { base_url: 'x' } },
+    expect(onChangeInterfaces).toHaveBeenCalledWith({
+      [DeploymentInterfaceType.OpenAIChatCompletions]: { base_url: 'x' },
     });
   });
 
@@ -178,7 +176,7 @@ describe('InterfacesField', () => {
     const user = userEvent.setup();
     render(
       <ControlledInterfacesField
-        initialEntity={{ interfaces: { [DeploymentInterfaceType.OpenAIChatCompletions]: { baseUrl: '' } } }}
+        initialInterfaces={{ [DeploymentInterfaceType.OpenAIChatCompletions]: { baseUrl: '' } }}
       />,
     );
 
@@ -196,8 +194,8 @@ describe('InterfacesField', () => {
   test('does not show a validation error for a blank required base URL until edited', () => {
     render(
       <InterfacesField
-        entity={{ interfaces: { [DeploymentInterfaceType.OpenAIChatCompletions]: { baseUrl: '' } } }}
-        onChangeEntity={vi.fn()}
+        interfaces={{ [DeploymentInterfaceType.OpenAIChatCompletions]: { baseUrl: '' } }}
+        onChangeInterfaces={vi.fn()}
         allowedTypes={SINGLE_TYPE}
       />,
     );
@@ -207,7 +205,7 @@ describe('InterfacesField', () => {
   });
 
   test('add button is wrapped in its own container so it does not stretch full width', () => {
-    render(<InterfacesField entity={{ interfaces: {} }} onChangeEntity={vi.fn()} allowedTypes={SINGLE_TYPE} />);
+    render(<InterfacesField interfaces={{}} onChangeInterfaces={vi.fn()} allowedTypes={SINGLE_TYPE} />);
 
     const addButton = screen.getByRole('button', { name: 'Buttons.AddInterface' });
     expect(addButton.parentElement?.tagName).toBe('DIV');
@@ -217,8 +215,8 @@ describe('InterfacesField', () => {
   test('disabled: hides add/delete controls and disables inputs', () => {
     render(
       <InterfacesField
-        entity={{ interfaces: { [DeploymentInterfaceType.OpenAIChatCompletions]: { baseUrl: 'https://x' } } }}
-        onChangeEntity={vi.fn()}
+        interfaces={{ [DeploymentInterfaceType.OpenAIChatCompletions]: { baseUrl: 'https://x' } }}
+        onChangeInterfaces={vi.fn()}
         allowedTypes={SINGLE_TYPE}
         disabled
       />,
@@ -232,8 +230,8 @@ describe('InterfacesField', () => {
   test('renders the interface type as a row title', () => {
     render(
       <InterfacesField
-        entity={{ interfaces: { [DeploymentInterfaceType.OpenAIChatCompletions]: { baseUrl: '' } } }}
-        onChangeEntity={vi.fn()}
+        interfaces={{ [DeploymentInterfaceType.OpenAIChatCompletions]: { baseUrl: '' } }}
+        onChangeInterfaces={vi.fn()}
         allowedTypes={SINGLE_TYPE}
       />,
     );

--- a/apps/ai-dial-admin/src/components/Interceptors/View/Properties/Properties.tsx
+++ b/apps/ai-dial-admin/src/components/Interceptors/View/Properties/Properties.tsx
@@ -61,8 +61,8 @@ const InterceptorProperties: FC<Props> = ({ selectedInterceptor, names, onChange
         onChangeValues={(defaults) => onChangeInterceptor({ ...selectedInterceptor, defaults })}
       />
       <InterfacesField
-        entity={selectedInterceptor}
-        onChangeEntity={onChangeInterceptor}
+        interfaces={selectedInterceptor.interfaces}
+        onChangeInterfaces={(interfaces) => onChangeInterceptor({ ...selectedInterceptor, interfaces })}
         allowedTypes={INTERCEPTOR_INTERFACE_TYPES}
       />
       <OverrideNameControl entity={selectedInterceptor as any} onChangeEntity={onChangeInterceptor} />

--- a/apps/ai-dial-admin/src/components/ModelView/ModelProperties/ModelProperties.tsx
+++ b/apps/ai-dial-admin/src/components/ModelView/ModelProperties/ModelProperties.tsx
@@ -92,7 +92,11 @@ const ModelProperties: FC<Props> = ({ model, modelsNames, onChangeModel }) => {
         />
       )}
 
-      <InterfacesField entity={model} onChangeEntity={onChangeModel} allowedTypes={MODEL_INTERFACE_TYPES} />
+      <InterfacesField
+        interfaces={model.interfaces}
+        onChangeInterfaces={(interfaces) => onChangeModel({ ...model, interfaces })}
+        allowedTypes={MODEL_INTERFACE_TYPES}
+      />
 
       <UpstreamEndpoints
         entity={model}

--- a/apps/ai-dial-admin/src/components/UpstreamEndpoints/Endpoint/Endpoint.tsx
+++ b/apps/ai-dial-admin/src/components/UpstreamEndpoints/Endpoint/Endpoint.tsx
@@ -7,7 +7,9 @@ import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
 import classNames from 'classnames';
 
 import EndpointControl from '@/src/components/BaseControls/Endpoint/Endpoint';
+import InterfacesField from '@/src/components/BaseControls/InterfacesField/InterfacesField';
 import ExtraDataField from '@/src/components/UpstreamEndpoints/ExtraData/ExtraDataField';
+import { MODEL_INTERFACE_TYPES } from '@/src/constants/deployment-interfaces';
 import {
   EntityFieldsI18nKey,
   EntityPlaceholdersI18nKey,
@@ -18,7 +20,8 @@ import { useSaveValidationContext, ValidationActionType } from '@/src/context/Sa
 import { BASE_BUTTON_ICON_PROPS } from '@/src/constants/main-layout';
 import { useIsTabletScreen } from '@/src/hooks/use-is-tablet-screen';
 import { useI18n } from '@/src/locales/client';
-import { DialEndpointExtraData, DialModelEndpoint } from '@/src/models/dial/model';
+import { InterfaceFieldVariant } from '@/src/models/dial/interfaces';
+import { DialEndpointExtraData, DialModelEndpoint, DialUpstreamInterface } from '@/src/models/dial/model';
 import { ApplicationRoute } from '@/src/types/routes';
 import { isDangerEndpoint } from '@/src/utils/validation/url-error';
 import WarningIcon from '@/src/components/Common/WarningIcon/WarningIcon';
@@ -256,6 +259,13 @@ const Endpoint: FC<Props> = ({
                 containerClassName="w-full"
                 onChange={onChangeSecretExtraData}
               />
+              <InterfacesField<DialUpstreamInterface>
+                interfaces={endpoint.interfaces}
+                onChangeInterfaces={(interfaces) => updateEndpoint({ ...endpoint, interfaces })}
+                allowedTypes={MODEL_INTERFACE_TYPES}
+                variant={InterfaceFieldVariant.Endpoint}
+                disabled={disabled}
+              />
             </>
           )}
         </div>
@@ -289,6 +299,16 @@ const Endpoint: FC<Props> = ({
                 isSecret
                 containerClassName="flex-1 min-w-0"
                 onChange={onChangeSecretExtraData}
+              />
+            </div>
+            <div className="mt-2 w-full">
+              <InterfacesField<DialUpstreamInterface>
+                interfaces={endpoint.interfaces}
+                onChangeInterfaces={(interfaces) => updateEndpoint({ ...endpoint, interfaces })}
+                allowedTypes={MODEL_INTERFACE_TYPES}
+                variant={InterfaceFieldVariant.Endpoint}
+                disabled={disabled}
+                className="w-full"
               />
             </div>
           </>

--- a/apps/ai-dial-admin/src/constants/i18n.ts
+++ b/apps/ai-dial-admin/src/constants/i18n.ts
@@ -1589,6 +1589,7 @@ export enum InterfacesI18nKey {
   BaseUrl = 'Interfaces.BaseUrl',
   BaseUrlPlaceholder = 'Interfaces.BaseUrlPlaceholder',
   InfoBaseUrl = 'Interfaces.InfoBaseUrl',
+  InfoEndpoint = 'Interfaces.InfoEndpoint',
 }
 
 export enum ImagesI18nKey {

--- a/apps/ai-dial-admin/src/locales/en.ts
+++ b/apps/ai-dial-admin/src/locales/en.ts
@@ -1621,6 +1621,7 @@ export default {
     BaseUrl: 'Base URL',
     BaseUrlPlaceholder: 'Enter {type} host',
     InfoBaseUrl: 'Base URL - service host',
+    InfoEndpoint: 'Endpoint - overrides this interface for the upstream; unset fields fall back to its own',
   },
   Images: {
     ImagesListTitle: 'Images',

--- a/apps/ai-dial-admin/src/models/dial/interfaces.ts
+++ b/apps/ai-dial-admin/src/models/dial/interfaces.ts
@@ -5,6 +5,13 @@ export enum DeploymentInterfaceType {
   OpenAIEmbeddings = 'openaiEmbeddings',
 }
 
+// Which field shape InterfacesField renders per row: a single base_url (deployment-side routing) or
+// the fuller endpoint/key/extraData override set (upstream-side, peer of DialModelEndpoint's own fields).
+export enum InterfaceFieldVariant {
+  BaseUrl = 'baseUrl',
+  Endpoint = 'endpoint',
+}
+
 export interface DialDeploymentInterface {
   baseUrl: string;
 }

--- a/apps/ai-dial-admin/src/models/dial/model.ts
+++ b/apps/ai-dial-admin/src/models/dial/model.ts
@@ -45,6 +45,16 @@ export interface DialModelLimit {
 
 export type DialEndpointExtraData = string | object;
 
+// Per-interface override for a DialModelEndpoint, peer of DialDeploymentInterface/DialResourceInterface
+// but carrying the upstream's own fields (a complete endpoint, not a base url) rather than one base_url.
+// Every field left unset here falls back to the DialModelEndpoint's own namesake for that interface.
+export interface DialUpstreamInterface {
+  endpoint?: string;
+  key?: string;
+  extraData?: DialEndpointExtraData;
+  secretExtraData?: DialEndpointExtraData;
+}
+
 export interface DialModelEndpoint {
   id?: string;
   endpoint?: string;
@@ -54,6 +64,7 @@ export interface DialModelEndpoint {
   extraData?: DialEndpointExtraData;
   secretExtraData?: DialEndpointExtraData;
   responsesEndpoint?: string;
+  interfaces?: Record<string, DialUpstreamInterface>;
 }
 
 export enum DialModelType {


### PR DESCRIPTION
**Description:**

DIAL Core v0.47.0 lets interfaces be configured per upstream instead of only at the deployment level. `InterfacesField` previously coupled its inputs to a single `entity`/`onChangeEntity` pair and rendered only a `baseUrl` per interface type, so it could not represent an upstream endpoint's own endpoint/key/extraData for a given interface. This change generalizes the field to a `interfaces`/`onChangeInterfaces` contract with a `variant` prop, and adds an endpoint-shaped row so a `DialModelEndpoint` upstream can override endpoint, key, and extra data per interface while unset fields fall back to the upstream's own values.

Issues:

- Issue #4433

**Key Changes:**

- [InterfaceEndpointRow.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/feat/add-upstream-interface-endpoint-overrides/apps/ai-dial-admin/src/components/BaseControls/InterfacesField/InterfaceEndpointRow.tsx) — new row rendering endpoint/key/extraData for the `Endpoint` variant
- [InterfacesField.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/feat/add-upstream-interface-endpoint-overrides/apps/ai-dial-admin/src/components/BaseControls/InterfacesField/InterfacesField.tsx) — generalized props (`interfaces`/`onChangeInterfaces`) and added `variant` to switch between base-URL and endpoint rows
- [Endpoint.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/feat/add-upstream-interface-endpoint-overrides/apps/ai-dial-admin/src/components/UpstreamEndpoints/Endpoint/Endpoint.tsx) — renders `InterfacesField` with the new `Endpoint` variant for per-upstream overrides
- [model.ts](https://github.com/epam/ai-dial-admin-frontend/blob/feat/add-upstream-interface-endpoint-overrides/apps/ai-dial-admin/src/models/dial/model.ts) — adds `DialUpstreamInterface` and `interfaces` on `DialModelEndpoint`
- [interfaces.ts](https://github.com/epam/ai-dial-admin-frontend/blob/feat/add-upstream-interface-endpoint-overrides/apps/ai-dial-admin/src/models/dial/interfaces.ts) — adds `InterfaceFieldVariant`
- [Properties.tsx (Applications/View)](https://github.com/epam/ai-dial-admin-frontend/blob/feat/add-upstream-interface-endpoint-overrides/apps/ai-dial-admin/src/components/Applications/View/Properties/Properties.tsx), [Properties.tsx (Interceptors/View)](https://github.com/epam/ai-dial-admin-frontend/blob/feat/add-upstream-interface-endpoint-overrides/apps/ai-dial-admin/src/components/Interceptors/View/Properties/Properties.tsx), [ModelProperties.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/feat/add-upstream-interface-endpoint-overrides/apps/ai-dial-admin/src/components/ModelView/ModelProperties/ModelProperties.tsx), and the `Assets/*` `Properties.tsx` siblings — updated to the new `interfaces`/`onChangeInterfaces` call shape

**New Components:**

- `InterfaceEndpointRow` — renders a single interface's endpoint, key, and extra data fields for the `Endpoint` variant of `InterfacesField`.

**Breaking Changes:**

`InterfacesField`'s props changed from `entity`/`onChangeEntity` to `interfaces`/`onChangeInterfaces`; every call site in this repo has been updated in this PR.

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #4433)` (comma-separated list of issues)