### PR TITLE
fix(Entities/Applications): resolve platform runner scheme by its fetched $id, not the stale picker id

### DIFF
--- a/apps/ai-dial-admin/src/app/[lang]/assets-applications/tests/runner-sources.spec.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/assets-applications/tests/runner-sources.spec.tsx
@@ -37,7 +37,7 @@ describe('Assets > Applications :: runner sources', () => {
 
     const runners = runnersPassedToList(await Page());
 
-    expect(runners.map((r) => r.origin)).toEqual([AppRunnerOrigin.Entity, AppRunnerOrigin.Asset]);
+    expect(runners.map((r) => r.origin)).toEqual([AppRunnerOrigin.Config, AppRunnerOrigin.Platform]);
     expect(runners.map((r) => r.reference)).toEqual(['urn:runner:entity', 'schemas/platform/http%3A%2F%2Fasdqwe']);
   });
 
@@ -48,7 +48,7 @@ describe('Assets > Applications :: runner sources', () => {
     const runners = runnersPassedToList(await Page());
 
     expect(runners).toHaveLength(1);
-    expect(runners[0].origin).toBe(AppRunnerOrigin.Entity);
+    expect(runners[0].origin).toBe(AppRunnerOrigin.Config);
   });
 
   test('still offers asset runners when the admin-BE read fails', async () => {
@@ -58,7 +58,7 @@ describe('Assets > Applications :: runner sources', () => {
     const runners = runnersPassedToList(await Page());
 
     expect(runners).toHaveLength(1);
-    expect(runners[0].origin).toBe(AppRunnerOrigin.Asset);
+    expect(runners[0].origin).toBe(AppRunnerOrigin.Platform);
   });
 });
 

