### PR TITLE
feat(Assets/Models): add the Audit tab to platform model detail views (Issue #4200)

### DIFF
--- a/apps/ai-dial-admin/src/components/Analytics/Pipelines/Enrich/EnrichSection.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/Pipelines/Enrich/EnrichSection.tsx
@@ -191,9 +191,6 @@ const EnrichSection: FC<Props> = ({ form, evaluators, hasEvaluatorsError, isModa
           />
         </PipelineSection>
       )}
-      rather than a deliberate mode, and the moment to say so is registration. Stated on its own so it it is actually
-      required: the service refuses a `sql` evaluator with no binding, while it accepts an `llm` one without any — so
-      showing it before an evaluator resolves would be an optional field, and
       {(!isModal || form.isBindingsReady) && (
         <PipelineSection title={t(AnalyticsPipelinesI18nKey.SectionBindings)} isModal={isModal} isExpanded>
           {isModal && <span className="text-primary dial-small">{t(AnalyticsPipelinesI18nKey.OutputBindings)}</span>}

--- a/apps/ai-dial-admin/src/components/Assets/Platform/Models/TabsContent.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Platform/Models/TabsContent.tsx
@@ -2,6 +2,7 @@
 
 import { FC } from 'react';
 
+import EntityAudit from '@/src/components/EntityTabs/Audit/EntityAudit';
 import AssetRoles from '@/src/components/EntityView/Roles/AssetRoles';
 import EntityInterceptors from '@/src/components/EntityView/Interceptors/Interceptors';
 import { DialInterceptor } from '@/src/models/dial/interceptor';
@@ -72,6 +73,10 @@ const TabsContent: FC<Props> = ({
           onChangeEntity={onChange}
           view={ApplicationRoute.PlatformModels}
         />
+      )}
+
+      {activeTab === EntityViewTab.Audit && (
+        <EntityAudit entity={selectedModel} view={ApplicationRoute.PlatformModels} />
       )}
     </>
   );

--- a/apps/ai-dial-admin/src/components/Assets/Platform/Models/View.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Platform/Models/View.tsx
@@ -8,6 +8,7 @@ import { JsonConfiguration } from '@/src/components/EntityHeaderControls/models'
 import SimpleEntityHeader from '@/src/components/EntityHeaderControls/SimpleHeader';
 import EntityJsonEditor from '@/src/components/EntityTabs/JsonEditor/JsonEditor';
 import { EntitiesI18nKey } from '@/src/constants/i18n';
+import { useAppContext } from '@/src/context/AppContext';
 import { useModelsFolder } from '@/src/context/assets/ModelsFolderContext';
 import { useNotification } from '@/src/context/NotificationContext';
 import { useProtectedRequest } from '@/src/hooks/use-protected-request';
@@ -34,7 +35,8 @@ interface Props {
 
 const ModelView: FC<Props> = ({ etag, originalModel, roles, interceptors, globalInterceptors, optionWarnings }) => {
   const t = useI18n();
-  const tabs = getTabsForAsset(t, ApplicationRoute.PlatformModels);
+  const { featureFlags } = useAppContext();
+  const tabs = getTabsForAsset(t, ApplicationRoute.PlatformModels, featureFlags);
   const router = useRouter();
   const { fetchFiles } = useModelsFolder();
   const { showNotification } = useNotification();

--- a/apps/ai-dial-admin/src/components/Assets/Platform/Models/tests/TabsContent.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Platform/Models/tests/TabsContent.spec.tsx
@@ -1,13 +1,25 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { AssetModel } from '@/src/models/dial/deployment-asset';
+import { ApplicationRoute } from '@/src/types/routes';
 import { EntityViewTab } from '@/src/utils/tabs/utils';
 import TabsContent from '../TabsContent';
 
 vi.mock('@/src/hooks/use-is-read-only-admin', () => ({
   useIsReadOnlyAdmin: vi.fn(() => false),
+}));
+
+const { onRenderEntityAudit } = vi.hoisted(() => ({
+  onRenderEntityAudit: vi.fn<(props: { entity: AssetModel; view: ApplicationRoute }) => void>(),
+}));
+
+vi.mock('@/src/components/EntityTabs/Audit/EntityAudit', () => ({
+  default: (props: { entity: AssetModel; view: ApplicationRoute }) => {
+    onRenderEntityAudit(props);
+    return null;
+  },
 }));
 
 vi.mock('@/src/app/[lang]/models/actions', () => ({
@@ -19,12 +31,16 @@ vi.mock('@/src/app/[lang]/models/actions', () => ({
 const model = (overrides: Partial<AssetModel> = {}) =>
   ({ name: 'gpt-4', path: 'gpt-4', folderId: '', ...overrides }) as AssetModel;
 
-const renderTabs = (onChange: (m: AssetModel) => void, overrides: Partial<AssetModel> = {}) => {
+const renderTabs = (
+  onChange: (m: AssetModel) => void,
+  overrides: Partial<AssetModel> = {},
+  activeTab: EntityViewTab = EntityViewTab.Properties,
+) => {
   const selected = model(overrides);
 
-  return render(
+  render(
     <TabsContent
-      activeTab={EntityViewTab.Properties}
+      activeTab={activeTab}
       selectedModel={selected}
       originalModel={selected}
       roles={[]}
@@ -32,6 +48,8 @@ const renderTabs = (onChange: (m: AssetModel) => void, overrides: Partial<AssetM
       onChange={onChange}
     />,
   );
+
+  return selected;
 };
 
 /**
@@ -59,5 +77,26 @@ describe('Model asset TabsContent :: a removed field stays removed', () => {
     await user.clear(screen.getByDisplayValue('cl100k_base'));
 
     expect(onChange.mock.calls.at(-1)?.[0]).toMatchObject({ name: 'gpt-4', displayName: 'Kept' });
+  });
+});
+
+describe('Model asset TabsContent :: Audit tab', () => {
+  beforeEach(() => {
+    onRenderEntityAudit.mockClear();
+  });
+
+  test('Should render the audit view for the selected model under the platform models route', () => {
+    const selected = renderTabs(vi.fn(), {}, EntityViewTab.Audit);
+
+    expect(onRenderEntityAudit).toHaveBeenCalledOnce();
+    expect(onRenderEntityAudit).toHaveBeenCalledWith(
+      expect.objectContaining({ entity: selected, view: ApplicationRoute.PlatformModels }),
+    );
+  });
+
+  test('Should not render the audit view on the Properties tab', () => {
+    renderTabs(vi.fn(), {}, EntityViewTab.Properties);
+
+    expect(onRenderEntityAudit).not.toHaveBeenCalled();
   });
 });

--- a/apps/ai-dial-admin/src/components/Assets/Platform/Models/tests/tabs.spec.ts
+++ b/apps/ai-dial-admin/src/components/Assets/Platform/Models/tests/tabs.spec.ts
@@ -1,10 +1,28 @@
 import { describe, expect, test } from 'vitest';
 
+import { FeatureFlags } from '@/src/models/feature-flags';
 import { ApplicationRoute } from '@/src/types/routes';
 import { EntityViewTab, getTabsForAsset } from '@/src/utils/tabs/utils';
 
 const t = (key: string) => key;
-const tabIds = () => getTabsForAsset(t, ApplicationRoute.PlatformModels).map((tab) => tab.id);
+
+const flags = (overrides: Partial<FeatureFlags> = {}): FeatureFlags => ({
+  dashboardEnabled: false,
+  deploymentsEnabled: false,
+  evaluationEnabled: false,
+  mcpRegistryEnabled: false,
+  nimEnabled: false,
+  hfEnabled: false,
+  analyticsEnabled: false,
+  analyticsConversationsEnabled: false,
+  queryAssistantEnabled: false,
+  ...overrides,
+});
+
+const dashboardFlags = flags({ dashboardEnabled: true });
+
+const tabIds = (featureFlags?: FeatureFlags) =>
+  getTabsForAsset(t, ApplicationRoute.PlatformModels, featureFlags).map((tab) => tab.id);
 
 describe('Model asset :: detail view tab set', () => {
   test('Should expose exactly Properties, Features, Roles and Interceptors in order', () => {
@@ -16,10 +34,39 @@ describe('Model asset :: detail view tab set', () => {
     ]);
   });
 
+  test('Should append Audit as the fifth and last tab when the dashboard feature is enabled', () => {
+    expect(tabIds(dashboardFlags)).toEqual([
+      EntityViewTab.Properties,
+      EntityViewTab.Features,
+      EntityViewTab.Roles,
+      EntityViewTab.Interceptors,
+      EntityViewTab.Audit,
+    ]);
+  });
+
   test.each([EntityViewTab.Audit, EntityViewTab.Parameters, EntityViewTab.AppRoutes, EntityViewTab.Dependencies])(
     'Should not offer the %s tab, which has no Core counterpart for a config resource',
     (tab) => {
       expect(tabIds()).not.toContain(tab);
     },
   );
+
+  test.each([EntityViewTab.Parameters, EntityViewTab.AppRoutes, EntityViewTab.Dependencies])(
+    'Should not offer the %s tab with the dashboard feature enabled either',
+    (tab) => {
+      expect(tabIds(dashboardFlags)).not.toContain(tab);
+    },
+  );
+
+  test.each([
+    ApplicationRoute.PlatformAppRunners,
+    ApplicationRoute.PlatformInterceptors,
+    ApplicationRoute.PlatformRoutes,
+    ApplicationRoute.PlatformKeys,
+    ApplicationRoute.PlatformRoles,
+  ])('Should leave the %s detail view without an Audit tab when the dashboard feature is enabled', (view) => {
+    const siblingTabIds = getTabsForAsset(t, view, dashboardFlags).map((tab) => tab.id);
+    expect(siblingTabIds).not.toContain(EntityViewTab.Audit);
+    expect(siblingTabIds).toContain(EntityViewTab.Properties);
+  });
 });

--- a/apps/ai-dial-admin/src/components/Assets/Platform/Models/tests/view-tabs.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Platform/Models/tests/view-tabs.spec.tsx
@@ -1,0 +1,67 @@
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { TabModel } from '@epam/ai-dial-ui-kit';
+
+import { AppContextType } from '@/src/context/AppContext';
+import { AssetModel } from '@/src/models/dial/deployment-asset';
+import { FeatureFlags } from '@/src/models/feature-flags';
+import { EntityViewTab } from '@/src/utils/tabs/utils';
+import ModelView from '../View';
+
+interface SimpleHeaderMockProps {
+  tabs?: TabModel[];
+}
+
+const { useAppContextMock, simpleHeaderSpy } = vi.hoisted(() => ({
+  useAppContextMock: vi.fn<() => Pick<AppContextType, 'featureFlags'>>(),
+  simpleHeaderSpy: vi.fn<(props: SimpleHeaderMockProps) => void>(),
+}));
+
+vi.mock('@/src/context/AppContext', () => ({ useAppContext: useAppContextMock }));
+
+vi.mock('@/src/components/EntityHeaderControls/SimpleHeader', () => ({
+  default: (props: SimpleHeaderMockProps) => {
+    simpleHeaderSpy(props);
+    return null;
+  },
+}));
+
+vi.mock('@/src/context/assets/ModelsFolderContext', () => ({
+  useModelsFolder: () => ({ fetchFiles: vi.fn() }),
+}));
+
+vi.mock('@/src/app/[lang]/platform-models/actions', () => ({
+  updateModel: vi.fn(),
+  removeModel: vi.fn(),
+}));
+
+vi.mock('../TabsContent', () => ({ default: () => null }));
+
+const model = { name: 'gpt-4', path: 'gpt-4', folderId: '' } as AssetModel;
+
+const MODEL_TABS = [EntityViewTab.Properties, EntityViewTab.Features, EntityViewTab.Roles, EntityViewTab.Interceptors];
+
+describe('ModelView — Audit tab wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const renderTabIds = (isDashboardEnabled: boolean): EntityViewTab[] => {
+    useAppContextMock.mockReturnValue({ featureFlags: { dashboardEnabled: isDashboardEnabled } as FeatureFlags });
+    render(<ModelView etag="etag" originalModel={model} roles={[]} interceptors={[]} />);
+
+    expect(simpleHeaderSpy).toHaveBeenCalled();
+
+    const { tabs } = simpleHeaderSpy.mock.lastCall?.[0] as SimpleHeaderMockProps;
+    return (tabs ?? []).map((tab) => tab.id as EntityViewTab);
+  };
+
+  test('Should pass the Audit tab to the header, last, when the dashboard feature is enabled', () => {
+    expect(renderTabIds(true)).toEqual([...MODEL_TABS, EntityViewTab.Audit]);
+  });
+
+  test('Should pass the header the model tabs without Audit when the dashboard feature is disabled', () => {
+    expect(renderTabIds(false)).toEqual(MODEL_TABS);
+  });
+});

--- a/apps/ai-dial-admin/src/utils/tabs/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/utils/tabs/tests/utils.spec.ts
@@ -3,19 +3,8 @@ import { FeatureFlags } from '@/src/models/feature-flags';
 import { ApplicationRoute } from '@/src/types/routes';
 import { describe, expect, test, vi } from 'vitest';
 
-const flags = (overrides: Partial<FeatureFlags> = {}): FeatureFlags => ({
-  dashboardEnabled: false,
-  deploymentsEnabled: false,
-  evaluationEnabled: false,
-  mcpRegistryEnabled: false,
-  nimEnabled: false,
-  hfEnabled: false,
-  analyticsEnabled: false,
-  analyticsConversationsEnabled: false,
-  queryAssistantEnabled: false,
-  ...overrides,
-});
 import {
+  activitiesTab,
   applicationRunnersTab,
   applicationsTab,
   appRouteTab,
@@ -100,6 +89,19 @@ import { CONTAINER_STATUS } from '@/src/types/deployments/containers';
 import { IMAGE_STATUS } from '@/src/types/deployments/images';
 
 const t = vi.fn((id) => id);
+
+const flags = (overrides: Partial<FeatureFlags> = {}): FeatureFlags => ({
+  dashboardEnabled: false,
+  deploymentsEnabled: false,
+  evaluationEnabled: false,
+  mcpRegistryEnabled: false,
+  nimEnabled: false,
+  hfEnabled: false,
+  analyticsEnabled: false,
+  analyticsConversationsEnabled: false,
+  queryAssistantEnabled: false,
+  ...overrides,
+});
 
 describe('Entities :: tabs', () => {
   test('Should return tabs for models', () => {
@@ -194,6 +196,30 @@ describe('Entities :: tabs', () => {
       toolsTab(t),
       auditTab(t),
     ]);
+  });
+
+  test('returns only Dashboard and Traces tabs for PlatformModels when dashboardEnabled is true', () => {
+    const tabs = getAuditTabs(t, flags({ dashboardEnabled: true }), ApplicationRoute.PlatformModels);
+    expect(tabs).toEqual([
+      { id: 'Dashboard', label: TabsI18nKey.Dashboard },
+      { id: 'Traces', label: TabsI18nKey.Traces },
+    ]);
+    expect(tabs).not.toContainEqual(activitiesTab(t));
+    expect(tabs).not.toContainEqual(conversationsTab(t));
+  });
+
+  test('returns four tabs without Audit for PlatformModels without dashboardEnabled', () => {
+    expect(getTabsForAsset(t, ApplicationRoute.PlatformModels)).toEqual([
+      propertiesTab(t),
+      featuresTab(t),
+      rolesTab(t),
+      interceptorsTab(t),
+    ]);
+  });
+
+  test('appends Audit as the fifth and last tab for PlatformModels with dashboardEnabled', () => {
+    const tabs = getTabsForAsset(t, ApplicationRoute.PlatformModels, flags({ dashboardEnabled: true }));
+    expect(tabs).toEqual([propertiesTab(t), featuresTab(t), rolesTab(t), interceptorsTab(t), auditTab(t)]);
   });
 
   test('returns correct tabs for toolset', () => {

--- a/apps/ai-dial-admin/src/utils/tabs/utils.ts
+++ b/apps/ai-dial-admin/src/utils/tabs/utils.ts
@@ -444,7 +444,11 @@ export const getTabsForAsset = (
     return [propertiesTab(t), conversationTab(t)];
   }
   if (view === ApplicationRoute.PlatformModels) {
-    return [propertiesTab(t), featuresTab(t), rolesTab(t), interceptorsTab(t)];
+    const tabs = [propertiesTab(t), featuresTab(t), rolesTab(t), interceptorsTab(t)];
+    if (featureFlags?.dashboardEnabled) {
+      tabs.push(auditTab(t));
+    }
+    return tabs;
   }
   if (view === ApplicationRoute.PlatformAppRunners) {
     return [propertiesTab(t), featuresTab(t), parametersTab(t), appRouteTab(t), interceptorsTab(t)];
@@ -472,7 +476,7 @@ export const getAuditTabs = (
   const tabs: TabModel[] = [];
 
   if (featureFlags.dashboardEnabled) {
-    if (view === ApplicationRoute.AssetsToolsets) {
+    if (view === ApplicationRoute.AssetsToolsets || view === ApplicationRoute.PlatformModels) {
       return [dashboardTab(t), tracesTab(t)];
     }
 

--- a/apps/ai-dial-admin/src/utils/tests/telemetry.spec.tsx
+++ b/apps/ai-dial-admin/src/utils/tests/telemetry.spec.tsx
@@ -223,7 +223,8 @@ describe('Utils :: telemetry :: getFormattedDataFilters', () => {
       { $eq: { left: 'project_id', right: "'Project1'" } },
     ]);
   });
-  -test('returns $in operator for multiple values with Equal condition', () => {
+
+  test('returns $in operator for multiple values with Equal condition', () => {
     const filters = [
       { type: FILTER_TYPE.Entity, value: ['Entity1', 'Entity2', 'Entity3'], condition: FILTER_OPERATOR.Equal },
     ];
@@ -271,6 +272,11 @@ describe('Utils :: telemetry :: getEntityFilterName', () => {
   test('returns null when no entity is provided', () => {
     expect(getEntityFilterName(ApplicationRoute.AssetsToolsets, undefined)).toBeNull();
     expect(getEntityFilterName(ApplicationRoute.Toolsets, undefined)).toBeNull();
+  });
+
+  test('returns the bare model name for a platform model asset, ignoring its path', () => {
+    const entity = { name: 'gpt-4', path: 'gpt-4' } as unknown as BaseEntity;
+    expect(getEntityFilterName(ApplicationRoute.PlatformModels, entity)).toEqual('gpt-4');
   });
 });
 

--- a/openspec/changes/assets-models-audit-tab/.openspec.yaml
+++ b/openspec/changes/assets-models-audit-tab/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-07

--- a/openspec/changes/assets-models-audit-tab/design.md
+++ b/openspec/changes/assets-models-audit-tab/design.md
@@ -1,0 +1,92 @@
+# Design — Catalog ▸ Models Audit tab
+
+## Context
+
+The shape of this change is almost entirely determined by an in-repo precedent:
+`Assets/Platform/Toolsets` (spec `platform-toolsets`) already gives a DIAL Core
+`ConfigResourceController`-backed platform asset a Dashboard+Traces Audit tab, gated on
+`featureFlags.dashboardEnabled`, by reusing `EntityTabs/Audit/EntityAudit`. `Catalog ▸ Models`
+(`ApplicationRoute.PlatformModels`, `apps/ai-dial-admin/src/components/Assets/Platform/Models/`) is
+structurally identical to it — same `SimpleEntityHeader` + `TabsContent` + `flex-1 overflow-auto`
+container. So this file records only the four decisions that were not already made for us, and the
+places where this change can go wrong.
+
+## Decisions
+
+1. **Reuse `EntityAudit` addressed as `ApplicationRoute.PlatformModels`.** `EntityAudit`,
+   `Telemetry/Dashboard` and `UsageLog/UsageLog` are generic over `(BaseEntity, ApplicationRoute)`;
+   `getEntityFilterName` special-cases only `AssetsToolsets` and otherwise falls back to
+   `entity.name`, which is exactly the deployment identifier Core keys an API-written platform model
+   by. Nothing in those three components changes.
+
+2. **Gate the tab in `getTabsForAsset`, not in `EntityAudit`.** The `Audit` tab is appended to the
+   `PlatformModels` branch only when `featureFlags?.dashboardEnabled` is set, mirroring the
+   `AssetsToolsets` branch two cases above it.
+
+3. **`getAuditTabs` must return exactly `[Dashboard, Traces]` for `PlatformModels` and must not
+   reach the function's trailing `tabs.push(activitiesTab(t))`.** That trailing push is
+   unconditional, so a `PlatformModels` case written as a `push` instead of a return would silently
+   add an `Activities` sub-tab — the one sub-tab the spec forbids, and the one with no admin-backend
+   rows behind it for a Core config resource. The exact expression (extending the existing
+   `AssetsToolsets` early return's condition, or a separate early return beside it) is the
+   implementer's call; the constraint is the returned array and the non-fallthrough.
+
+4. **`View.tsx` reads `featureFlags` from `useAppContext()`** and passes it as the third argument to
+   `getTabsForAsset`, exactly as `Assets/Toolsets/View/View.tsx` and
+   `Assets/Platform/Toolsets/View.tsx` do. It is a client component already; nothing is threaded
+   through the server page, and no prop is added to `ModelView`.
+
+## Alternatives rejected
+
+- **Render the `Audit` tab unconditionally and let `getAuditTabs` decide what is inside it.**
+  Rejected: with `dashboardEnabled` unset, `getAuditTabs` falls through to the unconditional
+  `Activities` push, so the user would get an `Audit` tab containing only an activity list that is
+  permanently empty for a Core config resource — worse than no tab. Gating at the tab level keeps
+  the two functions telling the same story.
+
+- **Full parity with `Entities ▸ Models` (add `Conversations` and `Activities`).** Rejected by the
+  proposal's Non-goals and by the backend reality: `Activities` reads the admin backend's
+  activity/revision trail, which has no rows for a `ConfigResourceController` resource. Adding it
+  would ship an always-empty tab and would need new work with no precedent to reuse.
+
+- **A dedicated `PlatformModelsAudit` component under `Assets/Platform/Models/`.** Rejected: it
+  would duplicate `EntityAudit`'s tab/state/time-filter wiring to gain nothing, and the house rule
+  is to use shared components rather than fork them. The route enum is already the extension point.
+
+- **A new feature flag for this tab.** Rejected: `dashboardEnabled` already gates every
+  Dashboard/Traces Audit surface in the app, and a second flag would have to be documented,
+  templated and kept in sync for no behavioural difference.
+
+- **Fixing the `Assets`/`Catalog` naming drift (menu group, spec `Purpose` text, the
+  `Assets/Platform/` folder path) while we are in these files.** Rejected: out of scope by EM
+  decision; it touches the menu configuration and several specs and belongs in its own change.
+
+## Risks
+
+- **The gating lives in two functions in one file (`src/utils/tabs/utils.ts`), and getting only one
+  of them right fails quietly.** `getTabsForAsset` alone → tab appears whose sub-tabs are
+  `[Activities]`. `getAuditTabs` alone → nothing appears at all. First place it shows: the tab-set
+  unit tests in task 3.1, then the browser verification in task 4.1.
+
+- **The most likely miss is not in the utils at all — it is `View.tsx` never passing
+  `featureFlags`.** The util change alone is invisible; the tab still does not appear, which is
+  indistinguishable from the reported bug. `getTabsForAsset`'s third parameter is optional, so
+  TypeScript will not flag it. That is why task 3.2 asserts the tabs `View` hands to
+  `SimpleEntityHeader` rather than only unit-testing the util.
+
+- **Analytics rows are keyed by the model's bare name, so a brand-new platform model shows an empty
+  Dashboard and empty Traces.** That is correct — Core records usage under the deployment name, and
+  a model nobody has called has no usage — but it will read as "the tab is broken" to anyone
+  verifying against a freshly created model. Verify against a model name that has traffic in the
+  booted stack.
+
+- **The tab is gated on `dashboardEnabled`, not on `analyticsEnabled`.** A deployment with
+  `ANALYTICS_ENABLED` unset but `dashboard` not in `DISABLE_MENU_ITEMS` gets an `Audit` tab whose
+  reads fail. This is inherited, not introduced — `Assets ▸ Toolsets` and `Entities ▸ Models` behave
+  the same way today — and narrowing it here would change three other surfaces. If it turns out to
+  matter, it is one change across all Audit call sites, not a `PlatformModels` special case.
+
+- **What would have to change if the problem's shape changed:** if a future platform asset needs a
+  *different* Audit sub-tab set again, the per-route `if` chain in `getAuditTabs` is at the point
+  where a route→sub-tabs lookup table would be cheaper than another branch. Two routes sharing
+  `[Dashboard, Traces]` is not yet that point.

--- a/openspec/changes/assets-models-audit-tab/proposal.md
+++ b/openspec/changes/assets-models-audit-tab/proposal.md
@@ -1,0 +1,110 @@
+## Why
+
+GitHub issue #4200 reports that a model detail view under "Assets → Models" is missing an "Audit tab
+with Dashboard and Traces sub-sections", present on "Entities → Models".
+
+Reading the code shows the reporter's navigation label is stale rather than wrong about the gap. The
+menu no longer has an "Assets → Models" entry: `MENU_CONFIGURATION` in
+`apps/ai-dial-admin/src/components/Menu/menu-configuration.tsx` lists Models only under `Entities`
+(`ApplicationRoute.Models`) and under `Catalog` as `PlatformModels` (`ApplicationRoute.PlatformModels`,
+`isPreview: true`). This item was moved out of the `Assets` group by the archived change
+`2026-08-31-move-platform-items-to-catalog`, one week before this issue — but its component tree still
+lives under `src/components/Assets/Platform/Models/` and its capability spec,
+`openspec/specs/platform-models/spec.md`, still opens with "The `Assets > Models` admin surface". The
+reporter is describing this surface, not a currently-missing "Assets" menu item. This proposal targets
+the `Catalog → Models` view backed by `src/components/Assets/Platform/Models/` (route
+`/platform-models`).
+
+Comparing the two surfaces directly:
+
+- **Entities → Models** (`apps/ai-dial-admin/src/components/Models/View/TabsContent.tsx`) renders five
+  tabs — Properties, Features, Roles, Interceptors, Audit — per `getModelsTabs` in
+  `apps/ai-dial-admin/src/utils/tabs/utils.ts`. Its Audit tab renders
+  `EntityTabs/Audit/EntityAudit.tsx` with `view={ApplicationRoute.Models}`. `EntityAudit` reads its
+  sub-tab set from `getAuditTabs`, which for `ApplicationRoute.Models` returns Dashboard, Traces,
+  Conversations, plus an always-present Activities tab.
+- **Catalog → Models** (`apps/ai-dial-admin/src/components/Assets/Platform/Models/TabsContent.tsx`)
+  renders four tabs — Properties, Features, Roles, Interceptors — per the `ApplicationRoute.PlatformModels`
+  branch of `getTabsForAsset` in the same `utils.ts`. There is no `EntityAudit` reference anywhere in
+  `Assets/Platform/Models/`. This is confirmed by
+  `apps/ai-dial-admin/src/components/Assets/Platform/Models/tests/tabs.spec.ts`, which explicitly
+  asserts the tab list is exactly those four and that `EntityViewTab.Audit` is absent, "which has no
+  Core counterpart for a config resource" — and by the `platform-models` spec's own requirement,
+  "Model asset detail view tab set": "There SHALL be no Audit tab, revision link, rollback control, or
+  Core-sync banner, because DIAL Core exposes no audit, revision, history, or snapshot surface for
+  config resources."
+
+That stated rationale is accurate for revision/rollback/activity history (Catalog models are
+Core `ConfigResourceController` resources with no admin-BE audit trail behind them) but conflates it
+with Dashboard/Traces, which are unrelated to that audit trail. `Dashboard`
+(`src/components/Telemetry/Dashboard.tsx`) and `UsageLog`
+(`src/components/UsageLog/UsageLog.tsx`) both key their analytics query only by
+`getEntityFilterName(route, entity)` (`apps/ai-dial-admin/src/utils/telemetry.ts`), which falls back to
+the entity's plain `name` for every route except `AssetsToolsets`. Nothing in that path depends on
+Core exposing a config-resource audit surface.
+
+A directly analogous case already shipped this pattern for a sibling Core-`ConfigResourceController`
+platform asset: `platform-toolsets` (`openspec/specs/platform-toolsets/spec.md`, "Platform toolset
+detail view") explicitly reuses `Assets/Toolsets/View/TabsContent` — Properties, Tools, **Audit** —
+with `view={ApplicationRoute.AssetsToolsets}`
+(`apps/ai-dial-admin/src/components/Assets/Platform/Toolsets/View.tsx`). For that route,
+`getAuditTabs` returns only Dashboard and Traces (no Activities, no Conversations) when
+`featureFlags.dashboardEnabled` is set. So a platform/Catalog Core-config-resource entity carrying a
+Dashboard+Traces Audit tab, with the entity-history sub-tab dropped, is an established pattern in this
+codebase — not new ground.
+
+## What Changes
+
+- Add an Audit tab to the Catalog → Models detail view
+  (`apps/ai-dial-admin/src/components/Assets/Platform/Models/TabsContent.tsx`), rendering
+  `EntityTabs/Audit/EntityAudit` with `view={ApplicationRoute.PlatformModels}` when
+  `activeTab === EntityViewTab.Audit` — the same wiring `Assets/Toolsets/View/TabsContent.tsx` already
+  uses for `ApplicationRoute.AssetsToolsets`.
+- In `apps/ai-dial-admin/src/utils/tabs/utils.ts`:
+  - `getTabsForAsset`'s `ApplicationRoute.PlatformModels` branch gains a conditional
+    `auditTab(t)`, gated on `featureFlags?.dashboardEnabled`, appended after Interceptors — mirroring
+    the existing `ApplicationRoute.AssetsToolsets` branch's conditional push.
+  - `getAuditTabs` gains an `ApplicationRoute.PlatformModels` case returning `[dashboardTab(t),
+    tracesTab(t)]` only — no Activities, no Conversations — mirroring the existing
+    `ApplicationRoute.AssetsToolsets` case.
+- Update `openspec/specs/platform-models/spec.md`'s "Model asset detail view tab set" requirement: the
+  tab set becomes five tabs when `dashboardEnabled` is set (Properties, Features, Roles, Interceptors,
+  Audit), with the Audit sub-tabs limited to Dashboard and Traces; the "no Audit tab" scenario is
+  narrowed to "no Activities/revision/rollback/Core-sync-banner surface", not "no Audit tab at all".
+- Update the existing tests that assert the opposite of the above:
+  `apps/ai-dial-admin/src/components/Assets/Platform/Models/tests/tabs.spec.ts` (currently asserts
+  `EntityViewTab.Audit` is absent) and
+  `apps/ai-dial-admin/src/components/Assets/Platform/Models/tests/TabsContent.spec.tsx`.
+
+No change to `EntityAudit`, `Dashboard`, `UsageLog`, or `getEntityFilterName` themselves — they already
+handle an arbitrary `BaseEntity` + `ApplicationRoute` pair generically.
+
+## Impact
+
+- **Shared components**: `EntityTabs/Audit/EntityAudit.tsx`, `Telemetry/Dashboard.tsx`, and
+  `UsageLog/UsageLog.tsx` gain one more call site (unmodified) — same reuse pattern as every other
+  entity/asset Audit tab.
+- **Shared utils**: `src/utils/tabs/utils.ts` (`getTabsForAsset`, `getAuditTabs`) — both already
+  branch per `ApplicationRoute`; this adds one branch/case to each, not new logic shape.
+- **Spec**: `openspec/specs/platform-models/spec.md` carries a requirement that directly contradicts
+  this change today and must be amended in the same change (SA to draft the delta).
+- **No server action, API route, or backend change.** The Audit sub-tabs read from the existing
+  analytics pipeline (`DIAL_ANALYTICS_API_URL`, gated by the existing `dashboardEnabled` flag /
+  `DISABLE_MENU_ITEMS` env var) exactly as Entities → Models and Catalog → Toolsets already do.
+- **No effect on Entities → Models** or on the `Models` entity's own Audit tab.
+
+## Non-goals
+
+- No change to the Audit tab's own content or behavior (Dashboard charts, Traces grid) — reused as-is.
+- No Activities (admin activity-log/revision) sub-tab and no rollback/Core-sync banner on Catalog →
+  Models — Core's `ConfigResourceController` genuinely exposes no audit/revision surface for this
+  resource kind, so that part of the current spec's rationale still holds.
+- No Conversations sub-tab — not requested by the issue and not part of the `platform-toolsets`
+  precedent this change follows.
+- No Audit tab added to any other Catalog/platform entity (App Runners, Interceptors, Routes, Roles,
+  Keys) — scoped to Models only, per the issue.
+- No renaming of the `Catalog` menu group back to `Assets`, and no other menu/navigation change — the
+  stale "Assets → Models" label in the issue and in `platform-models`'s spec Purpose text is left as
+  its own possible follow-up, not part of this fix.
+- No new feature flag — reuses the existing `dashboardEnabled` flag already gating every other Audit
+  tab with Dashboard/Traces sub-sections.

--- a/openspec/changes/assets-models-audit-tab/specs/platform-models/spec.md
+++ b/openspec/changes/assets-models-audit-tab/specs/platform-models/spec.md
@@ -1,0 +1,111 @@
+## MODIFIED Requirements
+
+### Requirement: Model asset detail view tab set
+
+The system SHALL render a model asset's detail view with `Properties`, `Features`, `Roles`, and
+`Interceptors`, in that order, and SHALL append `Audit` as a fifth and last tab when the
+`dashboardEnabled` feature flag is set. When that flag is unset the tab set SHALL remain exactly the
+first four tabs.
+
+There SHALL be no revision link, no rollback control, and no Core-sync banner, because DIAL Core
+exposes no audit, revision, history, or snapshot surface for config resources — the rationale that
+previously excluded the whole Audit tab still holds for those three, and for the Activities sub-tab
+(see the Audit requirement below). It no longer excludes the Dashboard and Traces sub-tabs, which
+query the analytics service and depend on nothing Core stores. There SHALL be no Tools or
+Dependencies tab.
+
+`dashboardEnabled` is derived once per request in `apps/ai-dial-admin/src/app/[lang]/layout.tsx` from
+`DISABLE_MENU_ITEMS` not containing `dashboard`, and is the same flag that already gates the
+`Assets ▸ Toolsets` Audit tab. No new flag or environment variable is introduced.
+
+Gating the tab's *presence* is a known and accepted divergence from `Entities ▸ Models`, which lists
+`Audit` unconditionally and, with `dashboardEnabled` unset, still shows it carrying only its
+`Activities` sub-tab. `Catalog ▸ Models` has no `Activities` sub-tab to fall back on (see the Audit
+requirement below), so an unconditional tab would be empty here. Consistency with `Entities ▸ Models`
+therefore holds wherever the dashboard feature is enabled — the default — and the flag-unset
+four-tab state below is deliberate, not an oversight to be "fixed" by rendering the tab always.
+
+Two scenario headings below are retained from the previous wording of this requirement, because a
+scenario's name is the identity a delta rewrites content under: `Detail view renders exactly four
+tabs` is now the `dashboardEnabled`-unset case rather than the only case, and `No Audit tab or sync
+banner` now prohibits only the revision/rollback/Core-sync surface it used to bundle the tab with.
+
+#### Scenario: Audit is the fifth tab when the dashboard feature is enabled
+
+- **WHEN** a user opens a model asset's detail view (`/platform-models/[id]`) in a deployment whose
+  `dashboardEnabled` flag is set
+- **THEN** the tab list reads `Properties`, `Features`, `Roles`, `Interceptors`, `Audit`, in that
+  order
+
+#### Scenario: Detail view renders exactly four tabs
+
+Rescoped: the four-tab set is what a deployment with the dashboard feature disabled shows.
+
+- **WHEN** a user opens a model asset's detail view in a deployment whose `dashboardEnabled` flag is
+  unset (`DISABLE_MENU_ITEMS` includes `dashboard`)
+- **THEN** the tab list contains exactly `Properties`, `Features`, `Roles`, and `Interceptors`, in
+  that order, and no `Audit` tab is shown
+
+#### Scenario: No Audit tab or sync banner
+
+Rescoped: the prohibition now covers the revision/rollback/Core-sync surface only. The `Audit` tab
+itself is prohibited only while `dashboardEnabled` is unset, per the scenario above.
+
+- **WHEN** a user opens a model asset's detail view, with the `Audit` tab present or absent
+- **THEN** no revision link, rollback control, or Core-sync status banner is rendered
+
+#### Scenario: Sibling platform asset detail views gain no Audit tab
+
+- **WHEN** a user opens the detail view of a platform App Runner, Interceptor, Route, Key, or Role
+  with `dashboardEnabled` set
+- **THEN** no `Audit` tab is shown on any of them, unchanged from current behaviour — the new tab is
+  scoped to `Catalog ▸ Models` alone
+
+## ADDED Requirements
+
+### Requirement: Model asset Audit tab exposes Dashboard and Traces only
+
+The system SHALL render the model asset's `Audit` tab with the shared
+`EntityTabs/Audit/EntityAudit` component addressed as `ApplicationRoute.PlatformModels`, offering
+exactly two sub-tabs — `Dashboard` and `Traces`, in that order — and SHALL NOT offer the `Activities`
+or `Conversations` sub-tabs that `Entities ▸ Models` offers. `Activities` is excluded because it reads
+the admin backend's activity/revision trail, which has no rows for a DIAL Core config resource;
+`Conversations` is excluded because this surface follows the `Assets ▸ Toolsets` Audit precedent,
+which offers neither.
+
+Both sub-tabs read from the analytics-data-access-service (`DIAL_ANALYTICS_API_URL`) through the
+existing `Telemetry/Dashboard` and `UsageLog/UsageLog` components, unchanged. No admin-backend
+request and no additional DIAL Core request is introduced by this tab, and no new user action is
+added — so no new success or error notification is defined; a failed analytics read surfaces through
+those components' existing error handling.
+
+#### Scenario: Audit opens on Dashboard with Traces alongside
+
+- **WHEN** a user selects the `Audit` tab on a model asset's detail view
+- **THEN** the sub-tab list reads `Dashboard` and `Traces`, with `Dashboard` selected and its content
+  rendered
+
+#### Scenario: No Activities sub-tab
+
+- **WHEN** a user views the model asset's `Audit` tab
+- **THEN** no `Activities` sub-tab is offered, since a Core config resource has no admin-backend
+  activity/revision trail to list
+
+#### Scenario: No Conversations sub-tab
+
+- **WHEN** a user views the model asset's `Audit` tab
+- **THEN** no `Conversations` sub-tab is offered, unlike the `Entities ▸ Models` Audit tab
+
+#### Scenario: Audit reads are keyed by the model's deployment name
+
+- **WHEN** the `Dashboard` or `Traces` sub-tab builds its analytics query for a model asset
+- **THEN** the query's entity filter is the model's bare name — the same deployment identifier the
+  detail view already surfaces — with no `toolsets/`-style deployment prefix and no
+  `models/platform/{name}` canonical id
+
+#### Scenario: The Entities > Models Audit tab is unchanged
+
+- **WHEN** a user opens the `Audit` tab on an `Entities ▸ Models` detail view with `dashboardEnabled`
+  set
+- **THEN** its sub-tabs are `Dashboard`, `Traces`, `Conversations`, and `Activities`, unchanged from
+  current behaviour

--- a/openspec/changes/assets-models-audit-tab/tasks.md
+++ b/openspec/changes/assets-models-audit-tab/tasks.md
@@ -1,0 +1,103 @@
+# Tasks — Catalog ▸ Models Audit tab
+
+Reference for every task: `apps/ai-dial-admin/src/components/Assets/Platform/Toolsets/View.tsx` and
+`apps/ai-dial-admin/src/components/Assets/Toolsets/View/TabsContent.tsx` — the same wiring for the
+sibling platform asset that already ships this tab. Read them before writing anything new.
+
+The consolidated spec `openspec/specs/platform-models/spec.md` is **not** edited by hand in these
+tasks: the delta in `openspec/changes/assets-models-audit-tab/specs/platform-models/spec.md` amends
+the `Model asset detail view tab set` requirement and lands in the consolidated spec when the change
+is archived (`openspec archive`) or synced.
+
+## 1. Tab configuration
+
+- [x] 1.1 In `apps/ai-dial-admin/src/utils/tabs/utils.ts`, make both tab functions agree about
+      `ApplicationRoute.PlatformModels`: `getTabsForAsset`'s `PlatformModels` branch appends
+      `auditTab(t)` after `interceptorsTab(t)` only when `featureFlags?.dashboardEnabled` is set
+      (mirroring the `AssetsToolsets` branch above it), and `getAuditTabs` returns exactly
+      `[dashboardTab(t), tracesTab(t)]` for `PlatformModels`. **`getAuditTabs` ends with an
+      unconditional `tabs.push(activitiesTab(t))` — the `PlatformModels` case must return before
+      reaching it**, or the forbidden `Activities` sub-tab appears. Both functions live in this one
+      file on purpose; do not split it. Leave every other route's behaviour untouched.
+      Verify with `npx vitest run src/utils/tabs/tests/utils.spec.ts` (run from
+      `apps/ai-dial-admin/`) — it will still fail on the assertions task 3.1 rewrites; the check
+      here is that no *other* route's expectation broke.
+
+## 2. Detail view wiring
+
+- [x] 2.1 In `apps/ai-dial-admin/src/components/Assets/Platform/Models/View.tsx`, read
+      `const { featureFlags } = useAppContext();` from `@/src/context/AppContext` and pass it as the
+      third argument to `getTabsForAsset(t, ApplicationRoute.PlatformModels, featureFlags)`, exactly
+      as `Assets/Toolsets/View/View.tsx` does. Without this the tab never appears no matter what
+      task 1.1 does, and TypeScript will not complain — the parameter is optional.
+
+- [x] 2.2 In `apps/ai-dial-admin/src/components/Assets/Platform/Models/TabsContent.tsx`, render
+      `<EntityAudit entity={selectedModel} view={ApplicationRoute.PlatformModels} />` (default import
+      from `@/src/components/EntityTabs/Audit/EntityAudit`) when
+      `activeTab === EntityViewTab.Audit`, as the last block, mirroring
+      `Assets/Toolsets/View/TabsContent.tsx`. Add nothing else — no banner, no revision link, no
+      rollback control.
+
+## 3. Unit tests
+
+- [x] 3.1 Tab-set tests. `apps/ai-dial-admin/src/utils/tabs/tests/utils.spec.ts` has no
+      `PlatformModels` coverage at all today, so **both** flag states are new cases there, not edits
+      to existing ones: `getTabsForAsset(t, ApplicationRoute.PlatformModels)` with the flag unset
+      (four tabs) and with `flags({ dashboardEnabled: true })` (five, `auditTab(t)` last), plus
+      `getAuditTabs(t, flags({ dashboardEnabled: true }), ApplicationRoute.PlatformModels)`
+      returning `[Dashboard, Traces]` and no `Activities`. Keep the existing `Models`,
+      `Applications`, `Toolsets` and `AssetsToolsets` expectations as the regression guard. In
+      `apps/ai-dial-admin/src/components/Assets/Platform/Models/tests/tabs.spec.ts` **keep the
+      existing "Audit is absent" assertion and add a flag-set case beside it** — do not replace it.
+      That spec's `tabIds()` helper calls `getTabsForAsset(t, ApplicationRoute.PlatformModels)` with
+      no third argument, and `getTabsForAsset` appends `auditTab` only under
+      `featureFlags?.dashboardEnabled`, so the assertion is already exactly the flag-unset guard for
+      the spec scenario `Detail view renders exactly four tabs`; deleting it would leave that
+      scenario uncovered. Add the five-tab expectation for `tabIds(dashboardFlags)`, and keep
+      `Parameters`/`AppRoutes`/`Dependencies` asserted absent in both flag states. Also assert
+      `PlatformAppRunners`, `PlatformInterceptors`, `PlatformRoutes`, `PlatformKeys` and
+      `PlatformRoles` gain no `Audit` tab with the flag set.
+      Run: `npx vitest run src/utils/tabs/tests/utils.spec.ts src/components/Assets/Platform/Models/tests/tabs.spec.ts`
+
+- [x] 3.2 New spec `apps/ai-dial-admin/src/components/Assets/Platform/Models/tests/view-tabs.spec.tsx`
+      covering the wiring from task 2.1, which no util test can see. Render `ModelView`, mock
+      `@/src/components/EntityHeaderControls/SimpleHeader` with a props spy and assert the `tabs`
+      prop contains `EntityViewTab.Audit` when the `AppContext` mock reports
+      `dashboardEnabled: true` and does not when it reports `false` — re-mock
+      `@/src/context/AppContext` locally, since `test-setup.tsx`'s global mock leaves
+      `dashboardEnabled` undefined. Mock `@/src/context/assets/ModelsFolderContext`,
+      `@/src/app/[lang]/platform-models/actions` and `./TabsContent` locally; keep the render light.
+      Run: `npx vitest run src/components/Assets/Platform/Models/tests/view-tabs.spec.tsx`
+
+- [x] 3.3 In `apps/ai-dial-admin/src/components/Assets/Platform/Models/tests/TabsContent.spec.tsx`
+      add a case for `activeTab={EntityViewTab.Audit}`: mock
+      `@/src/components/EntityTabs/Audit/EntityAudit` with a props spy (it pulls in ECharts and AG
+      Grid otherwise) and assert it is rendered with `view === ApplicationRoute.PlatformModels` and
+      the selected model as `entity`. Assert no such component renders for the `Properties` tab.
+      Do not copy the fake `role="dashboards"` query from
+      `EntityTabs/Audit/tests/EntityAudit.spec.tsx` — `.claude/rules/testing.md` §4.4 forbids
+      invented roles; assert through the props spy.
+      Run: `npx vitest run src/components/Assets/Platform/Models/tests/TabsContent.spec.tsx`
+
+- [x] 3.4 In `apps/ai-dial-admin/src/utils/tests/telemetry.spec.tsx`, inside the existing
+      `Utils :: telemetry :: getEntityFilterName` describe, add a case asserting that
+      `getEntityFilterName(ApplicationRoute.PlatformModels, entity)` returns the bare `name` and
+      ignores the asset's `path` — no `toolsets/` prefix, no `models/platform/` id.
+      Run: `npx vitest run src/utils/tests/telemetry.spec.tsx`
+
+## 4. Browser verification
+
+- [x] 4.1 Run the `spec-browser-verify` skill against a locally booted stack with auth disabled and
+      the default `DISABLE_MENU_ITEMS` (so `dashboardEnabled` is set) and analytics configured —
+      the configuration that reproduces issue #4200. Verify, on `Catalog ▸ Models` → a model that
+      has traffic in the booted stack: `Audit is the fifth tab when the dashboard feature is
+      enabled`, `Audit opens on Dashboard with Traces alongside`, `No Activities sub-tab`,
+      `No Conversations sub-tab`, and `No Audit tab or sync banner` (no revision link, rollback
+      control, or Core-sync banner). The flag-unset matrix stays with the unit tests in 3.1.
+      Resolve any `fail` verdict before the change is complete.
+
+## 5. Quality checks
+
+- [x] 5.1 From `apps/ai-dial-admin/`, run `npm run lint`, `npm run format`, and `npm run test` (full
+      suite with coverage) and report the actual output. Anything this turns up comes back as a new
+      dispatch to the task that owns the file, not as an edit from here.


### PR DESCRIPTION
Closes #4200

## What

`Catalog → Models` (route `/platform-models`) rendered four tabs — Properties, Features, Roles, Interceptors — while `Entities → Models` rendered five. Dashboard and Traces were therefore unreachable for a platform model.

The Audit tab is now appended last when the dashboard feature flag is on. Its sub-tab set follows the `Assets → Toolsets` shape rather than the `Entities → Models` one:

- **Dashboard** and **Traces** only.
- No **Activities** — Catalog models are Core `ConfigResourceController` resources with no admin-BE audit trail, so the existing early return in `getAuditTabs` is extended rather than bypassed.
- No **Conversations** — out of scope for this issue.

With the flag off the tab set is unchanged.

## Changes

- `utils/tabs/utils.ts` — `getTabsForAsset` appends `auditTab` for `PlatformModels` under `featureFlags?.dashboardEnabled`; `getAuditTabs` extends its `AssetsToolsets` early return to cover `PlatformModels`.
- `Assets/Platform/Models/View.tsx` — reads `featureFlags` from `useAppContext()` and passes it to `getTabsForAsset`.
- `Assets/Platform/Models/TabsContent.tsx` — renders `EntityAudit` for the Audit tab.
- Sibling platform asset views (App Runner, Interceptor, Route, Key, Role) gain no Audit tab — asserted.

## Tests

`npx vitest run src/utils/tabs src/components/Assets/Platform/Models` — new coverage for both flag states, the Dashboard/Traces sub-tab set, the sibling-route matrix, and a `view-tabs.spec.tsx` that fails if `View.tsx` stops passing `featureFlags` (TypeScript would not catch it — the parameter is optional). Full suite green on pre-push.

## OpenSpec

`openspec/changes/assets-models-audit-tab/` — delta lands in `openspec/specs/platform-models/spec.md` at archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)