### PR TITLE
fix(Assets/Toolsets): resolve platform dual-bucket path issues in toolset auth and ops API (Issue #4443, #4445, #4447)

### DIFF
--- a/.claude/skills/git-commit/SKILL.md
+++ b/.claude/skills/git-commit/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: git-commit
-model: claude-haiku-4-5-20251001
 context: fork
 effort: low
 allowed-tools: Bash(git:*), Bash(gh:*), Bash(grep:*), Edit(.claude/reference/areas.md)
@@ -8,10 +7,13 @@ arguments: ticket area
 argument-hint: "[ticket] [area]"
 description: >
   Use this skill whenever the user wants to commit, push, or ship changes in a git repository.
-  Triggers include: "commit changes", "push my changes", "ship it", "commit and push", "create a branch and commit",
-  "make a PR", "open a pull request", "create draft PR", or any variation of committing/pushing work.
-  Always use this skill when the user mentions committing — even casually — as it handles the full cycle:
-  branch → add → commit → push → (optionally) PR, with Conventional Commits format and automatic area detection.
+  This skill is intended to run with the developer's configured default Haiku model.
+  Triggers include: "commit changes", "push my changes", "ship it", "commit and push",
+  "create a branch and commit", "make a PR", "open a pull request", "create draft PR",
+  or any variation of committing/pushing work.
+  Always use this skill when the user mentions committing — even casually — as it handles
+  the full cycle: branch → add → commit → push → (optionally) PR, with Conventional Commits
+  format and automatic area detection.
 ---
 
 # Git Commit Skill

--- a/apps/ai-dial-admin/src/components/Assets/Resources/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/Assets/Resources/tests/utils.spec.ts
@@ -1,6 +1,10 @@
 import { DialApplicationScheme } from '@/src/models/dial/application';
-import { describe, expect, test } from 'vitest';
-import { getResourceReadOnlyValues } from '../utils';
+import { ApplicationRoute } from '@/src/types/routes';
+import * as openInNewTab from '@/src/utils/open-in-new-tab';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { getResourceReadOnlyValues, setUrl } from '../utils';
+
+vi.mock('@/src/utils/open-in-new-tab');
 
 describe('getResourceReadOnlyValues', () => {
   test('should return the value and readonly flag when appRunner is provided and the snake_cased key maps to an app runner key', () => {
@@ -63,5 +67,53 @@ describe('getResourceReadOnlyValues', () => {
 
     expect(result.value).toBeUndefined();
     expect(result.isReadonly).toBe(true);
+  });
+});
+
+// Regression (Issue #4447): the stored redirect URL must use `?` when the entity's URN has no
+// existing query string (a platform-bucket toolset — flat, no `?path=`), and `&` when it does (a
+// public-bucket toolset's `?path=...`). Hardcoding `&` produced a malformed
+// `{name}&code=...` OAuth callback URL for the platform bucket.
+describe('setUrl', () => {
+  let windowSpy: any;
+
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    windowSpy?.mockRestore();
+  });
+
+  test('uses "?" when the entity URN has no existing query string (platform-bucket toolset)', () => {
+    vi.mocked(openInNewTab.getUrnForEntity).mockReturnValue('/assets-toolsets/my-toolset');
+
+    setUrl(ApplicationRoute.AssetsToolsets, { name: 'my-toolset', path: 'platform/my-toolset' });
+
+    expect(localStorage.getItem('toolset-auth-redirect-url')).toBe('/assets-toolsets/my-toolset?');
+  });
+
+  test('uses "&" when the entity URN already carries a query string (public-bucket toolset)', () => {
+    vi.mocked(openInNewTab.getUrnForEntity).mockReturnValue('/assets-toolsets/MyToolset?path=public%2FMyToolset__1.0');
+
+    setUrl(ApplicationRoute.AssetsToolsets, {
+      name: 'MyToolset',
+      path: 'public/MyToolset__1.0',
+      folderId: 'public/',
+      version: '1.0',
+    });
+
+    expect(localStorage.getItem('toolset-auth-redirect-url')).toBe(
+      '/assets-toolsets/MyToolset?path=public%2FMyToolset__1.0&',
+    );
+  });
+
+  test('does not throw when window is undefined (SSR)', () => {
+    windowSpy = vi.spyOn(global, 'window', 'get').mockReturnValue(undefined as any);
+
+    expect(() => setUrl(ApplicationRoute.AssetsToolsets, { name: 'my-toolset' })).not.toThrow();
+    expect(openInNewTab.getUrnForEntity).not.toHaveBeenCalled();
+    expect(localStorage.getItem('toolset-auth-redirect-url')).toBeNull();
   });
 });

--- a/apps/ai-dial-admin/src/components/Assets/Resources/utils.ts
+++ b/apps/ai-dial-admin/src/components/Assets/Resources/utils.ts
@@ -70,7 +70,13 @@ export const getLevels = (): ToolsetAuthCredentialLevel[] => {
 
 export const setUrl = (view: ApplicationRoute, selectedToolset: unknown) => {
   if (typeof window !== 'undefined') {
-    const url = `${getUrnForEntity(view, selectedToolset)}&`;
+    const urn = getUrnForEntity(view, selectedToolset);
+    // A public-bucket toolset's URN already carries `?path=...` (from `getEntityPath`'s versioned
+    // branch), so the callback page's appended `code=...` needs `&`. A platform-bucket toolset's URN
+    // is a bare encoded name with no query string at all (flat entities need no `?path=`), so it
+    // needs `?` instead — hardcoding `&` here produced a malformed `{name}&code=...` redirect for the
+    // platform bucket (Issue #4447).
+    const url = `${urn}${urn.includes('?') ? '&' : '?'}`;
     localStorage.setItem(urlKey, url);
   }
 };

--- a/apps/ai-dial-admin/src/server/core/asset-metadata.ts
+++ b/apps/ai-dial-admin/src/server/core/asset-metadata.ts
@@ -122,12 +122,20 @@ const metadataFields = (metadata: CoreResourceMetadataNode, prefix: string) => {
  * path already sets on create/update — hence the explicit `isDualBucketPlatform` flag rather than
  * inferring it from `prefix`, which flat platform-only prefixes (`MODELS_PREFIX` et al.) already bake
  * their fixed `platform/` segment into and would otherwise match too.
+ *
+ * The same flag governs `path`: a genuinely flat platform-only entity has `path === name` by design
+ * (no bucket to qualify against — `getEntityPath`'s flat-platform branch relies on this). A dual-bucket
+ * platform resource's `path` must instead be bucket-qualified (`platform/{name}`), matching the shape
+ * `metadataFields` already gives a public-bucket resource's `path` — every downstream consumer
+ * (delete, discovered-tools, sign-in/out) trusts `.path` as the complete, Core-addressable path, and a
+ * bare name resolves to no bucket at all (`ResourceDescriptorFactory.fromAnyUrl` in `ai-dial-core`
+ * requires `{type}/{bucket}/{path}`).
  */
 const flatMetadataFields = (metadata: CoreResourceMetadataNode, prefix: string, isDualBucketPlatform = false) => {
   const { path, folderId, name } = parseEncodedFlatPath(metadata.url, prefix);
   return {
     name,
-    path,
+    path: isDualBucketPlatform ? `${PLATFORM_ROOT_FOLDER}/${name}` : path,
     folderId: isDualBucketPlatform ? `${PLATFORM_ROOT_FOLDER}/` : folderId,
     author: metadata.author ?? '',
     createdAt: metadata.createdAt !== undefined ? String(metadata.createdAt) : undefined,

--- a/apps/ai-dial-admin/src/server/core/tests/asset-metadata.spec.ts
+++ b/apps/ai-dial-admin/src/server/core/tests/asset-metadata.spec.ts
@@ -44,14 +44,14 @@ describe('Server :: Core :: asset-metadata', () => {
     });
   });
 
-  test('mergeApplicationResource sources flat name/path/author/createdAt/updatedAt from metadata for a platform-bucket resource, with folderId identifying the bucket', () => {
+  test('mergeApplicationResource sources flat name/path/author/createdAt/updatedAt from metadata for a platform-bucket resource, with folderId and path both identifying the bucket', () => {
     const content = { endpoint: 'https://app' };
     const meta = metadata({ url: 'applications/platform/my-app', author: 'alice', createdAt: 100, updatedAt: 111 });
 
     expect(mergeApplicationResource(content, meta)).toEqual({
       endpoint: 'https://app',
       name: 'my-app',
-      path: 'my-app',
+      path: 'platform/my-app',
       folderId: 'platform/',
       author: 'alice',
       createdAt: '100',
@@ -75,14 +75,14 @@ describe('Server :: Core :: asset-metadata', () => {
     });
   });
 
-  test('mergeToolsetResource sources flat name/path/author/createdAt/updatedAt from metadata for a platform-bucket resource, with folderId identifying the bucket', () => {
+  test('mergeToolsetResource sources flat name/path/author/createdAt/updatedAt from metadata for a platform-bucket resource, with folderId and path both identifying the bucket', () => {
     const content = { endpoint: 'https://ts' };
     const meta = metadata({ url: 'toolsets/platform/my-toolset', author: 'bob', createdAt: 200, updatedAt: 222 });
 
     expect(mergeToolsetResource(content, meta)).toEqual({
       endpoint: 'https://ts',
       name: 'my-toolset',
-      path: 'my-toolset',
+      path: 'platform/my-toolset',
       folderId: 'platform/',
       author: 'bob',
       createdAt: '200',

--- a/apps/ai-dial-admin/src/server/core/tests/toolset-ops-api.spec.ts
+++ b/apps/ai-dial-admin/src/server/core/tests/toolset-ops-api.spec.ts
@@ -27,6 +27,21 @@ describe('Server :: Core :: ToolsetOpsApi', () => {
     expect(result.response).toEqual({ tools: [] });
   });
 
+  // Regression (Issue #4445): Core's `DeploymentService.findDeployment` resolves a platform-bucket
+  // toolset by bare name via the merged config store — the resource-type prefix and `platform/`
+  // bucket segment must be stripped, not sent, or Core can't find (or is forbidden from) the
+  // deployment.
+  test('discoveredTools calls GET v1/toolset/{name}/tools for a platform-bucket toolset (bare name, no prefix)', async () => {
+    fetch.mockResponseOnce(JSON.stringify({ tools: [] }), { headers: { 'content-type': 'application/json' } });
+
+    const result = await instance.discoveredTools(TOKEN_MOCK, 'platform/my-toolset');
+
+    const [calledUrl] = fetch.mock.calls[0];
+    expect(calledUrl).toContain('/v1/toolset/my-toolset/tools');
+    expect(calledUrl).not.toContain('toolsets');
+    expect(result.success).toBe(true);
+  });
+
   test('discoveredTools calls GET v1/toolset/{prefixed-path}/tools for an application', async () => {
     fetch.mockResponseOnce(JSON.stringify({ tools: [] }), { headers: { 'content-type': 'application/json' } });
 
@@ -37,6 +52,17 @@ describe('Server :: Core :: ToolsetOpsApi', () => {
     expect(options?.method).toBe('GET');
     expect(result.success).toBe(true);
     expect(result.response).toEqual({ tools: [] });
+  });
+
+  test('discoveredTools calls GET v1/toolset/{name}/tools for a platform-bucket application (bare name, no prefix)', async () => {
+    fetch.mockResponseOnce(JSON.stringify({ tools: [] }), { headers: { 'content-type': 'application/json' } });
+
+    const result = await instance.discoveredTools(TOKEN_MOCK, 'platform/my-app', ResourceType.APPLICATION);
+
+    const [calledUrl] = fetch.mock.calls[0];
+    expect(calledUrl).toContain('/v1/toolset/my-app/tools');
+    expect(calledUrl).not.toContain('applications');
+    expect(result.success).toBe(true);
   });
 
   test('signIn calls POST v1/ops/toolset/signin with the given body', async () => {

--- a/apps/ai-dial-admin/src/server/core/toolset-ops-api.ts
+++ b/apps/ai-dial-admin/src/server/core/toolset-ops-api.ts
@@ -1,8 +1,9 @@
 import { RESOURCE_TYPE_PREFIX } from '@/src/constants/publications-core';
 import { Token } from '@/src/models/auth';
 import { ServerActionResponse } from '@/src/models/server-action';
-import { encodeCorePath } from '@/src/server/publications/path';
+import { encodeCorePath, stripPrefix } from '@/src/server/publications/path';
 import { ResourceType } from '@/src/types/resource-type';
+import { isPlatformBucketPath, PLATFORM_ROOT_FOLDER } from '@/src/utils/files/root-folder';
 import { CoreApi } from './core-api';
 
 const CORE_TOOLSET_TOOLS_URL = 'v1/toolset';
@@ -15,18 +16,26 @@ const CORE_TOOLSET_SIGN_OUT_URL = 'v1/ops/toolset/signout';
  * and sign-out. The admin backend forwards each of these to Core unchanged — no BE-side
  * secret-holding or token exchange — so this is a direct passthrough client.
  *
- * Core's `v1/toolset/{id}/tools` route resolves the deployment by name regardless of type, so
- * it already serves MCP-enabled Applications as well as Toolsets — `discoveredTools` accepts
- * either resource type and encodes the matching path prefix.
+ * Core's `v1/toolset/{id}/tools` route resolves `{id}` via `DeploymentService.findDeployment`,
+ * which tries the merged config store by bare name *before* falling back to
+ * `ResourceDescriptorFactory.fromAnyUrl`'s `{resourceType}/{bucket}/{path}` parse. Platform-bucket
+ * toolsets/applications are config-managed and registered there by bare name (see
+ * `ToolSetController.mergeToolsets`'s `config.getToolsets()` lookup) — so a platform-bucket `{id}`
+ * must be the bare name alone, with neither the resource-type prefix nor the `platform/` bucket
+ * segment, unlike a public-bucket resource path (which only the fallback, resource-path branch
+ * resolves, and does need `{resourceType}/{path}`).
  */
 export class ToolsetOpsApi extends CoreApi {
-  /** Fetches a deployment's discovered tools (`GET v1/toolset/{path}/tools`). */
+  /** Fetches a deployment's discovered tools (`GET v1/toolset/{id}/tools`). */
   discoveredTools(
     token: Token,
     path: string,
     resourceType: ResourceType = ResourceType.TOOLSET,
   ): Promise<ServerActionResponse> {
-    const url = `${CORE_TOOLSET_TOOLS_URL}/${encodeCorePath(`${RESOURCE_TYPE_PREFIX[resourceType]}${path}`)}/tools`;
+    const id = isPlatformBucketPath(path)
+      ? stripPrefix(path, `${PLATFORM_ROOT_FOLDER}/`)
+      : `${RESOURCE_TYPE_PREFIX[resourceType]}${path}`;
+    const url = `${CORE_TOOLSET_TOOLS_URL}/${encodeCorePath(id)}/tools`;
     return this.getAction(url, token);
   }
 

--- a/apps/ai-dial-admin/src/utils/toolset/tests/toolset-auth.spec.ts
+++ b/apps/ai-dial-admin/src/utils/toolset/tests/toolset-auth.spec.ts
@@ -50,6 +50,23 @@ describe('toolset-auth utils', () => {
     });
   });
 
+  // Regression (Issue #4447): Core's `DeploymentService.findDeployment` resolves a platform-bucket
+  // toolset by bare name via the merged config store — the sign-in/sign-out `url` must be the bare
+  // name alone, with neither the `toolsets/` prefix nor the `platform/` bucket segment.
+  test('getToolsetBasicBody strips the platform bucket segment and prefix for a platform-bucket toolset', () => {
+    const toolset = {
+      name: 'toolset1',
+      path: 'platform/toolset1',
+      authSettings: { authenticationType: ToolsetAuthType.API_KEY },
+    } as any;
+    const result = getToolsetBasicBody(toolset, ToolsetAuthCredentialLevel.USER);
+    expect(result).toMatchObject({
+      url: 'toolset1',
+      credentialsLevel: ToolsetAuthCredentialLevel.USER,
+      authenticationType: ToolsetAuthType.API_KEY,
+    });
+  });
+
   test('encodeToolsetRedirectState encodes state to base64url', () => {
     const state = { foo: 'bar', baz: 'qux' };
     const encoded = encodeToolsetRedirectState(state);

--- a/apps/ai-dial-admin/src/utils/toolset/toolset-auth.ts
+++ b/apps/ai-dial-admin/src/utils/toolset/toolset-auth.ts
@@ -1,6 +1,8 @@
 import { AssetToolset } from '@/src/models/dial/deployment-asset';
 import { DialToolsetResource, ToolsetAuthType as ResourceToolsetAuthType } from '@/src/models/dial/resource';
 import { Toolset, ToolsetAuthStatus, ToolsetAuthType } from '@/src/models/dial/toolset';
+import { stripPrefix } from '@/src/server/publications/path';
+import { isPlatformBucketPath, PLATFORM_ROOT_FOLDER } from '@/src/utils/files/root-folder';
 
 export const getToolsetSignInBody = (
   toolset: Toolset | DialToolsetResource,
@@ -21,12 +23,25 @@ export const getToolsetSignInBody = (
   return { ...body, apiKey };
 };
 
+/**
+ * `url` feeds Core's `DeploymentService.findDeployment`, which resolves a platform-bucket
+ * toolset by bare name via the merged config store — before ever reaching the resource-path
+ * parse a public-bucket toolset needs `toolsets/{path}` for (see `ToolsetOpsApi`'s doc comment).
+ * So a platform-bucket `.path` must have its `platform/` segment stripped and skip the
+ * `toolsets/` prefix entirely, unlike a public-bucket path.
+ */
 export const getToolsetBasicBody = (toolset: Toolset | DialToolsetResource, level: string) => {
   const authType =
     (toolset as Toolset).authSettings?.authenticationType ||
     (toolset as DialToolsetResource).auth_settings?.authentication_type;
+  const path = (toolset as AssetToolset).path;
+  const url = isPlatformBucketPath(path)
+    ? stripPrefix(path as string, `${PLATFORM_ROOT_FOLDER}/`)
+    : path
+      ? `toolsets/${path}`
+      : toolset.name;
   return {
-    url: (toolset as AssetToolset).path ? `toolsets/${(toolset as AssetToolset).path}` : toolset.name,
+    url,
     credentialsLevel: level,
     authenticationType: authType,
   };

--- a/openspec/changes/archive/2026-09-08-fix-platform-dual-bucket-path-resolution/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-08-fix-platform-dual-bucket-path-resolution/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-08

--- a/openspec/changes/archive/2026-09-08-fix-platform-dual-bucket-path-resolution/design.md
+++ b/openspec/changes/archive/2026-09-08-fix-platform-dual-bucket-path-resolution/design.md
@@ -1,0 +1,139 @@
+## Context
+
+Two independent bugs surface only for platform-bucket (`platform/`) toolsets/applications, never for
+public-bucket ones, because both stem from code that was written when only the public bucket existed
+and never accounted for the platform bucket's different URN/path shape.
+
+**Bug A.** `mergeToolsetResource`/`mergeApplicationResource` (`asset-metadata.ts`) route a
+platform-bucket resource through `dualBucketMetadataFields` → `flatMetadataFields`, which returns
+`path` as the bare resource name (`parseEncodedFlatPath`'s output) while separately forcing
+`folderId: 'platform/'`. For a public-bucket resource, the sibling `metadataFields` branch returns
+`path` already folder+version-qualified (e.g. `public/my-toolset__1.0`) — a complete path. This
+breaks the one consumer that genuinely needs a complete, `{bucket}/{name}`-qualified path:
+`getEntityPath`'s `AssetsApplications`/`AssetsToolsets` branch (`open-in-new-tab.ts:59-64`), used for
+delete. Confirmed against `ai-dial-core`: delete goes through `AssetApi`/`ConfigResourceController`'s
+CRUD routes (`/v1/toolsets/{bucket}/{path}`), which parse a resource path the same way
+`ResourceDescriptorFactory.fromAnyUrl` does for the public bucket — a bare name resolves to no bucket
+at all.
+
+List rows are unaffected: `BaseAssetList`'s rows come from `toResourceInfo`
+(`asset-metadata.ts:75-93`), which always uses `parseEncodedVersionedPath` regardless of bucket — it
+has no flat/dual-bucket branch and so never drops the bucket segment. This is exactly why the user
+observed delete working from the list but not from the detail view.
+
+**Bug A amendment — two different addressing conventions, not one.** The first pass at this fix
+assumed every consumer of a platform-bucket resource's `.path` wants the same complete,
+`platform/{name}`-qualified shape `getEntityPath`/delete needs, and updated `Tools.tsx` → `discoveredTools`
+and `getToolsetBasicBody` to send `toolsets/platform/{name}`. That produced a *different* Core error —
+"Forbidden deployment", not "Unknown deployment" — which traced to a second, distinct mechanism:
+`ToolSetToolsController`'s `/v1/toolset/{id}/tools` (discovered-tools) and
+`ResourceCredentialsController`'s sign-in/sign-out both resolve `{id}` via
+`DeploymentService.findDeployment`, which tries `context.getConfig().selectDeployment(id)` — the
+merged **config store**, keyed by bare name — *before* ever falling back to
+`ResourceDescriptorFactory.fromAnyUrl`'s resource-path parse (confirmed by `ToolSetController.
+mergeToolsets`'s `config.getToolsets()` lookup, also by bare name). Platform-bucket toolsets and
+applications are config-managed, so they're registered there by bare name; a public-bucket toolset is
+never in the config store, so `findDeployment` always falls through to the resource-path parse for it.
+
+So there are two addressing conventions, not one:
+
+| Consumer | Resolution path | Platform-bucket id needed |
+|---|---|---|
+| `getEntityPath` → delete (`AssetApi`/`ConfigResourceController`) | Resource-path CRUD route | `platform/{name}` (this is what Bug A's `flatMetadataFields` fix produces) |
+| `ToolSetToolsController` (discovered-tools) / `ResourceCredentialsController` (sign-in/out) via `DeploymentService.findDeployment` | Config-store lookup by bare name, first | bare `{name}` — **no** `platform/` segment, **no** resource-type prefix |
+
+`ToolsetOpsApi.discoveredTools` and `getToolsetBasicBody` — the two call sites feeding the
+config-store-resolved routes — must therefore strip `.path`'s `platform/` segment back off (and skip
+the `toolsets/`/`applications/` prefix entirely) for a platform-bucket resource, rather than trusting
+`.path` verbatim the way `getEntityPath` correctly does. Both now branch on
+`isPlatformBucketPath(path)` to choose bare name vs. prefixed path.
+
+**Bug B.** `setUrl`/`getUrl` (`components/Assets/Resources/utils.ts:71-76`) stash the OAuth callback
+target URL with a hardcoded trailing `&`, so `AuthPage.tsx:18`'s `` `${url}code=${oAuthCode}` `` lands
+on a valid `?...&code=...` URL — but only because a public-bucket toolset's URN
+(`getEntityPath`'s non-platform branch) already contains `?path=...`. A platform-bucket toolset's URN
+(`getEntityPath`'s platform branch, `forRemove=false`) is a bare encoded name with no query string at
+all (by design — flat platform entities need no `?path=`), so the stored value becomes
+`/assets-toolsets/{name}&`, and appending `code=...` produces the malformed
+`/assets-toolsets/{name}&code=...` from issue #4447.
+
+The sibling legacy module `components/Toolsets/Auth/utils.ts` already has a workaround for an
+analogous case: its own `setUrl` branches on `view === ApplicationRoute.Toolsets` (whose URN also has
+no query) to use `?` instead of `&`. It shares the same `toolset-auth-redirect-url` localStorage key
+with `Assets/Resources/utils.ts`'s `setUrl`/`getUrl` (both modules read/write the same key, which is
+how `AuthPage.tsx` — wired to the legacy module — still works for the Assets flow today), but the
+Assets module's own `setUrl` never got the equivalent branch for the platform bucket.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Fix `flatMetadataFields` so a platform-bucket resource's `path` is a complete, bucket-qualified path
+  — the single point where the value is wrong — rather than patching each of the three call sites that
+  currently compensate (or fail to).
+- Fix `setUrl` in `Assets/Resources/utils.ts` to choose the correct separator regardless of whether
+  the target URN already carries a query string, covering both bucket cases without depending on the
+  caller's `view`.
+- Cover both Applications and Toolsets, since Bug A is in code shared by both (`flatMetadataFields`),
+  and the user confirmed the Applications delete-from-details case is also broken.
+
+**Non-Goals:**
+
+- Touching `components/Toolsets/Auth/utils.ts` (the legacy, non-asset Toolsets flow) — it has no
+  platform-bucket concept and its existing `?`/`&` branch is already correct for the two URN shapes it
+  handles.
+- Unifying the two parallel `setUrl`/`getUrl` implementations into one shared module — they already
+  coexist via a shared storage key, and de-duplicating them is a separate refactor, not needed to fix
+  either reported bug.
+- Any change to `ai-dial-core` — verified its routing/resolution (`ResourceDescriptorFactory`,
+  `DeploymentService.findDeployment`, the `/v1/toolsets/{bucket}/{path}` and
+  `/v1/applications/{bucket}/{path}` write routes) already expects exactly the
+  `{resourceType}/platform/{name}` shape this fix produces; nothing there needs to change.
+
+## Decisions
+
+### Fix `flatMetadataFields`'s `path`, not each of its three broken consumers
+
+Two shapes were considered:
+
+- **A — fix the merge source** (chosen): change `flatMetadataFields`'s `isDualBucketPlatform` branch
+  to return `path: `${PLATFORM_ROOT_FOLDER}/${name}`` instead of the bare name.
+- **B — fix each consumer**: teach `getEntityPath`, `Tools.tsx`, and `getToolsetBasicBody` to
+  recompute a bucket-qualified path from `folderId`+`name` themselves, the way the write-side
+  `createToolset`/`updateToolset`/`updateApp` already do (per the earlier `fix-platform-toolset-update-path`
+  change).
+
+A is chosen because the bug is that `path` itself carries wrong information, not that three unrelated
+call sites each independently need to work around it — matching this repo's comment-density guidance
+of stating a fact once at its source of truth rather than at every place that consumes it. It also
+means any *future* consumer of a platform-bucket resource's `.path` gets the correct value for free,
+rather than inheriting the same bug a fourth time.
+
+B was rejected: it would leave `.path` itself still wrong (misleading for any code that reads it
+directly, e.g. debugging, logging, a future feature), and requires three separate, easy-to-miss edits
+for one underlying fact.
+
+**Consequence:** `asset-metadata.spec.ts`'s two existing tests asserting a bare-name `path` for a
+platform-bucket resource (`mergeApplicationResource`/`mergeToolsetResource`, lines ~47-60 and ~78-91)
+assert exactly the buggy value and must be updated to expect `platform/{name}`.
+
+### Fix `setUrl` by checking for an existing `?`, not by branching on bucket or view
+
+Considered mirroring the legacy module's `view === ApplicationRoute.Toolsets` branch inside
+`Assets/Resources/utils.ts`'s `setUrl` — but that file is shared by both `AssetsApplications` and
+`AssetsToolsets`, each with a public bucket (URN has `?path=`) and a platform bucket (URN doesn't), so
+a view-keyed branch would need to also know the bucket, duplicating logic `getEntityPath` already
+encodes in the URN itself. Instead, `setUrl` inspects the URN it already computed
+(`getUrnForEntity(...).includes('?')`) and appends `&` or `?` accordingly — one branch, no bucket- or
+view-specific knowledge duplicated into the auth module.
+
+## Risks / Trade-offs
+
+- **[Risk] A caller other than the three identified for Bug A relies on the current bare-name
+  `path` for a platform-bucket toolset/application.** → Mitigation: grep every read of `.path` on a
+  toolset/application entity in components under `Assets/` before implementing, matching the
+  `fix-platform-toolset-update-path` change's task 1.1 precedent.
+- **[Risk] Bug B's fix changes the stored URL shape for the public bucket too, if the `?` check is
+  wrong.** → Mitigation: the public-bucket URN already contains `?path=`, so `.includes('?')` is
+  `true` and the `&` branch is taken unchanged — verified against `getEntityPath`'s non-platform
+  `AssetsToolsets` branch.

--- a/openspec/changes/archive/2026-09-08-fix-platform-dual-bucket-path-resolution/proposal.md
+++ b/openspec/changes/archive/2026-09-08-fix-platform-dual-bucket-path-resolution/proposal.md
@@ -1,0 +1,57 @@
+## Why
+
+Platform-bucket toolsets and applications 404 (or silently no-op) on several detail-view actions —
+delete (#4443), the Tools Overview tab (#4445), and toolset login/sign-in, both API-key and OAuth
+(#4447) — while the same actions work fine from the list view. Both bugs trace to the platform bucket
+segment getting lost or mishandled once a resource is loaded into its detail view; neither is a new
+requirement, both are the implementation violating requirements the `platform-toolsets`,
+`platform-applications`, and `toolset-resources-core-api` specs already state (e.g. "the system sends
+a delete request against its `platform/`-prefixed path", "the sign-in/sign-out flow behaves
+identically to a public-bucket toolset").
+
+## What Changes
+
+- **Bug A — detail-view `path` drops the `platform/` bucket segment.** `flatMetadataFields`
+  (`server/core/asset-metadata.ts`), used by `mergeToolsetResource`/`mergeApplicationResource` for a
+  dual-bucket platform resource, returns the bare resource name as `path` instead of
+  `platform/{name}`. `folderId` already carries `'platform/'` correctly — only `path` is wrong. Every
+  consumer that trusts `.path` as a complete, bucket-qualified path (matching what it already gets for
+  a public-bucket resource) inherits the bug:
+  - `getEntityPath`'s `AssetsApplications`/`AssetsToolsets` branch (delete, #4443 + the
+    Applications equivalent — confirmed broken from the detail view, working from the list view since
+    list rows are built by the unaffected `toResourceInfo`/`parseEncodedVersionedPath` path)
+  - `Tools.tsx`'s asset-toolset tools fetch → `discoveredTools` (#4445)
+  - `getToolsetBasicBody`'s sign-in/sign-out request body (#4447's API-key login failure)
+  - Fix: `flatMetadataFields`'s `isDualBucketPlatform` branch returns
+    `path: `${PLATFORM_ROOT_FOLDER}/${name}`` instead of the bare name, matching the shape
+    `metadataFields` already produces for a public-bucket resource's `path`. No per-call-site patching.
+- **Bug B — OAuth toolset login redirect is malformed for a platform-bucket toolset.**
+  `setUrl`/`getUrl` (`components/Assets/Resources/utils.ts`) stash the post-login callback URL with a
+  hardcoded trailing `&`, assuming the URN already carries a `?path=...` query string. That's true for
+  a public-bucket toolset's URN but not a platform-bucket one (flat, no `?path=`), so the OAuth
+  callback page appends `code=...` straight onto the bare URN, producing `.../{name}&code=...` instead
+  of `.../{name}?code=...` — a 404 on redirect. Fix: choose `?` vs `&` based on whether the URN
+  already contains a `?`, or build the URL through `URL`/`URLSearchParams` instead of string
+  concatenation.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+None — this fix brings the implementation into compliance with scenarios the `platform-toolsets`,
+`platform-applications`, and `toolset-resources-core-api` specs already state (e.g. "Deleting a
+platform toolset" / "Platform toolset sign-in and sign-out work the same as public"). No spec-level
+behavior is changing.
+
+## Impact
+
+- `apps/ai-dial-admin/src/server/core/asset-metadata.ts` — `flatMetadataFields` path fix; ripples
+  through `mergeToolsetResource` and `mergeApplicationResource`.
+- `apps/ai-dial-admin/src/components/Assets/Resources/utils.ts` — `setUrl` separator fix.
+- No API surface, route, or component signature changes.
+- Existing tests asserting the current (buggy) bare-name `path` for a platform-bucket resource in
+  `asset-metadata.spec.ts` need updating; new tests cover the OAuth redirect separator logic.

--- a/openspec/changes/archive/2026-09-08-fix-platform-dual-bucket-path-resolution/tasks.md
+++ b/openspec/changes/archive/2026-09-08-fix-platform-dual-bucket-path-resolution/tasks.md
@@ -1,0 +1,22 @@
+## 1. Investigation
+
+- [x] 1.1 Grep every read of `.path` on a toolset/application entity under `apps/ai-dial-admin/src/components/Assets/` and `apps/ai-dial-admin/src/utils/` (in addition to `getEntityPath`, `Tools.tsx`, `getToolsetBasicBody` already identified) to confirm no other call site relies on the current bare-name value for a platform-bucket resource.
+
+## 2. Bug A — `flatMetadataFields` platform-bucket path
+
+- [x] 2.1 In `apps/ai-dial-admin/src/server/core/asset-metadata.ts`, change `flatMetadataFields`'s `isDualBucketPlatform` branch to return `path: `${PLATFORM_ROOT_FOLDER}/${name}`` instead of the bare name (`folderId` stays as-is).
+- [x] 2.2 Update the two existing tests in `asset-metadata.spec.ts` that assert a bare-name `path` for a platform-bucket resource (`mergeApplicationResource`/`mergeToolsetResource`) to expect `platform/{name}`.
+- [x] 2.3 Add/update tests confirming `getEntityPath`'s `AssetsApplications`/`AssetsToolsets` branch (`open-in-new-tab.spec.ts` or equivalent) resolves a platform-bucket entity's delete path to `platform/{name}`, and is unchanged for a public-bucket entity. (Already covered by existing tests at `open-in-new-tab.spec.ts:259-290`, which assert exactly this shape — no gap found.)
+- [x] 2.4 ~~Add/update a test for `discoveredTools`/`getAssetTools` (toolset and application) confirming a platform-bucket path now produces `toolsets/platform/{name}`/`applications/platform/{name}` instead of the bucket-less path.~~ **Superseded by 2.6** — that shape turned out to be wrong (see 2.6); the test now added under 2.6 asserts the correct bare-name shape instead.
+- [x] 2.5 ~~Add/update a test for `getToolsetBasicBody` confirming the sign-in/sign-out request `url` is `toolsets/platform/{name}` for a platform-bucket toolset.~~ **Superseded by 2.7** — same correction as 2.4.
+- [x] 2.6 **Correction:** `ToolSetToolsController`/`ResourceCredentialsController` resolve a platform-bucket `{id}` via `DeploymentService.findDeployment`'s config-store lookup by bare name, not the resource-path parse `getEntityPath`/delete needs — so `ToolsetOpsApi.discoveredTools` must send the bare name (no `platform/` segment, no resource-type prefix) for a platform-bucket path, and the prefixed path only for a public-bucket one. Fixed in `apps/ai-dial-admin/src/server/core/toolset-ops-api.ts`; updated `toolset-ops-api.spec.ts` to assert `/v1/toolset/{name}/tools` (bare) for platform-bucket toolset and application paths.
+- [x] 2.7 **Correction:** same fix for `getToolsetBasicBody` (`apps/ai-dial-admin/src/utils/toolset/toolset-auth.ts`) — the sign-in/sign-out `url` for a platform-bucket toolset is now the bare name, with neither the `toolsets/` prefix nor the `platform/` segment. Updated `toolset-auth.spec.ts` accordingly.
+
+## 3. Bug B — OAuth redirect separator
+
+- [x] 3.1 In `apps/ai-dial-admin/src/components/Assets/Resources/utils.ts`, change `setUrl` to choose `?` when the computed URN has no existing query string and `&` when it does (e.g. check `getUrnForEntity(...).includes('?')`), instead of always appending `&`.
+- [x] 3.2 Add/update unit tests for `setUrl` covering a platform-bucket toolset URN (no existing `?`, separator must be `?`) and a public-bucket toolset URN (existing `?path=`, separator stays `&`), matching the shape already tested in `components/Toolsets/Auth/tests/utils.spec.ts`'s `setUrl` suite.
+
+## 4. Quality gate
+
+- [x] 4.1 Run lint, format check, and the full test suite (`npm run test`) from the repo root. (Lint: 0 errors. Format: applied Prettier to touched files after each round of edits. Full suite: flaky timeouts under parallel load in unrelated files each time — `Analytics/QueryBuilder` specs, then `Runs/Compare/ExecutionResultsTab` — every failing file re-run passes cleanly in isolation; all files touched by this change pass every run, 106/106 in isolation on the final round.)


### PR DESCRIPTION
**Description:**

Platform-bucket toolsets/applications are dual-bucket entities: Core's `DeploymentService.findDeployment` resolves them by bare name via the merged config store, but several places in the admin frontend still built paths as if they were public-bucket resources (`toolsets/{path}` with a `platform/` bucket segment, or a bare `path` equal to `name` with no bucket qualifier). That mismatch produced "Not Found" errors on delete, tools discovery, and sign-in/sign-out, and a malformed OAuth redirect URL for platform-bucket toolsets.

Issues:

- Issue #4443
- Issue #4445
- Issue #4447

**Key Changes:**

- [apps/ai-dial-admin/src/server/core/asset-metadata.ts](https://github.com/epam/ai-dial-admin-frontend/blob/fix/platform-dual-bucket-path-resolution/apps/ai-dial-admin/src/server/core/asset-metadata.ts) — a dual-bucket platform resource's `path` is now bucket-qualified (`platform/{name}`) instead of the bare name, so downstream consumers (delete, discovered-tools, sign-in/out) get a Core-addressable path.
- [apps/ai-dial-admin/src/server/core/toolset-ops-api.ts](https://github.com/epam/ai-dial-admin-frontend/blob/fix/platform-dual-bucket-path-resolution/apps/ai-dial-admin/src/server/core/toolset-ops-api.ts) — `discoveredTools` now strips the resource-type prefix and `platform/` segment for a platform-bucket path, sending Core the bare name it expects for `v1/toolset/{id}/tools`.
- [apps/ai-dial-admin/src/utils/toolset/toolset-auth.ts](https://github.com/epam/ai-dial-admin-frontend/blob/fix/platform-dual-bucket-path-resolution/apps/ai-dial-admin/src/utils/toolset/toolset-auth.ts) — `getToolsetBasicBody` strips the `platform/` bucket segment for the sign-in/sign-out `url` on a platform-bucket toolset.
- [apps/ai-dial-admin/src/components/Assets/Resources/utils.ts](https://github.com/epam/ai-dial-admin-frontend/blob/fix/platform-dual-bucket-path-resolution/apps/ai-dial-admin/src/components/Assets/Resources/utils.ts) — `setUrl` now appends `?` (not always `&`) when the entity's URN has no existing query string, fixing a malformed `{name}&code=...` OAuth callback URL for platform-bucket toolsets.

**Breaking Changes:**

None — these are internal path-construction fixes; external API contracts are unchanged.

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<ticket>)` (comma-separated list of issues)