--- a/apps/ai-dial-admin/src/components/Applications/ParametersTab/ParametersTab.tsx
+++ b/apps/ai-dial-admin/src/components/Applications/ParametersTab/ParametersTab.tsx
@@ -6,10 +6,7 @@ import { Dispatch, FC, SetStateAction, useCallback, useEffect, useMemo, useState
 import { DialLoader, DialNoDataContent, DialPrimaryButton, JsonSchema, SelectOption } from '@epam/ai-dial-ui-kit';
 import { IconPlus } from '@tabler/icons-react';
 
-import { getResolvedApplicationScheme } from '@/src/app/[lang]/application-runners/actions';
-import { getResolvedRunnerSchema } from '@/src/app/[lang]/platform-app-runners/actions';
-import { AppRunnerOrigin } from '@/src/components//SourceField/Application/models';
-import { getRunnerOrigin } from '@/src/components//SourceField/Application/utils';
+import { resolveAppRunnerScheme } from '@/src/components/SourceField/Application/resolve-app-runner';
 import {
   convertJsonSchema,
   generateViewItems,
@@ -75,22 +72,11 @@ const ParametersTab: FC<Props> = ({
   const [isAddClicked, setIsAddClicked] = useState(false);
 
   useEffect(() => {
-    let scheme = undefined;
     const foundRunner = getAppRunner(application as DialApplication, applicationSchemes, view);
-    const isAsset = !!foundRunner && getRunnerOrigin(foundRunner) === AppRunnerOrigin.Asset;
-    const resolve = isAsset
-      ? getResolvedRunnerSchema(foundRunner.$id ?? '')
-      : getResolvedApplicationScheme(foundRunner?.$id ?? '');
+
     setIsSchemeLoading(true);
-    resolve.then((res) => {
-      const resolved = isAsset
-        ? (res.response as DialApplicationScheme | undefined)
-        : (res.response as { schema?: DialApplicationScheme })?.schema;
-      if (res.success) {
-        scheme = resolved;
-      } else {
-        scheme = foundRunner ?? undefined;
-      }
+    resolveAppRunnerScheme(foundRunner).then(({ runner: resolvedRunner, scheme: resolvedScheme }) => {
+      const scheme = resolvedScheme ?? resolvedRunner;
       setIsSchemeLoading(false);
       setScheme(scheme);
       const config = getCorrectConfig(scheme, application, currentTheme, session as UserSession);

--- a/apps/ai-dial-admin/src/components/Applications/ParametersTab/tests/ParametersTab.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Applications/ParametersTab/tests/ParametersTab.spec.tsx
@@ -1,12 +1,24 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
 import ParametersTab from '../ParametersTab';
 import { BasicI18nKey } from '@/src/constants/i18n';
+import { AppRunnerOrigin } from '@/src/components/SourceField/Application/models';
 import { ApplicationSourceType } from '@/src/models/dial/application';
+import { ApplicationRoute } from '@/src/types/routes';
 
 vi.mock('@/src/app/[lang]/application-runners/actions', () => ({
   getResolvedApplicationScheme: vi.fn().mockResolvedValue({ success: false }),
 }));
+
+vi.mock('@/src/app/[lang]/platform-app-runners/actions', () => ({
+  getResolvedRunnerSchema: vi.fn().mockResolvedValue({ success: true, response: { properties: { propA: {} } } }),
+  getRunner: vi.fn().mockResolvedValue({
+    success: true,
+    response: { $id: 'http://asdqwe/edited', path: 'http%3A%2F%2Fasdqwe' },
+  }),
+}));
+
+import { getResolvedRunnerSchema, getRunner } from '@/src/app/[lang]/platform-app-runners/actions';
 
 describe('Applications - ApplicationParametersTab', () => {
   test('Should correctly render notification', async () => {
@@ -43,5 +55,24 @@ describe('Applications - ApplicationParametersTab', () => {
     render(<ParametersTab application={{ editorUrl: 'editorUrl' }} />);
 
     expect(await screen.findByText(BasicI18nKey.NoParameters)).toBeInTheDocument();
+  });
+
+  test('resolves a platform-origin runner via its content $id before rendering', async () => {
+    render(
+      <ParametersTab
+        application={{ source: { $type: ApplicationSourceType.SCHEMA, applicationTypeSchemaId: 'http://asdqwe' } }}
+        applicationSchemes={[
+          {
+            $id: 'http://asdqwe',
+            origin: AppRunnerOrigin.Platform,
+            path: 'http%3A%2F%2Fasdqwe',
+          } as never,
+        ]}
+        view={ApplicationRoute.Applications}
+      />,
+    );
+
+    await waitFor(() => expect(getRunner).toHaveBeenCalledWith('http%3A%2F%2Fasdqwe', '*'));
+    await waitFor(() => expect(getResolvedRunnerSchema).toHaveBeenCalledWith('http://asdqwe/edited'));
   });
 });

--- a/apps/ai-dial-admin/src/components/Assets/Platform/use-asset-runner-details.ts
+++ b/apps/ai-dial-admin/src/components/Assets/Platform/use-asset-runner-details.ts
@@ -28,7 +28,7 @@ export const useAssetRunnerDetails = (runner?: DialApplicationScheme) => {
   const [error, setError] = useState<string | null>(null);
 
   const path =
-    runner && getRunnerOrigin(runner) === AppRunnerOrigin.Asset ? (runner as AppRunnerOption).path : undefined;
+    runner && getRunnerOrigin(runner) === AppRunnerOrigin.Platform ? (runner as AppRunnerOption).path : undefined;
 
   useEffect(() => {
     setRoutes(null);

--- a/apps/ai-dial-admin/src/components/Assets/Resources/ResourceFeatures.tsx
+++ b/apps/ai-dial-admin/src/components/Assets/Resources/ResourceFeatures.tsx
@@ -32,7 +32,7 @@ const ResourceFeatures: FC<Props> = ({ entity, appRunner, onChangeEntity }) => {
   const { features, isLoading } = useAssetRunnerDetails(appRunner);
 
   const fullRunner = useMemo(() => {
-    if ((appRunner as AppRunnerOption)?.origin === AppRunnerOrigin.Asset) {
+    if ((appRunner as AppRunnerOption)?.origin === AppRunnerOrigin.Platform) {
       return {
         ...appRunner,
         ...features,
@@ -42,7 +42,7 @@ const ResourceFeatures: FC<Props> = ({ entity, appRunner, onChangeEntity }) => {
   }, [appRunner, features]);
 
   const isFeaturesLoading = useMemo(() => {
-    if ((appRunner as AppRunnerOption)?.origin === AppRunnerOrigin.Asset) {
+    if ((appRunner as AppRunnerOption)?.origin === AppRunnerOrigin.Platform) {
       return isLoading;
     }
     return false;

--- a/apps/ai-dial-admin/src/components/EntityView/Interceptors/Interceptors.tsx
+++ b/apps/ai-dial-admin/src/components/EntityView/Interceptors/Interceptors.tsx
@@ -110,7 +110,7 @@ const EntityInterceptors = <T extends { interceptors?: string[]; 'dial:applicati
   const interceptorsRef = useRef(entityInterceptors);
 
   useEffect(() => {
-    if ((appRunner as AppRunnerOption)?.origin === AppRunnerOrigin.Asset && appRunnerInterceptors) {
+    if ((appRunner as AppRunnerOption)?.origin === AppRunnerOrigin.Platform && appRunnerInterceptors) {
       setRunnerInterceptors(appRunnerInterceptors);
     }
   }, [appRunnerInterceptors, appRunner, interceptors]);

--- a/apps/ai-dial-admin/src/components/SourceField/Application/AppRunners.tsx
+++ b/apps/ai-dial-admin/src/components/SourceField/Application/AppRunners.tsx
@@ -1,13 +1,18 @@
 'use client';
 
-import { DialInputPopup, DialLabel, DialNeutralButton, DialSelectField, SelectOption } from '@epam/ai-dial-ui-kit';
+import {
+  DialInputPopup,
+  DialLabel,
+  DialLoader,
+  DialNeutralButton,
+  DialSelectField,
+  SelectOption,
+} from '@epam/ai-dial-ui-kit';
 import { IconExternalLink } from '@tabler/icons-react';
 import classNames from 'classnames';
 import { JSONSchema7 } from 'json-schema';
 import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 
-import { getResolvedApplicationScheme } from '@/src/app/[lang]/application-runners/actions';
-import { getResolvedRunnerSchema } from '@/src/app/[lang]/platform-app-runners/actions';
 import { ButtonsI18nKey, EntityPlaceholdersI18nKey } from '@/src/constants/i18n';
 import { BASE_BUTTON_ICON_PROPS, CONTROL_WITH_BUTTON_WIDTH } from '@/src/constants/main-layout';
 import { useSaveValidationContext, ValidationActionType } from '@/src/context/SaveValidationContext';
@@ -20,6 +25,7 @@ import { createSchemaSource, getSchemaSourceId } from '@/src/utils/entities/appl
 import { getUrnForEntity } from '@/src/utils/open-in-new-tab';
 import { getSchemaDefaults } from '@/src/utils/schema';
 import { AppRunnerOrigin } from './models';
+import { resolveAppRunnerScheme } from './resolve-app-runner';
 import SelectAppRunnerModal from './SelectAppRunnersModal';
 import { getRunnerOrigin } from './utils';
 
@@ -60,6 +66,7 @@ const AppRunners: FC<Props> = ({
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [valueTitle, setValueTitle] = useState('');
+  const [isRunnerResolving, setIsRunnerResolving] = useState(false);
   const isMobile = useIsMobileScreen();
 
   const currentValue = entity ? getSchemaSourceId(entity.source) : selectedValue;
@@ -93,44 +100,43 @@ const AppRunners: FC<Props> = ({
   }, [runners, isMergedSource]);
 
   const handleRunnerSelect = useCallback(
-    (value?: string) => {
+    async (value?: string) => {
       onCloseModal();
-
-      let applicationProperties;
-      const baseEntity: DialApplication = {
-        ...entity,
-        source: value ? createSchemaSource(value) : undefined,
-        endpoint: undefined,
-        mcp: undefined,
-      };
 
       const runner = runners?.find((r) => r.$id === value);
 
       if (!runner && entity) {
-        onChange?.(baseEntity);
+        onChange?.({ ...entity, source: undefined, endpoint: undefined, mcp: undefined });
         return;
       }
 
-      const isAsset = !!runner && getRunnerOrigin(runner) === AppRunnerOrigin.Asset;
-      const resolve = isAsset
-        ? getResolvedRunnerSchema(runner.$id ?? '')
-        : getResolvedApplicationScheme(runner?.$id ?? '');
+      setIsRunnerResolving(true);
 
-      resolve.then((res) => {
-        const resolved = isAsset
-          ? (res.response as DialApplicationScheme | undefined)
-          : (res.response as { schema?: DialApplicationScheme })?.schema;
-        const scheme: DialApplicationScheme | undefined = res.success && resolved ? resolved : runner;
-        applicationProperties = getSchemaDefaults(scheme as JSONSchema7) as Record<string, unknown>;
+      try {
+        const { runner: resolvedRunner, scheme } = await resolveAppRunnerScheme(runner);
+        const resolvedId = resolvedRunner?.$id ?? value;
+        const applicationProperties = getSchemaDefaults((scheme ?? resolvedRunner) as JSONSchema7) as Record<
+          string,
+          unknown
+        >;
+        const baseEntity: DialApplication = {
+          ...entity,
+          source: resolvedId ? createSchemaSource(resolvedId) : undefined,
+          endpoint: undefined,
+          mcp: undefined,
+        };
+
         if (entity) {
           onChange?.({
             ...baseEntity,
             applicationProperties: { ...baseEntity.applicationProperties, ...applicationProperties },
           });
         } else if (onChangeValue) {
-          onChangeValue(value, applicationProperties);
+          onChangeValue(resolvedId, applicationProperties);
         }
-      });
+      } finally {
+        setIsRunnerResolving(false);
+      }
     },
     [entity, onChange, onChangeValue, onCloseModal, runners],
   );
@@ -139,7 +145,7 @@ const AppRunners: FC<Props> = ({
 
   const openInNewTab = useCallback(() => {
     const url =
-      selectedRunner && getRunnerOrigin(selectedRunner) === AppRunnerOrigin.Asset
+      selectedRunner && getRunnerOrigin(selectedRunner) === AppRunnerOrigin.Platform
         ? `/${currentLocale}${getUrnForEntity(ApplicationRoute.PlatformAppRunners, selectedRunner)}`
         : `/${currentLocale}${ApplicationRoute.ApplicationRunners}/${encodeURIComponent(`${currentValue}`)}`;
     window.open(url, '_blank');
@@ -150,25 +156,31 @@ const AppRunners: FC<Props> = ({
   }, [currentValue, dropdownItems]);
 
   return !isEntityImmutable ? (
-    <DialSelectField
-      value={currentValue}
-      searchable={true}
-      required
-      id="sourceEntity"
-      className="w-full mt-1"
-      disabled={isFieldDisabled}
-      options={dropdownItems}
-      label={label}
-      placeholder={t(EntityPlaceholdersI18nKey.SelectAppRunner)}
-      onChange={(runner) => handleRunnerSelect(runner as string)}
-    />
+    isRunnerResolving ? (
+      <div className="relative w-full h-10">
+        <DialLoader size={18} />
+      </div>
+    ) : (
+      <DialSelectField
+        value={currentValue}
+        searchable={true}
+        required
+        id="sourceEntity"
+        className="w-full mt-1"
+        disabled={isFieldDisabled || isRunnerResolving}
+        options={dropdownItems}
+        label={label}
+        placeholder={t(EntityPlaceholdersI18nKey.SelectAppRunner)}
+        onChange={(runner) => handleRunnerSelect(runner as string)}
+      />
+    )
   ) : (
     <div className="flex mt-1">
       <div className="flex gap-2 items-end">
         <div className={classNames(CONTROL_WITH_BUTTON_WIDTH, 'flex flex-col gap-y-1')}>
           <DialLabel label={label} required htmlFor="sourceEntity" />
           <DialInputPopup
-            disabled={isFieldDisabled}
+            disabled={isFieldDisabled || isRunnerResolving}
             placeholder={t(EntityPlaceholdersI18nKey.SelectAppRunner)}
             open={isModalOpen}
             onOpen={onOpenModal}

--- a/apps/ai-dial-admin/src/components/SourceField/Application/models.ts
+++ b/apps/ai-dial-admin/src/components/SourceField/Application/models.ts
@@ -1,8 +1,8 @@
 import { DialApplicationScheme } from '@/src/models/dial/application';
 
 export enum AppRunnerOrigin {
-  Entity = 'entity',
-  Asset = 'asset',
+  Config = 'config',
+  Platform = 'platform',
 }
 
 export interface AppRunnerOption extends DialApplicationScheme {

--- a/apps/ai-dial-admin/src/components/SourceField/Application/resolve-app-runner.ts
+++ b/apps/ai-dial-admin/src/components/SourceField/Application/resolve-app-runner.ts
@@ -1,0 +1,47 @@
+import { getResolvedApplicationScheme } from '@/src/app/[lang]/application-runners/actions';
+import { getResolvedRunnerSchema, getRunner } from '@/src/app/[lang]/platform-app-runners/actions';
+import { DEFAULT_ETAG } from '@/src/constants/api-headers';
+import { DialApplicationScheme } from '@/src/models/dial/application';
+import { AppRunnerOption, AppRunnerOrigin } from './models';
+import { getRunnerOrigin } from './utils';
+
+export interface ResolvedAppRunner {
+  runner?: DialApplicationScheme;
+  scheme?: DialApplicationScheme;
+}
+
+/**
+ * Resolves a picked/current runner's scheme by origin, shared by `AppRunners.tsx` (picker selection)
+ * and `ParametersTab.tsx` (Parameters view).
+ *
+ * A `Platform` runner's option `$id` is decoded from its Core resource name (see `toAssetOption`) and
+ * only reflects the runner's `$id` as of creation — a later edit to the runner's content changes its
+ * `$id` without renaming the resource. Resolving against that stale id both fetches the wrong scheme
+ * and, if the caller persists it, keeps failing to resolve on every future load. So a `Platform` runner
+ * is read fresh via `getRunner` first, and its *content* `$id` — carried on the returned `runner` — is
+ * what `getResolvedRunnerSchema` is called with; a failed content read falls back to the original
+ * option, matching this function's own failure-fallback behavior.
+ */
+export const resolveAppRunnerScheme = async (runner?: DialApplicationScheme): Promise<ResolvedAppRunner> => {
+  if (!runner) {
+    return {};
+  }
+
+  if (getRunnerOrigin(runner) === AppRunnerOrigin.Platform) {
+    const path = (runner as AppRunnerOption).path;
+    const detailRes = path ? await getRunner(path, DEFAULT_ETAG) : undefined;
+    const resolvedRunner = detailRes?.success ? (detailRes.response as DialApplicationScheme) : runner;
+
+    const schemeRes = await getResolvedRunnerSchema(resolvedRunner.$id ?? '');
+    return {
+      runner: resolvedRunner,
+      scheme: schemeRes.success ? (schemeRes.response as DialApplicationScheme) : resolvedRunner,
+    };
+  }
+
+  const schemeRes = await getResolvedApplicationScheme(runner.$id ?? '');
+  return {
+    runner,
+    scheme: schemeRes.success ? (schemeRes.response as { schema?: DialApplicationScheme })?.schema : runner,
+  };
+};

--- a/apps/ai-dial-admin/src/components/SourceField/Application/tests/AppRunnersMerged.spec.tsx
+++ b/apps/ai-dial-admin/src/components/SourceField/Application/tests/AppRunnersMerged.spec.tsx
@@ -14,6 +14,9 @@ vi.mock('@/src/app/[lang]/application-runners/actions', () => ({
 
 vi.mock('@/src/app/[lang]/platform-app-runners/actions', () => ({
   getResolvedRunnerSchema: vi.fn().mockResolvedValue({ success: true, response: { properties: {} } }),
+  getRunner: vi
+    .fn()
+    .mockResolvedValue({ success: true, response: { $id: 'http://asdqwe', path: 'http%3A%2F%2Fasdqwe' } }),
 }));
 
 vi.mock('@/src/utils/schema', () => ({
@@ -41,7 +44,7 @@ vi.mock('@/src/hooks/use-is-mobile-screen', () => ({ useIsMobileScreen: () => fa
 vi.mock('@/src/hooks/use-is-read-only-admin', () => ({ useIsReadOnlyAdmin: () => false }));
 
 import { getResolvedApplicationScheme } from '@/src/app/[lang]/application-runners/actions';
-import { getResolvedRunnerSchema } from '@/src/app/[lang]/platform-app-runners/actions';
+import { getResolvedRunnerSchema, getRunner } from '@/src/app/[lang]/platform-app-runners/actions';
 
 const ASSET_ID = 'http://asdqwe';
 
@@ -89,7 +92,7 @@ describe('AppRunners :: merged picker', () => {
     expect(screen.queryByRole('option', { name: 'urn:runner:entity' })).toBeNull();
   });
 
-  test('selecting an asset runner stores its $id', async () => {
+  test('selecting a platform runner fetches its content and stores the content $id', async () => {
     const onChangeValue = vi.fn();
     render(
       <AppRunners
@@ -102,8 +105,29 @@ describe('AppRunners :: merged picker', () => {
 
     await selectRunner(ASSET_ID);
 
-    await waitFor(() => expect(onChangeValue).toHaveBeenCalled());
+    await waitFor(() => expect(getRunner).toHaveBeenCalledWith('http%3A%2F%2Fasdqwe', '*'));
     expect(onChangeValue).toHaveBeenCalledWith('http://asdqwe', { propA: 'default-a' });
+  });
+
+  test('a platform runner whose content $id was edited resolves and stores the corrected id, not the picker option $id', async () => {
+    vi.mocked(getRunner).mockResolvedValueOnce({
+      success: true,
+      response: { $id: 'http://asdqwe/edited', path: 'http%3A%2F%2Fasdqwe' },
+    });
+    const onChangeValue = vi.fn();
+    render(
+      <AppRunners
+        selectedValue=""
+        onChangeValue={onChangeValue}
+        runners={options}
+        view={ApplicationRoute.AssetsApplications}
+      />,
+    );
+
+    await selectRunner(ASSET_ID);
+
+    await waitFor(() => expect(getResolvedRunnerSchema).toHaveBeenCalledWith('http://asdqwe/edited'));
+    expect(onChangeValue).toHaveBeenCalledWith('http://asdqwe/edited', { propA: 'default-a' });
   });
 
   test('selecting an entity runner still stores its bare $id', async () => {
@@ -123,7 +147,7 @@ describe('AppRunners :: merged picker', () => {
     expect(onChangeValue).toHaveBeenCalledWith('urn:runner:entity', { propA: 'default-a' });
   });
 
-  test('an asset selection resolves against Core using the asset $id', async () => {
+  test('a platform selection resolves against Core using the content $id', async () => {
     vi.mocked(getResolvedRunnerSchema).mockClear();
     vi.mocked(getResolvedApplicationScheme).mockClear();
 

--- a/apps/ai-dial-admin/src/components/SourceField/Application/tests/resolve-app-runner.spec.ts
+++ b/apps/ai-dial-admin/src/components/SourceField/Application/tests/resolve-app-runner.spec.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { DialApplicationScheme } from '@/src/models/dial/application';
+import { AppRunnerOrigin } from '../models';
+import { resolveAppRunnerScheme } from '../resolve-app-runner';
+
+vi.mock('@/src/app/[lang]/application-runners/actions', () => ({
+  getResolvedApplicationScheme: vi.fn(),
+}));
+
+vi.mock('@/src/app/[lang]/platform-app-runners/actions', () => ({
+  getResolvedRunnerSchema: vi.fn(),
+  getRunner: vi.fn(),
+}));
+
+import { getResolvedApplicationScheme } from '@/src/app/[lang]/application-runners/actions';
+import { getResolvedRunnerSchema, getRunner } from '@/src/app/[lang]/platform-app-runners/actions';
+
+const configRunner = { $id: 'urn:runner:config', origin: AppRunnerOrigin.Config } as DialApplicationScheme;
+
+const platformRunner = {
+  $id: 'http://asdqwe',
+  origin: AppRunnerOrigin.Platform,
+  path: 'http%3A%2F%2Fasdqwe',
+} as unknown as DialApplicationScheme;
+
+describe('resolveAppRunnerScheme', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('returns an empty result for no runner', async () => {
+    const result = await resolveAppRunnerScheme(undefined);
+
+    expect(result).toEqual({});
+    expect(getResolvedApplicationScheme).not.toHaveBeenCalled();
+    expect(getResolvedRunnerSchema).not.toHaveBeenCalled();
+    expect(getRunner).not.toHaveBeenCalled();
+  });
+
+  test('resolves a Config runner via the admin BE, unchanged on success', async () => {
+    const scheme = { $id: 'urn:runner:config', properties: {} };
+    vi.mocked(getResolvedApplicationScheme).mockResolvedValue({ success: true, response: { schema: scheme } });
+
+    const result = await resolveAppRunnerScheme(configRunner);
+
+    expect(getResolvedApplicationScheme).toHaveBeenCalledWith('urn:runner:config');
+    expect(getRunner).not.toHaveBeenCalled();
+    expect(result.runner).toBe(configRunner);
+    expect(result.scheme).toBe(scheme);
+  });
+
+  test('falls back to the Config runner itself when the admin BE resolve fails', async () => {
+    vi.mocked(getResolvedApplicationScheme).mockResolvedValue({ success: false });
+
+    const result = await resolveAppRunnerScheme(configRunner);
+
+    expect(result.runner).toBe(configRunner);
+    expect(result.scheme).toBe(configRunner);
+  });
+
+  test('resolves a Platform runner against its content $id, not the picker option $id', async () => {
+    const detail = { $id: 'http://asdqwe/edited', path: 'http%3A%2F%2Fasdqwe' };
+    const scheme = { $id: 'http://asdqwe/edited', properties: {} };
+    vi.mocked(getRunner).mockResolvedValue({ success: true, response: detail });
+    vi.mocked(getResolvedRunnerSchema).mockResolvedValue({ success: true, response: scheme });
+
+    const result = await resolveAppRunnerScheme(platformRunner);
+
+    expect(getRunner).toHaveBeenCalledWith('http%3A%2F%2Fasdqwe', '*');
+    expect(getResolvedRunnerSchema).toHaveBeenCalledWith('http://asdqwe/edited');
+    expect(getResolvedApplicationScheme).not.toHaveBeenCalled();
+    expect(result.runner).toBe(detail);
+    expect(result.scheme).toBe(scheme);
+  });
+
+  test('falls back to the picker option when the content fetch fails', async () => {
+    vi.mocked(getRunner).mockResolvedValue({ success: false });
+    vi.mocked(getResolvedRunnerSchema).mockResolvedValue({ success: false });
+
+    const result = await resolveAppRunnerScheme(platformRunner);
+
+    expect(getResolvedRunnerSchema).toHaveBeenCalledWith('http://asdqwe');
+    expect(result.runner).toBe(platformRunner);
+    expect(result.scheme).toBe(platformRunner);
+  });
+
+  test('falls back to the (possibly corrected) runner when the resolved-schema call fails', async () => {
+    const detail = { $id: 'http://asdqwe/edited', path: 'http%3A%2F%2Fasdqwe' };
+    vi.mocked(getRunner).mockResolvedValue({ success: true, response: detail });
+    vi.mocked(getResolvedRunnerSchema).mockResolvedValue({ success: false });
+
+    const result = await resolveAppRunnerScheme(platformRunner);
+
+    expect(result.runner).toBe(detail);
+    expect(result.scheme).toBe(detail);
+  });
+});

--- a/apps/ai-dial-admin/src/components/SourceField/Application/tests/runner-options.spec.ts
+++ b/apps/ai-dial-admin/src/components/SourceField/Application/tests/runner-options.spec.ts
@@ -26,14 +26,14 @@ describe('buildAppRunnerOptions', () => {
   it('references an entity runner by its bare $id', () => {
     const [option] = buildAppRunnerOptions([entityRunner], []);
 
-    expect(option.origin).toBe(AppRunnerOrigin.Entity);
+    expect(option.origin).toBe(AppRunnerOrigin.Config);
     expect(option.reference).toBe('http://entity-runner');
   });
 
   it('references an asset runner by its Core resource name', () => {
     const [option] = buildAppRunnerOptions([], [assetRunner]);
 
-    expect(option.origin).toBe(AppRunnerOrigin.Asset);
+    expect(option.origin).toBe(AppRunnerOrigin.Platform);
     expect(option.reference).toBe('schemas/platform/http%3A%2F%2Fasdqwe');
   });
 
@@ -63,7 +63,7 @@ describe('buildAppRunnerOptions', () => {
   it('merges both populations, entity rows first', () => {
     const options = buildAppRunnerOptions([entityRunner], [assetRunner]);
 
-    expect(options.map((o) => o.origin)).toEqual([AppRunnerOrigin.Entity, AppRunnerOrigin.Asset]);
+    expect(options.map((o) => o.origin)).toEqual([AppRunnerOrigin.Config, AppRunnerOrigin.Platform]);
   });
 
   it('tolerates either list being absent', () => {
@@ -94,7 +94,7 @@ describe('PICKER_RUNNER_COLUMNS', () => {
   it('renders the Source cell per origin', () => {
     const format = columns.find((c) => c.field === 'origin')?.valueFormatter as (p: { value: string }) => string;
 
-    expect(format({ value: AppRunnerOrigin.Asset })).toBe(SourceI18nKey.AssetRunner);
-    expect(format({ value: AppRunnerOrigin.Entity })).toBe(SourceI18nKey.EntityRunner);
+    expect(format({ value: AppRunnerOrigin.Platform })).toBe(SourceI18nKey.PlatformRunner);
+    expect(format({ value: AppRunnerOrigin.Config })).toBe(SourceI18nKey.ConfigRunner);
   });
 });

--- a/apps/ai-dial-admin/src/components/SourceField/Application/utils.ts
+++ b/apps/ai-dial-admin/src/components/SourceField/Application/utils.ts
@@ -4,19 +4,22 @@ import { toRunnerReference } from '@/src/utils/app-runners/runner-reference';
 import { AppRunnerOption, AppRunnerOrigin } from './models';
 
 export const getRunnerOrigin = (runner: DialApplicationScheme): AppRunnerOrigin =>
-  (runner as AppRunnerOption).origin || AppRunnerOrigin.Entity;
+  (runner as AppRunnerOption).origin || AppRunnerOrigin.Config;
 
-const toEntityOption = (runner: DialApplicationScheme): AppRunnerOption => ({
+const toConfigOption = (runner: DialApplicationScheme): AppRunnerOption => ({
   ...runner,
-  origin: AppRunnerOrigin.Entity,
+  origin: AppRunnerOrigin.Config,
   reference: runner.$id || '',
 });
 
 // Timestamps come from the Core metadata node, so they are available without a content read —
 // unlike display name, description and topics, which live in the body and stay empty here.
-const toAssetOption = (runner: ResourceInfo): AppRunnerOption => ({
+// `$id` here is only the name decoded at list-read time — it reflects the runner's `$id` as of
+// creation, not any later content edit. Resolving against a Platform runner's *current* `$id`
+// requires a content read; see `resolveAppRunnerScheme`.
+const toPlatformOption = (runner: ResourceInfo): AppRunnerOption => ({
   $id: runner.name,
-  origin: AppRunnerOrigin.Asset,
+  origin: AppRunnerOrigin.Platform,
   reference: toRunnerReference(runner.name),
   path: runner.path,
   author: runner.author,
@@ -27,4 +30,4 @@ const toAssetOption = (runner: ResourceInfo): AppRunnerOption => ({
 export const buildAppRunnerOptions = (
   entityRunners?: DialApplicationScheme[] | null,
   assetRunners?: ResourceInfo[] | null,
-): AppRunnerOption[] => [...(entityRunners || []).map(toEntityOption), ...(assetRunners || []).map(toAssetOption)];
+): AppRunnerOption[] => [...(entityRunners || []).map(toConfigOption), ...(assetRunners || []).map(toPlatformOption)];

--- a/apps/ai-dial-admin/src/constants/grid-columns/grid-columns.tsx
+++ b/apps/ai-dial-admin/src/constants/grid-columns/grid-columns.tsx
@@ -393,7 +393,7 @@ export const PICKER_RUNNER_COLUMNS = (t: (str: string) => string): ColDef[] => [
     field: 'origin',
     headerName: t(EntitiesI18nKey.Source),
     valueFormatter: ({ value }) =>
-      value === AppRunnerOrigin.Asset ? t(SourceI18nKey.AssetRunner) : t(SourceI18nKey.EntityRunner),
+      value === AppRunnerOrigin.Platform ? t(SourceI18nKey.PlatformRunner) : t(SourceI18nKey.ConfigRunner),
   },
   AUTHOR_COLUMN,
   { ...UPDATED_AT_COLUMN, filter: false },

--- a/apps/ai-dial-admin/src/constants/i18n.ts
+++ b/apps/ai-dial-admin/src/constants/i18n.ts
@@ -1170,8 +1170,8 @@ export enum SourceI18nKey {
   DockerImage = 'Source.DockerImage',
   NgcRegistry = 'Source.NgcRegistry',
   HuggingFace = 'Source.HuggingFace',
-  EntityRunner = 'Source.EntityRunner',
-  AssetRunner = 'Source.AssetRunner',
+  ConfigRunner = 'Source.ConfigRunner',
+  PlatformRunner = 'Source.PlatformRunner',
 }
 
 export enum TypeI18nKey {

--- a/apps/ai-dial-admin/src/locales/en.ts
+++ b/apps/ai-dial-admin/src/locales/en.ts
@@ -1530,8 +1530,8 @@ export default {
     DockerImage: 'Docker Image',
     NgcRegistry: 'NGC Registry',
     HuggingFace: 'Hugging Face',
-    EntityRunner: 'Configuration file',
-    AssetRunner: 'API',
+    ConfigRunner: 'Configuration file',
+    PlatformRunner: 'API',
   },
   Toolset: {
     Tools: 'Tools',

--- a/openspec/changes/archive/2026-09-08-app-runner-platform-id-resolution/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-08-app-runner-platform-id-resolution/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-08

--- a/openspec/changes/archive/2026-09-08-app-runner-platform-id-resolution/design.md
+++ b/openspec/changes/archive/2026-09-08-app-runner-platform-id-resolution/design.md
@@ -1,0 +1,157 @@
+## Context
+
+`AppRunnerOption` (`SourceField/Application/models.ts`) merges two runner populations into one list:
+
+- `Config` (was `Entity`): admin-backend `DialApplicationScheme[]`, whose `$id` is authoritative as-is.
+- `Platform` (was `Asset`): DIAL Core `ResourceInfo[]`, metadata-only. `toAssetOption` stamps
+  `$id: runner.name` — the Core resource name, decoded once via `fromCoreRunnerName` at the list-read
+  boundary (`toResourceInfo`). That decode recovers the id **encoded at creation time**
+  (`toCoreRunnerName(runner.$id)` in `createRunner`). If a runner's `$id` is edited afterwards through
+  its content (Properties tab / JSON editor), the Core resource name — and therefore this decoded
+  value — does not follow; only a content read (`getRunner`, via `mergeAppRunnerResource`) sees the
+  current `$id`.
+
+`AppRunners.tsx` (the picker, used from both `Entities > Applications` and `Assets > Applications`) and
+`ParametersTab.tsx` (the Parameters tab, used from Applications, Application Runners, and Assets
+Applications) each independently resolve a selected/current runner's scheme:
+
+```
+isAsset = origin === AppRunnerOrigin.Asset
+resolve = isAsset ? getResolvedRunnerSchema(runner.$id) : getResolvedApplicationScheme(runner.$id)
+```
+
+For a `Platform` runner this passes the possibly-stale list-derived `$id` straight to
+`getResolvedRunnerSchema`, which looks the schema up by `$id` on Core (`AppRunnerSchemaApi.resolvedSchema`,
+`v1/application_type_schemas/schema?id=…`). A stale id either resolves the wrong schema or fails to
+resolve at all, and `AppRunners.tsx` additionally persists that same stale id into the application's
+source (`createSchemaSource(value)` / `application_type_schema_id`), so the link keeps failing on every
+future load too.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- `Platform`-origin resolution always resolves against the runner's current, authoritative `$id`.
+- One shared implementation of "resolve a runner's scheme by origin" backs both `AppRunners.tsx` and
+  `ParametersTab.tsx`.
+- `AppRunnerOrigin` member names read as `Config`/`Platform` everywhere.
+
+**Non-Goals:**
+
+- Changing `Config`-origin resolution (already correct).
+- Reconciling `ResourceSourceField.tsx`'s flat `application_type_schema_id` field against the
+  `application-source` spec's aspirational unified `source.applicationTypeSchemaId` (pre-existing drift,
+  out of scope).
+- Changing the "Create Assets Application" seeding flow (writes a `schemas/platform/{id}` reference
+  form for a different purpose — pre-populating a brand-new application from the runner it was opened
+  from — not the picker/Parameters resolution this change touches).
+- Persisting/backfilling previously-stored stale ids; this change only affects a `Platform` runner the
+  next time it's selected or its Parameters tab is opened.
+
+## Decisions
+
+### A shared resolver, not a hook
+
+`AppRunners.tsx` resolves on a user action (`handleRunnerSelect`) and needs the resolved runner's
+corrected `$id` back to persist it; `ParametersTab.tsx` resolves in a `useEffect` keyed off the
+application's version and only needs the resolved *scheme* for display. Both are already client
+components calling server actions (`'use server'` functions) directly — the existing pattern in both
+files — so the shared piece is a plain async function, not a `use-*` hook: no shared React state to own,
+and a hook would force `ParametersTab.tsx`'s effect to depend on another hook's own effect timing for no
+benefit.
+
+It cannot live in `SourceField/Application/utils.ts` — that file holds pure helpers per
+`.claude/rules/utils.md` (§2: "No hidden side effects or I/O"), and this function calls three server
+actions. New file: `SourceField/Application/resolve-app-runner.ts`, exporting one function:
+
+```ts
+export interface ResolvedAppRunner {
+  runner?: DialApplicationScheme;
+  scheme?: DialApplicationScheme;
+}
+
+export const resolveAppRunnerScheme = async (
+  runner?: DialApplicationScheme,
+): Promise<ResolvedAppRunner> => { ... }
+```
+
+- `runner` in the result is the input runner, except for `Platform` origin where a successful detail
+  fetch replaces it with the fetched `DialAppRunnerResource` (cast to `DialApplicationScheme`) — carrying
+  the corrected `$id`. Callers needing the corrected id (`AppRunners.tsx`) read `result.runner.$id`;
+  callers that don't (`ParametersTab.tsx`) ignore it.
+- `scheme` is the resolved schema to render/derive defaults from, falling back to `result.runner` (not
+  the original input) when resolution fails or is skipped — matching today's "fall back to the runner
+  itself" behavior, now based on the corrected runner when one was fetched.
+- Given `undefined`, returns `{}` — both call sites already branch on "no runner selected" before this
+  point (`AppRunners.tsx`'s early return, `ParametersTab.tsx`'s `getAppRunner` returning `undefined`), so
+  this only needs to be a safe no-op, not a distinct code path.
+
+### Platform resolution fetches details first, then the resolved schema by the corrected id
+
+```ts
+if (getRunnerOrigin(runner) === AppRunnerOrigin.Platform) {
+  const path = (runner as AppRunnerOption).path;
+  const detail = path ? await getRunner(path, DEFAULT_ETAG) : undefined;
+  const resolvedRunner = (detail?.success ? (detail.response as DialApplicationScheme) : runner);
+  const schemeRes = await getResolvedRunnerSchema(resolvedRunner.$id ?? '');
+  return {
+    runner: resolvedRunner,
+    scheme: schemeRes.success ? (schemeRes.response as DialApplicationScheme) : resolvedRunner,
+  };
+}
+```
+
+Two requests (detail, then resolved-schema-by-corrected-id) rather than one, because `getRunner` returns
+the *stored* schema — `dial:applicationTypeSchemaEndpoint`-declared external properties are not merged
+in (see `AppRunnerSchemaApi`'s doc comment) — while `getResolvedRunnerSchema` is what performs that
+merge, but only when given the right id. Skipping the detail fetch and passing the list-derived id
+straight to `getResolvedRunnerSchema` is exactly today's bug. Skipping the resolved-schema call and
+using the detail fetch's content directly would silently lose externally-declared properties for any
+runner that has them.
+
+If the detail fetch fails (deleted, network), `resolvedRunner` stays the original list-derived option,
+matching today's fallback behavior instead of surfacing a harder failure for a case the UI already
+tolerates.
+
+`(runner as AppRunnerOption).path` mirrors the existing cast in `use-asset-runner-details.ts` — every
+`Platform`-origin `AppRunnerOption` carries `path` (set in `toAssetOption`); a `Config`-origin one
+never reaches this branch.
+
+### Config resolution is unchanged, just relocated
+
+```ts
+const schemeRes = await getResolvedApplicationScheme(runner?.$id ?? '');
+return {
+  runner,
+  scheme: schemeRes.success ? (schemeRes.response as { schema?: DialApplicationScheme })?.schema : runner,
+};
+```
+
+Moved verbatim into the shared function's other branch; no behavior change.
+
+### Rename scope
+
+`AppRunnerOrigin.Entity`/`.Asset` → `.Config`/`.Platform`, both the member name and string value (no
+consumer persists the string value — it exists only as an in-memory discriminator on `AppRunnerOption`,
+built fresh on every read). `SourceI18nKey.EntityRunner`/`.AssetRunner` → `.ConfigRunner`/`.PlatformRunner`
+for the same reason the enum is being renamed (the old names invite mapping runner "asset" to the
+`AssetApp`/`Assets` section, which is unrelated — an `AssetApp` can itself use either a `Config` or a
+`Platform` runner). English display strings ("Configuration file" / "API") are unchanged.
+
+## Risks / Trade-offs
+
+- [Selecting a `Platform` runner now costs one extra request (`getRunner`) before the picker applies] →
+  Acceptable: this happens once per selection, on a modal/dropdown apply action, not on every keystroke
+  or render; `ParametersTab.tsx`'s effect already made a comparable single extra request before this
+  change (it just used the wrong id).
+- [`getRunner`'s content read can itself fail for a runner whose `path` is stale] → Falls back to the
+  list-derived runner, so the picker degrades to today's behavior rather than blocking selection.
+- [Renaming the i18n keys touches `en.ts`/`i18n.ts` alongside the enum, widening the diff] → Kept
+  because leaving `SourceI18nKey.EntityRunner`/`.AssetRunner` un-renamed next to a freshly-renamed
+  `AppRunnerOrigin.Config`/`.Platform` (which the grid column formatter maps directly to those keys)
+  would immediately reintroduce the same naming mismatch this change is fixing.
+
+## Open Questions
+
+None — scope was confirmed with the user (enum rename covers both `AppRunnerOrigin` members and the
+paired `SourceI18nKey` members; display text unchanged).

--- a/openspec/changes/archive/2026-09-08-app-runner-platform-id-resolution/proposal.md
+++ b/openspec/changes/archive/2026-09-08-app-runner-platform-id-resolution/proposal.md
@@ -1,0 +1,68 @@
+## Why
+
+An application's runner-scheme source can point at either of two populations: an admin-backend "config
+file" runner (`AppRunnerOrigin.Entity`, read via `DialApplicationScheme[]`) or a DIAL Core "platform"
+(blob-stored) runner (`AppRunnerOrigin.Asset`, read via `ResourceInfo[]`). The merged option list stamps
+every platform runner's `$id` with its Core resource `name` (`toAssetOption` in
+`SourceField/Application/utils.ts`), because a metadata-only list read never sees the runner's real
+content. That name is only the runner's `$id` **at creation time** (Core stores it as
+`encodeURIComponent($id)`) — if a runner's `$id` is edited afterwards through its own content (the
+Properties tab / JSON editor), the resource name no longer changes, so the two diverge. Both
+`AppRunners.tsx` (the picker) and `ParametersTab.tsx` (the scheme-driven Parameters view) resolve a
+platform runner's scheme by this same possibly-stale `$id`, and `AppRunners.tsx` also writes it into the
+application's `source`/`application_type_schema_id` on selection — so a stale id both fetches the wrong
+scheme and persists a link that can silently stop resolving.
+
+`AppRunnerOrigin`'s member names (`Entity`/`Asset`) also no longer match how the two populations are
+described elsewhere in this codebase (config file vs. platform/Core), inviting the same confusion the
+`$id` bug came from.
+
+## What Changes
+
+- Rename `AppRunnerOrigin.Entity` → `AppRunnerOrigin.Config` and `AppRunnerOrigin.Asset` →
+  `AppRunnerOrigin.Platform` (enum member names and string values), and the paired i18n keys
+  `SourceI18nKey.EntityRunner` → `SourceI18nKey.ConfigRunner` and `SourceI18nKey.AssetRunner` →
+  `SourceI18nKey.PlatformRunner` (English display text is unchanged: "Configuration file" / "API").
+  **BREAKING** for any code importing the old enum member names (none outside this repo).
+- On selecting a `Platform`-origin runner, fetch that runner's full content (`getRunner(path,
+  DEFAULT_ETAG)`) before resolving its scheme, and use the fetched resource's own `$id` — not the
+  option's list-derived `$id` — as both the value written to the application's source and the id passed
+  to `getResolvedRunnerSchema`. `Config`-origin resolution (`getResolvedApplicationScheme`) is unchanged.
+- Extract the duplicated "resolve a runner's scheme by origin, unwrap the response, fall back to the
+  runner itself on failure" logic out of `AppRunners.tsx` and `ParametersTab.tsx` into one shared helper,
+  now also performing the platform detail fetch above, so both call sites stay in sync.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `application-source`: the "Applications Schema panel owns runner-scheme side-effects" requirement
+  changes to describe origin-aware resolution (`Config` vs `Platform`) and the platform detail-fetch
+  step; `AppRunnerOrigin` member names in referenced code change accordingly.
+
+## Impact
+
+- `apps/ai-dial-admin/src/components/SourceField/Application/{models.ts,utils.ts,AppRunners.tsx}`
+- `apps/ai-dial-admin/src/components/Applications/ParametersTab/ParametersTab.tsx`
+- New shared resolver module under `SourceField/Application/` (I/O, so not `utils.ts` per
+  `.claude/rules/utils.md`)
+- `apps/ai-dial-admin/src/constants/i18n.ts`, `apps/ai-dial-admin/src/locales/en.ts` (key rename only)
+- Every other reader of `AppRunnerOrigin.Entity`/`.Asset`: `constants/grid-columns/grid-columns.tsx`,
+  `components/EntityView/Interceptors/{Interceptors.tsx,models.ts}`,
+  `components/Assets/Resources/ResourceFeatures.tsx`, `components/Assets/Platform/use-asset-runner-details.ts`
+- Specs affected by the enum member rename: `platform-app-runners` (`assets-app-runners`) exposes the
+  merged picker used from `Assets > Applications`; no requirement text there names the enum, so no delta
+  needed for it.
+- Test files exercising the current names/flow: `SourceField/Application/tests/{AppRunnersMerged.spec.tsx,
+  runner-options.spec.ts,AppRunners.spec.tsx}`, `Applications/ParametersTab/tests/ParametersTab.spec.tsx`,
+  `EntityView/AppRoute/tests/ApplicationAppRoutes.spec.tsx`, `assets-applications/tests/runner-sources.spec.tsx`
+
+## Non-goals
+
+- Not touching how a *new* asset application is seeded from the "Create Assets Application" action
+  (which writes a `schemas/platform/{id}` reference form, not a bare `$id` — a separate, pre-existing
+  code path this change does not call).
+- Not reconciling `ResourceSourceField.tsx`'s use of the flat `DialApplicationResource.application_type_schema_id`
+  field against the `application-source` spec's aspirational unified `source.applicationTypeSchemaId` — that
+  drift predates this change and is out of scope here.
+- Not changing the `Config`-origin resolution flow, which is already correct.

--- a/openspec/changes/archive/2026-09-08-app-runner-platform-id-resolution/specs/application-source/spec.md
+++ b/openspec/changes/archive/2026-09-08-app-runner-platform-id-resolution/specs/application-source/spec.md
@@ -1,0 +1,39 @@
+## MODIFIED Requirements
+
+### Requirement: Applications Schema panel owns runner-scheme side-effects
+
+When source `$type === 'schema'` for a `DialApplication`, the `AppRunners` component SHALL own the runner-selection side-effects, resolving the selected runner's scheme through the shared `resolveAppRunnerScheme` helper rather than calling a resolver inline:
+
+1. On runner selection, it resolves the picked runner via `resolveAppRunnerScheme(runner)`:
+   - For a `Config`-origin runner (`AppRunnerOrigin.Config`), this fetches the resolved application scheme via `getResolvedApplicationScheme(runner.$id)` — unchanged from today.
+   - For a `Platform`-origin runner (`AppRunnerOrigin.Platform`), this first fetches the runner's full content (`getRunner(path, DEFAULT_ETAG)`) and uses **that resource's own `$id`** — not the picker option's list-derived `$id` — to call `getResolvedRunnerSchema`. The list-derived `$id` MUST NOT be passed to `getResolvedRunnerSchema` directly, since it reflects the runner's id at creation time and can be stale if the runner's `$id` was edited afterwards through its content.
+2. If the schema fetch succeeds, it derives default `applicationProperties` via `getSchemaDefaults(scheme)`.
+3. It calls `onChange` once with the combined update: `{ ...entity, source: { $type: SCHEMA, applicationTypeSchemaId: resolvedId }, applicationProperties }`, where `resolvedId` is the runner id returned by `resolveAppRunnerScheme` — the corrected content `$id` for a `Platform`-origin runner, or the picked `$id` unchanged for a `Config`-origin one.
+
+If the schema fetch fails, the component SHALL fall back to using the non-resolved runner (current behavior). If the `Platform`-origin content fetch itself fails, the component SHALL fall back to the picker option as originally listed (its list-derived `$id`), so a transient failure degrades to today's behavior rather than blocking selection.
+
+#### Scenario: Runner selection with successful schema fetch
+
+- **WHEN** the user picks a `Config`-origin runner and `getResolvedApplicationScheme` returns a schema
+- **THEN** `entity.source.$type` is set to `SCHEMA`
+- **AND** `entity.source.applicationTypeSchemaId` is set to the runner id
+- **AND** `entity.applicationProperties` is set to `getSchemaDefaults(schema)`
+
+#### Scenario: Runner selection with fetch failure
+
+- **WHEN** the user picks a `Config`-origin runner and `getResolvedApplicationScheme` fails
+- **THEN** `entity.source.$type` is set to `SCHEMA`
+- **AND** `entity.source.applicationTypeSchemaId` is set to the runner id
+- **AND** `entity.applicationProperties` is derived from the unresolved runner
+
+#### Scenario: Platform runner selection resolves against its content `$id`
+
+- **WHEN** the user picks a `Platform`-origin runner whose picker-option `$id` (derived from its Core resource name) differs from the `$id` currently stored in its content
+- **THEN** the component fetches the runner's content via `getRunner`
+- **AND** calls `getResolvedRunnerSchema` with the content's `$id`, not the picker option's `$id`
+- **AND** `entity.source.applicationTypeSchemaId` is set to the content's `$id`
+
+#### Scenario: Platform runner selection with a failed content fetch
+
+- **WHEN** the user picks a `Platform`-origin runner and the `getRunner` content fetch fails
+- **THEN** the component falls back to the picker option's own `$id` for both `getResolvedRunnerSchema` and `entity.source.applicationTypeSchemaId`, matching today's behavior

--- a/openspec/changes/archive/2026-09-08-app-runner-platform-id-resolution/tasks.md
+++ b/openspec/changes/archive/2026-09-08-app-runner-platform-id-resolution/tasks.md
@@ -1,0 +1,28 @@
+## 1. Rename `AppRunnerOrigin` and its paired i18n keys
+
+- [x] 1.1 In `SourceField/Application/models.ts`, rename `AppRunnerOrigin.Entity` → `AppRunnerOrigin.Config` and `AppRunnerOrigin.Asset` → `AppRunnerOrigin.Platform` (member name and string value).
+- [x] 1.2 In `SourceField/Application/utils.ts`, update `getRunnerOrigin`'s fallback and `toEntityOption`/`toAssetOption`'s `origin` assignments to the renamed members; update the doc comment on `toAssetOption` if it names the old members.
+- [x] 1.3 In `constants/i18n.ts`, rename `SourceI18nKey.EntityRunner` → `SourceI18nKey.ConfigRunner` and `SourceI18nKey.AssetRunner` → `SourceI18nKey.PlatformRunner`; update `locales/en.ts` to match (English text — "Configuration file" / "API" — unchanged).
+- [x] 1.4 Update every remaining reader of the old enum/i18n names: `constants/grid-columns/grid-columns.tsx` (`PICKER_RUNNER_COLUMNS`'s `origin` formatter), `components/EntityView/Interceptors/{Interceptors.tsx,models.ts}`, `components/Assets/Resources/ResourceFeatures.tsx`, `components/Assets/Platform/use-asset-runner-details.ts`, `components/Applications/ParametersTab/ParametersTab.tsx`, `components/SourceField/Application/AppRunners.tsx`.
+- [x] 1.5 Update the fixtures/assertions in `SourceField/Application/tests/runner-options.spec.ts` and `assets-applications/tests/runner-sources.spec.tsx` to the renamed members and i18n keys.
+
+## 2. Add the shared runner-scheme resolver
+
+- [x] 2.1 Create `SourceField/Application/resolve-app-runner.ts` exporting `resolveAppRunnerScheme(runner?: DialApplicationScheme): Promise<{ runner?: DialApplicationScheme; scheme?: DialApplicationScheme }>` per design.md's "A shared resolver, not a hook" and "Platform resolution fetches details first" / "Config resolution is unchanged, just relocated" decisions — branching on `getRunnerOrigin(runner)`, importing `getRunner` from `@/src/app/[lang]/platform-app-runners/actions`, `getResolvedRunnerSchema` from the same module, `getResolvedApplicationScheme` from `@/src/app/[lang]/application-runners/actions`, and `DEFAULT_ETAG` from `@/src/constants/api-headers`.
+- [x] 2.2 Add unit tests for `resolveAppRunnerScheme` (new `SourceField/Application/tests/resolve-app-runner.spec.ts`) covering: `Config`-origin success/failure (existing behavior, relocated), `Platform`-origin success (detail fetch succeeds, resolved schema uses the detail's `$id`, not the input's), `Platform`-origin with a failed detail fetch (falls back to the input runner and its `$id`), `Platform`-origin with a failed resolved-schema call (falls back to the — possibly corrected — runner), and `undefined` input (`{}`).
+
+## 3. Wire `AppRunners.tsx` through the shared resolver
+
+- [x] 3.1 Replace `handleRunnerSelect`'s inline origin-branching resolve logic with a call to `resolveAppRunnerScheme(runner)`; build `applicationProperties` from the returned `scheme` (falling back to the returned `runner`, per design.md).
+- [x] 3.2 Use the returned `runner`'s `$id` (falling back to the originally-picked `value` when there is no runner, e.g. a cleared selection) as the id written into `createSchemaSource(...)` for the entity-based API path, and as the first argument to `onChangeValue(...)` for the legacy callback-based API path.
+- [x] 3.3 Update `SourceField/Application/tests/AppRunnersMerged.spec.tsx` and `AppRunners.spec.tsx`: mock `getRunner` (platform-app-runners actions) alongside the existing `getResolvedRunnerSchema`/`getResolvedApplicationScheme` mocks; add/adjust cases asserting that selecting a platform runner calls `getRunner` with its `path`, that `getResolvedRunnerSchema` is then called with the *detail response's* `$id`, and that `onChangeValue`/`onChange` receive that corrected id — including the case where the detail fetch's `$id` differs from the picker option's `$id`.
+
+## 4. Wire `ParametersTab.tsx` through the shared resolver
+
+- [x] 4.1 Replace the scheme-resolution `useEffect`'s inline origin-branching resolve logic with a call to `resolveAppRunnerScheme(foundRunner)`, using the returned `scheme` (falling back to `foundRunner`) exactly where the old `scheme` local was used.
+- [x] 4.2 Update `Applications/ParametersTab/tests/ParametersTab.spec.tsx`: mock `getRunner` alongside the existing resolver mocks; add/adjust a case for a platform-origin `foundRunner` asserting `getRunner` is called with its `path` and the Parameters view renders the scheme from the detail-corrected `$id`'s resolution.
+
+## 5. Quality gate
+
+- [x] 5.1 Run `npx vitest run --coverage` from `apps/ai-dial-admin/` and confirm the coverage gate in `vitest.config.ts` is not regressed. Note: the full 11k+ test run is flaky under this environment's parallel workers — a different, unrelated set of files times out each run (confirmed pre-existing: reproduces on the unmodified `development` HEAD and every failing file passes cleanly in isolation). None of this change's files (`SourceField/Application/*`, `Applications/ParametersTab/*`, `resolve-app-runner.*`, i18n/grid-columns/Interceptors/ResourceFeatures/use-asset-runner-details) appeared among the failures in any run; all were run in isolation and pass.
+- [x] 5.2 Run `npm run lint` and `npm run format` (or `format:write`) and resolve any findings.

--- a/openspec/specs/application-source/spec.md
+++ b/openspec/specs/application-source/spec.md
@@ -85,27 +85,41 @@ The user MUST be able to enable chat endpoint and/or MCP endpoint independently 
 
 ### Requirement: Applications Schema panel owns runner-scheme side-effects
 
-When source `$type === 'schema'` for a `DialApplication`, the `AppRunners` component SHALL own the runner-selection side-effects:
+When source `$type === 'schema'` for a `DialApplication`, the `AppRunners` component SHALL own the runner-selection side-effects, resolving the selected runner's scheme through the shared `resolveAppRunnerScheme` helper rather than calling a resolver inline:
 
-1. On runner selection, it fetches the resolved application scheme via `getResolvedApplicationScheme(runnerId)`.
-2. If the fetch succeeds, it derives default `applicationProperties` via `getSchemaDefaults(scheme)`.
-3. It calls `onChange` once with the combined update: `{ ...entity, source: { $type: SCHEMA, applicationTypeSchemaId: runnerId }, applicationProperties }`.
+1. On runner selection, it resolves the picked runner via `resolveAppRunnerScheme(runner)`:
+   - For a `Config`-origin runner (`AppRunnerOrigin.Config`), this fetches the resolved application scheme via `getResolvedApplicationScheme(runner.$id)` — unchanged from today.
+   - For a `Platform`-origin runner (`AppRunnerOrigin.Platform`), this first fetches the runner's full content (`getRunner(path, DEFAULT_ETAG)`) and uses **that resource's own `$id`** — not the picker option's list-derived `$id` — to call `getResolvedRunnerSchema`. The list-derived `$id` MUST NOT be passed to `getResolvedRunnerSchema` directly, since it reflects the runner's id at creation time and can be stale if the runner's `$id` was edited afterwards through its content.
+2. If the schema fetch succeeds, it derives default `applicationProperties` via `getSchemaDefaults(scheme)`.
+3. It calls `onChange` once with the combined update: `{ ...entity, source: { $type: SCHEMA, applicationTypeSchemaId: resolvedId }, applicationProperties }`, where `resolvedId` is the runner id returned by `resolveAppRunnerScheme` — the corrected content `$id` for a `Platform`-origin runner, or the picked `$id` unchanged for a `Config`-origin one.
 
-If the fetch fails, the component SHALL fall back to using the non-resolved runner (current behavior).
+If the schema fetch fails, the component SHALL fall back to using the non-resolved runner (current behavior). If the `Platform`-origin content fetch itself fails, the component SHALL fall back to the picker option as originally listed (its list-derived `$id`), so a transient failure degrades to today's behavior rather than blocking selection.
 
 #### Scenario: Runner selection with successful schema fetch
 
-- **WHEN** the user picks a runner and `getResolvedApplicationScheme` returns a schema
+- **WHEN** the user picks a `Config`-origin runner and `getResolvedApplicationScheme` returns a schema
 - **THEN** `entity.source.$type` is set to `SCHEMA`
 - **AND** `entity.source.applicationTypeSchemaId` is set to the runner id
 - **AND** `entity.applicationProperties` is set to `getSchemaDefaults(schema)`
 
 #### Scenario: Runner selection with fetch failure
 
-- **WHEN** the user picks a runner and `getResolvedApplicationScheme` fails
+- **WHEN** the user picks a `Config`-origin runner and `getResolvedApplicationScheme` fails
 - **THEN** `entity.source.$type` is set to `SCHEMA`
 - **AND** `entity.source.applicationTypeSchemaId` is set to the runner id
 - **AND** `entity.applicationProperties` is derived from the unresolved runner
+
+#### Scenario: Platform runner selection resolves against its content `$id`
+
+- **WHEN** the user picks a `Platform`-origin runner whose picker-option `$id` (derived from its Core resource name) differs from the `$id` currently stored in its content
+- **THEN** the component fetches the runner's content via `getRunner`
+- **AND** calls `getResolvedRunnerSchema` with the content's `$id`, not the picker option's `$id`
+- **AND** `entity.source.applicationTypeSchemaId` is set to the content's `$id`
+
+#### Scenario: Platform runner selection with a failed content fetch
+
+- **WHEN** the user picks a `Platform`-origin runner and the `getRunner` content fetch fails
+- **THEN** the component falls back to the picker option's own `$id` for both `getResolvedRunnerSchema` and `entity.source.applicationTypeSchemaId`, matching today's behavior
 
 ### Requirement: Source-type change clears stale Application fields
 


### PR DESCRIPTION
**Description:**

An application's merged runner-scheme options stamp every platform (Core-stored) runner's `$id` with
its Core resource `name`, captured at creation time — but if the runner's actual `$id` is edited later
through its own content, the resource name no longer changes, so the two diverge. Both the runner
picker (`AppRunners.tsx`) and the scheme-driven Parameters view (`ParametersTab.tsx`) resolved a
platform runner's scheme using this possibly-stale `$id`, and the picker also persisted it into the
application's `source` — silently pointing at the wrong scheme going forward. This change fetches the
platform runner's actual content before resolving its scheme, uses the fetched resource's own `$id`
instead of the option's list-derived one, and extracts the duplicated origin-branching resolve logic
from both call sites into one shared helper. It also renames `AppRunnerOrigin.Entity`/`Asset` to
`Config`/`Platform` (and the paired i18n keys) to match how the two runner populations are described
elsewhere in the codebase.

**Key Changes:**

- [resolve-app-runner.ts](https://github.com/epam/ai-dial-admin-frontend/blob/fix/resolve-platform-runner-id/apps/ai-dial-admin/src/components/SourceField/Application/resolve-app-runner.ts) — new shared resolver: fetches platform runner detail before resolving scheme, falls back to `Config` resolution unchanged
- [AppRunners.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/fix/resolve-platform-runner-id/apps/ai-dial-admin/src/components/SourceField/Application/AppRunners.tsx) — picker now resolves via the shared helper and persists the fetched runner's own `$id`
- [ParametersTab.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/fix/resolve-platform-runner-id/apps/ai-dial-admin/src/components/Applications/ParametersTab/ParametersTab.tsx) — Parameters view resolves via the shared helper instead of inline origin-branching
- [models.ts](https://github.com/epam/ai-dial-admin-frontend/blob/fix/resolve-platform-runner-id/apps/ai-dial-admin/src/components/SourceField/Application/models.ts) — `AppRunnerOrigin.Entity`/`Asset` renamed to `Config`/`Platform`
- [utils.ts](https://github.com/epam/ai-dial-admin-frontend/blob/fix/resolve-platform-runner-id/apps/ai-dial-admin/src/components/SourceField/Application/utils.ts) — updated origin assignments to renamed members
- [constants/i18n.ts](https://github.com/epam/ai-dial-admin-frontend/blob/fix/resolve-platform-runner-id/apps/ai-dial-admin/src/constants/i18n.ts) — `SourceI18nKey.EntityRunner`/`AssetRunner` renamed to `ConfigRunner`/`PlatformRunner` (display text unchanged)

**New Components:**

- `resolveAppRunnerScheme` (`SourceField/Application/resolve-app-runner.ts`) — shared runner-scheme resolver used by both the picker and the Parameters view.

**Breaking Changes:**

`AppRunnerOrigin.Entity`/`Asset` and `SourceI18nKey.EntityRunner`/`AssetRunner` are renamed (member
names and string values) to `Config`/`Platform` and `ConfigRunner`/`PlatformRunner`. No code outside
this repo imports these.

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<ticket>)` (comma-separated list of issues)
