### PR TITLE
feat(Audit/ActivityAudit): extend activity audit to the analytics tables feature (Issue #4450)

### DIFF
--- a/apps/ai-dial-admin/src/app/[lang]/activity-audit/actions.spec.ts
+++ b/apps/ai-dial-admin/src/app/[lang]/activity-audit/actions.spec.ts
@@ -4,13 +4,14 @@ import { getUserToken } from '@/src/utils/auth/auth-request';
 import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
 import {
   getActivities,
+  getAnalyticsActivities,
   getEntitiesForRevision,
   getRevisionDetails,
   getRevisions,
   systemRollbackToRevision,
   getActivityById,
 } from './actions';
-import { activityAuditApi } from '@/src/app/api/api';
+import { activityAuditApi, analyticsAuditApi } from '@/src/app/api/api';
 import { TOKEN_MOCK, RESPONSE_MOCK } from '@/src/utils/tests/mock/api.mock';
 import { FilterDto, SortDto } from '@/src/models/request';
 import { SortDirectionDto } from '@/src/types/request';
@@ -38,6 +39,30 @@ describe('Activity audit :: server action', () => {
 
     expect(activityAuditApi.getActivitiesList).toHaveBeenCalledWith(pageSize, pageNumber, TOKEN_MOCK, sorts, filters);
     expect(result).toEqual(RESPONSE_MOCK);
+  });
+
+  test('Should call the analytics getActivitiesList action with the user token', async () => {
+    (analyticsAuditApi.getActivitiesList as any).mockResolvedValue(RESPONSE_MOCK);
+
+    const sorts = [{ column: 'epochTimestampMs', direction: SortDirectionDto.DESC }] as SortDto[];
+    const filters = [{ column: 'resourceType', value: 'Table' }] as FilterDto[];
+
+    const result = await getAnalyticsActivities(25, 0, sorts, filters);
+
+    expect(analyticsAuditApi.getActivitiesList).toHaveBeenCalledWith(25, 0, TOKEN_MOCK, sorts, filters);
+    expect(activityAuditApi.getActivitiesList).not.toHaveBeenCalled();
+    expect(result).toEqual(RESPONSE_MOCK);
+  });
+
+  test('Should forward an incremented page number for a subsequent analytics block', async () => {
+    (analyticsAuditApi.getActivitiesList as any).mockResolvedValue(RESPONSE_MOCK);
+
+    const sorts = [{ column: 'epochTimestampMs', direction: SortDirectionDto.DESC }] as SortDto[];
+    const filters = [{ column: 'resourceType', value: 'Table' }] as FilterDto[];
+
+    await getAnalyticsActivities(25, 1, sorts, filters);
+
+    expect(analyticsAuditApi.getActivitiesList).toHaveBeenCalledWith(25, 1, TOKEN_MOCK, sorts, filters);
   });
 
   test('Should call getRevisionDetails action', async () => {

--- a/apps/ai-dial-admin/src/app/[lang]/activity-audit/actions.ts
+++ b/apps/ai-dial-admin/src/app/[lang]/activity-audit/actions.ts
@@ -2,7 +2,7 @@
 
 import { cookies, headers } from 'next/headers';
 
-import { activityAuditApi, deploymentAuditApi } from '@/src/app/api/api';
+import { activityAuditApi, analyticsAuditApi, deploymentAuditApi } from '@/src/app/api/api';
 import { getUserToken } from '@/src/utils/auth/auth-request';
 import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
 import { FilterDto, SortDto } from '@/src/models/request';
@@ -20,6 +20,16 @@ export async function getDeploymentActivities(
 ) {
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
   return deploymentAuditApi.getActivitiesList(pageSize, pageNumber, token, sorts, filters);
+}
+
+export async function getAnalyticsActivities(
+  pageSize: number,
+  pageNumber: number,
+  sorts: SortDto[],
+  filters: FilterDto[],
+) {
+  const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
+  return analyticsAuditApi.getActivitiesList(pageSize, pageNumber, token, sorts, filters);
 }
 
 export async function getRevisionDetails(url: string) {

--- a/apps/ai-dial-admin/src/app/api/api.ts
+++ b/apps/ai-dial-admin/src/app/api/api.ts
@@ -1,4 +1,5 @@
 import { AnalyticsDataApi } from '@/src/server/analytics/analytics-data-api';
+import { AnalyticsAuditApi } from '@/src/server/analytics/audit-api';
 import { stripAssetIdentityFields } from '@/src/server/assets/exim';
 import { AppRunnerSchemaApi } from '@/src/server/core/app-runner-schema-api';
 import { ConfigFileApi } from '@/src/server/core/config-file-api';
@@ -168,6 +169,10 @@ export const structuredQueryApi = new StructuredQueryApi({
 });
 
 export const analyticsDataApi = new AnalyticsDataApi({
+  host: process.env.DIAL_ANALYTICS_API_URL,
+});
+
+export const analyticsAuditApi = new AnalyticsAuditApi({
   host: process.env.DIAL_ANALYTICS_API_URL,
 });
 

--- a/apps/ai-dial-admin/src/components/ActivityAudit/EntityGrid/constants.ts
+++ b/apps/ai-dial-admin/src/components/ActivityAudit/EntityGrid/constants.ts
@@ -19,9 +19,10 @@ import {
   STATUS_I18N_KEYS,
 } from '@/src/constants/deployments/images';
 import { sourceTypeFormatter } from '@/src/constants/grid-columns/formatters';
-import { EntityFieldsI18nKey, FeaturesI18nKey } from '@/src/constants/i18n';
+import { AnalyticsTablesI18nKey, EntityFieldsI18nKey, FeaturesI18nKey } from '@/src/constants/i18n';
 import {
   ActivityAuditResourceType,
+  isAnalyticsResource,
   isContainerDeploymentResource,
   isImageDefinitionResource,
 } from '@/src/types/activity-audit';
@@ -79,6 +80,30 @@ export const ROLE_LIMITS_DIFF_COLUMNS = [
   { field: 'enabled', headerName: 'Enabled' },
 ];
 
+export const ANALYTICS_ROW_LABEL_KEYS: Record<string, AnalyticsTablesI18nKey> = {
+  name: AnalyticsTablesI18nKey.Name,
+  description: AnalyticsTablesI18nKey.Description,
+  type: AnalyticsTablesI18nKey.Type,
+  status: AnalyticsTablesI18nKey.Status,
+  system: AnalyticsTablesI18nKey.System,
+  source_table: AnalyticsTablesI18nKey.SourceTable,
+  columns: AnalyticsTablesI18nKey.Columns,
+  column_count: AnalyticsTablesI18nKey.ColumnsCount,
+  ordering_key: AnalyticsTablesI18nKey.OrderingKey,
+  identity_column: AnalyticsTablesI18nKey.IdentityColumn,
+  version_column: AnalyticsTablesI18nKey.VersionColumn,
+  tag_order: AnalyticsTablesI18nKey.TagOrder,
+  'grain.grain_key': AnalyticsTablesI18nKey.GrainKey,
+  'partition_by.column': AnalyticsTablesI18nKey.PartitionColumn,
+  'partition_by.granularity': AnalyticsTablesI18nKey.Granularity,
+  element_type: AnalyticsTablesI18nKey.ElementType,
+  enum_values: AnalyticsTablesI18nKey.EnumValues,
+  nullable: AnalyticsTablesI18nKey.Nullable,
+  tag: AnalyticsTablesI18nKey.Tag,
+  display_name: AnalyticsTablesI18nKey.DisplayName,
+  sensitive: AnalyticsTablesI18nKey.Sensitive,
+};
+
 export const RESOURCE_DIFF_COLUMNS = (
   t: (stringToTranslate: string, params?: Record<string, string>) => string,
   parameter?: string,
@@ -87,12 +112,13 @@ export const RESOURCE_DIFF_COLUMNS = (
 ): ColDef[] => {
   const isImageRow = isImageDefinitionResource(resourceType);
   const isContainerRow = isContainerDeploymentResource(resourceType);
+  const isAnalyticsRow = isAnalyticsResource(resourceType);
   return [
     {
       field: 'parameter',
       headerName: 'Parameter',
-      valueFormatter: ({ value }) => formatParameter(value, t, isImageRow, isContainerRow),
-      tooltipValueGetter: ({ value }) => formatParameter(value, t, isImageRow, isContainerRow),
+      valueFormatter: ({ value }) => formatParameter(value, t, isImageRow, isContainerRow, isAnalyticsRow),
+      tooltipValueGetter: ({ value }) => formatParameter(value, t, isImageRow, isContainerRow, isAnalyticsRow),
     },
     {
       field: 'value',
@@ -134,12 +160,20 @@ const formatParameter = (
   t: (stringToTranslate: string) => string,
   isImageRow?: boolean,
   isContainerRow?: boolean,
+  isAnalyticsRow?: boolean,
 ) => {
   if ((isImageRow || isContainerRow) && value === '$type') {
     return t(EntityFieldsI18nKey.source);
   }
   if (isImageRow && value === 'url') {
     return t(EntityFieldsI18nKey.SourceURL);
+  }
+  if (isAnalyticsRow) {
+    const analyticsRowKey = ANALYTICS_ROW_LABEL_KEYS[value];
+    // Deliberately no fall-through to the generic lookups below: they are keyed by
+    // admin-config field names, and an analytics field sharing one of those names
+    // would be labelled with the wrong feature's wording.
+    return analyticsRowKey ? t(analyticsRowKey) : value;
   }
   const containerRowKey = CONTAINER_ROW_LABEL_KEYS[value];
   if (containerRowKey) {

--- a/apps/ai-dial-admin/src/components/ActivityAudit/EntityGrid/tests/constants.spec.ts
+++ b/apps/ai-dial-admin/src/components/ActivityAudit/EntityGrid/tests/constants.spec.ts
@@ -1,0 +1,91 @@
+import { ColDef, ValueFormatterParams } from 'ag-grid-community';
+import { describe, expect, test } from 'vitest';
+
+import { ANALYTICS_ROW_LABEL_KEYS, RESOURCE_DIFF_COLUMNS } from '@/src/components/ActivityAudit/EntityGrid/constants';
+import { EntityParameterKeys } from '@/src/components/ActivityAudit/constants';
+import {
+  ANALYTICS_COLUMN_PARAMETERS,
+  getSnapshotLeaves,
+} from '@/src/components/ActivityAudit/View/utils/analytics-diffs';
+import { AnalyticsTablesI18nKey } from '@/src/constants/i18n';
+import { ActivityAuditEntity, ActivityAuditResourceType } from '@/src/types/activity-audit';
+
+const t = (key: string) => key;
+
+// A table snapshot carrying every field of the persisted table definition, so the
+// label map is asserted against the parameters the diff actually emits rather than
+// against a list copied by hand.
+const TABLE_SNAPSHOT = {
+  name: 'orders',
+  description: 'Orders',
+  type: 'source',
+  status: 'active',
+  system: false,
+  source_table: 'raw_orders',
+  column_count: 2,
+  grain: { grain_key: 'chat_id', cardinality: 'zero_or_one' },
+  ordering_key: ['created_at', 'id'],
+  partition_by: { column: 'created_at', granularity: 'day' },
+  identity_column: 'id',
+  version_column: 'updated_at',
+  tag_order: ['a', 'b'],
+} as unknown as ActivityAuditEntity;
+
+// The tables feature defines no label for the grain's cardinality — v1 supports a
+// single value and no screen surfaces it — so it renders under its own name.
+const UNLABELLED_TABLE_PARAMETERS = ['grain.cardinality'];
+
+const getParameterFormatter = (resourceType?: ActivityAuditResourceType) => {
+  const [parameterColumn] = RESOURCE_DIFF_COLUMNS(t, EntityParameterKeys.COLUMNS, resourceType) as ColDef[];
+  const formatter = parameterColumn.valueFormatter as (params: ValueFormatterParams) => string;
+  return (value: string) => formatter({ value } as ValueFormatterParams);
+};
+
+describe('ANALYTICS_ROW_LABEL_KEYS', () => {
+  test('labels every attribute a column diff emits', () => {
+    ANALYTICS_COLUMN_PARAMETERS.forEach((parameter) => {
+      expect(ANALYTICS_ROW_LABEL_KEYS[parameter]).toBeTruthy();
+    });
+  });
+
+  test('labels every table-definition parameter a snapshot produces', () => {
+    const parameters = Object.keys(getSnapshotLeaves(TABLE_SNAPSHOT)).filter(
+      (parameter) => !UNLABELLED_TABLE_PARAMETERS.includes(parameter),
+    );
+
+    expect(parameters.length).toBeGreaterThan(0);
+    parameters.forEach((parameter) => {
+      expect(ANALYTICS_ROW_LABEL_KEYS[parameter]).toBeTruthy();
+    });
+  });
+
+  test('labels the nested table parameters by their dotted path', () => {
+    expect(ANALYTICS_ROW_LABEL_KEYS['grain.grain_key']).toBe(AnalyticsTablesI18nKey.GrainKey);
+    expect(ANALYTICS_ROW_LABEL_KEYS['partition_by.column']).toBe(AnalyticsTablesI18nKey.PartitionColumn);
+    expect(ANALYTICS_ROW_LABEL_KEYS['partition_by.granularity']).toBe(AnalyticsTablesI18nKey.Granularity);
+  });
+});
+
+describe('RESOURCE_DIFF_COLUMNS :: analytics parameter labels', () => {
+  test('renders an analytics parameter through its label key', () => {
+    const formatParameter = getParameterFormatter(ActivityAuditResourceType.TABLE);
+
+    expect(formatParameter('nullable')).toBe(AnalyticsTablesI18nKey.Nullable);
+    expect(formatParameter('enum_values')).toBe(AnalyticsTablesI18nKey.EnumValues);
+    expect(formatParameter('ordering_key')).toBe(AnalyticsTablesI18nKey.OrderingKey);
+  });
+
+  test('falls back to the raw field name for an analytics parameter with no label', () => {
+    const formatParameter = getParameterFormatter(ActivityAuditResourceType.TABLE_COLUMN);
+
+    expect(formatParameter('grain.cardinality')).toBe('grain.cardinality');
+    expect(formatParameter('field_added_later')).toBe('field_added_later');
+  });
+
+  test('leaves a non-analytics resource type on its existing labels', () => {
+    const formatParameter = getParameterFormatter(ActivityAuditResourceType.MODEL);
+
+    expect(formatParameter('nullable')).toBe('nullable');
+    expect(formatParameter('name')).not.toBe(AnalyticsTablesI18nKey.Name);
+  });
+});

--- a/apps/ai-dial-admin/src/components/ActivityAudit/List/List.tsx
+++ b/apps/ai-dial-admin/src/components/ActivityAudit/List/List.tsx
@@ -17,18 +17,15 @@ import { IconRefresh, IconRestore } from '@tabler/icons-react';
 import { GridApi, GridOptions, GridReadyEvent, IDatasource, IGetRowsParams } from 'ag-grid-community';
 import classNames from 'classnames';
 
-import { getActivities, getDeploymentActivities } from '@/src/app/[lang]/activity-audit/actions';
 import { buildResourceTypeLabelMap, getFormattedResourceType } from '@/src/constants/grid-columns/formatters';
 import { RESOURCE_TYPE_COLUMN } from '@/src/constants/grid-columns/grid-columns';
 import {
-  getActivityAuditColumns,
-  getAuditActivityHref,
-  getDeploymentActivityAuditColumns,
   getEndOfDay,
   getGridFilters,
   getStartOfDay,
   processActivitiesData,
 } from '@/src/components/ActivityAudit/List/utils';
+import { ACTIVITY_AUDIT_VIEW_CONFIG } from '@/src/components/ActivityAudit/List/view-config';
 import ActivityDetails from '@/src/components/ActivityAudit/Modals/Details';
 import { SYSTEM_ROLLBACK_ID } from '@/src/components/ActivityAudit/Rollback/constants';
 import TimeFilter from '@/src/components/Common/TimeFilter/TimeFilter';
@@ -39,6 +36,7 @@ import ListView from '@/src/components/ListView/ListView';
 import { ACTIONS_COLUMN_CEL_ID, EXPANDER_COLUMN_CEL_ID, infiniteGridOptions, PAGE_SIZE } from '@/src/constants/ag-grid';
 import { ButtonsI18nKey, CompareI18nKey, RollbackI18nKey, TelemetryI18nKey } from '@/src/constants/i18n';
 import { BASE_BUTTON_ICON_PROPS } from '@/src/constants/main-layout';
+import { useAppContext } from '@/src/context/AppContext';
 import { useNotification } from '@/src/context/NotificationContext';
 import { useIsReadOnlyAdmin } from '@/src/hooks/use-is-read-only-admin';
 import { useI18n } from '@/src/locales/client';
@@ -50,6 +48,9 @@ import { TimeFilterValue, TimeRange } from '@/src/models/time-range';
 import { ApplicationRoute } from '@/src/types/routes';
 import { AuditListPreselect } from '@/src/types/audit-list-preselect';
 import { clearAuditListPreselect, readAuditListPreselect } from '@/src/utils/audit-list-preselect';
+import { isResourceIdInTableScope } from '@/src/utils/audit/analytics-resource-id';
+import { filterOutDeletedTableChildren, getUnresolvedParentIds } from '@/src/utils/audit/deleted-parent-suppression';
+import { getEntityAuditFilters } from '@/src/utils/audit/entity-audit-filters';
 import {
   needsDeploymentLifecycleCheck,
   resolveDeploymentRollbackBlockReason,
@@ -97,6 +98,7 @@ const ActivityAuditList: FC<Props> = ({
   const isReadOnlyAdmin = useIsReadOnlyAdmin();
   const router = useRouter();
   const { showNotification } = useNotification();
+  const { featureFlags } = useAppContext();
 
   const [isRollbackModalOpen, setIsRollbackModalOpen] = useState(false);
   const [isDetailsModalOpen, setIsDetailsModalOpen] = useState(false);
@@ -121,9 +123,13 @@ const ActivityAuditList: FC<Props> = ({
     return viewMode ?? ActivityAuditView.Config;
   });
   const effectiveViewType = viewMode ?? activityViewType;
+  const viewConfig = ACTIVITY_AUDIT_VIEW_CONFIG[effectiveViewType];
   const resourceTypeLabelMap = useMemo(() => buildResourceTypeLabelMap(t), [t]);
   const hasAppliedPreselectRef = useRef(false);
   const childrenCacheRef = useRef<Record<string, DialActivity[]>>({});
+  // Activities resolved during one list pass, keyed by their own identifier: every fetched row
+  // plus every parent the suppression lookup answered for.
+  const resolvedActivitiesRef = useRef<Record<string, DialActivity>>({});
   const rowBufferRef = useRef<DialActivity[]>([]);
   const apiPageRef = useRef(0);
   const apiExhaustedRef = useRef(false);
@@ -138,22 +144,26 @@ const ActivityAuditList: FC<Props> = ({
 
   const openInNewTab = useCallback(
     (activity?: DialActivity) => {
-      if (effectiveViewType === ActivityAuditView.Deployments && !isDeploymentManagerResource(activity?.resourceType)) {
+      if (!viewConfig.isRowNavigable(activity?.resourceType)) {
         return;
       }
       onOpenInNewTab(ApplicationRoute.ActivityAudit, activity);
     },
-    [effectiveViewType],
+    [viewConfig],
   );
 
   const openInNewTabForEntity = useCallback(
     (activity?: DialActivity) => {
-      const href = getAuditActivityHref(entity, entityType as ActivityAuditResourceType, activity?.activityId);
+      const href = viewConfig.getEntityActivityHref({
+        entity,
+        entityType: entityType as ActivityAuditResourceType,
+        activityId: activity?.activityId,
+      });
       if (href) {
         window.open(href, '_blank');
       }
     },
-    [entity, entityType],
+    [entity, entityType, viewConfig],
   );
 
   const onOpenConfirmationModal = useCallback((activity?: DialActivity) => {
@@ -171,7 +181,10 @@ const ActivityAuditList: FC<Props> = ({
       .finally(() => setIsCheckingState(false));
   }, []);
 
-  const isDeploymentsView = effectiveViewType === ActivityAuditView.Deployments;
+  // The analytics entity feed is requested with a `co` (substring) match on the table name, so it
+  // also answers with a similarly named table's rows — they are dropped before the row buffer.
+  const analyticsTableScope =
+    effectiveViewType === ActivityAuditView.Analytics && entity ? getEntityAuditFilterId(entity) : void 0;
 
   const gridDataSource: IDatasource = useMemo(
     () => ({
@@ -183,6 +196,7 @@ const ActivityAuditList: FC<Props> = ({
           apiPageRef.current = 0;
           apiExhaustedRef.current = false;
           childrenCacheRef.current = {};
+          resolvedActivitiesRef.current = {};
         }
 
         const actualTimeRange = isCustom
@@ -191,24 +205,54 @@ const ActivityAuditList: FC<Props> = ({
         gridApi?.setGridOption('loading', true);
         const sorts = getRequestSorts(params.sortModel);
         const filters = [
-          ...(entity
-            ? [
-                {
-                  column: 'resourceId',
-                  value: getEntityAuditFilterId(entity),
-                  operator: FilterOperatorDto.EQUALS,
-                } as FilterDto,
-                {
-                  column: RESOURCE_TYPE_COLUMN,
-                  value: entityType,
-                  operator: FilterOperatorDto.EQUALS,
-                } as FilterDto,
-              ]
-            : []),
+          ...getEntityAuditFilters(entity, entityType, effectiveViewType),
           ...getGridFilters(params.filterModel, actualTimeRange, resourceTypeLabelMap),
         ];
 
-        const fetchActivities = isDeploymentsView ? getDeploymentActivities : getActivities;
+        const { fetchActivities, hasParentChildAggregation, hasDeletedParentSuppression } = viewConfig;
+
+        /**
+         * The rows of a page the list should show, once the per-column children of a table
+         * deletion have been dropped.
+         *
+         * A child row carries only `parentActivityId`, so the parent has to be held to tell a
+         * column of a deleted table from a column dropped out of a living one. Every row of the
+         * page is cached first — a parent that arrived in the same page then costs nothing, the
+         * common case — and the page's remaining parents are asked for in one request carrying no
+         * other filter, because a `Resource type` filter the reader applied would otherwise hide
+         * the very parent being resolved. One request is enough: a page holds at most `PAGE_SIZE`
+         * rows and therefore at most `PAGE_SIZE` distinct parent identifiers.
+         *
+         * Fail-open in both directions: a rejected lookup leaves the page's parents unresolved
+         * rather than failing the grid, and an unresolved parent leaves its child listed.
+         */
+        const getListedRows = async (pageRows: DialActivity[]): Promise<DialActivity[]> => {
+          pageRows.forEach((row) => {
+            resolvedActivitiesRef.current[row.activityId] = row;
+          });
+
+          const unresolvedParentIds = getUnresolvedParentIds(pageRows, resolvedActivitiesRef.current);
+
+          if (unresolvedParentIds.length > 0) {
+            try {
+              const parentsRes = await fetchActivities(PAGE_SIZE, 0, sorts, [
+                {
+                  column: 'activityId',
+                  value: unresolvedParentIds.join(','),
+                  operator: FilterOperatorDto.INCLUDES,
+                },
+              ]);
+              parentsRes?.data.forEach((parent) => {
+                resolvedActivitiesRef.current[parent.activityId] = parent;
+              });
+            } catch {
+              // Deliberately swallowed: hiding a row on the absence of evidence is the failure
+              // mode an audit surface must not have, so a failed lookup shows the page instead.
+            }
+          }
+
+          return filterOutDeletedTableChildren(pageRows, resolvedActivitiesRef.current);
+        };
 
         try {
           while (rowBufferRef.current.length < endRow && !apiExhaustedRef.current) {
@@ -221,10 +265,21 @@ const ActivityAuditList: FC<Props> = ({
               break;
             }
 
-            if (isDeploymentsView || entity) {
-              rowBufferRef.current.push(...res.data);
+            const scopedRows = analyticsTableScope
+              ? res.data.filter((activity) => isResourceIdInTableScope(activity.resourceId, analyticsTableScope))
+              : res.data;
+
+            // Suppression happens here, at the same point the table-scope narrowing already
+            // drops rows: before the row buffer, so the buffer, the page boundaries and the
+            // end-of-list signal count only rows that are shown.
+            const rows = hasDeletedParentSuppression ? await getListedRows(scopedRows) : scopedRows;
+
+            // `hasParentChildAggregation` states the view's stance; entity mode has always listed
+            // rows flat whatever the view, so both conditions have to hold.
+            if (!hasParentChildAggregation || entity) {
+              rowBufferRef.current.push(...rows);
             } else {
-              const missingParentIds = res.data
+              const missingParentIds = rows
                 .filter((a) => !a.parentActivityId && !childrenCacheRef.current[a.activityId])
                 .map((a) => a.activityId);
 
@@ -257,7 +312,7 @@ const ActivityAuditList: FC<Props> = ({
                 });
               }
 
-              rowBufferRef.current.push(...processActivitiesData(res.data, childrenCacheRef.current));
+              rowBufferRef.current.push(...processActivitiesData(rows, childrenCacheRef.current));
             }
 
             if (page + 1 >= (res?.totalPages ?? 1)) {
@@ -276,7 +331,18 @@ const ActivityAuditList: FC<Props> = ({
       },
     }),
 
-    [isCustom, timePeriod, timeRange, gridApi, entity, entityType, isDeploymentsView, resourceTypeLabelMap],
+    [
+      isCustom,
+      timePeriod,
+      timeRange,
+      gridApi,
+      entity,
+      entityType,
+      effectiveViewType,
+      viewConfig,
+      analyticsTableScope,
+      resourceTypeLabelMap,
+    ],
   );
 
   useEffect(() => {
@@ -291,6 +357,7 @@ const ActivityAuditList: FC<Props> = ({
     }
     gridApi.setFilterModel(null);
     childrenCacheRef.current = {};
+    resolvedActivitiesRef.current = {};
     gridApi.setGridOption('datasource', gridDataSource);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [effectiveViewType]);
@@ -326,12 +393,12 @@ const ActivityAuditList: FC<Props> = ({
     rowClassRules: {
       'ag-activity-row-clickable': (params) => {
         const data = params.data as DialActivity & { children?: DialActivity[] };
-        if (isDeploymentsView && !isDeploymentManagerResource(data?.resourceType)) return false;
+        if (!viewConfig.isRowNavigable(data?.resourceType)) return false;
         return !data?.children?.length;
       },
     },
     onCellClicked: (e) => {
-      if (isDeploymentsView && !isDeploymentManagerResource(e.data?.resourceType)) {
+      if (!viewConfig.isRowNavigable(e.data?.resourceType)) {
         return;
       }
       if (e.data?.activityType === ActivityAuditType.Rollback || e.data?.activityType === ActivityAuditType.Import) {
@@ -351,26 +418,14 @@ const ActivityAuditList: FC<Props> = ({
   };
 
   const columnDefs = useMemo(() => {
-    if (entity) {
-      return getActivityAuditColumns(
-        t,
-        openInNewTabForEntity,
-        isReadOnlyAdmin ? undefined : onOpenConfirmationModal,
-        void 0,
-        true,
-      );
-    }
-    if (isDeploymentsView) {
-      return getDeploymentActivityAuditColumns(t, openInNewTab, isReadOnlyAdmin ? undefined : onOpenConfirmationModal);
-    }
-    return getActivityAuditColumns(
+    const canRollback = viewConfig.hasRollback && !isReadOnlyAdmin;
+    return viewConfig.getColumns({
       t,
-      openInNewTab,
-      isReadOnlyAdmin ? undefined : onOpenConfirmationModal,
-      void 0,
-      void 0,
-    );
-  }, [entity, isDeploymentsView, t, openInNewTab, openInNewTabForEntity, isReadOnlyAdmin, onOpenConfirmationModal]);
+      open: entity ? openInNewTabForEntity : openInNewTab,
+      onRollback: canRollback ? onOpenConfirmationModal : void 0,
+      isSingleEntity: !!entity,
+    });
+  }, [entity, viewConfig, t, openInNewTab, openInNewTabForEntity, isReadOnlyAdmin, onOpenConfirmationModal]);
 
   const onRefresh = useCallback(() => {
     if (gridApi) {
@@ -467,25 +522,32 @@ const ActivityAuditList: FC<Props> = ({
     setActivityViewType(val);
   }, []);
 
-  const activityViewOptions = useMemo(
-    () => [
+  // The Analytics option is absent — not disabled — when the feature is off, so an installation
+  // without analytics never issues a request to the analytics activity feed.
+  const activityViewOptions = useMemo(() => {
+    const options = [
       { value: ActivityAuditView.Config, label: t(TelemetryI18nKey.ActivityViewConfig) },
       { value: ActivityAuditView.Deployments, label: t(TelemetryI18nKey.ActivityViewDeployments) },
-    ],
-    [t],
-  );
+    ];
+
+    if (featureFlags.analyticsEnabled) {
+      options.push({ value: ActivityAuditView.Analytics, label: t(TelemetryI18nKey.ActivityViewAnalytics) });
+    }
+
+    return options;
+  }, [t, featureFlags.analyticsEnabled]);
 
   return (
     <div role="activities" className="flex flex-col flex-1 min-h-0 w-full relative">
       <ListView
-        key={!entity ? activityViewType : void 0}
+        key={!entity ? effectiveViewType : void 0}
         additionalGridOptions={gridOptions}
         columnDefs={columnDefs}
         title={!entity ? t(listViewTitleMap[ApplicationRoute.ActivityAudit]) : void 0}
         emptyDataTitle={t(emptyDataTitleMap[ApplicationRoute.ActivityAudit])}
         onGridReady={onGridReady}
         view={!entity ? ApplicationRoute.ActivityAudit : void 0}
-        storageKey={!entity ? `${ApplicationRoute.ActivityAudit}:${activityViewType.toLowerCase()}` : void 0}
+        storageKey={!entity ? `${ApplicationRoute.ActivityAudit}:${effectiveViewType.toLowerCase()}` : void 0}
       >
         <div className={classNames('flex gap-4', entity ? 'flex-1 justify-between' : 'justify-end')}>
           {entity && (
@@ -526,6 +588,11 @@ const ActivityAuditList: FC<Props> = ({
             </div>
           )}
 
+          {/*
+            The page-level system rollback is a Config-view affordance, not a per-view one: the
+            Deployments view declares `hasRollback` (its rows offer a rollback) and has never
+            rendered this button, so the view identity — not the config flag — is the condition.
+          */}
           {!entity && !isReadOnlyAdmin && effectiveViewType === ActivityAuditView.Config && (
             <DialNeutralButton
               iconBefore={<IconRestore {...BASE_BUTTON_ICON_PROPS} />}

--- a/apps/ai-dial-admin/src/components/ActivityAudit/List/models.ts
+++ b/apps/ai-dial-admin/src/components/ActivityAudit/List/models.ts
@@ -1,0 +1,48 @@
+import { ColDef } from 'ag-grid-community';
+
+import { DialActivity } from '@/src/models/activity-audit';
+import { DialApplicationScheme } from '@/src/models/dial/application';
+import { BaseEntity } from '@/src/models/dial/base-entity';
+import { AuditPageData, FilterDto, SortDto } from '@/src/models/request';
+import { ActivityAuditResourceType } from '@/src/types/activity-audit';
+
+/**
+ * Signature shared by every activity-feed server action (`getActivities`,
+ * `getDeploymentActivities`, `getAnalyticsActivities`), so a view config can name one
+ * without the list knowing which backend answers it.
+ */
+export type ActivityAuditFetcher = (
+  pageSize: number,
+  pageNumber: number,
+  sorts: SortDto[],
+  filters: FilterDto[],
+) => Promise<AuditPageData<DialActivity> | null>;
+
+export type ActivityAuditRowAction = (activity?: DialActivity) => void;
+
+export interface ActivityAuditColumnsParams {
+  t: (key: string) => string;
+  open?: ActivityAuditRowAction;
+  onRollback?: ActivityAuditRowAction;
+  isSingleEntity?: boolean;
+}
+
+export interface ActivityAuditHrefParams {
+  entity?: BaseEntity | DialApplicationScheme;
+  entityType?: ActivityAuditResourceType;
+  activityId?: string;
+}
+
+export interface ActivityAuditViewConfig {
+  fetchActivities: ActivityAuditFetcher;
+  getColumns: (params: ActivityAuditColumnsParams) => ColDef[];
+  hasParentChildAggregation: boolean;
+  /**
+   * Whether the view resolves each row's parent activity and drops the per-column children
+   * of a table deletion. Only the analytics feed records those children.
+   */
+  hasDeletedParentSuppression: boolean;
+  hasRollback: boolean;
+  isRowNavigable: (resourceType?: string) => boolean;
+  getEntityActivityHref: (params: ActivityAuditHrefParams) => string;
+}

--- a/apps/ai-dial-admin/src/components/ActivityAudit/List/tests/List.spec.tsx
+++ b/apps/ai-dial-admin/src/components/ActivityAudit/List/tests/List.spec.tsx
@@ -1,9 +1,29 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { ReactNode } from 'react';
+import { ReactNode, useEffect } from 'react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import {
+  ColDef,
+  GridOptions,
+  GridReadyEvent,
+  IDatasource,
+  IGetRowsParams,
+  ValueFormatterParams,
+} from 'ag-grid-community';
+
+let isReadOnlyAdminMock = false;
 vi.mock('@/src/hooks/use-is-read-only-admin', () => ({
-  useIsReadOnlyAdmin: () => false,
+  useIsReadOnlyAdmin: () => isReadOnlyAdminMock,
+}));
+
+const featureFlagsMock = { deploymentsEnabled: true, analyticsEnabled: false };
+vi.mock('@/src/context/AppContext', () => ({
+  useAppContext: () => ({ featureFlags: featureFlagsMock }),
+}));
+
+const showNotificationMock = vi.fn();
+vi.mock('@/src/context/NotificationContext', () => ({
+  useNotification: () => ({ showNotification: showNotificationMock, removeNotification: vi.fn() }),
 }));
 
 vi.mock('@/src/hooks/use-time-filter', () => ({
@@ -18,7 +38,9 @@ vi.mock('@/src/hooks/use-time-filter', () => ({
 
 vi.mock('@/src/components/Common/TimeFilter/TimeFilter', () => ({
   __esModule: true,
-  default: () => <div />,
+  default: ({ onTimePeriodChange }: { onTimePeriodChange: (period: string) => void }) => (
+    <button onClick={() => onTimePeriodChange('last_24_hours')}>change-period</button>
+  ),
 }));
 
 vi.mock('@/src/components/ListView/Header/ResetFiltersButton', () => ({
@@ -26,9 +48,32 @@ vi.mock('@/src/components/ListView/Header/ResetFiltersButton', () => ({
   default: () => <button>ResetFilters</button>,
 }));
 
+interface ListViewMockProps {
+  children?: ReactNode;
+  columnDefs?: ColDef[];
+  additionalGridOptions?: GridOptions;
+  storageKey?: string;
+  onGridReady?: (event: GridReadyEvent) => void;
+}
+
+const gridApiMock = {
+  setGridOption: vi.fn(),
+  setFilterModel: vi.fn(),
+};
+
+const listViewPropsMock = vi.fn();
 vi.mock('@/src/components/ListView/ListView', () => ({
   __esModule: true,
-  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  default: (props: ListViewMockProps) => {
+    listViewPropsMock(props);
+    useEffect(() => {
+      props.onGridReady?.({ api: gridApiMock } as unknown as GridReadyEvent);
+      // The real grid reports readiness once; re-running it here would reset the datasource
+      // captured by these tests.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    return <div>{props.children}</div>;
+  },
 }));
 
 vi.mock('@/src/components/ActivityAudit/Modals/Details', () => ({
@@ -36,11 +81,14 @@ vi.mock('@/src/components/ActivityAudit/Modals/Details', () => ({
   default: () => null,
 }));
 
-const getActivitiesMock = vi.fn().mockResolvedValue({ data: [], total: 0, totalPages: 0 });
-const getDeploymentActivitiesMock = vi.fn().mockResolvedValue({ data: [], total: 0, totalPages: 0 });
+const emptyPage = { data: [], total: 0, totalPages: 0 };
+const getActivitiesMock = vi.fn().mockResolvedValue(emptyPage);
+const getDeploymentActivitiesMock = vi.fn().mockResolvedValue(emptyPage);
+const getAnalyticsActivitiesMock = vi.fn().mockResolvedValue(emptyPage);
 vi.mock('@/src/app/[lang]/activity-audit/actions', () => ({
   getActivities: (...args: unknown[]) => getActivitiesMock(...args),
   getDeploymentActivities: (...args: unknown[]) => getDeploymentActivitiesMock(...args),
+  getAnalyticsActivities: (...args: unknown[]) => getAnalyticsActivitiesMock(...args),
 }));
 
 vi.mock('@epam/ai-dial-ui-kit', async (importOriginal) => {
@@ -72,17 +120,98 @@ vi.mock('@epam/ai-dial-ui-kit', async (importOriginal) => {
 });
 
 import ActivityAuditList from '@/src/components/ActivityAudit/List/List';
-import { ButtonsI18nKey, RollbackI18nKey, TelemetryI18nKey } from '@/src/constants/i18n';
-import { ActivityAuditView } from '@/src/types/activity-audit';
+import { ACTIONS_COLUMN_CEL_ID, PAGE_SIZE } from '@/src/constants/ag-grid';
+import {
+  ActionMenuOperationI18nKey,
+  ButtonsI18nKey,
+  EntitiesI18nKey,
+  RollbackI18nKey,
+  TelemetryI18nKey,
+} from '@/src/constants/i18n';
+import { DialActivity } from '@/src/models/activity-audit';
+import { BaseEntity } from '@/src/models/dial/base-entity';
+import { FilterDto } from '@/src/models/request';
+import { ActivityAuditResourceType, ActivityAuditType, ActivityAuditView } from '@/src/types/activity-audit';
+import { FilterOperatorDto } from '@/src/types/request';
 import { AUDIT_LIST_PRESELECT_STORAGE_KEY } from '@/src/constants/audit-list-preselect';
 import { AuditListPreselect } from '@/src/types/audit-list-preselect';
 
-describe('ActivityAuditList :: view-aware behavior', () => {
-  beforeEach(() => {
-    getActivitiesMock.mockClear();
-    getDeploymentActivitiesMock.mockClear();
+const RESOURCE_ID_FIELD = 'resourceId';
+const RESOURCE_TYPE_FIELD = 'resourceType';
+
+const lastListViewProps = (): ListViewMockProps =>
+  listViewPropsMock.mock.calls[listViewPropsMock.mock.calls.length - 1][0] as ListViewMockProps;
+
+const lastColumnDefs = (): ColDef[] => lastListViewProps().columnDefs ?? [];
+
+const rowActionIds = (): string[] => {
+  const actionColumn = lastColumnDefs().find((column) => column.field === ACTIONS_COLUMN_CEL_ID);
+  const { items } = (actionColumn?.cellRendererParams ?? {}) as { items: { id: string }[] };
+  return items.map((item) => item.id);
+};
+
+const lastDatasource = (): IDatasource => {
+  const call = [...gridApiMock.setGridOption.mock.calls].reverse().find(([option]) => option === 'datasource');
+  return call?.[1] as IDatasource;
+};
+
+const requestRows = async (startRow = 0, endRow = PAGE_SIZE) => {
+  const successCallback = vi.fn();
+  const failCallback = vi.fn();
+  const params = {
+    startRow,
+    endRow,
+    successCallback,
+    failCallback,
+    sortModel: [],
+    filterModel: {},
+    context: void 0,
+  } as unknown as IGetRowsParams;
+
+  await act(async () => {
+    await lastDatasource().getRows(params);
   });
 
+  return { successCallback, failCallback };
+};
+
+const activity = (overrides: Partial<DialActivity> = {}): DialActivity =>
+  ({
+    activityId: 'abc-123',
+    activityType: ActivityAuditType.Update,
+    resourceType: ActivityAuditResourceType.TABLE,
+    resourceId: 'orders',
+    epochTimestampMs: 1,
+    ...overrides,
+  }) as DialActivity;
+
+const onePage = (data: DialActivity[]) => ({ data, total: data.length, totalPages: 1 });
+
+const renderAnalyticsTab = () =>
+  render(
+    <ActivityAuditList
+      entity={{ name: 'orders' } as BaseEntity}
+      entityType={ActivityAuditResourceType.TABLE}
+      viewMode={ActivityAuditView.Analytics}
+    />,
+  );
+
+beforeEach(() => {
+  // The preselect is read from session storage on mount in every test, not only in the
+  // preselect block, so a value left behind by one test would reach the next one.
+  sessionStorage.clear();
+  isReadOnlyAdminMock = false;
+  featureFlagsMock.analyticsEnabled = false;
+  showNotificationMock.mockClear();
+  listViewPropsMock.mockClear();
+  gridApiMock.setGridOption.mockClear();
+  gridApiMock.setFilterModel.mockClear();
+  getActivitiesMock.mockClear().mockResolvedValue(emptyPage);
+  getDeploymentActivitiesMock.mockClear().mockResolvedValue(emptyPage);
+  getAnalyticsActivitiesMock.mockClear().mockResolvedValue(emptyPage);
+});
+
+describe('ActivityAuditList :: view-aware behavior', () => {
   test('renders Rollback button by default (Config view)', () => {
     render(<ActivityAuditList />);
     expect(screen.getByText(RollbackI18nKey.Rollback)).toBeInTheDocument();
@@ -135,8 +264,6 @@ describe('ActivityAuditList :: view-aware behavior', () => {
 describe('ActivityAuditList :: audit-list-preselect', () => {
   beforeEach(() => {
     sessionStorage.clear();
-    getActivitiesMock.mockClear();
-    getDeploymentActivitiesMock.mockClear();
   });
 
   test('without preselect, default view is Config', () => {
@@ -161,5 +288,571 @@ describe('ActivityAuditList :: audit-list-preselect', () => {
     render(<ActivityAuditList />);
     expect((screen.getByLabelText('View') as HTMLSelectElement).value).toBe('Config');
     expect(sessionStorage.getItem(AUDIT_LIST_PRESELECT_STORAGE_KEY)).toBe('something-else');
+  });
+});
+
+describe('ActivityAuditList :: Analytics view option', () => {
+  const viewOptions = () => Array.from(screen.getByLabelText('View').querySelectorAll('option')) as HTMLOptionElement[];
+
+  test('omits the Analytics option and issues no analytics request when the feature is disabled', async () => {
+    render(<ActivityAuditList />);
+    await requestRows();
+
+    expect(viewOptions().map((option) => option.value)).toEqual([
+      ActivityAuditView.Config,
+      ActivityAuditView.Deployments,
+    ]);
+    expect(getAnalyticsActivitiesMock).not.toHaveBeenCalled();
+  });
+
+  test('lists Config, Deployments and Analytics when the analytics feature is enabled', () => {
+    featureFlagsMock.analyticsEnabled = true;
+    render(<ActivityAuditList />);
+
+    expect(viewOptions().map((option) => option.value)).toEqual([
+      ActivityAuditView.Config,
+      ActivityAuditView.Deployments,
+      ActivityAuditView.Analytics,
+    ]);
+    expect(screen.getByText(TelemetryI18nKey.ActivityViewAnalytics)).toBeInTheDocument();
+    expect((screen.getByLabelText('View') as HTMLSelectElement).value).toBe(ActivityAuditView.Config);
+  });
+
+  test('offers every view option as selectable to a read-only admin', () => {
+    isReadOnlyAdminMock = true;
+    featureFlagsMock.analyticsEnabled = true;
+    render(<ActivityAuditList />);
+
+    expect(viewOptions().every((option) => !option.disabled)).toBe(true);
+  });
+});
+
+describe('ActivityAuditList :: per-view fetcher', () => {
+  test('invokes getActivities on the default Config view', async () => {
+    render(<ActivityAuditList />);
+    await requestRows();
+
+    expect(getActivitiesMock).toHaveBeenCalled();
+    expect(getDeploymentActivitiesMock).not.toHaveBeenCalled();
+    expect(getAnalyticsActivitiesMock).not.toHaveBeenCalled();
+  });
+
+  test('invokes getDeploymentActivities when viewMode forces the Deployments view', async () => {
+    render(<ActivityAuditList viewMode={ActivityAuditView.Deployments} />);
+    await requestRows();
+
+    expect(getDeploymentActivitiesMock).toHaveBeenCalled();
+    expect(getActivitiesMock).not.toHaveBeenCalled();
+    expect(screen.queryByLabelText('View')).toBeNull();
+  });
+
+  test('invokes getAnalyticsActivities when viewMode forces the Analytics view', async () => {
+    render(<ActivityAuditList viewMode={ActivityAuditView.Analytics} />);
+    await requestRows();
+
+    expect(getAnalyticsActivitiesMock).toHaveBeenCalledWith(PAGE_SIZE, 0, [], expect.any(Array));
+    expect(getActivitiesMock).not.toHaveBeenCalled();
+    expect(getDeploymentActivitiesMock).not.toHaveBeenCalled();
+    expect(screen.queryByLabelText('View')).toBeNull();
+  });
+
+  test('switches to the analytics fetcher when the user selects the Analytics option', async () => {
+    featureFlagsMock.analyticsEnabled = true;
+    render(<ActivityAuditList />);
+    act(() => {
+      fireEvent.change(screen.getByLabelText('View'), { target: { value: ActivityAuditView.Analytics } });
+    });
+    await requestRows();
+
+    expect(getAnalyticsActivitiesMock).toHaveBeenCalled();
+  });
+});
+
+describe('ActivityAuditList :: Analytics view rows', () => {
+  test('renders a row for every resource type the analytics feed returns', async () => {
+    getAnalyticsActivitiesMock.mockResolvedValue(
+      onePage([
+        activity({ activityId: 't', resourceType: ActivityAuditResourceType.TABLE }),
+        activity({ activityId: 'c', resourceType: ActivityAuditResourceType.TABLE_COLUMN }),
+        activity({ activityId: 'p', resourceType: ActivityAuditResourceType.PIPELINE }),
+        activity({ activityId: 'q', resourceType: ActivityAuditResourceType.SAVED_QUERY }),
+      ]),
+    );
+    render(<ActivityAuditList viewMode={ActivityAuditView.Analytics} />);
+    const { successCallback } = await requestRows();
+
+    const [rows] = successCallback.mock.calls[0] as [DialActivity[]];
+    expect(rows.map((row) => row.resourceType)).toEqual([
+      ActivityAuditResourceType.TABLE,
+      ActivityAuditResourceType.TABLE_COLUMN,
+      ActivityAuditResourceType.PIPELINE,
+      ActivityAuditResourceType.SAVED_QUERY,
+    ]);
+  });
+
+  test('labels a pipeline and a saved-query row through the analytics Resource type column', async () => {
+    getAnalyticsActivitiesMock.mockResolvedValue(
+      onePage([
+        activity({ activityId: 'p', resourceType: ActivityAuditResourceType.PIPELINE, resourceId: 'daily_rollup' }),
+        activity({ activityId: 'q', resourceType: ActivityAuditResourceType.SAVED_QUERY, resourceId: 'q1' }),
+      ]),
+    );
+    render(<ActivityAuditList viewMode={ActivityAuditView.Analytics} />);
+    const { successCallback } = await requestRows();
+
+    const [rows] = successCallback.mock.calls[0] as [DialActivity[]];
+    const resourceType = lastColumnDefs().find((column) => column.field === RESOURCE_TYPE_FIELD);
+    const formatResourceType = resourceType?.valueFormatter as (params: ValueFormatterParams) => string;
+
+    // The two halves this joins: the rows reach the grid, and the analytics column set is what
+    // formats them. The local analytics feed carries neither type, so nothing else can prove it.
+    expect(rows.map((row) => formatResourceType({ value: row.resourceType } as ValueFormatterParams))).toEqual([
+      EntitiesI18nKey.AnalyticsPipeline,
+      EntitiesI18nKey.AnalyticsSavedQuery,
+    ]);
+  });
+
+  test('renders analytics rows flat, keeping the parent activity identifier', async () => {
+    getAnalyticsActivitiesMock.mockResolvedValue(
+      onePage([
+        activity({ activityId: 'parent-1', resourceType: ActivityAuditResourceType.TABLE }),
+        activity({
+          activityId: 'child-1',
+          resourceType: ActivityAuditResourceType.TABLE_COLUMN,
+          parentActivityId: 'parent-1',
+        }),
+      ]),
+    );
+    render(<ActivityAuditList viewMode={ActivityAuditView.Analytics} />);
+    const { successCallback } = await requestRows();
+
+    const [rows] = successCallback.mock.calls[0] as [(DialActivity & { children?: DialActivity[] })[]];
+    expect(rows.map((row) => row.activityId)).toEqual(['parent-1', 'child-1']);
+    expect(rows.every((row) => row.children === undefined)).toBe(true);
+    expect(rows[1].parentActivityId).toBe('parent-1');
+    // A single page of the feed is asked for exactly once — no child lookup is issued.
+    expect(getAnalyticsActivitiesMock).toHaveBeenCalledOnce();
+  });
+
+  test('renders neither the expander column nor the Version column', () => {
+    render(<ActivityAuditList viewMode={ActivityAuditView.Analytics} />);
+
+    const fields = lastColumnDefs().map((column) => column.field);
+    expect(fields).not.toContain('expanderColumn');
+    expect(fields).not.toContain('version');
+    expect(fields).toContain(RESOURCE_ID_FIELD);
+  });
+
+  test('persists analytics column state under its own storage key', () => {
+    featureFlagsMock.analyticsEnabled = true;
+    render(<ActivityAuditList />);
+    expect(lastListViewProps().storageKey).toBe('/activity-audit:config');
+
+    act(() => {
+      fireEvent.change(screen.getByLabelText('View'), { target: { value: ActivityAuditView.Analytics } });
+    });
+    expect(lastListViewProps().storageKey).toBe('/activity-audit:analytics');
+  });
+
+  test('renders no page-level Rollback button on the Analytics view', () => {
+    featureFlagsMock.analyticsEnabled = true;
+    render(<ActivityAuditList />);
+    act(() => {
+      fireEvent.change(screen.getByLabelText('View'), { target: { value: ActivityAuditView.Analytics } });
+    });
+
+    expect(screen.queryByText(RollbackI18nKey.Rollback)).toBeNull();
+  });
+
+  test('offers no Rollback row action on the Analytics view', () => {
+    render(<ActivityAuditList viewMode={ActivityAuditView.Analytics} />);
+
+    expect(rowActionIds()).toEqual([ActionMenuOperationI18nKey.Open_in_new_tab]);
+  });
+
+  test('opens the global detail page in a new tab on a row body click', () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    render(<ActivityAuditList viewMode={ActivityAuditView.Analytics} />);
+
+    const setSelected = vi.fn();
+    lastListViewProps().additionalGridOptions?.onCellClicked?.({
+      data: activity(),
+      colDef: { field: 'activityId' },
+      node: { setSelected },
+    } as never);
+
+    expect(setSelected).toHaveBeenCalled();
+    expect(openSpy).toHaveBeenCalledWith('/activity-audit/abc-123', '_blank');
+    openSpy.mockRestore();
+  });
+
+  test('opens the global detail page in a new tab from the row action', () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    render(<ActivityAuditList viewMode={ActivityAuditView.Analytics} />);
+
+    const actionColumn = lastColumnDefs().find((column) => column.field === ACTIONS_COLUMN_CEL_ID);
+    const { items } = (actionColumn?.cellRendererParams ?? {}) as {
+      items: { id: string; onClick: (row?: DialActivity) => void }[];
+    };
+    items[0].onClick(activity());
+
+    expect(openSpy).toHaveBeenCalledWith('/activity-audit/abc-123', '_blank');
+    openSpy.mockRestore();
+  });
+});
+
+describe('ActivityAuditList :: Analytics deleted-table child suppression', () => {
+  const ACTIVITY_ID_FIELD = 'activityId';
+
+  const tableDelete = (activityId: string, resourceId: string) =>
+    activity({
+      activityId,
+      resourceId,
+      resourceType: ActivityAuditResourceType.TABLE,
+      activityType: ActivityAuditType.Delete,
+    });
+
+  const columnDelete = (activityId: string, resourceId: string, parentActivityId: string) =>
+    activity({
+      activityId,
+      resourceId,
+      parentActivityId,
+      resourceType: ActivityAuditResourceType.TABLE_COLUMN,
+      activityType: ActivityAuditType.Delete,
+    });
+
+  const parentLookupCalls = (fetchMock: typeof getAnalyticsActivitiesMock) =>
+    fetchMock.mock.calls.filter((call) =>
+      ((call[3] ?? []) as FilterDto[]).some((filter) => filter.column === ACTIVITY_ID_FIELD),
+    );
+
+  const listedIds = (successCallback: ReturnType<typeof vi.fn>) =>
+    (successCallback.mock.calls[0][0] as DialActivity[]).map((row) => row.activityId);
+
+  // The feed and the parent lookup are the same server action, so the mock answers by what a
+  // call asks for rather than by call order: a lookup the component never issues then leaves no
+  // queued answer behind to reach the next test.
+  const mockFeedAndLookup = (feed: DialActivity[], onLookup: () => Promise<unknown>) =>
+    getAnalyticsActivitiesMock.mockImplementation((...args: unknown[]) =>
+      ((args[3] ?? []) as FilterDto[]).some((filter) => filter.column === ACTIVITY_ID_FIELD)
+        ? onLookup()
+        : Promise.resolve(onePage(feed)),
+    );
+
+  test('lists a table Delete without any of the column activities it recorded', async () => {
+    getAnalyticsActivitiesMock.mockResolvedValue(
+      onePage([
+        tableDelete('parent-delete', 'chat_ratings'),
+        columnDelete('col-1', 'chat_ratings:id', 'parent-delete'),
+        columnDelete('col-2', 'chat_ratings:rating', 'parent-delete'),
+        columnDelete('col-3', 'chat_ratings:chat_id', 'parent-delete'),
+      ]),
+    );
+    render(<ActivityAuditList viewMode={ActivityAuditView.Analytics} />);
+    const { successCallback } = await requestRows();
+
+    expect(listedIds(successCallback)).toEqual(['parent-delete']);
+    // The parent arrived in the same page, so it costs no request to resolve.
+    expect(parentLookupCalls(getAnalyticsActivitiesMock)).toHaveLength(0);
+  });
+
+  test('lists a column dropped from a living table with its parent identifier intact', async () => {
+    getAnalyticsActivitiesMock.mockResolvedValue(
+      onePage([
+        activity({
+          activityId: 'parent-update',
+          resourceId: 'test_new_flow',
+          resourceType: ActivityAuditResourceType.TABLE,
+          activityType: ActivityAuditType.Update,
+        }),
+        columnDelete('dropped-column', 'test_new_flow:gate_probe_col', 'parent-update'),
+      ]),
+    );
+    render(<ActivityAuditList viewMode={ActivityAuditView.Analytics} />);
+    const { successCallback } = await requestRows();
+
+    const [rows] = successCallback.mock.calls[0] as [DialActivity[]];
+    expect(rows.map((row) => row.activityId)).toEqual(['parent-update', 'dropped-column']);
+    expect(rows[1].parentActivityId).toBe('parent-update');
+  });
+
+  test('issues no resolution request for a page whose rows name no parent', async () => {
+    getAnalyticsActivitiesMock.mockResolvedValue(
+      onePage([tableDelete('t1', 'orders'), activity({ activityId: 't2', resourceId: 'daily_rollup' })]),
+    );
+    render(<ActivityAuditList viewMode={ActivityAuditView.Analytics} />);
+    const { successCallback } = await requestRows();
+
+    expect(getAnalyticsActivitiesMock).toHaveBeenCalledOnce();
+    expect(listedIds(successCallback)).toEqual(['t1', 't2']);
+  });
+
+  test('resolves a parent absent from the page in one unfiltered lookup and suppresses its children', async () => {
+    mockFeedAndLookup(
+      [
+        columnDelete('col-1', 'chat_ratings:id', 'parent-delete'),
+        columnDelete('col-2', 'chat_ratings:rating', 'parent-delete'),
+      ],
+      () => Promise.resolve(onePage([tableDelete('parent-delete', 'chat_ratings')])),
+    );
+    render(<ActivityAuditList viewMode={ActivityAuditView.Analytics} />);
+    const { successCallback } = await requestRows();
+
+    // One request for the whole page, carrying the parent identifiers and nothing else: a
+    // resource-type or time filter here would hide the very parent being resolved.
+    expect(getAnalyticsActivitiesMock).toHaveBeenNthCalledWith(
+      2,
+      PAGE_SIZE,
+      0,
+      [],
+      [{ column: ACTIVITY_ID_FIELD, value: 'parent-delete', operator: FilterOperatorDto.INCLUDES }],
+    );
+    expect(parentLookupCalls(getAnalyticsActivitiesMock)).toHaveLength(1);
+    expect(listedIds(successCallback)).toEqual([]);
+  });
+
+  test('lists a child whose parent the resolution does not answer for', async () => {
+    mockFeedAndLookup([columnDelete('orphan', 'orders:total', 'never-answered')], () => Promise.resolve(onePage([])));
+    render(<ActivityAuditList viewMode={ActivityAuditView.Analytics} />);
+    const { successCallback, failCallback } = await requestRows();
+
+    expect(parentLookupCalls(getAnalyticsActivitiesMock)).toHaveLength(1);
+    expect(listedIds(successCallback)).toEqual(['orphan']);
+    expect(failCallback).not.toHaveBeenCalled();
+  });
+
+  test('lists the page and raises nothing when the parent lookup itself fails', async () => {
+    mockFeedAndLookup([columnDelete('col-1', 'chat_ratings:id', 'parent-delete')], () =>
+      Promise.reject(new Error('lookup unavailable')),
+    );
+    render(<ActivityAuditList viewMode={ActivityAuditView.Analytics} />);
+    const { successCallback, failCallback } = await requestRows();
+
+    expect(parentLookupCalls(getAnalyticsActivitiesMock)).toHaveLength(1);
+    expect(listedIds(successCallback)).toEqual(['col-1']);
+    expect(failCallback).not.toHaveBeenCalled();
+    expect(showNotificationMock).not.toHaveBeenCalled();
+  });
+
+  test('resolves no parent and suppresses no row on the Config view', async () => {
+    const parent = tableDelete('parent-delete', 'chat_ratings');
+    const child = columnDelete('col-1', 'chat_ratings:id', 'parent-delete');
+    getActivitiesMock.mockResolvedValueOnce(onePage([parent, child])).mockResolvedValueOnce(onePage([child]));
+
+    render(<ActivityAuditList />);
+    const { successCallback } = await requestRows();
+
+    expect(listedIds(successCallback)).toEqual(['parent-delete', 'col-1']);
+    expect(parentLookupCalls(getActivitiesMock)).toHaveLength(0);
+  });
+
+  test('resolves no parent and suppresses no row on the Deployments view', async () => {
+    getDeploymentActivitiesMock.mockResolvedValue(
+      onePage([
+        tableDelete('parent-delete', 'chat_ratings'),
+        columnDelete('col-1', 'chat_ratings:id', 'parent-delete'),
+      ]),
+    );
+
+    render(<ActivityAuditList viewMode={ActivityAuditView.Deployments} />);
+    const { successCallback } = await requestRows();
+
+    expect(listedIds(successCallback)).toEqual(['parent-delete', 'col-1']);
+    expect(getDeploymentActivitiesMock).toHaveBeenCalledOnce();
+    expect(parentLookupCalls(getDeploymentActivitiesMock)).toHaveLength(0);
+  });
+});
+
+describe('ActivityAuditList :: Analytics entity audit tab', () => {
+  test('requests the analytics feed with the resource-type in and resource-id co filter pair', async () => {
+    renderAnalyticsTab();
+    await requestRows();
+
+    expect(getAnalyticsActivitiesMock).toHaveBeenCalledWith(
+      PAGE_SIZE,
+      0,
+      [],
+      expect.arrayContaining([
+        { column: RESOURCE_TYPE_FIELD, value: 'Table,TableColumn', operator: FilterOperatorDto.INCLUDES },
+        { column: RESOURCE_ID_FIELD, value: 'orders', operator: FilterOperatorDto.CONTAINS },
+      ]),
+    );
+  });
+
+  test('excludes an activity that belongs to a similarly named table', async () => {
+    getAnalyticsActivitiesMock.mockResolvedValue(
+      onePage([
+        activity({ activityId: 'own-table', resourceId: 'orders' }),
+        activity({
+          activityId: 'own-column',
+          resourceId: 'orders:total',
+          resourceType: ActivityAuditResourceType.TABLE_COLUMN,
+        }),
+        activity({
+          activityId: 'other-column',
+          resourceId: 'my_orders:total',
+          resourceType: ActivityAuditResourceType.TABLE_COLUMN,
+        }),
+      ]),
+    );
+    renderAnalyticsTab();
+    const { successCallback } = await requestRows();
+
+    const [rows] = successCallback.mock.calls[0] as [DialActivity[]];
+    expect(rows.map((row) => row.resourceId)).toEqual(['orders', 'orders:total']);
+  });
+
+  test('keeps the Resource type and Resource identifier columns so a column activity names its column', () => {
+    renderAnalyticsTab();
+
+    const columns = lastColumnDefs();
+    const resourceType = columns.find((column) => column.field === RESOURCE_TYPE_FIELD);
+    const resourceId = columns.find((column) => column.field === RESOURCE_ID_FIELD);
+
+    const formatResourceType = resourceType?.valueFormatter as (params: ValueFormatterParams) => string;
+
+    expect(resourceId?.headerName).toBe('Resource identifier');
+    expect(formatResourceType({ value: ActivityAuditResourceType.TABLE_COLUMN } as ValueFormatterParams)).toBe(
+      EntitiesI18nKey.AnalyticsTableColumn,
+    );
+  });
+
+  test('offers no Rollback row action', () => {
+    renderAnalyticsTab();
+
+    expect(rowActionIds()).toEqual([ActionMenuOperationI18nKey.Open_in_new_tab]);
+    expect(rowActionIds()).not.toContain(ActionMenuOperationI18nKey.Resource_rollback);
+  });
+
+  test('opens the global detail page in a new tab on a row click rather than an entity-namespaced route', () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    renderAnalyticsTab();
+
+    lastListViewProps().additionalGridOptions?.onCellClicked?.({
+      data: activity(),
+      colDef: { field: 'activityId' },
+      node: { setSelected: vi.fn() },
+    } as never);
+
+    expect(openSpy).toHaveBeenCalledWith('/activity-audit/abc-123', '_blank');
+    expect(openSpy).not.toHaveBeenCalledWith(expect.stringContaining('/tables/'), expect.anything());
+    openSpy.mockRestore();
+  });
+
+  test('reports an empty grid without a notification when the table has no recorded history', async () => {
+    renderAnalyticsTab();
+    const { successCallback, failCallback } = await requestRows();
+
+    expect(successCallback).toHaveBeenCalledWith([], 0);
+    expect(failCallback).not.toHaveBeenCalled();
+    expect(showNotificationMock).not.toHaveBeenCalled();
+  });
+
+  test('leaves the grid in its failure state without a notification when the feed request fails', async () => {
+    getAnalyticsActivitiesMock.mockRejectedValue(new Error('feed unavailable'));
+    renderAnalyticsTab();
+    const { successCallback, failCallback } = await requestRows();
+
+    expect(failCallback).toHaveBeenCalled();
+    expect(successCallback).not.toHaveBeenCalled();
+    expect(showNotificationMock).not.toHaveBeenCalled();
+  });
+
+  test('re-requests the list with the time-range filters when the time period changes', async () => {
+    renderAnalyticsTab();
+    getAnalyticsActivitiesMock.mockClear();
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'change-period' }));
+    });
+    await requestRows();
+
+    expect(getAnalyticsActivitiesMock).toHaveBeenCalledWith(
+      PAGE_SIZE,
+      0,
+      [],
+      expect.arrayContaining([
+        expect.objectContaining({
+          column: 'epochTimestampMs',
+          operator: FilterOperatorDto.GREATER_THAN_OR_EQUAL,
+        }),
+        expect.objectContaining({ column: 'epochTimestampMs', operator: FilterOperatorDto.LESS_THAN_OR_EQUAL }),
+      ]),
+    );
+  });
+});
+
+describe('ActivityAuditList :: Config view parent/child aggregation', () => {
+  test('aggregates child activities under their parent and fetches them by parent identifier', async () => {
+    const parent = activity({
+      activityId: 'parent-1',
+      resourceType: ActivityAuditResourceType.MODEL,
+      resourceId: 'gpt-4',
+    });
+    const child = activity({
+      activityId: 'child-1',
+      resourceType: ActivityAuditResourceType.MODEL,
+      resourceId: 'gpt-4',
+      parentActivityId: 'parent-1',
+    });
+    getActivitiesMock.mockResolvedValueOnce(onePage([parent])).mockResolvedValueOnce(onePage([child]));
+
+    render(<ActivityAuditList />);
+    const { successCallback } = await requestRows();
+
+    expect(getActivitiesMock).toHaveBeenNthCalledWith(
+      2,
+      PAGE_SIZE,
+      0,
+      [],
+      [{ column: 'parentActivityId', value: 'parent-1', operator: FilterOperatorDto.INCLUDES }],
+    );
+
+    const [rows] = successCallback.mock.calls[0] as [(DialActivity & { children?: DialActivity[] })[]];
+    expect(rows.map((row) => row.activityId)).toEqual(['parent-1', 'child-1']);
+    expect(rows[0].children?.map((row) => row.activityId)).toEqual(['child-1']);
+  });
+});
+
+describe('ActivityAuditList :: Config entity audit tab', () => {
+  const renderConfigTab = () =>
+    render(<ActivityAuditList entity={{ name: 'gpt-4' } as BaseEntity} entityType={ActivityAuditResourceType.MODEL} />);
+
+  test('keeps its Rollback row action', () => {
+    renderConfigTab();
+
+    expect(rowActionIds()).toEqual([
+      ActionMenuOperationI18nKey.Open_in_new_tab,
+      ActionMenuOperationI18nKey.Resource_rollback,
+    ]);
+  });
+
+  test('keeps the single-entity column set', () => {
+    renderConfigTab();
+
+    const fields = lastColumnDefs().map((column) => column.field);
+    expect(fields).not.toContain(RESOURCE_TYPE_FIELD);
+    expect(fields).not.toContain(RESOURCE_ID_FIELD);
+    expect(fields).toContain('activityType');
+  });
+
+  test('requests the admin feed with the exact resource-id and resource-type pair', async () => {
+    renderConfigTab();
+    await requestRows();
+
+    expect(getActivitiesMock).toHaveBeenCalledWith(
+      PAGE_SIZE,
+      0,
+      [],
+      expect.arrayContaining([
+        { column: RESOURCE_ID_FIELD, value: 'gpt-4', operator: FilterOperatorDto.EQUALS },
+        {
+          column: RESOURCE_TYPE_FIELD,
+          value: ActivityAuditResourceType.MODEL,
+          operator: FilterOperatorDto.EQUALS,
+        },
+      ]),
+    );
+    expect(getAnalyticsActivitiesMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/ai-dial-admin/src/components/ActivityAudit/List/tests/utils.spec.tsx
+++ b/apps/ai-dial-admin/src/components/ActivityAudit/List/tests/utils.spec.tsx
@@ -1,6 +1,7 @@
 import { ActivityAuditRevision } from '@/src/components/ActivityAudit/models';
 import {
   getActivityAuditColumns,
+  getAnalyticsActivityAuditColumns,
   getAuditActivityHref,
   getDeploymentActivityAuditColumns,
   getEndOfDay,
@@ -11,8 +12,10 @@ import {
 } from '@/src/components/ActivityAudit/List/utils';
 import { GridFilterType } from '@/src/types/grid-filter';
 import { FilterOperatorDto } from '@/src/types/request';
-import { describe, expect, test, vi } from 'vitest';
-import { ActivityAuditResourceType, ActivityAuditType } from '@/src/types/activity-audit';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { getResourceRollbackOperation } from '@/src/constants/grid-columns/actions';
+import { ACTIVITY_AUDIT_COLUMNS } from '@/src/constants/grid-columns/grid-columns';
+import { ActivityAuditResourceType, ActivityAuditType, ActivityAuditView } from '@/src/types/activity-audit';
 import type { FilterDto } from '@/src/models/request';
 import { DialActivity } from '@/src/models/activity-audit';
 
@@ -29,11 +32,15 @@ vi.mock('@/src/constants/grid-columns/actions', () => ({
 vi.mock('@/src/constants/grid-columns/grid-columns', async () => {
   const actual = (await vi.importActual('@/src/types/activity-audit')) as { ActivityAuditView: Record<string, string> };
   return {
-    ACTIVITY_AUDIT_COLUMNS: vi.fn((_t: unknown, view: string) =>
-      view === actual.ActivityAuditView.Deployments
-        ? [{ colId: 'd1' }, { colId: 'd2' }]
-        : [{ colId: 'a' }, { colId: 'b' }],
-    ),
+    ACTIVITY_AUDIT_COLUMNS: vi.fn((_t: unknown, view: string) => {
+      if (view === actual.ActivityAuditView.Deployments) {
+        return [{ colId: 'd1' }, { colId: 'd2' }];
+      }
+      if (view === actual.ActivityAuditView.Analytics) {
+        return [{ colId: 'an1' }, { colId: 'an2' }];
+      }
+      return [{ colId: 'a' }, { colId: 'b' }];
+    }),
     RESOURCE_TYPE_COLUMN: 'resourceType',
   };
 });
@@ -98,6 +105,45 @@ describe('Activity Audit List utils :: getDeploymentActivityAuditColumns', () =>
   });
 });
 
+describe('Activity Audit List utils :: getAnalyticsActivityAuditColumns', () => {
+  const t = (s: string) => s;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('returns the analytics column set with the action column at the end', () => {
+    const cols = getAnalyticsActivityAuditColumns(t, vi.fn());
+
+    expect(cols).toHaveLength(3);
+    expect(cols[0]).toEqual({ colId: 'an1' });
+    expect(cols[1]).toEqual({ colId: 'an2' });
+    expect(cols[2].colId).toBe('actions');
+  });
+
+  test('builds its columns for the Analytics view, so no expander and no Version column are added', () => {
+    getAnalyticsActivityAuditColumns(t, vi.fn());
+
+    expect(ACTIVITY_AUDIT_COLUMNS).toHaveBeenCalledWith(t, ActivityAuditView.Analytics);
+  });
+
+  test('offers Open in new tab as the only row action and never a rollback one', () => {
+    const cols = getAnalyticsActivityAuditColumns(t, vi.fn());
+
+    const actions = (cols[2] as { actions: { type: string }[] }).actions;
+    expect(actions).toHaveLength(1);
+    expect(actions[0].type).toBe('open');
+    expect(getResourceRollbackOperation).not.toHaveBeenCalled();
+  });
+
+  test('returns an empty action list when no open handler is provided', () => {
+    const cols = getAnalyticsActivityAuditColumns(t);
+
+    const actions = (cols[2] as { actions: { type: string }[] }).actions;
+    expect(actions).toHaveLength(0);
+  });
+});
+
 describe('Activity Audit List utils :: getGridFilters', () => {
   const mockStartDate = new Date('2024-01-01T00:00:00.000Z');
   const mockEndDate = new Date('2024-01-02T00:00:00.000Z');
@@ -149,6 +195,8 @@ describe('Activity Audit List utils :: getGridFilters', () => {
   });
 
   describe('resourceType label-aware filter transform', () => {
+    // This map is hand-built, so these tests prove the transform, not the real label → enum map the
+    // app passes in. That map is guarded in `src/constants/grid-columns/tests/formatters.spec.ts`.
     const labelMap = {
       'global firewall': [ActivityAuditResourceType.IMAGE_BUILD_DOMAIN_WHITELIST],
       'adapter container': [ActivityAuditResourceType.ADAPTER_DEPLOYMENT],
@@ -390,10 +438,18 @@ describe('getAuditActivityHref', () => {
     expect(href).toBe('');
   });
 
-  test('returns empty href for a resource type not registered in auditResourceRoute', () => {
+  test('returns empty href for a resource type not registered in auditResourceRoute, including the analytics types design.md D5 keeps out of it', () => {
     const mockEntity = { name: 'entity' };
-    const href = getAuditActivityHref(mockEntity, ActivityAuditResourceType.ADMIN_PROPERTIES, '1');
-    expect(href).toBe('');
+
+    expect(getAuditActivityHref(mockEntity, ActivityAuditResourceType.ADMIN_PROPERTIES, '1')).toBe('');
+
+    // Guard for design.md D5: analytics rows open the global detail page, so `auditResourceRoute`
+    // must stay free of analytics entries. Registering `Table` there to fix the audit detail
+    // header's external link would make these hrefs `/tables/entity/1`, an entity-namespaced audit
+    // route this change deliberately does not create — a 404 on every analytics row click. The
+    // header resolves its link through `View/Header/utils.ts` instead.
+    expect(getAuditActivityHref(mockEntity, ActivityAuditResourceType.TABLE, '1')).toBe('');
+    expect(getAuditActivityHref(mockEntity, ActivityAuditResourceType.TABLE_COLUMN, '1')).toBe('');
   });
 });
 

--- a/apps/ai-dial-admin/src/components/ActivityAudit/List/tests/view-config.spec.ts
+++ b/apps/ai-dial-admin/src/components/ActivityAudit/List/tests/view-config.spec.ts
@@ -1,0 +1,208 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  getActivities,
+  getAnalyticsActivities,
+  getDeploymentActivities,
+} from '@/src/app/[lang]/activity-audit/actions';
+import {
+  getActivityAuditColumns,
+  getAnalyticsActivityAuditColumns,
+  getAuditActivityHref,
+  getDeploymentActivityAuditColumns,
+} from '@/src/components/ActivityAudit/List/utils';
+import { ACTIVITY_AUDIT_VIEW_CONFIG } from '@/src/components/ActivityAudit/List/view-config';
+import { ActivityAuditResourceType, ActivityAuditView } from '@/src/types/activity-audit';
+
+vi.mock('@/src/app/[lang]/activity-audit/actions', () => ({
+  getActivities: vi.fn(),
+  getDeploymentActivities: vi.fn(),
+  getAnalyticsActivities: vi.fn(),
+}));
+
+vi.mock('@/src/components/ActivityAudit/List/utils', () => ({
+  getActivityAuditColumns: vi.fn(() => [{ colId: 'config-columns' }]),
+  getDeploymentActivityAuditColumns: vi.fn(() => [{ colId: 'deployment-columns' }]),
+  getAnalyticsActivityAuditColumns: vi.fn(() => [{ colId: 'analytics-columns' }]),
+  getAuditActivityHref: vi.fn(() => '/models/entity/abc-123'),
+}));
+
+const t = (key: string) => key;
+const open = vi.fn();
+const onRollback = vi.fn();
+
+describe('ACTIVITY_AUDIT_VIEW_CONFIG', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('declares an entry for every ActivityAuditView member', () => {
+    const views = Object.values(ActivityAuditView);
+
+    views.forEach((view) => {
+      expect(ACTIVITY_AUDIT_VIEW_CONFIG[view]).toBeTruthy();
+    });
+    expect(Object.keys(ACTIVITY_AUDIT_VIEW_CONFIG)).toHaveLength(views.length);
+  });
+
+  test('declares every field of the config for every view', () => {
+    Object.values(ActivityAuditView).forEach((view) => {
+      const config = ACTIVITY_AUDIT_VIEW_CONFIG[view];
+
+      expect(typeof config.fetchActivities).toBe('function');
+      expect(typeof config.getColumns).toBe('function');
+      expect(typeof config.isRowNavigable).toBe('function');
+      expect(typeof config.getEntityActivityHref).toBe('function');
+      expect(typeof config.hasParentChildAggregation).toBe('boolean');
+      expect(typeof config.hasRollback).toBe('boolean');
+      expect(typeof config.hasDeletedParentSuppression).toBe('boolean');
+    });
+  });
+
+  describe('fetchActivities', () => {
+    test('keeps the fetchers the Config and Deployments views use today', () => {
+      expect(ACTIVITY_AUDIT_VIEW_CONFIG[ActivityAuditView.Config].fetchActivities).toBe(getActivities);
+      expect(ACTIVITY_AUDIT_VIEW_CONFIG[ActivityAuditView.Deployments].fetchActivities).toBe(getDeploymentActivities);
+    });
+
+    test('names the analytics server action for the Analytics view', () => {
+      expect(ACTIVITY_AUDIT_VIEW_CONFIG[ActivityAuditView.Analytics].fetchActivities).toBe(getAnalyticsActivities);
+    });
+  });
+
+  describe('getColumns', () => {
+    test('Config delegates to the config column factory, passing the single-entity flag through', () => {
+      const columns = ACTIVITY_AUDIT_VIEW_CONFIG[ActivityAuditView.Config].getColumns({
+        t,
+        open,
+        onRollback,
+        isSingleEntity: true,
+      });
+
+      expect(getActivityAuditColumns).toHaveBeenCalledWith(t, open, onRollback, void 0, true);
+      expect(columns).toEqual([{ colId: 'config-columns' }]);
+    });
+
+    test('Deployments delegates to the deployment column factory on the global page', () => {
+      const columns = ACTIVITY_AUDIT_VIEW_CONFIG[ActivityAuditView.Deployments].getColumns({ t, open, onRollback });
+
+      expect(getDeploymentActivityAuditColumns).toHaveBeenCalledWith(t, open, onRollback);
+      expect(getActivityAuditColumns).not.toHaveBeenCalled();
+      expect(columns).toEqual([{ colId: 'deployment-columns' }]);
+    });
+
+    test('Deployments keeps the single-entity column set and its rollback action in an entity tab', () => {
+      const columns = ACTIVITY_AUDIT_VIEW_CONFIG[ActivityAuditView.Deployments].getColumns({
+        t,
+        open,
+        onRollback,
+        isSingleEntity: true,
+      });
+
+      expect(getActivityAuditColumns).toHaveBeenCalledWith(t, open, onRollback, void 0, true);
+      expect(getDeploymentActivityAuditColumns).not.toHaveBeenCalled();
+      expect(columns).toEqual([{ colId: 'config-columns' }]);
+    });
+
+    test('Analytics delegates to the analytics column factory and passes it no rollback handler', () => {
+      const columns = ACTIVITY_AUDIT_VIEW_CONFIG[ActivityAuditView.Analytics].getColumns({
+        t,
+        open,
+        onRollback,
+        isSingleEntity: true,
+      });
+
+      expect(getAnalyticsActivityAuditColumns).toHaveBeenCalledWith(t, open);
+      expect(getActivityAuditColumns).not.toHaveBeenCalled();
+      expect(getDeploymentActivityAuditColumns).not.toHaveBeenCalled();
+      expect(columns).toEqual([{ colId: 'analytics-columns' }]);
+    });
+  });
+
+  describe('hasParentChildAggregation and hasRollback', () => {
+    test('keeps the Config view aggregating children and offering rollback', () => {
+      const config = ACTIVITY_AUDIT_VIEW_CONFIG[ActivityAuditView.Config];
+
+      expect(config.hasParentChildAggregation).toBe(true);
+      expect(config.hasRollback).toBe(true);
+      expect(config.hasDeletedParentSuppression).toBe(false);
+    });
+
+    test('keeps the Deployments view flat and still offering rollback', () => {
+      const config = ACTIVITY_AUDIT_VIEW_CONFIG[ActivityAuditView.Deployments];
+
+      expect(config.hasParentChildAggregation).toBe(false);
+      expect(config.hasRollback).toBe(true);
+      expect(config.hasDeletedParentSuppression).toBe(false);
+    });
+
+    test('renders the Analytics view flat and offers no rollback', () => {
+      const config = ACTIVITY_AUDIT_VIEW_CONFIG[ActivityAuditView.Analytics];
+
+      expect(config.hasParentChildAggregation).toBe(false);
+      expect(config.hasRollback).toBe(false);
+      expect(config.hasDeletedParentSuppression).toBe(true);
+    });
+  });
+
+  describe('isRowNavigable', () => {
+    test('treats every Config row as navigable', () => {
+      const { isRowNavigable } = ACTIVITY_AUDIT_VIEW_CONFIG[ActivityAuditView.Config];
+
+      expect(isRowNavigable(ActivityAuditResourceType.MODEL)).toBe(true);
+      expect(isRowNavigable(ActivityAuditResourceType.ADMIN_PROPERTIES)).toBe(true);
+      expect(isRowNavigable(void 0)).toBe(true);
+    });
+
+    test('restricts Deployments rows to deployment-manager resources', () => {
+      const { isRowNavigable } = ACTIVITY_AUDIT_VIEW_CONFIG[ActivityAuditView.Deployments];
+
+      expect(isRowNavigable(ActivityAuditResourceType.MCP_DEPLOYMENT)).toBe(true);
+      expect(isRowNavigable(ActivityAuditResourceType.MODEL)).toBe(false);
+      expect(isRowNavigable(void 0)).toBe(false);
+    });
+
+    test('treats every Analytics row as navigable', () => {
+      const { isRowNavigable } = ACTIVITY_AUDIT_VIEW_CONFIG[ActivityAuditView.Analytics];
+
+      expect(isRowNavigable(ActivityAuditResourceType.TABLE)).toBe(true);
+      expect(isRowNavigable(ActivityAuditResourceType.TABLE_COLUMN)).toBe(true);
+      expect(isRowNavigable(ActivityAuditResourceType.PIPELINE)).toBe(true);
+      expect(isRowNavigable(ActivityAuditResourceType.SAVED_QUERY)).toBe(true);
+    });
+  });
+
+  describe('getEntityActivityHref', () => {
+    const entity = { name: 'entity' };
+
+    test('Config and Deployments keep resolving the entity-namespaced href', () => {
+      const params = { entity, entityType: ActivityAuditResourceType.MODEL, activityId: 'abc-123' };
+
+      expect(ACTIVITY_AUDIT_VIEW_CONFIG[ActivityAuditView.Config].getEntityActivityHref(params)).toBe(
+        '/models/entity/abc-123',
+      );
+      expect(ACTIVITY_AUDIT_VIEW_CONFIG[ActivityAuditView.Deployments].getEntityActivityHref(params)).toBe(
+        '/models/entity/abc-123',
+      );
+      expect(getAuditActivityHref).toHaveBeenCalledWith(entity, ActivityAuditResourceType.MODEL, 'abc-123');
+    });
+
+    test('Analytics resolves the global audit detail page instead of an entity-namespaced route', () => {
+      const href = ACTIVITY_AUDIT_VIEW_CONFIG[ActivityAuditView.Analytics].getEntityActivityHref({
+        entity,
+        entityType: ActivityAuditResourceType.TABLE,
+        activityId: 'abc-123',
+      });
+
+      expect(href).toBe('/activity-audit/abc-123');
+      expect(getAuditActivityHref).not.toHaveBeenCalled();
+    });
+
+    test('Analytics encodes the activity identifier and answers empty without one', () => {
+      const { getEntityActivityHref } = ACTIVITY_AUDIT_VIEW_CONFIG[ActivityAuditView.Analytics];
+
+      expect(getEntityActivityHref({ entity, activityId: 'abc/123' })).toBe('/activity-audit/abc%2F123');
+      expect(getEntityActivityHref({ entity })).toBe('');
+    });
+  });
+});

--- a/apps/ai-dial-admin/src/components/ActivityAudit/List/utils.tsx
+++ b/apps/ai-dial-admin/src/components/ActivityAudit/List/utils.tsx
@@ -111,6 +111,26 @@ export const getDeploymentActivityAuditColumns = (
 };
 
 /**
+ * Generate columns with actions for the analytics activity audit grid.
+ * `Open in new tab` is the only row action: the analytics backend exposes no endpoint
+ * that writes an audit record, revision or snapshot, so no rollback is offered here.
+ *
+ * @param {(activity: DialActivity) => void} open - open in new tab action
+ * @returns {ColDef[]} - columns
+ */
+export const getAnalyticsActivityAuditColumns = (
+  t: (key: string) => string,
+  open?: (activity?: DialActivity) => void,
+): ColDef[] => {
+  const actions = [];
+  if (open) {
+    actions.push(getOpenInNewTabOperation(open));
+  }
+
+  return [...ACTIVITY_AUDIT_COLUMNS(t, ActivityAuditView.Analytics), ACTION_COLUMN(actions)];
+};
+
+/**
  * Generate filters for grid data request
  *
  * @param {Record<string, GridFilter>} gridFilter - grid filter object

--- a/apps/ai-dial-admin/src/components/ActivityAudit/List/view-config.ts
+++ b/apps/ai-dial-admin/src/components/ActivityAudit/List/view-config.ts
@@ -1,0 +1,74 @@
+import {
+  getActivities,
+  getAnalyticsActivities,
+  getDeploymentActivities,
+} from '@/src/app/[lang]/activity-audit/actions';
+import { ActivityAuditHrefParams, ActivityAuditViewConfig } from '@/src/components/ActivityAudit/List/models';
+import {
+  getActivityAuditColumns,
+  getAnalyticsActivityAuditColumns,
+  getAuditActivityHref,
+  getDeploymentActivityAuditColumns,
+} from '@/src/components/ActivityAudit/List/utils';
+import { ActivityAuditView, isDeploymentManagerResource } from '@/src/types/activity-audit';
+import { ApplicationRoute } from '@/src/types/routes';
+
+const isAnyRowNavigable = (): boolean => true;
+
+const getNamespacedEntityActivityHref = ({ entity, entityType, activityId }: ActivityAuditHrefParams): string =>
+  getAuditActivityHref(entity, entityType, activityId);
+
+// Analytics rows resolve to the global detail page, not to an entity-namespaced audit route:
+// `/tables/{name}/{activityId}` and its siblings do not exist, so `auditResourceRoute` has no
+// analytics entry and this view does not read it.
+const getGlobalActivityHref = ({ activityId }: ActivityAuditHrefParams): string =>
+  activityId ? `${ApplicationRoute.ActivityAudit}/${encodeURIComponent(activityId)}` : '';
+
+/**
+ * Everything `ActivityAuditList` needs to know about the active view, declared per view.
+ *
+ * Typed as a full `Record` rather than a `Partial<Record>` on purpose: a fifth
+ * `ActivityAuditView` member then fails to compile here instead of resolving to `undefined`
+ * at runtime.
+ */
+export const ACTIVITY_AUDIT_VIEW_CONFIG: Record<ActivityAuditView, ActivityAuditViewConfig> = {
+  [ActivityAuditView.Config]: {
+    fetchActivities: getActivities,
+    getColumns: ({ t, open, onRollback, isSingleEntity }) =>
+      getActivityAuditColumns(t, open, onRollback, void 0, isSingleEntity),
+    hasParentChildAggregation: true,
+    hasDeletedParentSuppression: false,
+    hasRollback: true,
+    isRowNavigable: isAnyRowNavigable,
+    getEntityActivityHref: getNamespacedEntityActivityHref,
+  },
+  [ActivityAuditView.Deployments]: {
+    fetchActivities: getDeploymentActivities,
+    // Entity mode has always rendered the shared single-entity column set — with its row
+    // Rollback action — whatever the view; the deployment column set belongs to the global page.
+    getColumns: ({ t, open, onRollback, isSingleEntity }) =>
+      isSingleEntity
+        ? getActivityAuditColumns(t, open, onRollback, void 0, true)
+        : getDeploymentActivityAuditColumns(t, open, onRollback),
+    hasParentChildAggregation: false,
+    hasDeletedParentSuppression: false,
+    hasRollback: true,
+    isRowNavigable: isDeploymentManagerResource,
+    getEntityActivityHref: getNamespacedEntityActivityHref,
+  },
+  [ActivityAuditView.Analytics]: {
+    fetchActivities: getAnalyticsActivities,
+    // No `onRollback` and no `isSingleEntity`: the analytics view offers no row rollback, and it
+    // keeps `Resource type` / `Resource identifier` visible in an entity tab too, because the
+    // feed carries both `Table` and `TableColumn` rows.
+    getColumns: ({ t, open }) => getAnalyticsActivityAuditColumns(t, open),
+    hasParentChildAggregation: false,
+    // Deleting a table records a `Delete` per column, each naming the table activity as its
+    // parent; the parent's own detail view already renders every one of those columns as
+    // removed, so the children are noise. Only this feed produces them.
+    hasDeletedParentSuppression: true,
+    hasRollback: false,
+    isRowNavigable: isAnyRowNavigable,
+    getEntityActivityHref: getGlobalActivityHref,
+  },
+};

--- a/apps/ai-dial-admin/src/components/ActivityAudit/View/AuditView.tsx
+++ b/apps/ai-dial-admin/src/components/ActivityAudit/View/AuditView.tsx
@@ -33,6 +33,7 @@ import {
   ActivityAuditView,
   CompareView,
   DiffView,
+  isAnalyticsResource,
   isDeploymentManagerResource,
 } from '@/src/types/activity-audit';
 import { AuditListPreselect } from '@/src/types/audit-list-preselect';
@@ -90,6 +91,7 @@ const AuditView: FC<Props> = ({
 
   const isDeployment = isDeploymentManagerResource(activity.resourceType);
   const needsLifecycleCheck = needsDeploymentLifecycleCheck(activity);
+  const canRollbackResource = !isReadOnlyAdmin && !isAnalyticsResource(activity.resourceType);
 
   useEffect(() => {
     if (!needsLifecycleCheck) {
@@ -218,7 +220,7 @@ const AuditView: FC<Props> = ({
             <div className="flex flex-row items-center gap-4 flex-wrap">
               <CompareControl compareView={compareView} setCompareView={setCompareView} />
               <FilterControl diffView={diffView} setDiffView={setDiffView} />
-              {!isReadOnlyAdmin && (
+              {canRollbackResource && (
                 <DialNeutralButton
                   iconBefore={<IconRestore {...BASE_BUTTON_ICON_PROPS} />}
                   label={t(RollbackI18nKey.Resource)}

--- a/apps/ai-dial-admin/src/components/ActivityAudit/View/DiffReport/DiffSection.tsx
+++ b/apps/ai-dial-admin/src/components/ActivityAudit/View/DiffReport/DiffSection.tsx
@@ -1,8 +1,9 @@
 import { FC } from 'react';
 
 import { EntityParameterKeys } from '@/src/components/ActivityAudit/constants';
-import { CompareI18nKey, EntityFieldsI18nKey } from '@/src/constants/i18n';
-import { ActivityAuditDiffSection } from '@/src/models/activity-audit';
+import { getAnalyticsColumnHeading } from '@/src/components/ActivityAudit/View/utils/analytics-diffs';
+import { AnalyticsTablesI18nKey, CompareI18nKey, EntityFieldsI18nKey } from '@/src/constants/i18n';
+import { ActivityAuditDiffSection, TranslateFn } from '@/src/models/activity-audit';
 import { ActivityAuditResourceType, CompareView, DiffStatus, DiffView } from '@/src/types/activity-audit';
 import { InlineTextDiffSide } from '@/src/utils/diff/models';
 import { filterNotEmptySections, getDiffCount } from '@/src/components/ActivityAudit/View/DiffReport/utils';
@@ -29,6 +30,27 @@ const CONTAINER_SECTION_TITLE_KEYS: Record<string, EntityFieldsI18nKey> = {
   [EntityParameterKeys.CONFIGURATION]: EntityFieldsI18nKey.Configuration,
 };
 
+const ANALYTICS_SECTION_TITLE_KEYS: Record<string, AnalyticsTablesI18nKey> = {
+  [EntityParameterKeys.COLUMNS]: AnalyticsTablesI18nKey.Columns,
+};
+
+const DIFF_STATUS_LABEL_KEYS: Partial<Record<DiffStatus, CompareI18nKey>> = {
+  [DiffStatus.ADDED]: CompareI18nKey.Added,
+  [DiffStatus.REMOVED]: CompareI18nKey.Removed,
+  [DiffStatus.CHANGED]: CompareI18nKey.Changed,
+};
+
+const getSectionTitle = (t: TranslateFn, name: string, type?: ActivityAuditResourceType): string => {
+  if (type === ActivityAuditResourceType.ROLE && name === EntityParameterKeys.ROLES) {
+    return t(EntityFieldsI18nKey.entities);
+  }
+  const sectionKey = CONTAINER_SECTION_TITLE_KEYS[name] ?? ANALYTICS_SECTION_TITLE_KEYS[name];
+  if (sectionKey) {
+    return t(sectionKey);
+  }
+  return t(EntityFieldsI18nKey[name as keyof typeof EntityFieldsI18nKey]);
+};
+
 const DiffSection: FC<Props> = ({ sections, name, type, diffView, compareView }) => {
   const t = useI18n();
 
@@ -40,13 +62,7 @@ const DiffSection: FC<Props> = ({ sections, name, type, diffView, compareView })
 
   if (validSections.length === 0) return null;
 
-  const containerSectionKey = CONTAINER_SECTION_TITLE_KEYS[name];
-  const title =
-    type === ActivityAuditResourceType.ROLE && name === EntityParameterKeys.ROLES
-      ? t(EntityFieldsI18nKey.entities)
-      : containerSectionKey
-        ? t(containerSectionKey)
-        : t(EntityFieldsI18nKey[name as keyof typeof EntityFieldsI18nKey]);
+  const title = getSectionTitle(t, name, type);
 
   return (
     <div
@@ -65,33 +81,45 @@ const DiffSection: FC<Props> = ({ sections, name, type, diffView, compareView })
           </div>
         }
       >
-        {validSections.map(({ index, currentData, compareData }) => {
-          const prefix = name === EntityParameterKeys.METADATA ? `Variable ${index + 1} ` : '';
+        {validSections.map(({ index, label, diffStatus, currentData, compareData }) => {
+          const groupHeading = getAnalyticsColumnHeading(t, label);
+          const inlinePrefix = !groupHeading && name === EntityParameterKeys.METADATA ? `Variable ${index + 1} ` : '';
+          const statusKey = diffStatus ? DIFF_STATUS_LABEL_KEYS[diffStatus] : void 0;
+          const status = statusKey ? t(statusKey) : '';
+          const groupLabel = [groupHeading ?? `${inlinePrefix}${title}`, status].filter(Boolean).join(', ');
           const compareLabel =
             compareView === CompareView.CURRENT ? t(CompareI18nKey.Current) : t(CompareI18nKey.After);
           return (
-            <div key={index} className="flex flex-row gap-8">
-              <div className="flex flex-col flex-1">
-                <h4 className="mb-2 text-secondary">{`${prefix}${t(CompareI18nKey.Before)}`}</h4>
-                <AuditEntityGrid
-                  data={currentData}
-                  parameter={name}
-                  type={type}
-                  index={index}
-                  diffView={diffView}
-                  diffSide={InlineTextDiffSide.Before}
-                />
-              </div>
-              <div className="flex flex-col flex-1">
-                <h4 className="mb-2 text-secondary">{`${prefix}${compareLabel}`}</h4>
-                <AuditEntityGrid
-                  data={compareData}
-                  parameter={name}
-                  type={type}
-                  index={index}
-                  diffView={diffView}
-                  diffSide={InlineTextDiffSide.After}
-                />
+            <div key={index} role="group" aria-label={groupLabel} className="flex flex-col">
+              {(groupHeading || status) && (
+                <div className="flex flex-row items-center gap-2 mb-2">
+                  {groupHeading && <h4>{groupHeading}</h4>}
+                  {status && <span className="text-secondary small">{status}</span>}
+                </div>
+              )}
+              <div className="flex flex-row gap-8">
+                <div className="flex flex-col flex-1">
+                  <h4 className="mb-2 text-secondary">{`${inlinePrefix}${t(CompareI18nKey.Before)}`}</h4>
+                  <AuditEntityGrid
+                    data={currentData}
+                    parameter={name}
+                    type={type}
+                    index={index}
+                    diffView={diffView}
+                    diffSide={InlineTextDiffSide.Before}
+                  />
+                </div>
+                <div className="flex flex-col flex-1">
+                  <h4 className="mb-2 text-secondary">{`${inlinePrefix}${compareLabel}`}</h4>
+                  <AuditEntityGrid
+                    data={compareData}
+                    parameter={name}
+                    type={type}
+                    index={index}
+                    diffView={diffView}
+                    diffSide={InlineTextDiffSide.After}
+                  />
+                </div>
               </div>
             </div>
           );

--- a/apps/ai-dial-admin/src/components/ActivityAudit/View/DiffReport/tests/DiffSection.spec.tsx
+++ b/apps/ai-dial-admin/src/components/ActivityAudit/View/DiffReport/tests/DiffSection.spec.tsx
@@ -1,0 +1,136 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+import DiffSection from '@/src/components/ActivityAudit/View/DiffReport/DiffSection';
+import { EntityParameterKeys } from '@/src/components/ActivityAudit/constants';
+import { AnalyticsTablesI18nKey, CompareI18nKey, EntityFieldsI18nKey } from '@/src/constants/i18n';
+import { ActivityAuditDiff, ActivityAuditDiffSection } from '@/src/models/activity-audit';
+import { ActivityAuditResourceType, DiffStatus, DiffView } from '@/src/types/activity-audit';
+
+// The global `t()` mock returns the key as-is and drops interpolation params, which
+// would make every column group heading read `Compare.ColumnGroup` — override it
+// here so the column name a group is headed by is observable.
+vi.mock('@/src/locales/client', () => ({
+  useI18n: () => (key: string, options?: Record<string, string>) =>
+    options ? `${key}:${Object.values(options).join(',')}` : key,
+  useCurrentLocale: () => 'en',
+}));
+
+// AG Grid is heavy and irrelevant here: the rows it receives are asserted as text.
+vi.mock('@/src/components/ActivityAudit/EntityGrid/EntityGrid', () => ({
+  default: ({ data }: { data?: ActivityAuditDiff[] }) => (
+    <div>{(data ?? []).map((row) => row.parameter).join(',')}</div>
+  ),
+}));
+
+const columnHeading = (name: string) => `${CompareI18nKey.ColumnGroup}:${name}`;
+
+const row = (parameter: string, diffStatus?: DiffStatus): ActivityAuditDiff => ({
+  parameter,
+  value: 'value',
+  diffStatus,
+});
+
+const columnSection = (label: string, diffStatus?: DiffStatus, rows = [row('name'), row('type')]) =>
+  ({ current: rows, compare: rows, label, diffStatus }) as ActivityAuditDiffSection;
+
+const renderSection = (sections: ActivityAuditDiffSection[], name: string, diffView = DiffView.ALL) =>
+  render(<DiffSection sections={sections} name={name} type={ActivityAuditResourceType.TABLE} diffView={diffView} />);
+
+describe('DiffSection', () => {
+  test('heads a labelled section with the column name rather than the section title lookup', () => {
+    renderSection([columnSection('amount'), columnSection('total')], EntityParameterKeys.COLUMNS);
+
+    expect(screen.getByRole('heading', { name: columnHeading('amount') })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: columnHeading('total') })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: AnalyticsTablesI18nKey.Columns })).toBeTruthy();
+  });
+
+  test('renders the status of a labelled section as visible text', () => {
+    renderSection([columnSection('total', DiffStatus.ADDED)], EntityParameterKeys.COLUMNS);
+
+    expect(screen.getByText(CompareI18nKey.Added)).toBeTruthy();
+  });
+
+  test('exposes each labelled section as a group whose accessible name carries the column name and its status', () => {
+    renderSection(
+      [columnSection('legacy_id', DiffStatus.REMOVED), columnSection('email', DiffStatus.CHANGED)],
+      EntityParameterKeys.COLUMNS,
+    );
+
+    expect(
+      screen.getByRole('group', { name: `${columnHeading('legacy_id')}, ${CompareI18nKey.Removed}` }),
+    ).toBeTruthy();
+    expect(screen.getByRole('group', { name: `${columnHeading('email')}, ${CompareI18nKey.Changed}` })).toBeTruthy();
+  });
+
+  test('names an unlabelled section group by its existing section title', () => {
+    render(
+      <DiffSection
+        sections={[{ current: [row('cpu')], compare: [row('cpu')] }]}
+        name={EntityParameterKeys.RESOURCES}
+        diffView={DiffView.ALL}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: EntityFieldsI18nKey.Compute })).toBeTruthy();
+    expect(screen.getByRole('group', { name: EntityFieldsI18nKey.Compute })).toBeTruthy();
+  });
+
+  test('keeps the Variable N prefix of the environment-variable section', () => {
+    render(
+      <DiffSection
+        sections={[{ current: [row('envName')], compare: [row('envName')] }]}
+        name={EntityParameterKeys.METADATA}
+        diffView={DiffView.ALL}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: `Variable 1 ${CompareI18nKey.Before}` })).toBeTruthy();
+  });
+
+  test('renders only the changed column group in diff-only view', () => {
+    const sections = [
+      columnSection('amount'),
+      columnSection('email', DiffStatus.CHANGED, [row('name'), row('sensitive', DiffStatus.CHANGED)]),
+    ];
+
+    renderSection(sections, EntityParameterKeys.COLUMNS, DiffView.DIFF);
+
+    expect(screen.queryByRole('group', { name: new RegExp(columnHeading('amount')) })).toBeNull();
+    expect(screen.getByRole('group', { name: `${columnHeading('email')}, ${CompareI18nKey.Changed}` })).toBeTruthy();
+  });
+
+  test('renders every column group again in all-parameters view', () => {
+    const sections = [
+      columnSection('amount'),
+      columnSection('email', DiffStatus.CHANGED, [row('name'), row('sensitive', DiffStatus.CHANGED)]),
+    ];
+
+    renderSection(sections, EntityParameterKeys.COLUMNS, DiffView.ALL);
+
+    expect(screen.getByRole('group', { name: columnHeading('amount') })).toBeTruthy();
+    expect(screen.getByRole('group', { name: `${columnHeading('email')}, ${CompareI18nKey.Changed}` })).toBeTruthy();
+  });
+
+  test('keeps a removed column group whose one side holds only mirror placeholders in diff-only view', () => {
+    const removed = {
+      current: [row('name', DiffStatus.MIRROR)],
+      compare: [row('name', DiffStatus.REMOVED)],
+      label: 'legacy_id',
+      diffStatus: DiffStatus.REMOVED,
+    } as ActivityAuditDiffSection;
+
+    renderSection([removed], EntityParameterKeys.COLUMNS, DiffView.DIFF);
+
+    expect(
+      screen.getByRole('group', { name: `${columnHeading('legacy_id')}, ${CompareI18nKey.Removed}` }),
+    ).toBeTruthy();
+  });
+
+  test('renders nothing when no section has data', () => {
+    const { container } = renderSection([{ current: [], compare: [] }], EntityParameterKeys.COLUMNS);
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/apps/ai-dial-admin/src/components/ActivityAudit/View/DiffReport/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/ActivityAudit/View/DiffReport/tests/utils.spec.ts
@@ -1,6 +1,8 @@
-import { DiffStatus } from '@/src/types/activity-audit';
+import { EntityParameterKeys } from '@/src/components/ActivityAudit/constants';
+import { ActivityAuditDiffSection } from '@/src/models/activity-audit';
+import { DiffStatus, DiffView } from '@/src/types/activity-audit';
 import { describe, expect, test } from 'vitest';
-import { getDiffCount } from '../utils';
+import { filterNotEmptySections, getDiffCount } from '../utils';
 
 describe('Activity audit :: getDiffCount', () => {
   const createItem = (diffStatus?: DiffStatus) => ({ parameter: 'param', value: 'val', diffStatus });
@@ -76,5 +78,71 @@ describe('Activity audit :: getDiffCount', () => {
     ];
     const count = getDiffCount(sections, DiffStatus.ADDED);
     expect(count).toBe(1);
+  });
+});
+
+describe('Activity audit :: filterNotEmptySections', () => {
+  const row = (parameter: string, diffStatus?: DiffStatus) => ({ parameter, value: 'value', diffStatus });
+
+  const columnSection = (label: string, diffStatus?: DiffStatus): ActivityAuditDiffSection => ({
+    current: [row('name'), row('type')],
+    compare: [row('name'), row('type')],
+    label,
+    diffStatus,
+  });
+
+  test('passes the label and the status of a named section through to the renderer', () => {
+    const groups = filterNotEmptySections(
+      [columnSection('amount', DiffStatus.ADDED)],
+      EntityParameterKeys.COLUMNS,
+      DiffView.ALL,
+    );
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].label).toBe('amount');
+    expect(groups[0].diffStatus).toBe(DiffStatus.ADDED);
+  });
+
+  test('leaves the label and the status undefined for a section that carries neither', () => {
+    const groups = filterNotEmptySections(
+      [{ current: [row('cpu')], compare: [row('cpu')] }],
+      EntityParameterKeys.RESOURCES,
+      DiffView.ALL,
+    );
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].label).toBeUndefined();
+    expect(groups[0].diffStatus).toBeUndefined();
+  });
+
+  test('drops a named section with no marked row in diff-only view and keeps a marked one', () => {
+    const unchanged = columnSection('amount');
+    const changed: ActivityAuditDiffSection = {
+      current: [row('name'), row('sensitive', DiffStatus.CHANGED)],
+      compare: [row('name'), row('sensitive', DiffStatus.CHANGED)],
+      label: 'email',
+      diffStatus: DiffStatus.CHANGED,
+    };
+
+    const groups = filterNotEmptySections([unchanged, changed], EntityParameterKeys.COLUMNS, DiffView.DIFF);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].label).toBe('email');
+    expect(groups[0].diffStatus).toBe(DiffStatus.CHANGED);
+  });
+
+  test('keeps a removed column in diff-only view, where one side holds only mirror placeholders', () => {
+    const removed: ActivityAuditDiffSection = {
+      current: [row('name', DiffStatus.MIRROR), row('type', DiffStatus.MIRROR)],
+      compare: [row('name', DiffStatus.REMOVED), row('type', DiffStatus.REMOVED)],
+      label: 'legacy_id',
+      diffStatus: DiffStatus.REMOVED,
+    };
+
+    const groups = filterNotEmptySections([removed], EntityParameterKeys.COLUMNS, DiffView.DIFF);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].currentData).toHaveLength(2);
+    expect(groups[0].compareData).toHaveLength(2);
   });
 });

--- a/apps/ai-dial-admin/src/components/ActivityAudit/View/DiffReport/utils.ts
+++ b/apps/ai-dial-admin/src/components/ActivityAudit/View/DiffReport/utils.ts
@@ -1,6 +1,6 @@
 import { EntityParameterKeys } from '@/src/components/ActivityAudit/constants';
 import { UNLIMITED_ACCEPTED_USERS, UNLIMITED_VALUE, NO_LIMITS_KEY, UNLIMITED_KEY } from '@/src/constants/role';
-import { ActivityAuditDiff, ActivityAuditDiffSection } from '@/src/models/activity-audit';
+import { ActivityAuditDiff, ActivityAuditDiffGroup, ActivityAuditDiffSection } from '@/src/models/activity-audit';
 import { ActivityAuditResourceType, DiffStatus, DiffView } from '@/src/types/activity-audit';
 
 export const roleLimitsKeys = ['minute', 'day', 'week', 'month', 'enabled'];
@@ -77,30 +77,28 @@ export const getDiffCount = (sections: ActivityAuditDiffSection[], diffStatus?: 
  * @param {string} name - section title
  * @param {?DiffView} [diffView] - variable to control showing only changes or all values
  * @param {?ActivityAuditResourceType} [type] - resource type
- * @returns {*} - sections data compare and current with index
+ * @returns {ActivityAuditDiffGroup[]} - renderable groups: both sides with the
+ *   index, plus the section's own label and status when it carries them
  */
 export const filterNotEmptySections = (
   sections: ActivityAuditDiffSection[],
   name: string,
   diffView?: DiffView,
   type?: ActivityAuditResourceType,
-) => {
-  return sections.reduce<{ index: number; currentData?: ActivityAuditDiff[]; compareData?: ActivityAuditDiff[] }[]>(
-    (acc, item, index) => {
-      const current = getRowDataByParameter(item.current, name, index, type);
-      const compare = getRowDataByParameter(item.compare, name, index, type);
+): ActivityAuditDiffGroup[] => {
+  return sections.reduce<ActivityAuditDiffGroup[]>((acc, item, index) => {
+    const current = getRowDataByParameter(item.current, name, index, type);
+    const compare = getRowDataByParameter(item.compare, name, index, type);
 
-      const currentData = diffView === DiffView.ALL ? current : current?.filter((d) => d.diffStatus);
-      const compareData = diffView === DiffView.ALL ? compare : compare?.filter((d) => d.diffStatus);
+    const currentData = diffView === DiffView.ALL ? current : current?.filter((d) => d.diffStatus);
+    const compareData = diffView === DiffView.ALL ? compare : compare?.filter((d) => d.diffStatus);
 
-      const hasData = (currentData && currentData.length > 0) || (compareData && compareData.length > 0);
+    const hasData = (currentData && currentData.length > 0) || (compareData && compareData.length > 0);
 
-      if (hasData) {
-        acc.push({ index, currentData, compareData });
-      }
+    if (hasData) {
+      acc.push({ index, currentData, compareData, label: item.label, diffStatus: item.diffStatus });
+    }
 
-      return acc;
-    },
-    [],
-  );
+    return acc;
+  }, []);
 };

--- a/apps/ai-dial-admin/src/components/ActivityAudit/View/Header/Header.tsx
+++ b/apps/ai-dial-admin/src/components/ActivityAudit/View/Header/Header.tsx
@@ -3,7 +3,7 @@ import { FC, ReactNode } from 'react';
 import { DialIconButton, DialTooltip } from '@epam/ai-dial-ui-kit';
 import { IconExternalLink } from '@tabler/icons-react';
 
-import { auditResourceRoute } from '@/src/constants/activity-audit';
+import { getAuditResourceHref } from '@/src/components/ActivityAudit/View/Header/utils';
 import LabelledText from '@/src/components/Common/LabelledText/LabelledText';
 import { getFormattedResourceType } from '@/src/constants/grid-columns/formatters';
 import { ActivityAuditI18nKey, EntitiesI18nKey } from '@/src/constants/i18n';
@@ -22,11 +22,10 @@ const ViewHeader: FC<Props> = ({ activity, children }) => {
   const currentLocale = useCurrentLocale();
   const epochTimestamp = useLocalDateTimeString(activity.epochTimestampMs);
 
-  const openResourceInNewTab = (activity: DialActivity) => {
-    window.open(
-      `/${currentLocale}${auditResourceRoute[activity.resourceType]}/${encodeURIComponent(activity.resourceId)}`,
-      '_blank',
-    );
+  const resourceHref = getAuditResourceHref(activity.resourceType, activity.resourceId);
+
+  const openResourceInNewTab = (href: string) => {
+    window.open(`/${currentLocale}${href}`, '_blank');
   };
 
   return (
@@ -49,11 +48,12 @@ const ViewHeader: FC<Props> = ({ activity, children }) => {
             <LabelledText label={t(ActivityAuditI18nKey.ResourceId)}>
               <div className="flex flex-row gap-1 items-center">
                 <DialTooltip tooltip={activity.resourceId}>{activity.resourceId}</DialTooltip>
-                {activity.activityType != ActivityAuditType.Delete && (
+                {activity.activityType !== ActivityAuditType.Delete && resourceHref && (
                   <DialIconButton
-                    onClick={() => openResourceInNewTab(activity)}
+                    onClick={() => openResourceInNewTab(resourceHref)}
                     className="text-secondary size-auto"
-                    icon={<IconExternalLink {...BASE_BUTTON_ICON_PROPS} />}
+                    aria-label={t(ActivityAuditI18nKey.OpenResourceInNewTab)}
+                    icon={<IconExternalLink {...BASE_BUTTON_ICON_PROPS} aria-hidden />}
                   />
                 )}
               </div>

--- a/apps/ai-dial-admin/src/components/ActivityAudit/View/Header/test/Header.spec.tsx
+++ b/apps/ai-dial-admin/src/components/ActivityAudit/View/Header/test/Header.spec.tsx
@@ -1,9 +1,12 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, test, vi } from 'vitest';
 import ViewHeader from '../Header';
 import { DialActivity } from '@/src/models/activity-audit';
 import { ActivityAuditResourceType, ActivityAuditType } from '@/src/types/activity-audit';
 import { ActivityAuditI18nKey } from '@/src/constants/i18n';
+
+const resourceLinkButton = () => screen.getByRole('button', { name: ActivityAuditI18nKey.OpenResourceInNewTab });
 
 describe('ViewHeader', () => {
   const baseActivity: DialActivity = {
@@ -32,12 +35,13 @@ describe('ViewHeader', () => {
     expect(screen.getByText('userId')).toBeInTheDocument();
   });
 
-  test('calls openResourceInNewTab when resource external link is clicked', () => {
+  test('opens the resource page in a new tab when the resource external link is clicked', async () => {
+    const user = userEvent.setup();
     global.open = vi.fn();
     render(<ViewHeader activity={baseActivity} />);
-    const buttons = screen.getAllByRole('button');
-    // The first button is for resource external link
-    fireEvent.click(buttons[0]);
+
+    await user.click(resourceLinkButton());
+
     expect(global.open).toHaveBeenCalledWith('/en/models/123', '_blank');
   });
 
@@ -86,6 +90,52 @@ describe('ViewHeader', () => {
 
     expect(screen.getByText(ActivityAuditI18nKey.ResourceId)).toBeInTheDocument();
     expect(screen.getByText('mcp-deploy-1')).toBeInTheDocument();
-    expect(screen.getAllByRole('button').length).toBeGreaterThan(0);
+    expect(resourceLinkButton()).toBeInTheDocument();
+  });
+});
+
+describe('ViewHeader — analytics activities', () => {
+  const analyticsActivity: DialActivity = {
+    activityType: ActivityAuditType.Update,
+    resourceType: ActivityAuditResourceType.TABLE,
+    resourceId: 'orders',
+    epochTimestampMs: 123456789,
+    initiatedEmail: 'user@example.com',
+    initiatedAuthor: 'userId',
+    activityId: 'act-1',
+    revision: 2,
+  };
+
+  const renderHeader = (activity?: Partial<DialActivity>) =>
+    render(<ViewHeader activity={{ ...analyticsActivity, ...activity }} />);
+
+  test('links a table activity to its table page', async () => {
+    const user = userEvent.setup();
+    global.open = vi.fn();
+    renderHeader();
+
+    await user.click(resourceLinkButton());
+
+    expect(global.open).toHaveBeenCalledWith('/en/tables/orders', '_blank');
+  });
+
+  test('links a column activity to the table page its identifier carries', async () => {
+    const user = userEvent.setup();
+    global.open = vi.fn();
+    renderHeader({ resourceType: ActivityAuditResourceType.TABLE_COLUMN, resourceId: 'orders:total' });
+
+    expect(screen.getByText('orders:total')).toBeInTheDocument();
+    await user.click(resourceLinkButton());
+
+    expect(global.open).toHaveBeenCalledWith('/en/tables/orders', '_blank');
+  });
+
+  test('omits the external link when the resource type resolves to no page', () => {
+    const { container } = renderHeader({ resourceType: 'BrandNewBackendType' as ActivityAuditResourceType });
+
+    expect(screen.getByText(ActivityAuditI18nKey.ResourceId)).toBeInTheDocument();
+    expect(screen.getByText('orders')).toBeInTheDocument();
+    expect(screen.queryAllByRole('button')).toHaveLength(0);
+    expect(container.innerHTML).not.toContain('/en/undefined');
   });
 });

--- a/apps/ai-dial-admin/src/components/ActivityAudit/View/Header/test/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/ActivityAudit/View/Header/test/utils.spec.ts
@@ -8,7 +8,7 @@ import { CONTAINER_TYPE } from '@/src/types/deployments/containers';
 import { IMAGE_TYPE } from '@/src/types/deployments/images';
 import { ApplicationRoute } from '@/src/types/routes';
 
-import { resolveEntityAuditType } from '../utils';
+import { getAuditResourceHref, resolveEntityAuditType } from '../utils';
 
 describe('resolveEntityAuditType', () => {
   test('resolves NIM container to NimDeployment', () => {
@@ -81,5 +81,45 @@ describe('resolveEntityAuditType', () => {
 
   test('returns undefined when entity is undefined and route is not mapped', () => {
     expect(resolveEntityAuditType(undefined, ApplicationRoute.Dashboard)).toBeUndefined();
+  });
+});
+
+describe('getAuditResourceHref', () => {
+  test('resolves a table activity to its table page', () => {
+    expect(getAuditResourceHref(ActivityAuditResourceType.TABLE, 'orders')).toBe('/tables/orders');
+  });
+
+  test('resolves a column activity to the page of the table its identifier carries', () => {
+    expect(getAuditResourceHref(ActivityAuditResourceType.TABLE_COLUMN, 'orders:total')).toBe('/tables/orders');
+  });
+
+  test('resolves a pipeline and a saved query to their own pages', () => {
+    expect(getAuditResourceHref(ActivityAuditResourceType.PIPELINE, 'daily-load')).toBe('/pipelines/daily-load');
+    expect(getAuditResourceHref(ActivityAuditResourceType.SAVED_QUERY, 'q-1')).toBe('/queries/q-1');
+  });
+
+  test('resolves a non-analytics type through the shared auditResourceRoute map', () => {
+    expect(getAuditResourceHref(ActivityAuditResourceType.MODEL, 'gpt-4')).toBe('/models/gpt-4');
+    expect(getAuditResourceHref(ActivityAuditResourceType.MCP_DEPLOYMENT, 'mcp-1')).toBe('/mcp-containers/mcp-1');
+  });
+
+  test('encodes the resource identifier in both the analytics and the shared branch', () => {
+    expect(getAuditResourceHref(ActivityAuditResourceType.TABLE, 'my orders/2024')).toBe('/tables/my%20orders%2F2024');
+    expect(getAuditResourceHref(ActivityAuditResourceType.MODEL, 'gpt 4/turbo')).toBe('/models/gpt%204%2Fturbo');
+  });
+
+  test('returns undefined for a resource type with no known route', () => {
+    expect(getAuditResourceHref(ActivityAuditResourceType.ADMIN_PROPERTIES, 'settings')).toBeUndefined();
+    expect(getAuditResourceHref('BrandNewBackendType' as ActivityAuditResourceType, 'whatever')).toBeUndefined();
+  });
+
+  test('returns undefined when the resource type or the resource identifier is missing', () => {
+    expect(getAuditResourceHref(undefined, 'orders')).toBeUndefined();
+    expect(getAuditResourceHref(ActivityAuditResourceType.TABLE, undefined)).toBeUndefined();
+    expect(getAuditResourceHref(ActivityAuditResourceType.TABLE, '')).toBeUndefined();
+  });
+
+  test('returns undefined for a column identifier with no table half', () => {
+    expect(getAuditResourceHref(ActivityAuditResourceType.TABLE_COLUMN, ':total')).toBeUndefined();
   });
 });

--- a/apps/ai-dial-admin/src/components/ActivityAudit/View/Header/utils.ts
+++ b/apps/ai-dial-admin/src/components/ActivityAudit/View/Header/utils.ts
@@ -4,7 +4,13 @@ import { CONTAINER_TYPE } from '@/src/types/deployments/containers';
 import { IMAGE_TYPE } from '@/src/types/deployments/images';
 import { ApplicationRoute } from '@/src/types/routes';
 
-import { CONTAINER_TYPE_TO_AUDIT, IMAGE_TYPE_TO_AUDIT, routeAuditResource } from '@/src/constants/activity-audit';
+import {
+  auditResourceRoute,
+  CONTAINER_TYPE_TO_AUDIT,
+  IMAGE_TYPE_TO_AUDIT,
+  routeAuditResource,
+} from '@/src/constants/activity-audit';
+import { getTableNameFromAnalyticsResourceId } from '@/src/utils/audit/analytics-resource-id';
 
 export const resolveEntityAuditType = (
   entity: BaseEntity | undefined,
@@ -20,4 +26,51 @@ export const resolveEntityAuditType = (
     }
   }
   return routeAuditResource[view];
+};
+
+/**
+ * Analytics resource types resolve to their own feature routes here rather than through the shared
+ * `auditResourceRoute`, which the audit list's entity-namespaced href builder also reads: an entry
+ * there would send every analytics row to `/tables/{name}/{activityId}`, a route this change does
+ * not create. Kept local so the header link and the row href stay independent.
+ */
+const ANALYTICS_RESOURCE_ROUTE: Partial<Record<ActivityAuditResourceType, ApplicationRoute>> = {
+  [ActivityAuditResourceType.TABLE]: ApplicationRoute.AnalyticsTables,
+  [ActivityAuditResourceType.TABLE_COLUMN]: ApplicationRoute.AnalyticsTables,
+  [ActivityAuditResourceType.PIPELINE]: ApplicationRoute.AnalyticsPipelines,
+  [ActivityAuditResourceType.SAVED_QUERY]: ApplicationRoute.AnalyticsQueries,
+};
+
+const isTableScopedResource = (resourceType: ActivityAuditResourceType): boolean =>
+  resourceType === ActivityAuditResourceType.TABLE || resourceType === ActivityAuditResourceType.TABLE_COLUMN;
+
+/**
+ * Resolve the detail page an audited resource lives on, for the header's external-link control.
+ *
+ * A `TableColumn` identifier is `<table>:<column>`, so a column links to its table's page.
+ *
+ * @param {ActivityAuditResourceType} [resourceType] - the audited activity's resource type
+ * @param {string} [resourceId] - the audited activity's resource identifier
+ * @returns {string | undefined} a locale-less path, or `undefined` when the type has no known route
+ */
+export const getAuditResourceHref = (
+  resourceType?: ActivityAuditResourceType,
+  resourceId?: string,
+): string | undefined => {
+  if (!resourceType || !resourceId) {
+    return undefined;
+  }
+
+  const analyticsRoute = ANALYTICS_RESOURCE_ROUTE[resourceType];
+  if (analyticsRoute) {
+    const segment = isTableScopedResource(resourceType) ? getTableNameFromAnalyticsResourceId(resourceId) : resourceId;
+    return segment ? `${analyticsRoute}/${encodeURIComponent(segment)}` : undefined;
+  }
+
+  const route = auditResourceRoute[resourceType];
+  if (!route) {
+    return undefined;
+  }
+
+  return `${route}/${encodeURIComponent(resourceId)}`;
 };

--- a/apps/ai-dial-admin/src/components/ActivityAudit/View/tests/AuditView.spec.tsx
+++ b/apps/ai-dial-admin/src/components/ActivityAudit/View/tests/AuditView.spec.tsx
@@ -81,7 +81,13 @@ const buildActivity = (
   revision: 42,
 });
 
-const rollbackButton = () => screen.getByText(RollbackI18nKey.Resource).closest('button');
+const rollbackButton = () => screen.getByRole('button', { name: RollbackI18nKey.Resource });
+const queryRollbackButton = () => screen.queryByRole('button', { name: RollbackI18nKey.Resource });
+
+const renderAuditView = (resourceType: ActivityAuditResourceType, resourceId?: string) =>
+  render(
+    <AuditView activity={buildActivity(resourceType, resourceId)} activityRevision={null} previousRevision={null} />,
+  );
 
 describe('AuditView :: Resource Rollback', () => {
   beforeEach(() => {
@@ -110,7 +116,7 @@ describe('AuditView :: Resource Rollback', () => {
         previousRevision={null}
       />,
     );
-    expect(screen.getByText(RollbackI18nKey.Resource)).toBeInTheDocument();
+    expect(rollbackButton()).toBeInTheDocument();
   });
 
   test('disables rollback while the image is building', async () => {
@@ -160,5 +166,37 @@ describe('AuditView :: Resource Rollback', () => {
     );
     expect(rollbackButton()).toBeEnabled();
     expect(getDeploymentEntityStateMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('AuditView :: Resource Rollback — analytics resources', () => {
+  beforeEach(() => {
+    getDeploymentEntityStateMock.mockReset();
+    getDeploymentEntityStateMock.mockResolvedValue(null);
+  });
+
+  test.each([
+    ActivityAuditResourceType.TABLE,
+    ActivityAuditResourceType.TABLE_COLUMN,
+    ActivityAuditResourceType.PIPELINE,
+    ActivityAuditResourceType.SAVED_QUERY,
+  ])('does not render the Resource Rollback button for a %s activity', (resourceType) => {
+    renderAuditView(resourceType);
+    expect(queryRollbackButton()).toBeNull();
+  });
+
+  test('renders no disabled control in place of the suppressed rollback button', () => {
+    renderAuditView(ActivityAuditResourceType.TABLE);
+    expect(screen.queryByText(RollbackI18nKey.Resource)).toBeNull();
+    const disabledControls = screen
+      .queryAllByRole('button')
+      .filter((button) => button.matches('[disabled], [aria-disabled="true"]'));
+    expect(disabledControls).toEqual([]);
+  });
+
+  test('keeps the Resource Rollback button unchanged for an admin activity', () => {
+    renderAuditView(ActivityAuditResourceType.MODEL);
+    expect(rollbackButton()).toBeEnabled();
+    expect(rollbackButton()).not.toHaveAttribute('title');
   });
 });

--- a/apps/ai-dial-admin/src/components/ActivityAudit/View/utils/analytics-diffs.ts
+++ b/apps/ai-dial-admin/src/components/ActivityAudit/View/utils/analytics-diffs.ts
@@ -1,0 +1,306 @@
+import { EntityParameterKeys } from '@/src/components/ActivityAudit/constants';
+import { CompareI18nKey } from '@/src/constants/i18n';
+import {
+  ActivityAuditDiff,
+  ActivityAuditDiffSection,
+  ActivityAuditSection,
+  FlatRow,
+  TranslateFn,
+} from '@/src/models/activity-audit';
+import { ActivityAuditEntity, DiffStatus } from '@/src/types/activity-audit';
+import { sortKeys } from './compare-helpers';
+import { compareNestedFlatObject, fillNestedFlatObject } from './create-simple-diffs';
+
+// Attributes an analytics table column carries, in render order. Exported so the
+// row-label map can be asserted to cover every one of them.
+export const ANALYTICS_COLUMN_PARAMETERS = [
+  'name',
+  'type',
+  'element_type',
+  'enum_values',
+  'nullable',
+  'tag',
+  'display_name',
+  'description',
+  'sensitive',
+];
+
+const COLUMN_NAME_PARAMETER = 'name';
+const COLUMNS_BUCKET_PREFIX = `${EntityParameterKeys.COLUMNS}:`;
+const PATH_SEPARATOR = '.';
+const VALUE_SEPARATOR = ', ';
+
+const toLeafValue = (value: unknown): string => {
+  if (value == null) return '';
+  if (typeof value === 'object') return '';
+  return String(value);
+};
+
+const isScalar = (value: unknown): boolean => value == null || typeof value !== 'object';
+
+const collectLeaves = (value: unknown, path: string, leaves: Record<string, string>): void => {
+  if (isScalar(value)) {
+    leaves[path] = toLeafValue(value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    // Scalar arrays join in the snapshot's own order: `ordering_key` and
+    // `tag_order` are ordered fields whose order is their meaning, so sorting
+    // them would render a reordering as no change at all.
+    if (value.every(isScalar)) {
+      leaves[path] = value.map(toLeafValue).join(VALUE_SEPARATOR);
+      return;
+    }
+    value.forEach((item, index) => collectLeaves(item, `${path}${PATH_SEPARATOR}${index}`, leaves));
+    return;
+  }
+  const entries = Object.entries(value as Record<string, unknown>);
+  if (entries.length === 0) {
+    leaves[path] = '';
+    return;
+  }
+  entries.forEach(([key, item]) => collectLeaves(item, path ? `${path}${PATH_SEPARATOR}${key}` : key, leaves));
+};
+
+const toColumnValue = (value: unknown): string | undefined => {
+  if (value == null) return undefined;
+  // `enum_values` and its siblings keep the order the column lists them in.
+  if (Array.isArray(value)) return value.map((item) => toColumnValue(item) ?? '').join(VALUE_SEPARATOR);
+  if (typeof value === 'object') {
+    const leaves: Record<string, string> = {};
+    collectLeaves(value, '', leaves);
+    return Object.entries(leaves)
+      .map(([parameter, leaf]) => `${parameter}: ${leaf}`)
+      .join(VALUE_SEPARATOR);
+  }
+  return String(value);
+};
+
+/**
+ * Flatten every field of a snapshot other than `columns` to a map of dotted
+ * parameter path to rendered value.
+ *
+ * @param {?ActivityAuditEntity} [snapshot] - analytics revision snapshot
+ * @returns {Record<string, string>} - leaf parameter path to value
+ */
+export const getSnapshotLeaves = (snapshot?: ActivityAuditEntity | null): Record<string, string> => {
+  const leaves: Record<string, string> = {};
+  Object.entries(snapshot ?? {}).forEach(([key, value]) => {
+    if (key === EntityParameterKeys.COLUMNS) return;
+    collectLeaves(value, key, leaves);
+  });
+  return leaves;
+};
+
+/**
+ * Project a snapshot to diff rows — one per leaf, no hidden-key set.
+ *
+ * @param {?ActivityAuditEntity} [snapshot] - analytics revision snapshot
+ * @param {?string[]} [parameters] - parameter order to emit; both sides of a
+ *   comparison must be projected against the same list, since
+ *   `compareNestedFlatObject` pairs rows by index
+ * @returns {FlatRow[]} - rows ready for the nested-flat comparator
+ */
+export const snapshotRows = (snapshot?: ActivityAuditEntity | null, parameters?: string[]): FlatRow[] => {
+  const leaves = getSnapshotLeaves(snapshot);
+  const emittedParameters = parameters ?? Object.keys(leaves).sort(sortKeys);
+  return emittedParameters.map((parameter) => ({ parameter, value: leaves[parameter] }));
+};
+
+/**
+ * Project one column to diff rows.
+ *
+ * @param {?object} [column] - column object from a snapshot's `columns` array
+ * @param {?string[]} [extraParameters] - attributes beyond the known ones, so a
+ *   field the backend adds later renders unlabelled rather than being dropped
+ * @returns {FlatRow[]} - rows ready for the nested-flat comparator
+ */
+export const columnRows = (column?: object | null, extraParameters: string[] = []): FlatRow[] => {
+  const source = (column ?? {}) as Record<string, unknown>;
+  return [...ANALYTICS_COLUMN_PARAMETERS, ...extraParameters].map((parameter) => ({
+    parameter,
+    value: toColumnValue(source[parameter]),
+  }));
+};
+
+const getColumnsByName = (snapshot?: ActivityAuditEntity | null): Record<string, object> => {
+  const columns = snapshot?.[EntityParameterKeys.COLUMNS];
+  if (!Array.isArray(columns)) return {};
+  const byName: Record<string, object> = {};
+  columns.forEach((column, index) => {
+    if (column == null || typeof column !== 'object') return;
+    const name = (column as Record<string, unknown>)[COLUMN_NAME_PARAMETER];
+    byName[typeof name === 'string' && name ? name : `#${index}`] = column as object;
+  });
+  return byName;
+};
+
+const getExtraColumnParameters = (...columns: (object | undefined)[]): string[] => {
+  const extra = new Set<string>();
+  columns.forEach((column) => {
+    Object.keys(column ?? {}).forEach((parameter) => {
+      if (!ANALYTICS_COLUMN_PARAMETERS.includes(parameter)) extra.add(parameter);
+    });
+  });
+  return Array.from(extra).sort();
+};
+
+const union = (...keyLists: string[][]): string[] => Array.from(new Set(keyLists.flat()));
+
+export const getColumnBucketKey = (name: string): string => `${COLUMNS_BUCKET_PREFIX}${name}`;
+
+export const isColumnBucketKey = (key: string): boolean => key.startsWith(COLUMNS_BUCKET_PREFIX);
+
+export const getColumnNameFromBucketKey = (key: string): string => key.slice(COLUMNS_BUCKET_PREFIX.length);
+
+const applyBucketStatus = (result: Record<string, ActivityAuditDiff[]>, status: DiffStatus): void => {
+  Object.values(result).forEach((rows) => {
+    rows.forEach((row) => {
+      if (row.diffStatus == null) row.diffStatus = status;
+    });
+  });
+};
+
+/**
+ * Build the diff buckets for one side of an analytics revision comparison:
+ * `properties` from every field other than `columns`, plus one `columns:<name>`
+ * bucket per column present in either revision.
+ *
+ * Unlike `compareMetadataEnvs`, this emits in both directions — a column present
+ * on one side only still produces a bucket on both, so a removed column stays
+ * visible with placeholder rows instead of disappearing.
+ *
+ * @param {ActivityAuditEntity | null} current - the opposite side of the comparison
+ * @param {ActivityAuditEntity | null} compare - the side being rendered
+ * @param {?boolean} [isCurrent] - true while building the older (Before) side
+ * @returns {Record<string, ActivityAuditDiff[]>} - diff buckets
+ */
+export const buildAnalyticsDiff = (
+  current: ActivityAuditEntity | null,
+  compare: ActivityAuditEntity | null,
+  isCurrent?: boolean,
+): Record<string, ActivityAuditDiff[]> => {
+  const result: Record<string, ActivityAuditDiff[]> = { properties: [] };
+  if (!compare) return result;
+
+  const hasBothSides = current != null;
+  const currentParameters = Object.keys(getSnapshotLeaves(current));
+  const compareParameters = Object.keys(getSnapshotLeaves(compare));
+  const parameters = union(currentParameters, compareParameters).sort(sortKeys);
+
+  if (hasBothSides) {
+    compareNestedFlatObject(
+      result.properties,
+      snapshotRows(current, parameters),
+      snapshotRows(compare, parameters),
+      isCurrent,
+    );
+  } else {
+    fillNestedFlatObject(result.properties, snapshotRows(compare, parameters));
+  }
+
+  const currentColumns = getColumnsByName(current);
+  const compareColumns = getColumnsByName(compare);
+  const names = union(Object.keys(currentColumns), Object.keys(compareColumns)).sort((a, b) => a.localeCompare(b));
+
+  names.forEach((name) => {
+    const bucket: ActivityAuditDiff[] = [];
+    const extraParameters = getExtraColumnParameters(currentColumns[name], compareColumns[name]);
+    if (hasBothSides) {
+      compareNestedFlatObject(
+        bucket,
+        columnRows(currentColumns[name], extraParameters),
+        columnRows(compareColumns[name], extraParameters),
+        isCurrent,
+      );
+    } else {
+      fillNestedFlatObject(bucket, columnRows(compareColumns[name], extraParameters));
+    }
+    if (bucket.length) result[getColumnBucketKey(name)] = bucket;
+  });
+
+  if (!hasBothSides && isCurrent !== undefined) {
+    applyBucketStatus(result, isCurrent ? DiffStatus.REMOVED : DiffStatus.ADDED);
+  }
+  return result;
+};
+
+/**
+ * Status of a column group, read off the rows of the newer side. The `name` row
+ * is always emitted and is never empty for a column that exists, so its status
+ * answers presence exactly: a group is `Added` / `Removed` only when the column
+ * itself appeared or disappeared, not when one of its attributes did.
+ *
+ * @param {?ActivityAuditDiff[]} [rows] - rows of the newer side of the comparison
+ * @returns {DiffStatus | undefined} - group status, or undefined when unchanged
+ */
+export const getColumnGroupStatus = (rows?: ActivityAuditDiff[]): DiffStatus | undefined => {
+  if (!rows?.length) return undefined;
+  const nameRow = rows.find((row) => row.parameter === COLUMN_NAME_PARAMETER);
+  if (nameRow?.diffStatus === DiffStatus.ADDED) return DiffStatus.ADDED;
+  if (nameRow?.diffStatus === DiffStatus.REMOVED) return DiffStatus.REMOVED;
+  const hasChange = rows.some((row) => row.diffStatus != null && row.diffStatus !== DiffStatus.MIRROR);
+  return hasChange ? DiffStatus.CHANGED : undefined;
+};
+
+export const hasAnalyticsColumnBuckets = (diffMap: Record<string, ActivityAuditDiff[]>): boolean =>
+  Object.keys(diffMap).some(isColumnBucketKey);
+
+/**
+ * Drop the `columns:<name>` buckets from a diff map, so the generic section
+ * walk cannot mistake a column called `metadata` or `defaults` for one of the
+ * container / admin sections whose collector matches a key by substring.
+ *
+ * @param {Record<string, ActivityAuditDiff[]>} diffMap - diff buckets
+ * @returns {Record<string, ActivityAuditDiff[]>} - buckets without column ones
+ */
+export const omitAnalyticsColumnBuckets = (
+  diffMap: Record<string, ActivityAuditDiff[]>,
+): Record<string, ActivityAuditDiff[]> =>
+  Object.fromEntries(Object.entries(diffMap).filter(([key]) => !isColumnBucketKey(key)));
+
+/**
+ * Collect the `columns:<name>` buckets of both passes into the `columns`
+ * section, one entry per column name, ordered by name.
+ *
+ * @param {ActivityAuditSection} sections - section map being built
+ * @param {Record<string, ActivityAuditDiff[]>} current - before-pass buckets
+ * @param {Record<string, ActivityAuditDiff[]>} compare - after-pass buckets
+ */
+export const setAnalyticsColumnDiffs = (
+  sections: ActivityAuditSection,
+  current: Record<string, ActivityAuditDiff[]>,
+  compare: Record<string, ActivityAuditDiff[]>,
+): void => {
+  const names = union(
+    Object.keys(current).filter(isColumnBucketKey).map(getColumnNameFromBucketKey),
+    Object.keys(compare).filter(isColumnBucketKey).map(getColumnNameFromBucketKey),
+  ).sort((a, b) => a.localeCompare(b));
+
+  names.forEach((name) => {
+    const key = getColumnBucketKey(name);
+    const currentRows = current[key];
+    const compareRows = compare[key];
+    if (!currentRows?.length && !compareRows?.length) return;
+    if (!sections[EntityParameterKeys.COLUMNS]) sections[EntityParameterKeys.COLUMNS] = [];
+    const section: ActivityAuditDiffSection = {
+      current: currentRows,
+      compare: compareRows,
+      label: name,
+      diffStatus: getColumnGroupStatus(compareRows?.length ? compareRows : currentRows),
+    };
+    sections[EntityParameterKeys.COLUMNS].push(section);
+  });
+};
+
+/**
+ * Heading of a column group. The interpolation lives here because
+ * `createSectionFromDiffs` has no translator, so the section carries the bare
+ * column name and the renderer resolves it.
+ *
+ * @param {TranslateFn} t - translator
+ * @param {?string} [label] - column name from the section entry
+ * @returns {string | undefined} - localized heading, or undefined without a label
+ */
+export const getAnalyticsColumnHeading = (t: TranslateFn, label?: string): string | undefined =>
+  label == null ? undefined : t(CompareI18nKey.ColumnGroup, { name: label });

--- a/apps/ai-dial-admin/src/components/ActivityAudit/View/utils/generate-diffs.ts
+++ b/apps/ai-dial-admin/src/components/ActivityAudit/View/utils/generate-diffs.ts
@@ -17,10 +17,17 @@ import {
   ActivityAuditEntity,
   ActivityAuditResourceType,
   DiffStatus,
+  isAnalyticsResource,
   isContainerDeploymentResource,
   isImageDefinitionResource,
 } from '@/src/types/activity-audit';
 import { isEqualSkippingUndefined } from '@/src/utils/is-equals-entity';
+import {
+  buildAnalyticsDiff,
+  hasAnalyticsColumnBuckets,
+  omitAnalyticsColumnBuckets,
+  setAnalyticsColumnDiffs,
+} from './analytics-diffs';
 import { isAppRunnerParameter, isRoleSharingParameter, sortKeys } from './compare-helpers';
 import { setObjectsArrayDiff } from './set-objects-array-diffs';
 import { setRolesDiffs } from './set-roles-diffs';
@@ -126,6 +133,8 @@ const ADMIN_SECTION_ORDER: EntityParameterKeys[] = [
   EntityParameterKeys.DOMAINS,
 ];
 
+const ANALYTICS_SECTION_ORDER: EntityParameterKeys[] = [EntityParameterKeys.COLUMNS];
+
 const isEmptyPrimitive = (v: unknown): boolean => v == null || v === '';
 
 const applyDiffStatus = (result: Record<string, ActivityAuditDiff[]>, status: DiffStatus): void => {
@@ -164,6 +173,10 @@ export const generateCurrentResource = (
   isCurrent?: boolean,
   t?: (str: string) => string,
 ): Record<string, ActivityAuditDiff[]> => {
+  if (isAnalyticsResource(type)) {
+    return buildAnalyticsDiff(current, compare, isCurrent);
+  }
+
   const result: Record<string, ActivityAuditDiff[]> = {
     properties: [],
   };
@@ -629,22 +642,33 @@ export const createSectionFromDiffs = (
   current: Record<string, ActivityAuditDiff[]>,
   compare: Record<string, ActivityAuditDiff[]>,
 ): ActivityAuditSection => {
-  const sectionNames = [EntityParameterKeys.PROPERTIES, ...CONTAINER_SECTION_ORDER, ...ADMIN_SECTION_ORDER];
+  const sectionNames = [
+    EntityParameterKeys.PROPERTIES,
+    ...CONTAINER_SECTION_ORDER,
+    ...ADMIN_SECTION_ORDER,
+    ...ANALYTICS_SECTION_ORDER,
+  ];
   const sections: ActivityAuditSection = {};
+
+  const hasColumnBuckets = hasAnalyticsColumnBuckets(current) || hasAnalyticsColumnBuckets(compare);
+  const currentGeneric = hasColumnBuckets ? omitAnalyticsColumnBuckets(current) : current;
+  const compareGeneric = hasColumnBuckets ? omitAnalyticsColumnBuckets(compare) : compare;
 
   sectionNames.forEach((name) => {
     if (name == EntityParameterKeys.ROLES) {
-      setRolesDiffs(sections, current, compare);
+      setRolesDiffs(sections, currentGeneric, compareGeneric);
     } else if (
       name === EntityParameterKeys.UPSTREAMS ||
       name === EntityParameterKeys.DEFAULTS ||
       name === EntityParameterKeys.APP_PROPERTIES ||
       name === EntityParameterKeys.METADATA
     ) {
-      setObjectsArrayDiff(sections, name, current, compare);
+      setObjectsArrayDiff(sections, name, currentGeneric, compareGeneric);
+    } else if (name === EntityParameterKeys.COLUMNS) {
+      setAnalyticsColumnDiffs(sections, current, compare);
     } else {
-      const currentItem = current[name];
-      const compareItem = compare[name];
+      const currentItem = currentGeneric[name];
+      const compareItem = compareGeneric[name];
       if (currentItem?.length || compareItem?.length) {
         sections[name] = [{ current: currentItem, compare: compareItem }];
       }

--- a/apps/ai-dial-admin/src/components/ActivityAudit/View/utils/tests/analytics-diffs.spec.ts
+++ b/apps/ai-dial-admin/src/components/ActivityAudit/View/utils/tests/analytics-diffs.spec.ts
@@ -1,0 +1,400 @@
+import { EntityParameterKeys } from '@/src/components/ActivityAudit/constants';
+import { CompareI18nKey } from '@/src/constants/i18n';
+import { ActivityAuditDiff, ActivityAuditSection } from '@/src/models/activity-audit';
+import { ActivityAuditEntity, DiffStatus } from '@/src/types/activity-audit';
+import { describe, expect, test, vi } from 'vitest';
+import {
+  ANALYTICS_COLUMN_PARAMETERS,
+  buildAnalyticsDiff,
+  columnRows,
+  getAnalyticsColumnHeading,
+  getColumnBucketKey,
+  getColumnGroupStatus,
+  getColumnNameFromBucketKey,
+  hasAnalyticsColumnBuckets,
+  isColumnBucketKey,
+  omitAnalyticsColumnBuckets,
+  setAnalyticsColumnDiffs,
+  snapshotRows,
+} from '../analytics-diffs';
+
+const parametersOf = (rows?: { parameter: string }[]): string[] => (rows || []).map((row) => row.parameter);
+
+const rowFor = (rows: ActivityAuditDiff[] | undefined, parameter: string): ActivityAuditDiff | undefined =>
+  rows?.find((row) => row.parameter === parameter);
+
+const olderTable: ActivityAuditEntity = {
+  name: 'orders',
+  description: 'Order facts',
+  type: 'FACT',
+  source_table: 'raw.orders',
+  status: 'ACTIVE',
+  system: false,
+  ordering_key: ['created_at', 'id'],
+  partition_by: { granularity: 'DAY', column: 'created_at' },
+  grain: { grain_key: 'order_id' },
+  identity_column: 'id',
+  version_column: 'updated_at',
+  tag_order: ['pii', 'internal'],
+  columns: [
+    { name: 'amount', type: 'DECIMAL', nullable: false, sensitive: false },
+    { name: 'legacy_id', type: 'STRING' },
+  ],
+};
+
+// Newer revision: adds `total`, drops `legacy_id`, marks `amount` sensitive.
+const newerTable: ActivityAuditEntity = {
+  ...olderTable,
+  columns: [
+    { name: 'total', type: 'DECIMAL' },
+    { name: 'amount', type: 'DECIMAL', nullable: false, sensitive: true },
+  ],
+};
+
+// AuditView convention: BEFORE pass renders the older revision, AFTER pass the newer one.
+const beforePass = (newer: ActivityAuditEntity | null, older: ActivityAuditEntity | null) =>
+  buildAnalyticsDiff(newer, older, true);
+const afterPass = (older: ActivityAuditEntity | null, newer: ActivityAuditEntity | null) =>
+  buildAnalyticsDiff(older, newer, false);
+
+describe('Activity audit :: snapshotRows', () => {
+  test('emits one row per scalar field with the snapshot value', () => {
+    const rows = snapshotRows({ name: 'orders', status: 'ACTIVE', system: false });
+
+    expect(rows).toEqual([
+      { parameter: 'name', value: 'orders' },
+      { parameter: 'status', value: 'ACTIVE' },
+      { parameter: 'system', value: 'false' },
+    ]);
+  });
+
+  test('flattens a nested object into one row per leaf with a dotted parameter', () => {
+    const rows = snapshotRows({ grain: { grain_key: 'order_id' }, partition_by: { granularity: 'DAY' } });
+
+    expect(rows).toEqual([
+      { parameter: 'grain.grain_key', value: 'order_id' },
+      { parameter: 'partition_by.granularity', value: 'DAY' },
+    ]);
+  });
+
+  test('joins a scalar array in the order the snapshot lists it and does not sort it', () => {
+    const rows = snapshotRows({ ordering_key: ['created_at', 'id'], tag_order: ['pii', 'internal'] });
+
+    expect(rowFor(rows as ActivityAuditDiff[], 'ordering_key')?.value).toBe('created_at, id');
+    expect(rowFor(rows as ActivityAuditDiff[], 'tag_order')?.value).toBe('pii, internal');
+  });
+
+  test('never emits the columns field, which is grouped separately', () => {
+    const rows = snapshotRows({ name: 'orders', columns: [{ name: 'amount' }] });
+
+    expect(parametersOf(rows)).toEqual(['name']);
+  });
+
+  test('projects against a supplied parameter list so both sides of a comparison align', () => {
+    const rows = snapshotRows({ name: 'orders' }, ['name', 'description']);
+
+    expect(rows).toEqual([
+      { parameter: 'name', value: 'orders' },
+      { parameter: 'description', value: undefined },
+    ]);
+  });
+
+  test('returns no rows for an absent snapshot', () => {
+    expect(snapshotRows(null)).toEqual([]);
+    expect(snapshotRows(undefined)).toEqual([]);
+  });
+});
+
+describe('Activity audit :: columnRows', () => {
+  test('emits every known column attribute in declared order', () => {
+    expect(parametersOf(columnRows({ name: 'amount' }))).toEqual(ANALYTICS_COLUMN_PARAMETERS);
+  });
+
+  test('renders false and zero rather than dropping them', () => {
+    const rows = columnRows({ name: 'amount', nullable: false, sensitive: false });
+
+    expect(rowFor(rows as ActivityAuditDiff[], 'nullable')?.value).toBe('false');
+    expect(rowFor(rows as ActivityAuditDiff[], 'sensitive')?.value).toBe('false');
+  });
+
+  test('joins enum values in the order the column lists them', () => {
+    const rows = columnRows({ name: 'state', enum_values: ['new', 'done'] });
+
+    expect(rowFor(rows as ActivityAuditDiff[], 'enum_values')?.value).toBe('new, done');
+  });
+
+  test('appends extra parameters so an attribute this repo does not model is still shown', () => {
+    const rows = columnRows({ name: 'amount', precision: 12 }, ['precision']);
+
+    expect(parametersOf(rows)).toEqual([...ANALYTICS_COLUMN_PARAMETERS, 'precision']);
+    expect(rowFor(rows as ActivityAuditDiff[], 'precision')?.value).toBe('12');
+  });
+
+  test('emits undefined values for an absent column, keeping both sides aligned', () => {
+    const rows = columnRows(undefined);
+
+    expect(parametersOf(rows)).toEqual(ANALYTICS_COLUMN_PARAMETERS);
+    expect(rows.every((row) => row.value === undefined)).toBe(true);
+  });
+});
+
+describe('Activity audit :: buildAnalyticsDiff', () => {
+  test('emits a properties row for every field of a table snapshot', () => {
+    const result = afterPass(olderTable, newerTable);
+
+    expect(parametersOf(result.properties)).toEqual([
+      'name',
+      'description',
+      'grain.grain_key',
+      'identity_column',
+      'ordering_key',
+      'partition_by.column',
+      'partition_by.granularity',
+      'source_table',
+      'status',
+      'system',
+      'tag_order',
+      'type',
+      'version_column',
+    ]);
+  });
+
+  test('keeps an ordered list field in the order the snapshot lists it', () => {
+    const result = afterPass(olderTable, newerTable);
+
+    expect(rowFor(result.properties, 'ordering_key')?.value).toBe('created_at, id');
+    expect(rowFor(result.properties, 'tag_order')?.value).toBe('pii, internal');
+  });
+
+  test('creates one bucket per column present in either revision, ordered by name', () => {
+    const result = afterPass(olderTable, newerTable);
+
+    expect(Object.keys(result).filter(isColumnBucketKey)).toEqual([
+      getColumnBucketKey('amount'),
+      getColumnBucketKey('legacy_id'),
+      getColumnBucketKey('total'),
+    ]);
+  });
+
+  test('marks a column added in the newer revision as added on the side that carries it', () => {
+    const result = afterPass(olderTable, newerTable);
+    const bucket = result[getColumnBucketKey('total')];
+
+    expect(rowFor(bucket, 'name')).toEqual({ parameter: 'name', value: 'total', diffStatus: DiffStatus.ADDED });
+    expect(rowFor(bucket, 'type')?.diffStatus).toBe(DiffStatus.ADDED);
+    expect(getColumnGroupStatus(bucket)).toBe(DiffStatus.ADDED);
+  });
+
+  test('keeps an added column visible as placeholder rows on the older side', () => {
+    const result = beforePass(newerTable, olderTable);
+    const bucket = result[getColumnBucketKey('total')];
+
+    expect(bucket).toBeTruthy();
+    expect(bucket.every((row) => row.diffStatus === DiffStatus.MIRROR)).toBe(true);
+  });
+
+  test('marks a column dropped in the newer revision as removed', () => {
+    const result = afterPass(olderTable, newerTable);
+    const bucket = result[getColumnBucketKey('legacy_id')];
+
+    expect(rowFor(bucket, 'name')?.diffStatus).toBe(DiffStatus.REMOVED);
+    expect(getColumnGroupStatus(bucket)).toBe(DiffStatus.REMOVED);
+  });
+
+  test('keeps a dropped column visible on the older side too', () => {
+    const result = beforePass(newerTable, olderTable);
+    const bucket = result[getColumnBucketKey('legacy_id')];
+
+    expect(rowFor(bucket, 'name')?.value).toBe('legacy_id');
+  });
+
+  test('marks a changed attribute as changed and still emits the unchanged rows', () => {
+    const result = afterPass(olderTable, newerTable);
+    const bucket = result[getColumnBucketKey('amount')];
+
+    expect(rowFor(bucket, 'sensitive')).toEqual({
+      parameter: 'sensitive',
+      value: 'true',
+      pairedValue: 'false',
+      diffStatus: DiffStatus.CHANGED,
+    });
+    expect(rowFor(bucket, 'name')).toEqual({ parameter: 'name', value: 'amount' });
+    expect(rowFor(bucket, 'nullable')).toEqual({ parameter: 'nullable', value: 'false' });
+    expect(getColumnGroupStatus(bucket)).toBe(DiffStatus.CHANGED);
+  });
+
+  test('renders a pipeline snapshot field by field with no column bucket', () => {
+    const older: ActivityAuditEntity = { name: 'daily_rollup', schedule: '0 2 * * *', enabled: true };
+    const newer: ActivityAuditEntity = { name: 'daily_rollup', schedule: '0 3 * * *', enabled: true };
+
+    const result = afterPass(older, newer);
+
+    expect(Object.keys(result)).toEqual([EntityParameterKeys.PROPERTIES]);
+    expect(rowFor(result.properties, 'schedule')?.diffStatus).toBe(DiffStatus.CHANGED);
+    expect(rowFor(result.properties, 'enabled')?.value).toBe('true');
+  });
+
+  test('returns only an empty properties bucket when the rendered side is absent', () => {
+    expect(beforePass(newerTable, null)).toEqual({ [EntityParameterKeys.PROPERTIES]: [] });
+    expect(buildAnalyticsDiff(null, null, false)).toEqual({ [EntityParameterKeys.PROPERTIES]: [] });
+  });
+
+  test('fills and stamps every row when the opposite side is absent', () => {
+    const result = afterPass(null, newerTable);
+
+    expect(result.properties.every((row) => row.diffStatus === DiffStatus.ADDED)).toBe(true);
+    expect(result[getColumnBucketKey('total')].every((row) => row.diffStatus === DiffStatus.ADDED)).toBe(true);
+  });
+
+  test('stamps a filled older side as removed', () => {
+    const result = beforePass(null, olderTable);
+
+    expect(rowFor(result[getColumnBucketKey('legacy_id')], 'name')?.diffStatus).toBe(DiffStatus.REMOVED);
+  });
+
+  test('groups a nameless column entry by its index rather than dropping it', () => {
+    const snapshot: ActivityAuditEntity = { name: 'orders', columns: [{ type: 'STRING' }] };
+
+    const result = afterPass(snapshot, snapshot);
+
+    expect(Object.keys(result).filter(isColumnBucketKey)).toEqual([getColumnBucketKey('#0')]);
+  });
+});
+
+describe('Activity audit :: getColumnGroupStatus', () => {
+  test('answers undefined for an unchanged column and for no rows', () => {
+    expect(getColumnGroupStatus([{ parameter: 'name', value: 'amount' }])).toBeUndefined();
+    expect(getColumnGroupStatus([])).toBeUndefined();
+    expect(getColumnGroupStatus(undefined)).toBeUndefined();
+  });
+
+  test('answers changed when an attribute changed but the column itself did not', () => {
+    const rows: ActivityAuditDiff[] = [
+      { parameter: 'name', value: 'amount' },
+      { parameter: 'description', value: '', diffStatus: DiffStatus.REMOVED },
+    ];
+
+    expect(getColumnGroupStatus(rows)).toBe(DiffStatus.CHANGED);
+  });
+
+  test('ignores placeholder rows', () => {
+    const rows: ActivityAuditDiff[] = [
+      { parameter: 'name', value: 'amount', diffStatus: DiffStatus.MIRROR },
+      { parameter: 'type', value: 'DECIMAL', diffStatus: DiffStatus.MIRROR },
+    ];
+
+    expect(getColumnGroupStatus(rows)).toBeUndefined();
+  });
+});
+
+describe('Activity audit :: column bucket keys', () => {
+  test('builds, recognizes and parses a column bucket key', () => {
+    const key = getColumnBucketKey('amount');
+
+    expect(key).toBe('columns:amount');
+    expect(isColumnBucketKey(key)).toBe(true);
+    expect(isColumnBucketKey(EntityParameterKeys.PROPERTIES)).toBe(false);
+    expect(getColumnNameFromBucketKey(key)).toBe('amount');
+  });
+
+  test('reports and omits column buckets, leaving other buckets untouched', () => {
+    const diffMap: Record<string, ActivityAuditDiff[]> = {
+      properties: [{ parameter: 'name', value: 'orders' }],
+      [getColumnBucketKey('metadata')]: [{ parameter: 'name', value: 'metadata' }],
+    };
+
+    expect(hasAnalyticsColumnBuckets(diffMap)).toBe(true);
+    expect(hasAnalyticsColumnBuckets({ properties: [] })).toBe(false);
+    expect(omitAnalyticsColumnBuckets(diffMap)).toEqual({ properties: diffMap.properties });
+  });
+});
+
+describe('Activity audit :: setAnalyticsColumnDiffs', () => {
+  test('collects one entry per column name in name order, labelled by column name', () => {
+    const current: Record<string, ActivityAuditDiff[]> = {
+      [getColumnBucketKey('total')]: [{ parameter: 'name', value: 'total' }],
+      [getColumnBucketKey('amount')]: [{ parameter: 'name', value: 'amount' }],
+    };
+    const compare: Record<string, ActivityAuditDiff[]> = {
+      [getColumnBucketKey('total')]: [{ parameter: 'name', value: 'total' }],
+      [getColumnBucketKey('amount')]: [{ parameter: 'name', value: 'amount' }],
+    };
+    const sections: ActivityAuditSection = {};
+
+    setAnalyticsColumnDiffs(sections, current, compare);
+
+    expect(sections[EntityParameterKeys.COLUMNS]).toEqual([
+      {
+        current: current[getColumnBucketKey('amount')],
+        compare: compare[getColumnBucketKey('amount')],
+        label: 'amount',
+        diffStatus: undefined,
+      },
+      {
+        current: current[getColumnBucketKey('total')],
+        compare: compare[getColumnBucketKey('total')],
+        label: 'total',
+        diffStatus: undefined,
+      },
+    ]);
+  });
+
+  test('carries the group status of an added and of a removed column', () => {
+    const current: Record<string, ActivityAuditDiff[]> = {
+      [getColumnBucketKey('legacy_id')]: [{ parameter: 'name', value: 'legacy_id', diffStatus: DiffStatus.MIRROR }],
+      [getColumnBucketKey('total')]: [{ parameter: 'name', value: '', diffStatus: DiffStatus.MIRROR }],
+    };
+    const compare: Record<string, ActivityAuditDiff[]> = {
+      [getColumnBucketKey('legacy_id')]: [{ parameter: 'name', value: '', diffStatus: DiffStatus.REMOVED }],
+      [getColumnBucketKey('total')]: [{ parameter: 'name', value: 'total', diffStatus: DiffStatus.ADDED }],
+    };
+    const sections: ActivityAuditSection = {};
+
+    setAnalyticsColumnDiffs(sections, current, compare);
+
+    expect(sections[EntityParameterKeys.COLUMNS].map((section) => section.label)).toEqual(['legacy_id', 'total']);
+    expect(sections[EntityParameterKeys.COLUMNS].map((section) => section.diffStatus)).toEqual([
+      DiffStatus.REMOVED,
+      DiffStatus.ADDED,
+    ]);
+  });
+
+  test('falls back to the older side when the newer side has no rows at all', () => {
+    const current: Record<string, ActivityAuditDiff[]> = {
+      [getColumnBucketKey('legacy_id')]: [{ parameter: 'name', value: 'legacy_id', diffStatus: DiffStatus.REMOVED }],
+    };
+    const sections: ActivityAuditSection = {};
+
+    setAnalyticsColumnDiffs(sections, current, {});
+
+    expect(sections[EntityParameterKeys.COLUMNS]).toEqual([
+      {
+        current: current[getColumnBucketKey('legacy_id')],
+        compare: undefined,
+        label: 'legacy_id',
+        diffStatus: DiffStatus.REMOVED,
+      },
+    ]);
+  });
+
+  test('adds no section when there are no column buckets', () => {
+    const sections: ActivityAuditSection = {};
+
+    setAnalyticsColumnDiffs(sections, { properties: [] }, { properties: [] });
+
+    expect(sections[EntityParameterKeys.COLUMNS]).toBeUndefined();
+  });
+});
+
+describe('Activity audit :: getAnalyticsColumnHeading', () => {
+  test('interpolates the column name into the group heading key', () => {
+    const t = vi.fn(() => 'Column total');
+
+    expect(getAnalyticsColumnHeading(t, 'total')).toBe('Column total');
+    expect(t).toHaveBeenCalledWith(CompareI18nKey.ColumnGroup, { name: 'total' });
+  });
+
+  test('answers undefined without a label, so an unlabelled section keeps its own title', () => {
+    expect(getAnalyticsColumnHeading(vi.fn(), undefined)).toBeUndefined();
+  });
+});

--- a/apps/ai-dial-admin/src/components/ActivityAudit/View/utils/tests/generate-diffs.spec.ts
+++ b/apps/ai-dial-admin/src/components/ActivityAudit/View/utils/tests/generate-diffs.spec.ts
@@ -9,6 +9,7 @@ import {
   generateCurrentResource,
   mergeEntityMaps,
 } from '../generate-diffs';
+import { getColumnBucketKey, isColumnBucketKey } from '../analytics-diffs';
 import { ActivityAuditDiff } from '@/src/models/activity-audit';
 
 describe('Activity audit :: generateCurrentResource ', () => {
@@ -921,5 +922,115 @@ describe('Container detail :: nodePool rows', () => {
     const result = generateCurrentResource(current, compare, containerType, true);
     expect(propRows(result, 'displayName')).toHaveLength(1);
     expect(computeRows(result, 'nodePoolId')).toEqual([]);
+  });
+});
+
+describe('Analytics revision :: generateCurrentResource routes analytics types to the analytics builder', () => {
+  const olderTable: ActivityAuditEntity = {
+    name: 'orders',
+    grain: { grain_key: 'order_id' },
+    ordering_key: ['created_at', 'id'],
+    tag_order: ['pii', 'internal'],
+    columns: [{ name: 'amount', type: 'DECIMAL' }],
+  };
+  const newerTable: ActivityAuditEntity = {
+    ...olderTable,
+    columns: [
+      { name: 'amount', type: 'DECIMAL' },
+      { name: 'total', type: 'DECIMAL' },
+    ],
+  };
+
+  test('renders the fields the generic object path has no handler for', () => {
+    const result = generateCurrentResource(olderTable, newerTable, ActivityAuditResourceType.TABLE, false);
+    const parameters = result.properties.map((row) => row.parameter);
+
+    expect(parameters).toContain('grain.grain_key');
+    expect(parameters).toContain('ordering_key');
+    expect(parameters).toContain('tag_order');
+  });
+
+  test('drops the same fields for a resource type outside analytics, as it does today', () => {
+    const result = generateCurrentResource(olderTable, newerTable, ActivityAuditResourceType.MODEL, false);
+    const parameters = result.properties.map((row) => row.parameter);
+
+    expect(parameters).not.toContain('grain.grain_key');
+    expect(parameters).not.toContain('ordering_key');
+    expect(Object.keys(result).filter(isColumnBucketKey)).toEqual([]);
+  });
+
+  test('emits a column bucket per column for every analytics resource type', () => {
+    [
+      ActivityAuditResourceType.TABLE,
+      ActivityAuditResourceType.TABLE_COLUMN,
+      ActivityAuditResourceType.PIPELINE,
+      ActivityAuditResourceType.SAVED_QUERY,
+    ].forEach((type) => {
+      const result = generateCurrentResource(olderTable, newerTable, type, false);
+      expect(Object.keys(result).filter(isColumnBucketKey)).toEqual([
+        getColumnBucketKey('amount'),
+        getColumnBucketKey('total'),
+      ]);
+    });
+  });
+
+  test('createSectionFromDiffs collects the column buckets into one name-ordered columns section', () => {
+    const before = generateCurrentResource(newerTable, olderTable, ActivityAuditResourceType.TABLE, true);
+    const after = generateCurrentResource(olderTable, newerTable, ActivityAuditResourceType.TABLE, false);
+
+    const sections = createSectionFromDiffs(before, after);
+
+    expect(Object.keys(sections)).toEqual([EntityParameterKeys.PROPERTIES, EntityParameterKeys.COLUMNS]);
+    expect(sections[EntityParameterKeys.COLUMNS]).toHaveLength(2);
+    expect(sections[EntityParameterKeys.COLUMNS].map((section) => section.label)).toEqual(['amount', 'total']);
+    expect(sections[EntityParameterKeys.COLUMNS][1].diffStatus).toBe(DiffStatus.ADDED);
+    expect(sections[EntityParameterKeys.COLUMNS][0].diffStatus).toBeUndefined();
+  });
+
+  test('a column whose name matches a container or admin section does not create that section', () => {
+    const snapshot: ActivityAuditEntity = {
+      name: 'orders',
+      columns: [
+        { name: 'metadata', type: 'STRING' },
+        { name: 'defaults', type: 'STRING' },
+      ],
+    };
+    const diffs = generateCurrentResource(snapshot, snapshot, ActivityAuditResourceType.TABLE, true);
+
+    const sections = createSectionFromDiffs(diffs, diffs);
+
+    expect(Object.keys(sections)).toEqual([EntityParameterKeys.PROPERTIES, EntityParameterKeys.COLUMNS]);
+    expect(sections[EntityParameterKeys.METADATA]).toBeUndefined();
+    expect(sections[EntityParameterKeys.DEFAULTS]).toBeUndefined();
+  });
+});
+
+describe('Analytics revision :: container sections are unchanged by the analytics branch', () => {
+  const containerType = ActivityAuditResourceType.MCP_DEPLOYMENT;
+  const previous: ActivityAuditEntity = {
+    displayName: 'Interceptor',
+    resources: { requests: { cpu: '100m', memory: '256Mi' }, limits: { cpu: '500m', memory: '1Gi' } },
+    scaling: { minReplicas: 1, maxReplicas: 1, scaleToZeroDelaySeconds: 0 },
+    metadata: { envs: [{ name: 'A', description: '', value: { $type: 'simple', value: '1' }, mountType: 'content' }] },
+  };
+  const latest: ActivityAuditEntity = {
+    ...previous,
+    metadata: { envs: [{ name: 'A', description: '', value: { $type: 'simple', value: '2' }, mountType: 'content' }] },
+  };
+
+  test('keeps the Compute, Autoscaling and Environment variables sections', () => {
+    const before = generateCurrentResource(latest, previous, containerType, true);
+    const after = generateCurrentResource(previous, latest, containerType, false);
+
+    const sections = createSectionFromDiffs(before, after);
+
+    expect(Object.keys(sections)).toEqual([
+      EntityParameterKeys.PROPERTIES,
+      EntityParameterKeys.SCALING,
+      EntityParameterKeys.METADATA,
+      EntityParameterKeys.RESOURCES,
+    ]);
+    expect(sections[EntityParameterKeys.METADATA]).toHaveLength(1);
+    expect(sections[EntityParameterKeys.COLUMNS]).toBeUndefined();
   });
 });

--- a/apps/ai-dial-admin/src/components/ActivityAudit/constants.ts
+++ b/apps/ai-dial-admin/src/components/ActivityAudit/constants.ts
@@ -53,6 +53,7 @@ export enum EntityParameterKeys {
   PROBE_PROPERTIES = 'probeProperties',
   ENDPOINT_CONFIGURATION = 'endpointConfiguration',
   CONFIGURATION = 'configuration',
+  COLUMNS = 'columns',
 }
 
 export const dateKeys = ['expiresAt', 'keyGeneratedAt', 'createdAt', 'updatedAt'];

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/TableAudit.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/TableAudit.tsx
@@ -1,0 +1,25 @@
+import { FC, useMemo } from 'react';
+
+import { AnalyticsTable } from '@/src/models/analytics/table';
+import { BaseEntity } from '@/src/models/dial/base-entity';
+
+import EntityAudit from '@/src/components/EntityTabs/Audit/EntityAudit';
+import { ActivityAuditView } from '@/src/types/activity-audit';
+import { ApplicationRoute } from '@/src/types/routes';
+
+interface Props {
+  table: AnalyticsTable;
+}
+
+const TableAudit: FC<Props> = ({ table }) => {
+  // Memoized because `ActivityAuditList` keys its AG Grid datasource on the `entity` reference: a
+  // fresh object per render re-sets the datasource and re-requests the first row block.
+  const entity: BaseEntity = useMemo(
+    () => ({ name: table.name, description: table.description }),
+    [table.name, table.description],
+  );
+
+  return <EntityAudit entity={entity} view={ApplicationRoute.AnalyticsTables} viewMode={ActivityAuditView.Analytics} />;
+};
+
+export default TableAudit;

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/TableDetailView.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/TableDetailView.tsx
@@ -4,7 +4,7 @@ import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useRouter } from 'next/navigation';
 
-import { ColDef, GridApi, ICellRendererParams, IRowNode, ITooltipParams, ValueGetterParams } from 'ag-grid-community';
+import { GridApi, IRowNode } from 'ag-grid-community';
 import {
   ConfirmationPopupVariant,
   DialConfirmationPopup,
@@ -12,9 +12,9 @@ import {
   DialEllipsisTooltip,
   DialFormPopup,
   DialGhostButton,
-  DialLabelledText,
   DialNeutralButton,
   DialPrimaryButton,
+  DialTabs,
   PopupSize,
 } from '@epam/ai-dial-ui-kit';
 import { IconPlugConnected } from '@tabler/icons-react';
@@ -23,10 +23,10 @@ import { addRows, defineTableSchema, deleteTable, getTable, updateTableSchema } 
 import ColumnRowsEditor from '@/src/components/Analytics/Tables/ColumnRowsEditor';
 import ConnectPanel from '@/src/components/Analytics/Tables/ConnectPanel/ConnectPanel';
 import { isEnrichmentRead } from '@/src/components/Analytics/Tables/ConnectPanel/connect-snippets';
-import DraftSchemaEditor from '@/src/components/Analytics/Tables/DraftSchemaEditor';
 import EditColumnPopup from '@/src/components/Analytics/Tables/EditColumnPopup';
-import KeyFieldLabel from '@/src/components/Analytics/Tables/KeyFieldLabel';
 import TableAccessPanel from '@/src/components/Analytics/Tables/TableAccessPanel';
+import TableAudit from '@/src/components/Analytics/Tables/TableAudit';
+import TableProperties from '@/src/components/Analytics/Tables/TableProperties';
 import TableStatusBadge from '@/src/components/Analytics/Tables/TableStatusBadge';
 import { useDraftSchemaForm } from '@/src/components/Analytics/Tables/use-draft-schema-form';
 import {
@@ -39,15 +39,11 @@ import {
   parseRowsJson,
   toTableColumns,
 } from '@/src/components/Analytics/Tables/utils';
-import { TypeCellRenderer } from '@/src/components/Analytics/Common/TypeBadge';
-import SensitiveIndicator from '@/src/components/Common/SensitiveIndicator/SensitiveIndicator';
-import GridView from '@/src/components/Grid/GridView/GridView';
 import JsonEditorBase from '@/src/components/Common/JsonEditorBase/JsonEditorBase';
 import { useAnalyticsTablePermissions } from '@/src/hooks/use-analytics-table-permissions';
-import { ACTION_COLUMN } from '@/src/constants/ag-grid';
-import { capitalize } from '@/src/constants/analytics/tables';
 import { getDeleteOperation, getEditOperation } from '@/src/constants/grid-columns/actions';
 import { AnalyticsTablesI18nKey, ButtonsI18nKey } from '@/src/constants/i18n';
+import { useAppContext } from '@/src/context/AppContext';
 import { useNotification } from '@/src/context/NotificationContext';
 import { useI18n } from '@/src/locales/client';
 import { ActionMenuOperationDeclaration } from '@/src/models/action-menu-operations';
@@ -63,6 +59,7 @@ import {
 import { ColumnRow } from '@/src/models/analytics/tables-ui';
 import { ServerActionResponse } from '@/src/models/server-action';
 import { ApplicationRoute } from '@/src/types/routes';
+import { auditTab, EntityViewTab, propertiesTab } from '@/src/utils/tabs/utils';
 import { getAnalyticsIdentifierError } from '@/src/utils/validation/analytics-table-error';
 import { getErrorNotification, getSuccessNotification } from '@/src/utils/notification';
 
@@ -76,16 +73,6 @@ interface Props {
   flightUri: string;
 }
 
-// Renders the column name with a trailing sensitive marker; editing still swaps in the cell editor.
-// The dot is tooltip-less — the grid's cell tooltip (see the name column's tooltipValueGetter) carries
-// the sensitive note, so the two don't double up.
-const ColumnNameCellRenderer: FC<ICellRendererParams<AnalyticsTableColumn>> = ({ value, data }) => (
-  <span className="flex items-center gap-1.5">
-    <span className="truncate">{value}</span>
-    {data?.sensitive && <SensitiveIndicator />}
-  </span>
-);
-
 // The grain-key row is pinned to the grid's top (see `grainKeyRow` below) rather than a real editable
 // column, so its inline rename and row actions are disabled wherever this check is used.
 const isPinnedRow = (_api: GridApi, node: IRowNode) => Boolean(node.rowPinned);
@@ -94,8 +81,13 @@ const TableDetailView: FC<Props> = ({ name, initialTable, apiBaseUrl, flightUri 
   const t = useI18n();
   const router = useRouter();
   const { showNotification } = useNotification();
+  // `/tables/[id]` has no feature-flag guard, so a bookmarked link reaches this view on an install with
+  // analytics off. Gating the tab strip here is what keeps the Audit tab — and its activity request —
+  // out of that install.
+  const { featureFlags } = useAppContext();
 
   const [table, setTable] = useState<AnalyticsTable>(initialTable);
+  const [activeTab, setActiveTab] = useState<EntityViewTab>(EntityViewTab.Properties);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [addOpen, setAddOpen] = useState(false);
   const [writeOpen, setWriteOpen] = useState(false);
@@ -298,45 +290,21 @@ const TableDetailView: FC<Props> = ({ name, initialTable, apiBaseUrl, flightUri 
     [onDrop, isDropRestricted],
   );
 
-  const columnDefs = useMemo<ColDef[]>(
-    () => [
-      {
-        headerName: t(AnalyticsTablesI18nKey.ColumnName),
-        field: 'name',
-        editable: (params) => canModify && !params.node.rowPinned,
-        cellRenderer: ColumnNameCellRenderer,
-        // Fold the sensitive note into the single cell tooltip so it doesn't double with the dot.
-        tooltipValueGetter: (params: ITooltipParams<AnalyticsTableColumn>) =>
-          [params.data?.name, params.data?.sensitive ? t(AnalyticsTablesI18nKey.Sensitive) : '']
-            .filter(Boolean)
-            .join(' — '),
-        flex: 2,
-      },
-      {
-        headerName: t(AnalyticsTablesI18nKey.Type),
-        field: 'type',
-        cellRenderer: TypeCellRenderer,
-        // An enum column's declared domain, reachable without opening the edit modal. It rides the cell's
-        // own tooltip rather than the badge's: the badge is a non-focusable span, so a tooltip on it would
-        // be mouse-only, while the grid cell is reachable by keyboard navigation.
-        tooltipValueGetter: (params: ITooltipParams<AnalyticsTableColumn>) =>
-          params.data?.enum_values?.length ? params.data.enum_values.join(', ') : '',
-        flex: 1,
-      },
-      { headerName: t(AnalyticsTablesI18nKey.Tag), field: 'tag', flex: 1 },
-      // Long display names/descriptions truncate in the cell; the grid's default tooltip exposes the full value.
-      { headerName: t(AnalyticsTablesI18nKey.DisplayName), field: 'display_name', flex: 2 },
-      { headerName: t(AnalyticsTablesI18nKey.Description), field: 'description', flex: 3 },
-      {
-        headerName: t(AnalyticsTablesI18nKey.Nullable),
-        colId: 'nullable',
-        flex: 1,
-        cellDataType: false,
-        valueGetter: (params: ValueGetterParams<AnalyticsTableColumn>) => String(Boolean(params.data?.nullable)),
-      },
-      ...(canModify ? [ACTION_COLUMN(actions)] : []),
-    ],
-    [t, actions, canModify],
+  // Audit is offered only on an active table: a table that was never materialized has no columns and no
+  // recorded activities, so the tab could only ever be empty (design.md D12). FAILED and an unreported
+  // status take the same branch as a draft — the branch that already renders the draft schema editor.
+  // On an active table it needs no permission the detail view does not already require.
+  const tabs = useMemo(() => [propertiesTab(t), auditTab(t)], [t]);
+
+  const properties = (
+    <TableProperties
+      table={table}
+      grainKeyRow={grainKeyRow}
+      draft={draft}
+      actions={actions}
+      canModify={canModify}
+      onRenameCell={onRenameCell}
+    />
   );
 
   return (
@@ -403,110 +371,24 @@ const TableDetailView: FC<Props> = ({ name, initialTable, apiBaseUrl, flightUri 
         {table.description && <DialEllipsisTooltip text={table.description} className="text-primary dial-small" />}
       </div>
 
-      {/* The summary is otherwise ACTIVE-only, because a draft's keys live in DraftSchemaEditor as
-          editable inputs. An enrichment's source table has no such input — it is fixed at create — so
-          it shows at any status, including while the draft schema is being defined. */}
-      {(isActive || isEnrichment) && (
-        <div className="flex flex-wrap gap-8 mb-6">
-          {table.type === AnalyticsTableType.Source ? (
-            <>
-              {!!table.ordering_key?.length && (
-                <DialLabelledText
-                  label={
-                    <KeyFieldLabel
-                      label={t(AnalyticsTablesI18nKey.OrderingKey)}
-                      hint={t(AnalyticsTablesI18nKey.OrderingKeyHint)}
-                    />
-                  }
-                  text={table.ordering_key.join(', ')}
-                />
-              )}
-              {table.partition_by && (
-                <>
-                  <DialLabelledText
-                    label={
-                      <KeyFieldLabel
-                        label={t(AnalyticsTablesI18nKey.PartitionColumn)}
-                        hint={t(AnalyticsTablesI18nKey.PartitionColumnHint)}
-                      />
-                    }
-                    text={table.partition_by.column}
-                  />
-                  <DialLabelledText
-                    label={
-                      <KeyFieldLabel
-                        label={t(AnalyticsTablesI18nKey.Granularity)}
-                        hint={t(AnalyticsTablesI18nKey.GranularityHint)}
-                      />
-                    }
-                    text={capitalize(table.partition_by.granularity)}
-                  />
-                </>
-              )}
-              {table.identity_column && (
-                <DialLabelledText
-                  label={
-                    <KeyFieldLabel
-                      label={t(AnalyticsTablesI18nKey.IdentityColumn)}
-                      hint={t(AnalyticsTablesI18nKey.IdentityColumnHint)}
-                    />
-                  }
-                  text={table.identity_column}
-                />
-              )}
-              {table.version_column && (
-                <DialLabelledText
-                  label={
-                    <KeyFieldLabel
-                      label={t(AnalyticsTablesI18nKey.VersionColumn)}
-                      hint={t(AnalyticsTablesI18nKey.VersionColumnHint)}
-                    />
-                  }
-                  text={table.version_column}
-                />
-              )}
-            </>
-          ) : (
-            <>
-              {/* No KeyFieldLabel hint: unlike the keys beside it, the source table is not chosen on the
-                  draft surface — it is fixed at create — so there is no explanation to keep in step. */}
-              {table.source_table && (
-                <DialLabelledText label={t(AnalyticsTablesI18nKey.SourceTable)} text={table.source_table} />
-              )}
-              {!!table.grain?.grain_key && (
-                <DialLabelledText
-                  label={
-                    <KeyFieldLabel
-                      label={t(AnalyticsTablesI18nKey.GrainKey)}
-                      hint={t(AnalyticsTablesI18nKey.GrainKeyHint)}
-                    />
-                  }
-                  text={table.grain.grain_key}
-                />
-              )}
-            </>
+      {/* One fallback for both conditions: with analytics disabled, or on a table that is not active,
+          the Properties body is the whole view — no tab strip, and no Audit tab to issue an analytics
+          activity request from. */}
+      {featureFlags.analyticsEnabled && isActive ? (
+        <>
+          <div className="mb-6">
+            <DialTabs tabs={tabs} activeTab={activeTab} onClick={(tab) => setActiveTab(tab as EntityViewTab)} />
+          </div>
+          {activeTab === EntityViewTab.Properties && properties}
+          {activeTab === EntityViewTab.Audit && (
+            <div className="flex min-h-0 flex-1 flex-col">
+              <TableAudit table={table} />
+            </div>
           )}
-        </div>
+        </>
+      ) : (
+        properties
       )}
-
-      <div className="flex min-h-0 flex-1 flex-col overflow-auto">
-        {isActive ? (
-          <GridView
-            columnDefs={columnDefs}
-            rowData={columns}
-            getRowId={(params) => params.data.name}
-            additionalGridOptions={{
-              pinnedTopRowData: grainKeyRow ? [grainKeyRow] : undefined,
-              onCellValueChanged: (e) => {
-                if (e.colDef.field === 'name') onRenameCell(e.oldValue as string, e.newValue as string);
-              },
-            }}
-            emptyDataProps={{ title: t(AnalyticsTablesI18nKey.NoColumns) }}
-          />
-        ) : (
-          <DraftSchemaEditor table={table} draft={draft} />
-        )}
-      </div>
 
       {confirmOpen && (
         <DialConfirmationPopup

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/TableProperties.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/TableProperties.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import { FC, useMemo } from 'react';
+
+import { ColDef, ICellRendererParams, ITooltipParams, ValueGetterParams } from 'ag-grid-community';
+import { DialLabelledText } from '@epam/ai-dial-ui-kit';
+
+import { TypeCellRenderer } from '@/src/components/Analytics/Common/TypeBadge';
+import DraftSchemaEditor from '@/src/components/Analytics/Tables/DraftSchemaEditor';
+import KeyFieldLabel from '@/src/components/Analytics/Tables/KeyFieldLabel';
+import { useDraftSchemaForm } from '@/src/components/Analytics/Tables/use-draft-schema-form';
+import SensitiveIndicator from '@/src/components/Common/SensitiveIndicator/SensitiveIndicator';
+import GridView from '@/src/components/Grid/GridView/GridView';
+import { ACTION_COLUMN } from '@/src/constants/ag-grid';
+import { capitalize } from '@/src/constants/analytics/tables';
+import { AnalyticsTablesI18nKey } from '@/src/constants/i18n';
+import { useI18n } from '@/src/locales/client';
+import { ActionMenuOperationDeclaration } from '@/src/models/action-menu-operations';
+import { AnalyticsTable, AnalyticsTableColumn, AnalyticsTableType, TableStatus } from '@/src/models/analytics/table';
+
+interface Props {
+  table: AnalyticsTable;
+  // The enrichment grain key, already resolved against the source table by TableDetailView, or null
+  // for a table that has none. Pinned atop the grid rather than rendered as an editable column.
+  grainKeyRow: AnalyticsTableColumn | null;
+  draft: ReturnType<typeof useDraftSchemaForm>;
+  actions: ActionMenuOperationDeclaration<AnalyticsTableColumn>[];
+  canModify: boolean;
+  onRenameCell: (from: string, to: string) => void;
+}
+
+// Renders the column name with a trailing sensitive marker; editing still swaps in the cell editor.
+// The dot is tooltip-less — the grid's cell tooltip (see the name column's tooltipValueGetter) carries
+// the sensitive note, so the two don't double up.
+const ColumnNameCellRenderer: FC<ICellRendererParams<AnalyticsTableColumn>> = ({ value, data }) => (
+  <span className="flex items-center gap-1.5">
+    <span className="truncate">{value}</span>
+    {data?.sensitive && <SensitiveIndicator />}
+  </span>
+);
+
+const TableProperties: FC<Props> = ({ table, grainKeyRow, draft, actions, canModify, onRenameCell }) => {
+  const t = useI18n();
+
+  const isActive = table.status === TableStatus.Active;
+  const isEnrichment = table.type === AnalyticsTableType.Enrichment;
+  const columns = useMemo(() => table.columns ?? [], [table.columns]);
+
+  const columnDefs = useMemo<ColDef[]>(
+    () => [
+      {
+        headerName: t(AnalyticsTablesI18nKey.ColumnName),
+        field: 'name',
+        editable: (params) => canModify && !params.node.rowPinned,
+        cellRenderer: ColumnNameCellRenderer,
+        // Fold the sensitive note into the single cell tooltip so it doesn't double with the dot.
+        tooltipValueGetter: (params: ITooltipParams<AnalyticsTableColumn>) =>
+          [params.data?.name, params.data?.sensitive ? t(AnalyticsTablesI18nKey.Sensitive) : '']
+            .filter(Boolean)
+            .join(' — '),
+        flex: 2,
+      },
+      {
+        headerName: t(AnalyticsTablesI18nKey.Type),
+        field: 'type',
+        cellRenderer: TypeCellRenderer,
+        // An enum column's declared domain, reachable without opening the edit modal. It rides the cell's
+        // own tooltip rather than the badge's: the badge is a non-focusable span, so a tooltip on it would
+        // be mouse-only, while the grid cell is reachable by keyboard navigation.
+        tooltipValueGetter: (params: ITooltipParams<AnalyticsTableColumn>) =>
+          params.data?.enum_values?.length ? params.data.enum_values.join(', ') : '',
+        flex: 1,
+      },
+      { headerName: t(AnalyticsTablesI18nKey.Tag), field: 'tag', flex: 1 },
+      // Long display names/descriptions truncate in the cell; the grid's default tooltip exposes the full value.
+      { headerName: t(AnalyticsTablesI18nKey.DisplayName), field: 'display_name', flex: 2 },
+      { headerName: t(AnalyticsTablesI18nKey.Description), field: 'description', flex: 3 },
+      {
+        headerName: t(AnalyticsTablesI18nKey.Nullable),
+        colId: 'nullable',
+        flex: 1,
+        cellDataType: false,
+        valueGetter: (params: ValueGetterParams<AnalyticsTableColumn>) => String(Boolean(params.data?.nullable)),
+      },
+      ...(canModify ? [ACTION_COLUMN(actions)] : []),
+    ],
+    [t, actions, canModify],
+  );
+
+  return (
+    <>
+      {/* The summary is otherwise ACTIVE-only, because a draft's keys live in DraftSchemaEditor as
+          editable inputs. An enrichment's source table has no such input — it is fixed at create — so
+          it shows at any status, including while the draft schema is being defined. */}
+      {(isActive || isEnrichment) && (
+        <div className="flex flex-wrap gap-8 mb-6">
+          {table.type === AnalyticsTableType.Source ? (
+            <>
+              {!!table.ordering_key?.length && (
+                <DialLabelledText
+                  label={
+                    <KeyFieldLabel
+                      label={t(AnalyticsTablesI18nKey.OrderingKey)}
+                      hint={t(AnalyticsTablesI18nKey.OrderingKeyHint)}
+                    />
+                  }
+                  text={table.ordering_key.join(', ')}
+                />
+              )}
+              {table.partition_by && (
+                <>
+                  <DialLabelledText
+                    label={
+                      <KeyFieldLabel
+                        label={t(AnalyticsTablesI18nKey.PartitionColumn)}
+                        hint={t(AnalyticsTablesI18nKey.PartitionColumnHint)}
+                      />
+                    }
+                    text={table.partition_by.column}
+                  />
+                  <DialLabelledText
+                    label={
+                      <KeyFieldLabel
+                        label={t(AnalyticsTablesI18nKey.Granularity)}
+                        hint={t(AnalyticsTablesI18nKey.GranularityHint)}
+                      />
+                    }
+                    text={capitalize(table.partition_by.granularity)}
+                  />
+                </>
+              )}
+              {table.identity_column && (
+                <DialLabelledText
+                  label={
+                    <KeyFieldLabel
+                      label={t(AnalyticsTablesI18nKey.IdentityColumn)}
+                      hint={t(AnalyticsTablesI18nKey.IdentityColumnHint)}
+                    />
+                  }
+                  text={table.identity_column}
+                />
+              )}
+              {table.version_column && (
+                <DialLabelledText
+                  label={
+                    <KeyFieldLabel
+                      label={t(AnalyticsTablesI18nKey.VersionColumn)}
+                      hint={t(AnalyticsTablesI18nKey.VersionColumnHint)}
+                    />
+                  }
+                  text={table.version_column}
+                />
+              )}
+            </>
+          ) : (
+            <>
+              {/* No KeyFieldLabel hint: unlike the keys beside it, the source table is not chosen on the
+                  draft surface — it is fixed at create — so there is no explanation to keep in step. */}
+              {table.source_table && (
+                <DialLabelledText label={t(AnalyticsTablesI18nKey.SourceTable)} text={table.source_table} />
+              )}
+              {!!table.grain?.grain_key && (
+                <DialLabelledText
+                  label={
+                    <KeyFieldLabel
+                      label={t(AnalyticsTablesI18nKey.GrainKey)}
+                      hint={t(AnalyticsTablesI18nKey.GrainKeyHint)}
+                    />
+                  }
+                  text={table.grain.grain_key}
+                />
+              )}
+            </>
+          )}
+        </div>
+      )}
+
+      <div className="flex min-h-0 flex-1 flex-col overflow-auto">
+        {isActive ? (
+          <GridView
+            columnDefs={columnDefs}
+            rowData={columns}
+            getRowId={(params) => params.data.name}
+            additionalGridOptions={{
+              pinnedTopRowData: grainKeyRow ? [grainKeyRow] : undefined,
+              onCellValueChanged: (e) => {
+                if (e.colDef.field === 'name') onRenameCell(e.oldValue as string, e.newValue as string);
+              },
+            }}
+            emptyDataProps={{ title: t(AnalyticsTablesI18nKey.NoColumns) }}
+          />
+        ) : (
+          <DraftSchemaEditor table={table} draft={draft} />
+        )}
+      </div>
+    </>
+  );
+};
+
+export default TableProperties;

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/tests/TableAudit.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/tests/TableAudit.spec.tsx
@@ -1,0 +1,90 @@
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const entityAuditSpy = vi.fn();
+
+vi.mock('@/src/components/EntityTabs/Audit/EntityAudit', () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => {
+    entityAuditSpy(props);
+    return <div />;
+  },
+}));
+
+import TableAudit from '@/src/components/Analytics/Tables/TableAudit';
+import { resolveEntityAuditType } from '@/src/components/ActivityAudit/View/Header/utils';
+import { AnalyticsTable, AnalyticsTableType } from '@/src/models/analytics/table';
+import { BaseEntity } from '@/src/models/dial/base-entity';
+import { FeatureFlags } from '@/src/models/feature-flags';
+import { ActivityAuditResourceType, ActivityAuditView } from '@/src/types/activity-audit';
+import { ApplicationRoute } from '@/src/types/routes';
+import { EntityViewTab, getAuditTabs } from '@/src/utils/tabs/utils';
+
+const table: AnalyticsTable = {
+  name: 'orders',
+  description: 'Order facts',
+  type: AnalyticsTableType.Source,
+};
+
+const renderTableAudit = (props?: Partial<AnalyticsTable>) => render(<TableAudit table={{ ...table, ...props }} />);
+
+const lastEntity = (): BaseEntity => entityAuditSpy.mock.lastCall?.[0].entity as BaseEntity;
+
+describe('TableAudit', () => {
+  beforeEach(() => {
+    entityAuditSpy.mockClear();
+  });
+
+  test('renders EntityAudit for the analytics tables route in the Analytics view mode', () => {
+    renderTableAudit();
+
+    expect(entityAuditSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity: { name: 'orders', description: 'Order facts' },
+        view: ApplicationRoute.AnalyticsTables,
+        viewMode: ActivityAuditView.Analytics,
+      }),
+    );
+  });
+
+  test('projects the table onto an entity carrying its name so the list is narrowed to that table', () => {
+    renderTableAudit({ name: 'conversations' });
+
+    expect(lastEntity().name).toBe('conversations');
+  });
+
+  test('projects a table with no description onto an entity with an undefined description', () => {
+    renderTableAudit({ description: void 0 });
+
+    expect(lastEntity()).toEqual({ name: 'orders', description: void 0 });
+  });
+
+  test('keeps the projected entity reference stable across a re-render with the same table', () => {
+    const { rerender } = renderTableAudit();
+    const firstEntity = lastEntity();
+
+    rerender(<TableAudit table={{ ...table }} />);
+
+    expect(lastEntity()).toBe(firstEntity);
+  });
+
+  test('projects an entity whose audit resource type resolves to Table', () => {
+    renderTableAudit();
+
+    expect(resolveEntityAuditType(lastEntity(), ApplicationRoute.AnalyticsTables)).toBe(
+      ActivityAuditResourceType.TABLE,
+    );
+  });
+});
+
+describe('TableAudit — sub-tab rail', () => {
+  const featureFlags = { dashboardEnabled: true, analyticsEnabled: true } as FeatureFlags;
+
+  // The view the component passes decides the rail EntityAudit renders; the telemetry sub-tabs are
+  // keyed by a deployment name and have no meaning for a catalog table.
+  test('resolves to Activities and nothing else for the analytics tables route', () => {
+    const tabs = getAuditTabs((key: string) => key, featureFlags, ApplicationRoute.AnalyticsTables);
+
+    expect(tabs.map((tab) => tab.id)).toEqual([EntityViewTab.Activities]);
+  });
+});

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/tests/TableDetailView.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/tests/TableDetailView.spec.tsx
@@ -4,9 +4,27 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { getTable, getTableAccess, updateTableSchema } from '@/src/app/[lang]/tables/actions';
 import TableDetailView from '@/src/components/Analytics/Tables/TableDetailView';
-import { ActionMenuOperationI18nKey, AnalyticsTablesI18nKey, ButtonsI18nKey } from '@/src/constants/i18n';
+import { ActionMenuOperationI18nKey, AnalyticsTablesI18nKey, ButtonsI18nKey, TabsI18nKey } from '@/src/constants/i18n';
 import { AnalyticsFieldType } from '@/src/models/analytics/entity';
-import { AnalyticsTable, AnalyticsTableType, PartitionGranularity, TableStatus } from '@/src/models/analytics/table';
+import { AnalyticsTable, AnalyticsTableType, TableStatus } from '@/src/models/analytics/table';
+
+// The view is only reachable with analytics on in practice, so that is the default here; the flag-off
+// case is asserted explicitly below.
+const featureFlags = { analyticsEnabled: true };
+vi.mock('@/src/context/AppContext', () => ({
+  useAppContext: () => ({ featureFlags }),
+}));
+
+// The Audit tab's own contract (the projected entity, the view and the view mode it hands EntityAudit)
+// is covered in TableAudit.spec.tsx; here it stands in for "the activities list rendered", and its
+// absence stands in for "no analytics activity request issued".
+const auditPropsSpy = vi.fn();
+vi.mock('@/src/components/Analytics/Tables/TableAudit', () => ({
+  default: (props: { table: AnalyticsTable }) => {
+    auditPropsSpy(props);
+    return <div>table-audit</div>;
+  },
+}));
 
 // Monaco is heavy and not meaningful in jsdom — assert on the value/onChange contract instead.
 vi.mock('@/src/components/Common/JsonEditorBase/JsonEditorBase', () => ({
@@ -111,6 +129,7 @@ const setPerms = (over: Partial<typeof permissions>) =>
 
 beforeEach(() => {
   vi.clearAllMocks();
+  featureFlags.analyticsEnabled = true;
   Object.assign(permissions, {
     canCreate: true,
     canDelete: true,
@@ -297,240 +316,10 @@ describe('TableDetailView header', () => {
   });
 });
 
-describe('TableDetailView columns grid', () => {
-  test('the grid includes Display name and Description columns', () => {
-    render(<TableDetailView name="dial_usage_log" initialTable={table()} apiBaseUrl="" flightUri="" />);
-
-    const headers = screen.getByText(/^headers:/);
-    expect(headers).toHaveTextContent(AnalyticsTablesI18nKey.DisplayName);
-    expect(headers).toHaveTextContent(AnalyticsTablesI18nKey.Description);
-  });
-});
-
+// The read-only key summary and the columns grid itself now live in TableProperties; their cases moved
+// with them to TableProperties.spec.tsx. What stays here is the grain-key row, which TableDetailView
+// resolves against the source table before handing it down.
 describe('TableDetailView schema metadata', () => {
-  test('an active source table shows its ordering key, partition column, and granularity', () => {
-    render(
-      <TableDetailView
-        name="dial_usage_log"
-        initialTable={table({
-          ordering_key: ['event_id', 'request_time'],
-          partition_by: { column: 'request_time', granularity: PartitionGranularity.Day },
-        })}
-        apiBaseUrl=""
-        flightUri=""
-      />,
-    );
-
-    expect(screen.getByText(AnalyticsTablesI18nKey.OrderingKey)).toBeInTheDocument();
-    expect(screen.getByText('event_id, request_time')).toBeInTheDocument();
-    expect(screen.getByText(AnalyticsTablesI18nKey.PartitionColumn)).toBeInTheDocument();
-    expect(screen.getByText('request_time')).toBeInTheDocument();
-    expect(screen.getByText(AnalyticsTablesI18nKey.Granularity)).toBeInTheDocument();
-    expect(screen.getByText('Day')).toBeInTheDocument();
-  });
-
-  test('an active source table with no partition hides partition column and granularity', () => {
-    render(
-      <TableDetailView
-        name="dial_usage_log"
-        initialTable={table({ ordering_key: ['event_id'] })}
-        apiBaseUrl=""
-        flightUri=""
-      />,
-    );
-
-    expect(screen.getByText(AnalyticsTablesI18nKey.OrderingKey)).toBeInTheDocument();
-    expect(screen.queryByText(AnalyticsTablesI18nKey.PartitionColumn)).not.toBeInTheDocument();
-    expect(screen.queryByText(AnalyticsTablesI18nKey.Granularity)).not.toBeInTheDocument();
-  });
-
-  test('an active source table shows its declared scan-metadata pair', () => {
-    render(
-      <TableDetailView
-        name="dial_usage_log"
-        initialTable={table({
-          // Distinct from both pair values so each assertion below matches exactly one node.
-          ordering_key: ['total'],
-          identity_column: 'event_id',
-          version_column: 'request_time',
-        })}
-        apiBaseUrl=""
-        flightUri=""
-      />,
-    );
-
-    expect(screen.getByText(AnalyticsTablesI18nKey.IdentityColumn)).toBeInTheDocument();
-    expect(screen.getByText('event_id')).toBeInTheDocument();
-    expect(screen.getByText(AnalyticsTablesI18nKey.VersionColumn)).toBeInTheDocument();
-    expect(screen.getByText('request_time')).toBeInTheDocument();
-  });
-
-  test('a source declaring no scan metadata shows neither label and no substitute message', () => {
-    render(
-      <TableDetailView
-        name="dial_usage_log"
-        initialTable={table({ ordering_key: ['event_id'] })}
-        apiBaseUrl=""
-        flightUri=""
-      />,
-    );
-
-    expect(screen.queryByText(AnalyticsTablesI18nKey.IdentityColumn)).not.toBeInTheDocument();
-    expect(screen.queryByText(AnalyticsTablesI18nKey.VersionColumn)).not.toBeInTheDocument();
-  });
-
-  test('a source declaring only one member shows that one and omits the other', () => {
-    render(
-      <TableDetailView
-        name="dial_usage_log"
-        initialTable={table({ ordering_key: ['event_id'], version_column: 'request_time' })}
-        apiBaseUrl=""
-        flightUri=""
-      />,
-    );
-
-    expect(screen.getByText(AnalyticsTablesI18nKey.VersionColumn)).toBeInTheDocument();
-    expect(screen.queryByText(AnalyticsTablesI18nKey.IdentityColumn)).not.toBeInTheDocument();
-  });
-
-  test('a system scan-metadata column absent from the columns grid still renders in the summary', () => {
-    render(
-      <TableDetailView
-        name="dial_usage_log"
-        initialTable={table({
-          ordering_key: ['event_id'],
-          identity_column: 'event_id',
-          // A `_`-prefixed system column: legitimately not among `columns`.
-          version_column: '_ingested_at',
-          columns: [{ source_name: 'event_id', name: 'event_id', type: AnalyticsFieldType.Uuid }],
-        })}
-        apiBaseUrl=""
-        flightUri=""
-      />,
-    );
-
-    expect(screen.getByText('_ingested_at')).toBeInTheDocument();
-    expect(screen.getByText('columns: 1')).toBeInTheDocument();
-  });
-
-  test('an active enrichment table shows its grain key', () => {
-    render(
-      <TableDetailView
-        name="order_flags"
-        initialTable={table({
-          name: 'order_flags',
-          type: AnalyticsTableType.Enrichment,
-          source_table: 'orders',
-          grain: { grain_key: 'order_id' },
-        })}
-        apiBaseUrl=""
-        flightUri=""
-      />,
-    );
-
-    expect(screen.getByText(AnalyticsTablesI18nKey.GrainKey)).toBeInTheDocument();
-    expect(screen.getByText('order_id')).toBeInTheDocument();
-    expect(screen.queryByText(AnalyticsTablesI18nKey.OrderingKey)).not.toBeInTheDocument();
-  });
-
-  // The summary is where a key is read rather than chosen, so it carries the same explanations the draft
-  // surface does — minus the group note, whose point is that the values can still be set.
-  test('an active source table explains every summarized key', () => {
-    render(
-      <TableDetailView
-        name="dial_usage_log"
-        initialTable={table({
-          ordering_key: ['event_id'],
-          partition_by: { column: 'request_time', granularity: PartitionGranularity.Day },
-          identity_column: 'event_id',
-          version_column: 'request_time',
-        })}
-        apiBaseUrl=""
-        flightUri=""
-      />,
-    );
-
-    [
-      AnalyticsTablesI18nKey.OrderingKeyHint,
-      AnalyticsTablesI18nKey.PartitionColumnHint,
-      AnalyticsTablesI18nKey.GranularityHint,
-      AnalyticsTablesI18nKey.IdentityColumnHint,
-      AnalyticsTablesI18nKey.VersionColumnHint,
-    ].forEach((hint) => expect(screen.getByRole('button', { name: hint })).toBeInTheDocument());
-    expect(screen.queryByText(AnalyticsTablesI18nKey.KeysNote)).toBeNull();
-  });
-
-  test('an active enrichment table explains its grain key', () => {
-    render(
-      <TableDetailView
-        name="order_flags"
-        initialTable={table({
-          name: 'order_flags',
-          type: AnalyticsTableType.Enrichment,
-          source_table: 'orders',
-          grain: { grain_key: 'order_id' },
-        })}
-        apiBaseUrl=""
-        flightUri=""
-      />,
-    );
-
-    expect(screen.getByRole('button', { name: AnalyticsTablesI18nKey.GrainKeyHint })).toBeInTheDocument();
-    expect(screen.queryByText(AnalyticsTablesI18nKey.KeysNote)).toBeNull();
-  });
-
-  test('an active enrichment table names the source table it enriches', () => {
-    render(
-      <TableDetailView
-        name="order_flags"
-        initialTable={table({
-          name: 'order_flags',
-          type: AnalyticsTableType.Enrichment,
-          source_table: 'orders',
-          grain: { grain_key: 'order_id' },
-        })}
-        apiBaseUrl=""
-        flightUri=""
-      />,
-    );
-
-    expect(screen.getByText(AnalyticsTablesI18nKey.SourceTable)).toBeInTheDocument();
-    expect(screen.getByText('orders')).toBeInTheDocument();
-  });
-
-  test('a draft enrichment table names its source table and shows no grain key', () => {
-    render(
-      <TableDetailView
-        name="order_flags"
-        initialTable={table({
-          name: 'order_flags',
-          type: AnalyticsTableType.Enrichment,
-          status: TableStatus.Pending,
-          source_table: 'orders',
-        })}
-        apiBaseUrl=""
-        flightUri=""
-      />,
-    );
-
-    expect(screen.getByText(AnalyticsTablesI18nKey.SourceTable)).toBeInTheDocument();
-    expect(screen.getByText('orders')).toBeInTheDocument();
-    expect(screen.queryByText(AnalyticsTablesI18nKey.GrainKey)).not.toBeInTheDocument();
-  });
-
-  test('a source table shows no source-table value, since it enriches nothing', () => {
-    render(
-      <TableDetailView
-        name="dial_usage_log"
-        initialTable={table({ ordering_key: ['event_id'] })}
-        apiBaseUrl=""
-        flightUri=""
-      />,
-    );
-
-    expect(screen.queryByText(AnalyticsTablesI18nKey.SourceTable)).not.toBeInTheDocument();
-  });
-
   test('an active enrichment table pins its grain key as a read-only row atop the columns grid', () => {
     render(
       <TableDetailView
@@ -599,19 +388,6 @@ describe('TableDetailView schema metadata', () => {
     render(<TableDetailView name="dial_usage_log" initialTable={table()} apiBaseUrl="" flightUri="" />);
 
     expect(screen.getByText('pinned: none')).toBeInTheDocument();
-  });
-
-  test('a PENDING table does not show the read-only metadata row (the draft editor covers it)', () => {
-    render(
-      <TableDetailView
-        name="dial_usage_log"
-        initialTable={table({ status: TableStatus.Pending, ordering_key: ['event_id'] })}
-        apiBaseUrl=""
-        flightUri=""
-      />,
-    );
-
-    expect(screen.queryByText(AnalyticsTablesI18nKey.OrderingKey)).not.toBeInTheDocument();
   });
 });
 
@@ -930,5 +706,105 @@ describe('TableDetailView scan-metadata column guards', () => {
     );
 
     expect(screen.getByRole('button', { name: `event_id:${ActionMenuOperationI18nKey.Delete}` })).toBeInTheDocument();
+  });
+});
+
+describe('TableDetailView tabs', () => {
+  const renderView = (overrides: Partial<AnalyticsTable> = {}) =>
+    render(<TableDetailView name="dial_usage_log" initialTable={table(overrides)} apiBaseUrl="" flightUri="" />);
+
+  test('opens an ACTIVE table with Properties selected and the columns grid beneath the strip', () => {
+    renderView({ status: TableStatus.Active });
+
+    expect(screen.getByRole('tab', { name: TabsI18nKey.Properties })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: TabsI18nKey.Audit })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { selected: true })).toHaveTextContent(TabsI18nKey.Properties);
+    expect(screen.getByText(/^columns:/)).toBeInTheDocument();
+    expect(screen.queryByText('table-audit')).not.toBeInTheDocument();
+  });
+
+  // A table that was never materialized has no audit history to show, so the tab is not offered at all
+  // rather than offered empty — and the unmounted TableAudit is what "no activity request" means here.
+  test('renders no tab strip, no Audit tab and no activity request on a PENDING table', () => {
+    renderView({ status: TableStatus.Pending });
+
+    expect(screen.queryByRole('tab')).not.toBeInTheDocument();
+    expect(screen.queryByRole('tab', { name: TabsI18nKey.Audit })).not.toBeInTheDocument();
+    expect(screen.queryByText('table-audit')).not.toBeInTheDocument();
+    expect(auditPropsSpy).not.toHaveBeenCalled();
+    // The draft schema editor is the whole body instead, directly beneath the header.
+    expect(screen.getByText('draft-schema-editor')).toBeInTheDocument();
+  });
+
+  // The gate is `isActive`, not `!isPending`: a table whose materialization failed, and one whose status
+  // the backend does not report, have no more history than one that never started.
+  test.each([TableStatus.Failed, undefined])('renders no tab strip for the %s status either', (status) => {
+    renderView({ status });
+
+    expect(screen.queryByRole('tab')).not.toBeInTheDocument();
+    expect(auditPropsSpy).not.toHaveBeenCalled();
+    expect(screen.getByText('draft-schema-editor')).toBeInTheDocument();
+  });
+
+  test('keeps the header and every permitted header action above the tab strip while Audit is selected', async () => {
+    const user = userEvent.setup();
+    renderView({ status: TableStatus.Active, description: 'Raw usage events.' });
+
+    await user.click(screen.getByRole('tab', { name: TabsI18nKey.Audit }));
+
+    const propertiesTab = screen.getByRole('tab', { name: TabsI18nKey.Properties });
+    [
+      AnalyticsTablesI18nKey.ManageAccess,
+      AnalyticsTablesI18nKey.DeleteTable,
+      AnalyticsTablesI18nKey.AddColumns,
+      AnalyticsTablesI18nKey.AddRows,
+      AnalyticsTablesI18nKey.Connect,
+    ].forEach((label) => {
+      const action = screen.getByRole('button', { name: label });
+      // The action precedes the tab strip in document order — i.e. it is rendered above it, not inside
+      // the Properties tab.
+      expect(action.compareDocumentPosition(propertiesTab) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    });
+    expect(screen.getByRole('heading', { name: 'dial_usage_log' })).toBeInTheDocument();
+    expect(screen.getByText(AnalyticsTablesI18nKey.StatusActive)).toBeInTheDocument();
+    expect(screen.getByText(AnalyticsTablesI18nKey.TypeSource)).toBeInTheDocument();
+    expect(screen.getByText('Raw usage events.')).toBeInTheDocument();
+  });
+
+  test('shows the activities list for the table when the Audit tab is selected on an ACTIVE table', async () => {
+    const user = userEvent.setup();
+    renderView({ status: TableStatus.Active });
+
+    await user.click(screen.getByRole('tab', { name: TabsI18nKey.Audit }));
+
+    expect(screen.getByRole('tab', { selected: true })).toHaveTextContent(TabsI18nKey.Audit);
+    expect(screen.getByText('table-audit')).toBeInTheDocument();
+    expect(auditPropsSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ table: expect.objectContaining({ name: 'dial_usage_log' }) }),
+    );
+    expect(screen.queryByText(/^columns:/)).not.toBeInTheDocument();
+  });
+
+  test('offers the Audit tab on an ACTIVE table to a viewer who can neither write nor modify it', async () => {
+    const user = userEvent.setup();
+    setPerms({});
+    renderView({ status: TableStatus.Active });
+
+    await user.click(screen.getByRole('tab', { name: TabsI18nKey.Audit }));
+
+    expect(screen.getByText('table-audit')).toBeInTheDocument();
+  });
+
+  // The table is ACTIVE, so the flag alone decides.
+  test('renders no tab strip, no Audit tab and no activity request when analytics is disabled', () => {
+    featureFlags.analyticsEnabled = false;
+    renderView({ status: TableStatus.Active });
+
+    expect(screen.queryByRole('tab')).not.toBeInTheDocument();
+    expect(screen.queryByRole('tab', { name: TabsI18nKey.Audit })).not.toBeInTheDocument();
+    expect(screen.queryByText('table-audit')).not.toBeInTheDocument();
+    expect(auditPropsSpy).not.toHaveBeenCalled();
+    // The Properties body is the whole view instead.
+    expect(screen.getByText(/^columns:/)).toBeInTheDocument();
   });
 });

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/tests/TableProperties.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/tests/TableProperties.spec.tsx
@@ -1,0 +1,331 @@
+import { ComponentProps } from 'react';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test, vi } from 'vitest';
+
+import TableProperties from '@/src/components/Analytics/Tables/TableProperties';
+import { useDraftSchemaForm } from '@/src/components/Analytics/Tables/use-draft-schema-form';
+import { AnalyticsTablesI18nKey } from '@/src/constants/i18n';
+import { AnalyticsFieldType } from '@/src/models/analytics/entity';
+import { AnalyticsTable, AnalyticsTableType, PartitionGranularity, TableStatus } from '@/src/models/analytics/table';
+
+// Mock the ellipsis tooltip so labelled values are plain, assertable text.
+vi.mock('@epam/ai-dial-ui-kit', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@epam/ai-dial-ui-kit')>();
+  return {
+    ...actual,
+    DialEllipsisTooltip: ({ text }: { text: string }) => <span>{text}</span>,
+  };
+});
+
+// Exposes the parts of the grid contract TableProperties owns: the header set, the row data, the pinned
+// row, whether the name cell is editable and the action column is present, and a trigger for the
+// cell-value-changed handler that carries the inline rename.
+vi.mock('@/src/components/Grid/GridView/GridView', () => ({
+  default: ({
+    rowData,
+    columnDefs,
+    additionalGridOptions,
+  }: {
+    rowData?: { name: string }[];
+    columnDefs?: {
+      headerName?: string;
+      editable?: (params: { node: { rowPinned: string | null } }) => boolean;
+      cellRendererParams?: { items?: unknown[] };
+    }[];
+    additionalGridOptions?: {
+      pinnedTopRowData?: { name: string; type: string; tag?: string }[];
+      onCellValueChanged?: (event: { colDef: { field: string }; oldValue: string; newValue: string }) => void;
+    };
+  }) => {
+    const nameColumn = columnDefs?.[0];
+    const onCellValueChanged = additionalGridOptions?.onCellValueChanged;
+    return (
+      <div>
+        <div>headers: {columnDefs?.map((c) => c.headerName).join('|')}</div>
+        <div>columns: {rowData?.length ?? 0}</div>
+        <div>pinned: {additionalGridOptions?.pinnedTopRowData?.map((r) => r.name).join('|') ?? 'none'}</div>
+        <div>name editable: {String(Boolean(nameColumn?.editable?.({ node: { rowPinned: null } })))}</div>
+        <div>action column: {String(columnDefs?.some((c) => !!c.cellRendererParams?.items))}</div>
+        <button
+          onClick={() => onCellValueChanged?.({ colDef: { field: 'name' }, oldValue: 'total', newValue: 'total_usd' })}
+        >
+          commit name edit
+        </button>
+        <button onClick={() => onCellValueChanged?.({ colDef: { field: 'tag' }, oldValue: 'old', newValue: 'new' })}>
+          commit tag edit
+        </button>
+      </div>
+    );
+  },
+}));
+
+// The draft-schema surface's own behavior (completeness gating, column/key controls) is covered in
+// DraftSchemaEditor.spec.tsx; here we only assert TableProperties renders it for a non-active table.
+vi.mock('@/src/components/Analytics/Tables/DraftSchemaEditor', () => ({
+  default: () => <div>draft-schema-editor</div>,
+}));
+
+const table = (overrides: Partial<AnalyticsTable> = {}): AnalyticsTable => ({
+  name: 'dial_usage_log',
+  type: AnalyticsTableType.Source,
+  status: TableStatus.Active,
+  columns: [],
+  ...overrides,
+});
+
+// TableProperties only forwards `draft` to the mocked DraftSchemaEditor, so a bare stub is enough here;
+// the form's own behavior is covered by use-draft-schema-form's and DraftSchemaEditor's specs.
+const draftStub = {} as ReturnType<typeof useDraftSchemaForm>;
+
+const renderProperties = (tbl: AnalyticsTable, props?: Partial<ComponentProps<typeof TableProperties>>) =>
+  render(
+    <TableProperties
+      table={tbl}
+      grainKeyRow={null}
+      draft={draftStub}
+      actions={[]}
+      canModify
+      onRenameCell={vi.fn()}
+      {...props}
+    />,
+  );
+
+describe('TableProperties columns grid', () => {
+  test('the grid includes Display name and Description columns', () => {
+    renderProperties(table());
+
+    const headers = screen.getByText(/^headers:/);
+    expect(headers).toHaveTextContent(AnalyticsTablesI18nKey.DisplayName);
+    expect(headers).toHaveTextContent(AnalyticsTablesI18nKey.Description);
+  });
+
+  test('pins the grain-key row it is given atop the grid', () => {
+    renderProperties(table({ name: 'order_flags', type: AnalyticsTableType.Enrichment, source_table: 'orders' }), {
+      grainKeyRow: { source_name: 'order_id', name: 'order_id', type: AnalyticsFieldType.Uuid },
+    });
+
+    expect(screen.getByText('pinned: order_id')).toBeInTheDocument();
+  });
+
+  test('offers an editable name cell and the action column to a viewer who may modify the table', () => {
+    renderProperties(table());
+
+    expect(screen.getByText('name editable: true')).toBeInTheDocument();
+    expect(screen.getByText('action column: true')).toBeInTheDocument();
+  });
+
+  test('offers neither an editable name cell nor the action column to a viewer who may not modify it', () => {
+    renderProperties(table(), { canModify: false });
+
+    expect(screen.getByText('name editable: false')).toBeInTheDocument();
+    expect(screen.getByText('action column: false')).toBeInTheDocument();
+  });
+
+  test('reports an inline name edit as a rename of the old value to the new one', async () => {
+    const user = userEvent.setup();
+    const onRenameCell = vi.fn();
+    renderProperties(table(), { onRenameCell });
+
+    await user.click(screen.getByRole('button', { name: 'commit name edit' }));
+
+    expect(onRenameCell).toHaveBeenCalledOnce();
+    expect(onRenameCell).toHaveBeenCalledWith('total', 'total_usd');
+  });
+
+  test('reports no rename when a cell other than the name is edited', async () => {
+    const user = userEvent.setup();
+    const onRenameCell = vi.fn();
+    renderProperties(table(), { onRenameCell });
+
+    await user.click(screen.getByRole('button', { name: 'commit tag edit' }));
+
+    expect(onRenameCell).not.toHaveBeenCalled();
+  });
+});
+
+describe('TableProperties schema metadata', () => {
+  test('an active source table shows its ordering key, partition column, and granularity', () => {
+    renderProperties(
+      table({
+        ordering_key: ['event_id', 'request_time'],
+        partition_by: { column: 'request_time', granularity: PartitionGranularity.Day },
+      }),
+    );
+
+    expect(screen.getByText(AnalyticsTablesI18nKey.OrderingKey)).toBeInTheDocument();
+    expect(screen.getByText('event_id, request_time')).toBeInTheDocument();
+    expect(screen.getByText(AnalyticsTablesI18nKey.PartitionColumn)).toBeInTheDocument();
+    expect(screen.getByText('request_time')).toBeInTheDocument();
+    expect(screen.getByText(AnalyticsTablesI18nKey.Granularity)).toBeInTheDocument();
+    expect(screen.getByText('Day')).toBeInTheDocument();
+  });
+
+  test('an active source table with no partition hides partition column and granularity', () => {
+    renderProperties(table({ ordering_key: ['event_id'] }));
+
+    expect(screen.getByText(AnalyticsTablesI18nKey.OrderingKey)).toBeInTheDocument();
+    expect(screen.queryByText(AnalyticsTablesI18nKey.PartitionColumn)).not.toBeInTheDocument();
+    expect(screen.queryByText(AnalyticsTablesI18nKey.Granularity)).not.toBeInTheDocument();
+  });
+
+  test('an active source table shows its declared scan-metadata pair', () => {
+    renderProperties(
+      table({
+        // Distinct from both pair values so each assertion below matches exactly one node.
+        ordering_key: ['total'],
+        identity_column: 'event_id',
+        version_column: 'request_time',
+      }),
+    );
+
+    expect(screen.getByText(AnalyticsTablesI18nKey.IdentityColumn)).toBeInTheDocument();
+    expect(screen.getByText('event_id')).toBeInTheDocument();
+    expect(screen.getByText(AnalyticsTablesI18nKey.VersionColumn)).toBeInTheDocument();
+    expect(screen.getByText('request_time')).toBeInTheDocument();
+  });
+
+  test('a source declaring no scan metadata shows neither label and no substitute message', () => {
+    renderProperties(table({ ordering_key: ['event_id'] }));
+
+    expect(screen.queryByText(AnalyticsTablesI18nKey.IdentityColumn)).not.toBeInTheDocument();
+    expect(screen.queryByText(AnalyticsTablesI18nKey.VersionColumn)).not.toBeInTheDocument();
+  });
+
+  test('a source declaring only one member shows that one and omits the other', () => {
+    renderProperties(table({ ordering_key: ['event_id'], version_column: 'request_time' }));
+
+    expect(screen.getByText(AnalyticsTablesI18nKey.VersionColumn)).toBeInTheDocument();
+    expect(screen.queryByText(AnalyticsTablesI18nKey.IdentityColumn)).not.toBeInTheDocument();
+  });
+
+  test('a system scan-metadata column absent from the columns grid still renders in the summary', () => {
+    renderProperties(
+      table({
+        ordering_key: ['event_id'],
+        identity_column: 'event_id',
+        // A `_`-prefixed system column: legitimately not among `columns`.
+        version_column: '_ingested_at',
+        columns: [{ source_name: 'event_id', name: 'event_id', type: AnalyticsFieldType.Uuid }],
+      }),
+    );
+
+    expect(screen.getByText('_ingested_at')).toBeInTheDocument();
+    expect(screen.getByText('columns: 1')).toBeInTheDocument();
+  });
+
+  test('an active enrichment table shows its grain key', () => {
+    renderProperties(
+      table({
+        name: 'order_flags',
+        type: AnalyticsTableType.Enrichment,
+        source_table: 'orders',
+        grain: { grain_key: 'order_id' },
+      }),
+    );
+
+    expect(screen.getByText(AnalyticsTablesI18nKey.GrainKey)).toBeInTheDocument();
+    expect(screen.getByText('order_id')).toBeInTheDocument();
+    expect(screen.queryByText(AnalyticsTablesI18nKey.OrderingKey)).not.toBeInTheDocument();
+  });
+
+  // The summary is where a key is read rather than chosen, so it carries the same explanations the draft
+  // surface does — minus the group note, whose point is that the values can still be set.
+  test('an active source table explains every summarized key', () => {
+    renderProperties(
+      table({
+        ordering_key: ['event_id'],
+        partition_by: { column: 'request_time', granularity: PartitionGranularity.Day },
+        identity_column: 'event_id',
+        version_column: 'request_time',
+      }),
+    );
+
+    [
+      AnalyticsTablesI18nKey.OrderingKeyHint,
+      AnalyticsTablesI18nKey.PartitionColumnHint,
+      AnalyticsTablesI18nKey.GranularityHint,
+      AnalyticsTablesI18nKey.IdentityColumnHint,
+      AnalyticsTablesI18nKey.VersionColumnHint,
+    ].forEach((hint) => expect(screen.getByRole('button', { name: hint })).toBeInTheDocument());
+    expect(screen.queryByText(AnalyticsTablesI18nKey.KeysNote)).toBeNull();
+  });
+
+  test('an active enrichment table explains its grain key', () => {
+    renderProperties(
+      table({
+        name: 'order_flags',
+        type: AnalyticsTableType.Enrichment,
+        source_table: 'orders',
+        grain: { grain_key: 'order_id' },
+      }),
+    );
+
+    expect(screen.getByRole('button', { name: AnalyticsTablesI18nKey.GrainKeyHint })).toBeInTheDocument();
+    expect(screen.queryByText(AnalyticsTablesI18nKey.KeysNote)).toBeNull();
+  });
+
+  test('an active enrichment table names the source table it enriches', () => {
+    renderProperties(
+      table({
+        name: 'order_flags',
+        type: AnalyticsTableType.Enrichment,
+        source_table: 'orders',
+        grain: { grain_key: 'order_id' },
+      }),
+    );
+
+    expect(screen.getByText(AnalyticsTablesI18nKey.SourceTable)).toBeInTheDocument();
+    expect(screen.getByText('orders')).toBeInTheDocument();
+  });
+
+  test('a draft enrichment table names its source table and shows no grain key', () => {
+    renderProperties(
+      table({
+        name: 'order_flags',
+        type: AnalyticsTableType.Enrichment,
+        status: TableStatus.Pending,
+        source_table: 'orders',
+      }),
+    );
+
+    expect(screen.getByText(AnalyticsTablesI18nKey.SourceTable)).toBeInTheDocument();
+    expect(screen.getByText('orders')).toBeInTheDocument();
+    expect(screen.queryByText(AnalyticsTablesI18nKey.GrainKey)).not.toBeInTheDocument();
+  });
+
+  test('a source table shows no source-table value, since it enriches nothing', () => {
+    renderProperties(table({ ordering_key: ['event_id'] }));
+
+    expect(screen.queryByText(AnalyticsTablesI18nKey.SourceTable)).not.toBeInTheDocument();
+  });
+
+  test('a PENDING table does not show the read-only metadata row (the draft editor covers it)', () => {
+    renderProperties(table({ status: TableStatus.Pending, ordering_key: ['event_id'] }));
+
+    expect(screen.queryByText(AnalyticsTablesI18nKey.OrderingKey)).not.toBeInTheDocument();
+  });
+});
+
+describe('TableProperties lifecycle status', () => {
+  test('an ACTIVE table shows the columns grid rather than the draft editor', () => {
+    renderProperties(table({ status: TableStatus.Active }));
+
+    expect(screen.getByText(/^columns:/)).toBeInTheDocument();
+    expect(screen.queryByText('draft-schema-editor')).not.toBeInTheDocument();
+  });
+
+  test('a PENDING table shows the draft schema editor rather than the columns grid', () => {
+    renderProperties(table({ status: TableStatus.Pending }));
+
+    expect(screen.getByText('draft-schema-editor')).toBeInTheDocument();
+    expect(screen.queryByText(/^columns:/)).not.toBeInTheDocument();
+  });
+
+  test('a FAILED table also shows the draft schema editor', () => {
+    renderProperties(table({ status: TableStatus.Failed }));
+
+    expect(screen.getByText('draft-schema-editor')).toBeInTheDocument();
+  });
+});

--- a/apps/ai-dial-admin/src/constants/activity-audit.ts
+++ b/apps/ai-dial-admin/src/constants/activity-audit.ts
@@ -39,6 +39,7 @@ export const routeAuditResource: Partial<Record<ApplicationRoute, ActivityAuditR
   [ApplicationRoute.Routes]: ActivityAuditResourceType.ROUTE,
   [ApplicationRoute.InterceptorTemplates]: ActivityAuditResourceType.INTERCEPTOR_TEMPLATE,
   [ApplicationRoute.Toolsets]: ActivityAuditResourceType.TOOLSET,
+  [ApplicationRoute.AnalyticsTables]: ActivityAuditResourceType.TABLE,
 };
 
 export const CONTAINER_TYPE_TO_AUDIT: Record<CONTAINER_TYPE, ActivityAuditResourceType> = {

--- a/apps/ai-dial-admin/src/constants/grid-columns/formatters.ts
+++ b/apps/ai-dial-admin/src/constants/grid-columns/formatters.ts
@@ -43,6 +43,14 @@ export const getFormattedResourceType = (value: string, t: (key: string) => stri
       return t(EntitiesI18nKey.Image);
     case ActivityAuditResourceType.IMAGE_BUILD_DOMAIN_WHITELIST:
       return t(EntitiesI18nKey.GlobalFirewall);
+    case ActivityAuditResourceType.TABLE:
+      return t(EntitiesI18nKey.Table);
+    case ActivityAuditResourceType.TABLE_COLUMN:
+      return t(EntitiesI18nKey.AnalyticsTableColumn);
+    case ActivityAuditResourceType.PIPELINE:
+      return t(EntitiesI18nKey.AnalyticsPipeline);
+    case ActivityAuditResourceType.SAVED_QUERY:
+      return t(EntitiesI18nKey.AnalyticsSavedQuery);
   }
 
   return value;

--- a/apps/ai-dial-admin/src/constants/grid-columns/tests/formatters.spec.ts
+++ b/apps/ai-dial-admin/src/constants/grid-columns/tests/formatters.spec.ts
@@ -13,6 +13,7 @@ import {
   getTopics,
   numberValueFormatter,
   priceValueFormatter,
+  ResourceTypeLabelMap,
   sourceTypeFormatter,
   sourceValueFormatter,
   toNumberOrNull,
@@ -21,6 +22,7 @@ import { ActivityAuditResourceType } from '@/src/types/activity-audit';
 import { SOURCE_FIELD, SOURCE_TYPE } from '@/src/components/SourceField/types';
 import { ApplicationRoute } from '@/src/types/routes';
 import { AttachmentsI18nKey, BasicI18nKey, EntitiesI18nKey, MenuI18nKey, SourceI18nKey } from '@/src/constants/i18n';
+import en from '@/src/locales/en';
 
 const t = (s: string) => s;
 
@@ -99,6 +101,26 @@ describe('Formatters :: getFormattedResourceType', () => {
     const res = getFormattedResourceType(ActivityAuditResourceType.IMAGE_BUILD_DOMAIN_WHITELIST, t);
     expect(res).toBe(EntitiesI18nKey.GlobalFirewall);
   });
+
+  test('returns the Table label for the analytics Table resource type', () => {
+    expect(getFormattedResourceType(ActivityAuditResourceType.TABLE, t)).toBe(EntitiesI18nKey.Table);
+  });
+
+  test('returns the Table column label for the analytics TableColumn resource type', () => {
+    expect(getFormattedResourceType(ActivityAuditResourceType.TABLE_COLUMN, t)).toBe(
+      EntitiesI18nKey.AnalyticsTableColumn,
+    );
+  });
+
+  test('returns the Pipeline label for the analytics Pipeline resource type', () => {
+    expect(getFormattedResourceType(ActivityAuditResourceType.PIPELINE, t)).toBe(EntitiesI18nKey.AnalyticsPipeline);
+  });
+
+  test('returns the Saved query label for the analytics SavedQuery resource type', () => {
+    expect(getFormattedResourceType(ActivityAuditResourceType.SAVED_QUERY, t)).toBe(
+      EntitiesI18nKey.AnalyticsSavedQuery,
+    );
+  });
 });
 
 describe('Formatters :: buildResourceTypeLabelMap', () => {
@@ -140,6 +162,118 @@ describe('Formatters :: buildResourceTypeLabelMap', () => {
     const map = buildResourceTypeLabelMap(altT);
 
     expect(map[`xx:${EntitiesI18nKey.GlobalFirewall}`.toLowerCase()]).toEqual([
+      ActivityAuditResourceType.IMAGE_BUILD_DOMAIN_WHITELIST,
+    ]);
+  });
+});
+
+type LocaleNode = string | { [key: string]: LocaleNode };
+
+/**
+ * The label map's collision risk lives in the rendered English labels, not in the i18n keys: with the
+ * identity `t` used above, every label is a distinct key and no collision can be observed. This block
+ * therefore resolves keys through the shipped dictionary, and throws on a key it cannot find, so a
+ * label whose key is missing from `en.ts` fails here rather than being silently pinned to the key.
+ */
+const translateWithEnDictionary = (key: string): string => {
+  let node: LocaleNode | undefined = en as LocaleNode;
+  for (const part of key.split('.')) {
+    node = typeof node === 'object' ? node[part] : void 0;
+  }
+  if (typeof node !== 'string') {
+    throw new Error(`Missing en locale entry for "${key}"`);
+  }
+  return node;
+};
+
+/**
+ * Mirrors `expandResourceTypeFilter` (`ActivityAudit/List/utils.tsx`), which narrows a `contains`
+ * needle to `equals` only while exactly one enum member matches. Duplicated rather than imported so
+ * that this spec stays within the constants layer; the filter transform keeps its own tests.
+ */
+const resolveNeedleToTypes = (map: ResourceTypeLabelMap, needle: string): ActivityAuditResourceType[] => {
+  const lowered = needle.toLowerCase();
+  const matched = new Set<ActivityAuditResourceType>();
+  for (const [label, types] of Object.entries(map)) {
+    if (label.includes(lowered)) {
+      for (const type of types) {
+        matched.add(type);
+      }
+    }
+  }
+  return [...matched];
+};
+
+describe('Formatters :: buildResourceTypeLabelMap — analytics additions guard', () => {
+  const labelOf = (key: EntitiesI18nKey) => translateWithEnDictionary(key).toLowerCase();
+  const buildMap = () => buildResourceTypeLabelMap(translateWithEnDictionary);
+
+  test('renders the guarded labels from the shipped en dictionary', () => {
+    expect(translateWithEnDictionary(EntitiesI18nKey.GlobalFirewall)).toBe('Global firewall');
+    expect(translateWithEnDictionary(EntitiesI18nKey.Image)).toBe('Image');
+    expect(translateWithEnDictionary(EntitiesI18nKey.ModelServingLabel)).toBe('Model serving');
+    expect(translateWithEnDictionary(EntitiesI18nKey.AdapterContainer)).toBe('Adapter container');
+    expect(translateWithEnDictionary(EntitiesI18nKey.ApplicationContainer)).toBe('Application container');
+    expect(translateWithEnDictionary(EntitiesI18nKey.InterceptorContainer)).toBe('Interceptor container');
+    expect(translateWithEnDictionary(EntitiesI18nKey.McpContainer)).toBe('MCP container');
+    expect(translateWithEnDictionary(EntitiesI18nKey.Table)).toBe('Table');
+    expect(translateWithEnDictionary(EntitiesI18nKey.AnalyticsTableColumn)).toBe('Table column');
+    expect(translateWithEnDictionary(EntitiesI18nKey.AnalyticsPipeline)).toBe('Pipeline');
+    expect(translateWithEnDictionary(EntitiesI18nKey.AnalyticsSavedQuery)).toBe('Saved query');
+  });
+
+  test('still resolves the global firewall label to exactly ImageBuildDomainWhitelist', () => {
+    expect(buildMap()[labelOf(EntitiesI18nKey.GlobalFirewall)]).toEqual([
+      ActivityAuditResourceType.IMAGE_BUILD_DOMAIN_WHITELIST,
+    ]);
+  });
+
+  test('still resolves the image label to exactly the four image definition types', () => {
+    expect(new Set(buildMap()[labelOf(EntitiesI18nKey.Image)])).toEqual(
+      new Set([
+        ActivityAuditResourceType.ADAPTER_IMAGE_DEFINITION,
+        ActivityAuditResourceType.APPLICATION_IMAGE_DEFINITION,
+        ActivityAuditResourceType.INTERCEPTOR_IMAGE_DEFINITION,
+        ActivityAuditResourceType.MCP_IMAGE_DEFINITION,
+      ]),
+    );
+  });
+
+  test('still resolves the model serving label to exactly NimDeployment and InferenceDeployment', () => {
+    expect(new Set(buildMap()[labelOf(EntitiesI18nKey.ModelServingLabel)])).toEqual(
+      new Set([ActivityAuditResourceType.NIM_DEPLOYMENT, ActivityAuditResourceType.INFERENCE_DEPLOYMENT]),
+    );
+  });
+
+  test('still resolves each container label to exactly one deployment type', () => {
+    const map = buildMap();
+
+    expect(map[labelOf(EntitiesI18nKey.AdapterContainer)]).toEqual([ActivityAuditResourceType.ADAPTER_DEPLOYMENT]);
+    expect(map[labelOf(EntitiesI18nKey.ApplicationContainer)]).toEqual([
+      ActivityAuditResourceType.APPLICATION_DEPLOYMENT,
+    ]);
+    expect(map[labelOf(EntitiesI18nKey.InterceptorContainer)]).toEqual([
+      ActivityAuditResourceType.INTERCEPTOR_DEPLOYMENT,
+    ]);
+    expect(map[labelOf(EntitiesI18nKey.McpContainer)]).toEqual([ActivityAuditResourceType.MCP_DEPLOYMENT]);
+  });
+
+  test('gives each analytics type a label of its own, equal to no pre-existing label', () => {
+    const map = buildMap();
+
+    expect(map[labelOf(EntitiesI18nKey.Table)]).toEqual([ActivityAuditResourceType.TABLE]);
+    expect(map[labelOf(EntitiesI18nKey.AnalyticsTableColumn)]).toEqual([ActivityAuditResourceType.TABLE_COLUMN]);
+    expect(map[labelOf(EntitiesI18nKey.AnalyticsPipeline)]).toEqual([ActivityAuditResourceType.PIPELINE]);
+    expect(map[labelOf(EntitiesI18nKey.AnalyticsSavedQuery)]).toEqual([ActivityAuditResourceType.SAVED_QUERY]);
+  });
+
+  test('keeps the Global Firewall audit shortcut narrowing to one type', () => {
+    const shortcutNeedle = getFormattedResourceType(
+      ActivityAuditResourceType.IMAGE_BUILD_DOMAIN_WHITELIST,
+      translateWithEnDictionary,
+    );
+
+    expect(resolveNeedleToTypes(buildMap(), shortcutNeedle)).toEqual([
       ActivityAuditResourceType.IMAGE_BUILD_DOMAIN_WHITELIST,
     ]);
   });

--- a/apps/ai-dial-admin/src/constants/i18n.ts
+++ b/apps/ai-dial-admin/src/constants/i18n.ts
@@ -251,6 +251,9 @@ export enum EntitiesI18nKey {
   SaveParametersTitle = 'Entities.SaveParametersTitle',
   SaveParametersDescription = 'Entities.SaveParametersDescription',
   Table = 'Entities.Table',
+  AnalyticsTableColumn = 'Entities.AnalyticsTableColumn',
+  AnalyticsPipeline = 'Entities.AnalyticsPipeline',
+  AnalyticsSavedQuery = 'Entities.AnalyticsSavedQuery',
   Form = 'Entities.Form',
   Ui = 'Entities.Ui',
   NewVersion = 'Entities.NewVersion',
@@ -783,6 +786,7 @@ export enum TelemetryI18nKey {
   Unknown = 'Telemetry.Unknown',
   ActivityViewConfig = 'Telemetry.ActivityView.Config',
   ActivityViewDeployments = 'Telemetry.ActivityView.Deployments',
+  ActivityViewAnalytics = 'Telemetry.ActivityView.Analytics',
 }
 
 export enum RoutesI18nKey {
@@ -862,6 +866,10 @@ export enum CompareI18nKey {
   After = 'Compare.After',
   CompareVersions = 'Compare.CompareVersions',
   Version = 'Compare.Version',
+  Added = 'Compare.Added',
+  Removed = 'Compare.Removed',
+  Changed = 'Compare.Changed',
+  ColumnGroup = 'Compare.ColumnGroup',
 }
 
 export enum PromptsI18nKey {
@@ -1012,6 +1020,7 @@ export enum ActivityAuditI18nKey {
   ActivityType = 'ActivityAudit.ActivityType',
   ResourceType = 'ActivityAudit.ResourceType',
   ResourceId = 'ActivityAudit.ResourceId',
+  OpenResourceInNewTab = 'ActivityAudit.OpenResourceInNewTab',
   Time = 'ActivityAudit.Time',
   Initiated = 'ActivityAudit.Initiated',
   UserId = 'ActivityAudit.UserId',

--- a/apps/ai-dial-admin/src/locales/en.ts
+++ b/apps/ai-dial-admin/src/locales/en.ts
@@ -264,6 +264,9 @@ export default {
     Runner: 'Runner',
     FolderStorage: 'Folder Storage',
     Table: 'Table',
+    AnalyticsTableColumn: 'Table column',
+    AnalyticsPipeline: 'Pipeline',
+    AnalyticsSavedQuery: 'Saved query',
     Form: 'Generated form',
     Ui: 'Application custom UI',
     NewVersion: 'New Version',
@@ -543,6 +546,10 @@ export default {
     After: 'After',
     CompareVersions: 'Compare versions',
     Version: 'Version',
+    Added: 'Added',
+    Removed: 'Removed',
+    Changed: 'Changed',
+    ColumnGroup: 'Column {name}',
   },
   UpstreamEndpoints: {
     Upstream: 'Upstream',
@@ -800,6 +807,7 @@ export default {
     ActivityView: {
       Config: 'Config',
       Deployments: 'Deployments',
+      Analytics: 'Analytics',
     },
   },
   Routes: {
@@ -1052,6 +1060,7 @@ export default {
     ActivityType: 'Activity type',
     ResourceType: 'Resource type',
     ResourceId: 'Resource Identifier',
+    OpenResourceInNewTab: 'Open resource in a new tab',
     Time: 'Time',
     Initiated: 'Initiated',
     UserId: 'User ID',

--- a/apps/ai-dial-admin/src/models/activity-audit.ts
+++ b/apps/ai-dial-admin/src/models/activity-audit.ts
@@ -1,5 +1,6 @@
 import { Token } from '@/src/models/auth';
 import { FilterDto, SortDto } from '@/src/models/request';
+import { ServerActionResponse } from '@/src/models/server-action';
 import {
   ActivityAuditEntity,
   ActivityAuditResourceType,
@@ -43,6 +44,16 @@ export interface FlatRow {
 export interface ActivityAuditDiffSection {
   current: ActivityAuditDiff[];
   compare: ActivityAuditDiff[];
+  label?: string;
+  diffStatus?: DiffStatus;
+}
+
+export interface ActivityAuditDiffGroup {
+  index: number;
+  currentData?: ActivityAuditDiff[];
+  compareData?: ActivityAuditDiff[];
+  label?: string;
+  diffStatus?: DiffStatus;
 }
 
 export type ActivityAuditSection = Record<string, ActivityAuditDiffSection[]>;
@@ -73,7 +84,7 @@ export type ImageSourceShape = Record<string, unknown> & {
 };
 
 // Resolver bundle picked by `pickActivityHandlers` per activity branch
-// (admin / image / firewall / container).
+// (admin / image / firewall / container / analytics).
 export interface ResolverHandlers {
   filter: (activity: DialActivity) => FilterDto[];
   fetchSnapshot: (activity: DialActivity, revision: number, token: Token) => Promise<ActivityAuditEntity | null>;
@@ -83,6 +94,16 @@ export interface ResolverHandlers {
 // Duck types for the API instances the resolver factories consume.
 export interface RevisionApi {
   getRevisionDetails: (url: string, token: Token) => Promise<ActivityAuditEntity | null>;
+}
+
+// One backend of the detail page's activity fallback chain. `backend` and `route` carry no
+// behaviour: they exist so a probe that *rejects* — an upstream that is down, or whose host
+// variable is unset — can be named in the log, which is the only place it is distinguishable from
+// the backend simply not owning the activity.
+export interface ActivityLookupSource {
+  backend: string;
+  route: string;
+  getActivityById: (id: string, token: Token) => Promise<ServerActionResponse<DialActivity> | null>;
 }
 
 export interface ListApi {

--- a/apps/ai-dial-admin/src/server/analytics/audit-api.ts
+++ b/apps/ai-dial-admin/src/server/analytics/audit-api.ts
@@ -1,0 +1,40 @@
+import { DialActivity } from '@/src/models/activity-audit';
+import { Token } from '@/src/models/auth';
+import { AuditPageData, FilterDto, SortDto } from '@/src/models/request';
+import { ServerActionResponse } from '@/src/models/server-action';
+import { ActivityAuditEntity } from '@/src/types/activity-audit';
+import { BaseApi } from '@/src/server/base-api';
+
+// The analytics service exposes its routes under a bare `v1/` prefix, unlike the admin and
+// deployment-manager backends' `api/v1/` — see `analytics-data-api.ts`, which uses the same prefix.
+export const ANALYTICS_API = 'v1';
+export const ANALYTICS_ACTIVITIES_URL = `${ANALYTICS_API}/activities`;
+
+export class AnalyticsAuditApi extends BaseApi {
+  getActivitiesList(
+    pageSize: number,
+    pageNumber: number,
+    token: Token,
+    sorts: SortDto[],
+    filters: FilterDto[],
+  ): Promise<AuditPageData<DialActivity> | null> {
+    return this.post(
+      ANALYTICS_ACTIVITIES_URL,
+      {
+        pageSize,
+        pageNumber,
+        sorts,
+        filters,
+      },
+      token,
+    );
+  }
+
+  getActivityById(id: string, token: Token): Promise<ServerActionResponse<DialActivity>> {
+    return this.getAction(`${ANALYTICS_ACTIVITIES_URL}/${id}`, token);
+  }
+
+  getRevisionDetails(url: string, token: Token): Promise<ActivityAuditEntity | null> {
+    return this.get(`${ANALYTICS_API}${url}`, token);
+  }
+}

--- a/apps/ai-dial-admin/src/server/analytics/tests/audit-api.spec.ts
+++ b/apps/ai-dial-admin/src/server/analytics/tests/audit-api.spec.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import createFetchMock from 'vitest-fetch-mock';
+
+import { DialActivity } from '@/src/models/activity-audit';
+import { AuditPageData, FilterDto, SortDto } from '@/src/models/request';
+import { ActivityAuditEntity } from '@/src/types/activity-audit';
+import { FilterOperatorDto, SortDirectionDto } from '@/src/types/request';
+import { ANALYTICS_ACTIVITIES_URL, AnalyticsAuditApi } from '@/src/server/analytics/audit-api';
+import { TEST_URL, TOKEN_MOCK } from '@/src/utils/tests/mock/api.mock';
+
+const fetch = createFetchMock(vi);
+fetch.enableMocks();
+
+const JSON_HEADERS = { headers: { 'content-type': 'application/json' } };
+
+describe('Server :: AnalyticsAuditApi', () => {
+  const instance = new AnalyticsAuditApi({ host: TEST_URL });
+
+  const activity = { activityId: 'abc-123', resourceType: 'TableColumn', resourceId: 'orders:total' } as DialActivity;
+  const page: AuditPageData<DialActivity> = { total: 1, totalPages: 1, data: [activity] };
+
+  const sorts: SortDto[] = [{ column: 'epochTimestampMs', direction: SortDirectionDto.DESC }];
+  const filters: FilterDto[] = [{ column: 'resourceType', operator: FilterOperatorDto.EQUALS, value: 'Table' }];
+
+  beforeEach(() => {
+    fetch.resetMocks();
+  });
+
+  test('getActivitiesList issues POST v1/activities with the paging, sort and filter body', async () => {
+    fetch.mockResponseOnce(JSON.stringify(page), JSON_HEADERS);
+
+    await instance.getActivitiesList(25, 0, TOKEN_MOCK, sorts, filters);
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining(`/${ANALYTICS_ACTIVITIES_URL}`),
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ pageSize: 25, pageNumber: 0, sorts, filters }),
+      }),
+    );
+  });
+
+  test('getActivitiesList returns the parsed total, totalPages and data envelope', async () => {
+    fetch.mockResponseOnce(JSON.stringify(page), JSON_HEADERS);
+
+    const res = await instance.getActivitiesList(25, 0, TOKEN_MOCK, sorts, filters);
+
+    expect(res).toEqual(page);
+  });
+
+  test('getActivitiesList carries an incremented page number for a subsequent block', async () => {
+    fetch.mockResponseOnce(JSON.stringify({ total: 60, totalPages: 3, data: [activity] }), JSON_HEADERS);
+
+    await instance.getActivitiesList(25, 1, TOKEN_MOCK, sorts, filters);
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining(`/${ANALYTICS_ACTIVITIES_URL}`),
+      expect.objectContaining({
+        body: JSON.stringify({ pageSize: 25, pageNumber: 1, sorts, filters }),
+      }),
+    );
+  });
+
+  test('getActivitiesList returns null when the backend fails', async () => {
+    fetch.mockResponseOnce('', { status: 500 });
+
+    const res = await instance.getActivitiesList(25, 0, TOKEN_MOCK, sorts, filters);
+
+    expect(res).toBeNull();
+  });
+
+  test('getActivityById issues GET v1/activities/{id} and returns the activity', async () => {
+    fetch.mockResponseOnce(JSON.stringify(activity), JSON_HEADERS);
+
+    const res = await instance.getActivityById('abc-123', TOKEN_MOCK);
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining(`/${ANALYTICS_ACTIVITIES_URL}/abc-123`),
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(res.response).toEqual(activity);
+  });
+
+  test('getActivityById reports the failure rather than throwing when the activity is unknown', async () => {
+    fetch.mockResponseOnce('', { status: 404 });
+
+    const res = await instance.getActivityById('missing', TOKEN_MOCK);
+
+    expect(res.success).toBe(false);
+    expect(res.status).toBe(404);
+  });
+
+  // The service omits `initiatedEmail` and `parentActivityId` on a table-level activity, so the
+  // envelope must survive a partial `DialActivity` — the resolver treats a falsy `response` as
+  // "this backend does not own the activity" and moves on.
+  test('getActivityById returns the activity for a payload that carries no email or parent id', async () => {
+    const bare = {
+      activityId: 'abc-123',
+      activityType: 'Update',
+      resourceType: 'Table',
+      resourceId: 'orders',
+      epochTimestampMs: 1_700_000_000_000,
+      initiatedAuthor: 'unknown',
+      revision: 37,
+    };
+    fetch.mockResponseOnce(JSON.stringify(bare), JSON_HEADERS);
+
+    const res = await instance.getActivityById('abc-123', TOKEN_MOCK);
+
+    expect(res.success).toBe(true);
+    expect(res.response).toEqual(bare);
+  });
+
+  // An unreachable or unconfigured host does not answer `404` — it rejects. Pinned here because the
+  // detail-page resolver's fallback chain has to isolate that per backend, and this is the contract
+  // it isolates.
+  test('getActivityById rejects when the upstream cannot be reached', async () => {
+    fetch.mockRejectOnce(new TypeError('fetch failed'));
+
+    await expect(instance.getActivityById('abc-123', TOKEN_MOCK)).rejects.toThrow('fetch failed');
+  });
+
+  test('getRevisionDetails prefixes the revision route with the analytics v1 segment', async () => {
+    const snapshot = { name: 'orders' } as ActivityAuditEntity;
+    fetch.mockResponseOnce(JSON.stringify(snapshot), JSON_HEADERS);
+
+    const res = await instance.getRevisionDetails('/tables/orders/revision/7', TOKEN_MOCK);
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/v1/tables/orders/revision/7'),
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(res).toEqual(snapshot);
+  });
+
+  test('getRevisionDetails returns null for a snapshot the backend answers as absent', async () => {
+    fetch.mockResponseOnce('', { status: 404 });
+
+    const res = await instance.getRevisionDetails('/tables/orders/revision/1', TOKEN_MOCK);
+
+    expect(res).toBeNull();
+  });
+
+  test('getRevisionDetails rejects when the upstream cannot be reached', async () => {
+    fetch.mockRejectOnce(new TypeError('fetch failed'));
+
+    await expect(instance.getRevisionDetails('/tables/orders/revision/7', TOKEN_MOCK)).rejects.toThrow('fetch failed');
+  });
+});

--- a/apps/ai-dial-admin/src/types/activity-audit.ts
+++ b/apps/ai-dial-admin/src/types/activity-audit.ts
@@ -28,6 +28,7 @@ export enum ActivityAuditType {
 export enum ActivityAuditView {
   Config = 'Config',
   Deployments = 'Deployments',
+  Analytics = 'Analytics',
 }
 
 export enum ActivityAuditResourceType {
@@ -54,6 +55,10 @@ export enum ActivityAuditResourceType {
   INTERCEPTOR_IMAGE_DEFINITION = 'InterceptorImageDefinition',
   MCP_IMAGE_DEFINITION = 'McpImageDefinition',
   IMAGE_BUILD_DOMAIN_WHITELIST = 'ImageBuildDomainWhitelist',
+  TABLE = 'Table',
+  TABLE_COLUMN = 'TableColumn',
+  PIPELINE = 'Pipeline',
+  SAVED_QUERY = 'SavedQuery',
 }
 
 const IMAGE_DEFINITION_RESOURCE_TYPES = new Set<string>([
@@ -70,6 +75,13 @@ const CONTAINER_DEPLOYMENT_RESOURCE_TYPES = new Set<string>([
   ActivityAuditResourceType.MCP_DEPLOYMENT,
   ActivityAuditResourceType.NIM_DEPLOYMENT,
   ActivityAuditResourceType.INFERENCE_DEPLOYMENT,
+]);
+
+const ANALYTICS_RESOURCE_TYPES = new Set<string>([
+  ActivityAuditResourceType.TABLE,
+  ActivityAuditResourceType.TABLE_COLUMN,
+  ActivityAuditResourceType.PIPELINE,
+  ActivityAuditResourceType.SAVED_QUERY,
 ]);
 
 const DEPLOYMENT_MANAGER_RESOURCE_TYPES = new Set<string>([
@@ -89,3 +101,5 @@ export const isContainerDeploymentResource = (type?: string): boolean =>
 
 export const isDeploymentManagerResource = (type?: string): boolean =>
   !!type && DEPLOYMENT_MANAGER_RESOURCE_TYPES.has(type);
+
+export const isAnalyticsResource = (type?: string): boolean => !!type && ANALYTICS_RESOURCE_TYPES.has(type);

--- a/apps/ai-dial-admin/src/types/tests/activity-audit.spec.ts
+++ b/apps/ai-dial-admin/src/types/tests/activity-audit.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest';
 
 import {
   ActivityAuditResourceType,
+  isAnalyticsResource,
   isContainerDeploymentResource,
   isDeploymentManagerResource,
   isGlobalFirewallResource,
@@ -123,5 +124,51 @@ describe('activity-audit predicates :: isContainerDeploymentResource', () => {
 
   test('returns false for undefined', () => {
     expect(isContainerDeploymentResource(undefined)).toBe(false);
+  });
+});
+
+describe('activity-audit predicates :: isAnalyticsResource', () => {
+  const analyticsTypes = [
+    ActivityAuditResourceType.TABLE,
+    ActivityAuditResourceType.TABLE_COLUMN,
+    ActivityAuditResourceType.PIPELINE,
+    ActivityAuditResourceType.SAVED_QUERY,
+  ];
+
+  test.each(analyticsTypes)('returns true for %s', (type) => {
+    expect(isAnalyticsResource(type)).toBe(true);
+  });
+
+  test('covers the four PascalCase values the analytics backend emits', () => {
+    expect(analyticsTypes).toEqual(['Table', 'TableColumn', 'Pipeline', 'SavedQuery']);
+  });
+
+  test.each([
+    ActivityAuditResourceType.MODEL,
+    ActivityAuditResourceType.APPLICATION,
+    ActivityAuditResourceType.ROLE,
+    ActivityAuditResourceType.TOOLSET,
+  ])('returns false for admin-backend %s', (type) => {
+    expect(isAnalyticsResource(type)).toBe(false);
+  });
+
+  test.each([
+    ActivityAuditResourceType.MCP_DEPLOYMENT,
+    ActivityAuditResourceType.NIM_DEPLOYMENT,
+    ActivityAuditResourceType.MCP_IMAGE_DEFINITION,
+    ActivityAuditResourceType.IMAGE_BUILD_DOMAIN_WHITELIST,
+  ])('returns false for deployment-manager %s', (type) => {
+    expect(isAnalyticsResource(type)).toBe(false);
+  });
+
+  test('returns false for undefined', () => {
+    expect(isAnalyticsResource(undefined)).toBe(false);
+  });
+
+  test.each(analyticsTypes)('leaves the existing resource-set predicates answering false for %s', (type) => {
+    expect(isDeploymentManagerResource(type)).toBe(false);
+    expect(isContainerDeploymentResource(type)).toBe(false);
+    expect(isImageDefinitionResource(type)).toBe(false);
+    expect(isGlobalFirewallResource(type)).toBe(false);
   });
 });

--- a/apps/ai-dial-admin/src/utils/audit/analytics-resource-id.ts
+++ b/apps/ai-dial-admin/src/utils/audit/analytics-resource-id.ts
@@ -1,0 +1,49 @@
+/**
+ * The analytics backend names a column activity `<table>:<column>`, so `:` is the
+ * one separator inside an analytics resource identifier. A table, a pipeline and a
+ * saved query carry a bare name.
+ */
+const ANALYTICS_RESOURCE_ID_SEPARATOR = ':';
+
+/**
+ * Resolve the table an analytics resource identifier belongs to: the part before
+ * the first separator for a `TableColumn`, the whole value for a bare table name.
+ *
+ * @param {string} [resourceId] - an analytics activity's resource identifier
+ * @returns {string | undefined} the table half of the identifier, or `undefined` when there is no identifier
+ */
+export const getTableNameFromAnalyticsResourceId = (resourceId?: string): string | undefined => {
+  if (resourceId == null) {
+    return undefined;
+  }
+
+  const separatorIndex = resourceId.indexOf(ANALYTICS_RESOURCE_ID_SEPARATOR);
+  if (separatorIndex === -1) {
+    return resourceId;
+  }
+
+  return resourceId.slice(0, separatorIndex);
+};
+
+/**
+ * Whether an analytics resource identifier belongs to the given table — the table
+ * definition itself or one of its columns.
+ *
+ * The activity feed is queried with the `co` (contains) operator, which is a substring
+ * match: a request narrowed to `orders` also answers with activities for `my_orders` and
+ * for the column `my_orders:total`. This predicate is the exactness check that keeps
+ * another table's history out of the tab, so neither `includes` nor a bare `startsWith`
+ * is sufficient — the identifier must be the table name exactly, or the table name
+ * followed by the separator.
+ *
+ * @param {string} [resourceId] - an analytics activity's resource identifier
+ * @param {string} [tableName] - the name of the table whose audit surface is being rendered
+ * @returns {boolean} true when the identifier is the table itself or one of its columns
+ */
+export const isResourceIdInTableScope = (resourceId?: string, tableName?: string): boolean => {
+  if (!resourceId || !tableName) {
+    return false;
+  }
+
+  return resourceId === tableName || resourceId.startsWith(`${tableName}${ANALYTICS_RESOURCE_ID_SEPARATOR}`);
+};

--- a/apps/ai-dial-admin/src/utils/audit/deleted-parent-suppression.ts
+++ b/apps/ai-dial-admin/src/utils/audit/deleted-parent-suppression.ts
@@ -1,0 +1,72 @@
+import { DialActivity } from '@/src/models/activity-audit';
+import { ActivityAuditResourceType, ActivityAuditType } from '@/src/types/activity-audit';
+
+/**
+ * Activities already resolved during one list pass, keyed by their own `activityId`.
+ * Both a row that arrived in a page and a row fetched by the parent lookup go in here.
+ */
+export type ResolvedActivities = Record<string, DialActivity>;
+
+/**
+ * The parent identifiers of `rows` that no resolved activity answers for yet — distinct,
+ * in first-seen order, skipping rows that carry no parent.
+ *
+ * Callers use this to decide whether a parent lookup is needed at all: an empty result
+ * means the page can be filtered without a request.
+ *
+ * @param {DialActivity[]} rows - the page's activities
+ * @param {ResolvedActivities} resolved - activities resolved so far in this list pass
+ * @returns {string[]} distinct parent identifiers still to resolve
+ */
+export const getUnresolvedParentIds = (rows: DialActivity[], resolved: ResolvedActivities): string[] => {
+  const ids: string[] = [];
+
+  rows.forEach(({ parentActivityId }) => {
+    if (!parentActivityId || resolved[parentActivityId] || ids.includes(parentActivityId)) {
+      return;
+    }
+    ids.push(parentActivityId);
+  });
+
+  return ids;
+};
+
+/**
+ * Whether an activity is one of the per-column children a table `Delete` records.
+ *
+ * Nothing on the child distinguishes it from a column dropped out of a table that still
+ * exists — both are a `TableColumn` `Delete` naming a parent — so the answer comes entirely
+ * from the resolved parent: a `Table` activity whose own type is `Delete`. A column dropped
+ * from a living table has a `Table` `Update` parent and is therefore kept.
+ *
+ * Deliberately false when the parent is not resolved: a row is hidden only on positive
+ * evidence about its parent, never on the absence of it.
+ *
+ * @param {DialActivity} activity - the activity being considered for the list
+ * @param {ResolvedActivities} resolved - activities resolved so far in this list pass
+ * @returns {boolean} true only when the resolved parent is a table deletion
+ */
+export const isChildOfDeletedTable = (activity: DialActivity, resolved: ResolvedActivities): boolean => {
+  const parentActivityId = activity.parentActivityId;
+  if (!parentActivityId) {
+    return false;
+  }
+
+  const parent = resolved[parentActivityId];
+  if (!parent) {
+    return false;
+  }
+
+  return parent.resourceType === ActivityAuditResourceType.TABLE && parent.activityType === ActivityAuditType.Delete;
+};
+
+/**
+ * The rows of a page that the list should show: every row except the per-column children
+ * of a deleted table.
+ *
+ * @param {DialActivity[]} rows - the page's activities
+ * @param {ResolvedActivities} resolved - activities resolved so far in this list pass
+ * @returns {DialActivity[]} the rows to buffer, in their original order
+ */
+export const filterOutDeletedTableChildren = (rows: DialActivity[], resolved: ResolvedActivities): DialActivity[] =>
+  rows.filter((activity) => !isChildOfDeletedTable(activity, resolved));

--- a/apps/ai-dial-admin/src/utils/audit/entity-audit-filters.ts
+++ b/apps/ai-dial-admin/src/utils/audit/entity-audit-filters.ts
@@ -1,0 +1,65 @@
+import { DialApplicationScheme } from '@/src/models/dial/application';
+import { BaseEntity } from '@/src/models/dial/base-entity';
+import { FilterDto } from '@/src/models/request';
+import { ActivityAuditResourceType, ActivityAuditView } from '@/src/types/activity-audit';
+import { FilterOperatorDto } from '@/src/types/request';
+import { getEntityAuditFilterId } from '@/src/utils/open-in-new-tab';
+
+const RESOURCE_ID_COLUMN = 'resourceId';
+const RESOURCE_TYPE_COLUMN = 'resourceType';
+
+// A table's audit surface shows the table definition and its columns, which the analytics
+// backend records as two resource types.
+const TABLE_SCOPE_RESOURCE_TYPES = [ActivityAuditResourceType.TABLE, ActivityAuditResourceType.TABLE_COLUMN].join(',');
+
+/**
+ * Build the request filters that narrow an entity Audit tab to the entity being viewed.
+ *
+ * `Config` and `Deployments` ask for one exact `(resourceId, resourceType)` pair. `Analytics`
+ * cannot: a column activity's resource identifier is `<table>:<column>`, so an `eq` on the table
+ * name would answer with the table definition's history only. It asks for both resource types
+ * and a `co` (substring) match on the table name instead — which over-matches a similarly named
+ * table, so rows still have to pass `isResourceIdInTableScope` before they are displayed.
+ *
+ * @param {BaseEntity | DialApplicationScheme} [entity] - the entity whose Audit tab is rendered
+ * @param {string} [entityType] - the entity's audit resource type
+ * @param {ActivityAuditView} [view] - the active audit view
+ * @returns {FilterDto[]} filters for the activity feed request, empty when there is no entity
+ */
+export const getEntityAuditFilters = (
+  entity?: BaseEntity | DialApplicationScheme,
+  entityType?: string,
+  view?: ActivityAuditView,
+): FilterDto[] => {
+  if (!entity) {
+    return [];
+  }
+
+  if (view === ActivityAuditView.Analytics) {
+    return [
+      {
+        column: RESOURCE_TYPE_COLUMN,
+        value: TABLE_SCOPE_RESOURCE_TYPES,
+        operator: FilterOperatorDto.INCLUDES,
+      },
+      {
+        column: RESOURCE_ID_COLUMN,
+        value: getEntityAuditFilterId(entity),
+        operator: FilterOperatorDto.CONTAINS,
+      } as FilterDto,
+    ];
+  }
+
+  return [
+    {
+      column: RESOURCE_ID_COLUMN,
+      value: getEntityAuditFilterId(entity),
+      operator: FilterOperatorDto.EQUALS,
+    } as FilterDto,
+    {
+      column: RESOURCE_TYPE_COLUMN,
+      value: entityType,
+      operator: FilterOperatorDto.EQUALS,
+    } as FilterDto,
+  ];
+};

--- a/apps/ai-dial-admin/src/utils/audit/get-activity-audit-detail-data.ts
+++ b/apps/ai-dial-admin/src/utils/audit/get-activity-audit-detail-data.ts
@@ -1,8 +1,24 @@
-import { activityAuditApi, containersApi, deploymentAuditApi, globalFirewallApi, imagesApi } from '@/src/app/api/api';
-import { DialActivity, ListApi, ResolverHandlers, RevisionApi } from '@/src/models/activity-audit';
+import {
+  activityAuditApi,
+  analyticsAuditApi,
+  containersApi,
+  deploymentAuditApi,
+  globalFirewallApi,
+  imagesApi,
+} from '@/src/app/api/api';
+import {
+  ActivityLookupSource,
+  DialActivity,
+  ListApi,
+  ResolverHandlers,
+  RevisionApi,
+} from '@/src/models/activity-audit';
 import { Token } from '@/src/models/auth';
 import { BaseEntity } from '@/src/models/dial/base-entity';
-import { FilterDto, SortDto } from '@/src/models/request';
+import { SortDto } from '@/src/models/request';
+import { ANALYTICS_ACTIVITIES_URL } from '@/src/server/analytics/audit-api';
+import { DEPLOYMENT_ACTIVITIES_URL } from '@/src/server/deployments/audit-api';
+import { ACTIVITIES_URL } from '@/src/server/entities/activity-audit-api';
 import { errorObjLog } from '@/src/server/logger';
 import {
   ActivityAuditEntity,
@@ -10,8 +26,9 @@ import {
   isGlobalFirewallResource,
   isImageDefinitionResource,
 } from '@/src/types/activity-audit';
-import { SortDirectionDto } from '@/src/types/request';
+import { FilterOperatorDto, SortDirectionDto } from '@/src/types/request';
 import { getRevisionRouteForEntityType } from '@/src/utils/audit/get-revision-route';
+import { isValueTruthy } from '@/src/utils/types';
 
 const SORT_BY_TIME_DESC: SortDto[] = [{ column: 'epochTimestampMs', direction: SortDirectionDto.DESC }];
 
@@ -38,11 +55,11 @@ const fetchFirewallSnapshot: ResolverHandlers['fetchSnapshot'] = async (_activit
 };
 
 const filterByResourceId: ResolverHandlers['filter'] = (activity) => [
-  { column: 'resourceId', value: activity.resourceId ?? '', operator: 'eq' } as FilterDto,
+  { column: 'resourceId', value: activity.resourceId ?? '', operator: FilterOperatorDto.EQUALS },
 ];
 
 const filterByResourceType: ResolverHandlers['filter'] = (activity) => [
-  { column: 'resourceType', value: activity.resourceType, operator: 'eq' } as FilterDto,
+  { column: 'resourceType', value: activity.resourceType, operator: FilterOperatorDto.EQUALS },
 ];
 
 const adminListActivities = makeListActivities(activityAuditApi);
@@ -72,12 +89,84 @@ const containerHandlers: ResolverHandlers = {
   listActivities: deploymentListActivities,
 };
 
-const pickActivityHandlers = (activity: DialActivity, isDeploymentActivity: boolean): ResolverHandlers | null => {
+const analyticsHandlers: ResolverHandlers = {
+  filter: filterByResourceId,
+  fetchSnapshot: makeRouteSnapshotFetcher(analyticsAuditApi),
+  listActivities: makeListActivities(analyticsAuditApi),
+};
+
+// `isAnalyticsActivity` is the backend the activity came from, not its resource type: only the
+// analytics backend owns the snapshots and the activity list for a resource it resolved.
+const pickActivityHandlers = (
+  activity: DialActivity,
+  isDeploymentActivity: boolean,
+  isAnalyticsActivity: boolean,
+): ResolverHandlers | null => {
+  if (isAnalyticsActivity) return analyticsHandlers;
   if (!isDeploymentActivity) return adminHandlers;
   if (isGlobalFirewallResource(activity.resourceType)) return firewallHandlers;
   if (isImageDefinitionResource(activity.resourceType)) return imageHandlers;
   if (isContainerDeploymentResource(activity.resourceType)) return containerHandlers;
   return null;
+};
+
+const ADMIN_LOOKUP: ActivityLookupSource = {
+  backend: 'admin',
+  route: ACTIVITIES_URL,
+  getActivityById: (id, token) => activityAuditApi.getActivityById(id, token),
+};
+
+const DEPLOYMENT_LOOKUP: ActivityLookupSource = {
+  backend: 'deployment manager',
+  route: DEPLOYMENT_ACTIVITIES_URL,
+  getActivityById: (id, token) => deploymentAuditApi.getActivityById(id, token),
+};
+
+const ANALYTICS_LOOKUP: ActivityLookupSource = {
+  backend: 'analytics',
+  route: ANALYTICS_ACTIVITIES_URL,
+  getActivityById: (id, token) => analyticsAuditApi.getActivityById(id, token),
+};
+
+/**
+ * Probe one backend of the fallback chain for the activity.
+ *
+ * A backend that is unreachable, or whose host variable is unset, *rejects* rather than answering
+ * `404` — and the chain must survive that, because the activity may well live in a backend probed
+ * later. Two things follow, and both are the point of this helper:
+ *
+ * - the rejection is confined to the step that produced it, so a dead deployment manager can no
+ *   longer hide every analytics activity behind the page's `notFound()`;
+ * - the rejection is logged with the backend and the route it was asked for. The page renders the
+ *   same 404 for a failure and for a genuine miss, so the log is the only place the two are
+ *   distinguishable: a miss is silent, a failure is not.
+ */
+const lookupActivity = async (
+  source: ActivityLookupSource,
+  activityId: string,
+  token: Token,
+): Promise<DialActivity | null> => {
+  try {
+    const response = await source.getActivityById(activityId, token);
+    return (response?.response as DialActivity | null) ?? null;
+  } catch (e) {
+    errorObjLog(e, `Activity lookup failed on the ${source.backend} backend: ${source.route}/${activityId}`);
+    return null;
+  }
+};
+
+/**
+ * Keeps one failing upstream call from discarding the results of the calls issued beside it — a
+ * snapshot the backend cannot serve leaves that one side of the comparison empty, rather than
+ * blanking the whole detail view.
+ */
+const settled = async <T>(request: () => Promise<T>, message: string): Promise<T | null> => {
+  try {
+    return await request();
+  } catch (e) {
+    errorObjLog(e, message);
+    return null;
+  }
 };
 
 export interface ActivityAuditDetailData {
@@ -87,45 +176,62 @@ export interface ActivityAuditDetailData {
   entity: BaseEntity | undefined;
 }
 
+const noActivityFound = (): ActivityAuditDetailData => ({
+  activity: null,
+  activityRevision: null,
+  previousRevision: null,
+  entity: void 0,
+});
+
 export const getActivityAuditDetailData = async (
   activityId: string,
   token: Token,
 ): Promise<ActivityAuditDetailData> => {
-  let activity: DialActivity | null = null;
-  let activityRevision: ActivityAuditEntity | null = null;
-  let previousRevision: ActivityAuditEntity | null = null;
-  let entity: BaseEntity | undefined = void 0;
+  let activity = await lookupActivity(ADMIN_LOOKUP, activityId, token);
+  let isDeploymentActivity = false;
+  let isAnalyticsActivity = false;
 
-  try {
-    const adminResponse = await activityAuditApi.getActivityById(activityId, token);
-    activity = (adminResponse?.response as DialActivity | null) ?? null;
-    let isDeploymentActivity = false;
-
-    if (!activity) {
-      const deploymentResponse = await deploymentAuditApi.getActivityById(activityId, token);
-      activity = (deploymentResponse?.response as DialActivity | null) ?? null;
-      isDeploymentActivity = activity != null;
-    }
-
-    const handlers = activity ? pickActivityHandlers(activity, isDeploymentActivity) : null;
-    if (activity && handlers) {
-      const [activities, fetchedActivityRevision, fetchedPreviousRevision] = await Promise.all([
-        handlers.listActivities(handlers.filter(activity), token),
-        handlers.fetchSnapshot(activity, activity.revision, token),
-        handlers.fetchSnapshot(activity, activity.revision - 1, token),
-      ]);
-      activityRevision = fetchedActivityRevision;
-      previousRevision = fetchedPreviousRevision;
-      const latestRevision = activities?.data?.[0]?.revision;
-      if (latestRevision != null) {
-        entity = (await handlers.fetchSnapshot(activity, latestRevision, token)) as BaseEntity | undefined;
-      }
-    } else {
-      activity = null;
-    }
-  } catch (e) {
-    errorObjLog(e, 'Failed to fetch activity view data');
+  if (!activity) {
+    activity = await lookupActivity(DEPLOYMENT_LOOKUP, activityId, token);
+    isDeploymentActivity = activity != null;
   }
 
-  return { activity, activityRevision, previousRevision, entity };
+  // Last step of the chain, and only on an install that has analytics: `isValueTruthy` answers true
+  // for the exact string `true` alone, so this agrees with `featureFlags.analyticsEnabled`, which
+  // `layout.tsx` reads from the same variable through the same helper.
+  if (!activity && isValueTruthy(process.env.ANALYTICS_ENABLED)) {
+    activity = await lookupActivity(ANALYTICS_LOOKUP, activityId, token);
+    isAnalyticsActivity = activity != null;
+  }
+
+  if (!activity) return noActivityFound();
+
+  const handlers = pickActivityHandlers(activity, isDeploymentActivity, isAnalyticsActivity);
+  if (!handlers) return noActivityFound();
+
+  // `activity` is a reassigned `let`, so its non-null narrowing does not survive into the closures
+  // below — they capture this `const` instead.
+  const resolvedActivity = activity;
+  const snapshotFailure = `Failed to fetch a revision snapshot for activity ${activityId}`;
+
+  const [activities, activityRevision, previousRevision] = await Promise.all([
+    settled(
+      () => handlers.listActivities(handlers.filter(resolvedActivity), token),
+      `Failed to fetch the activity list for activity ${activityId}`,
+    ),
+    settled(() => handlers.fetchSnapshot(resolvedActivity, resolvedActivity.revision, token), snapshotFailure),
+    settled(() => handlers.fetchSnapshot(resolvedActivity, resolvedActivity.revision - 1, token), snapshotFailure),
+  ]);
+
+  const latestRevision = activities?.data?.[0]?.revision;
+  let entity: BaseEntity | undefined = void 0;
+  if (latestRevision != null) {
+    const latestSnapshot = await settled(
+      () => handlers.fetchSnapshot(resolvedActivity, latestRevision, token),
+      snapshotFailure,
+    );
+    entity = (latestSnapshot ?? void 0) as BaseEntity | undefined;
+  }
+
+  return { activity: resolvedActivity, activityRevision, previousRevision, entity };
 };

--- a/apps/ai-dial-admin/src/utils/audit/get-revision-route.ts
+++ b/apps/ai-dial-admin/src/utils/audit/get-revision-route.ts
@@ -1,5 +1,17 @@
 import { ActivityAuditResourceType } from '@/src/types/activity-audit';
+import { getTableNameFromAnalyticsResourceId } from '@/src/utils/audit/analytics-resource-id';
 
+/**
+ * Resolve the snapshot route for one resource at one revision. The route is relative
+ * to the backend that owns the resource, and this table spans two of them: the four
+ * analytics types (`isAnalyticsResource`) resolve against the analytics backend, every
+ * other type against the admin backend. A route must therefore be issued through the
+ * client for its own resource type — the caller picks the client, this only names the path.
+ *
+ * @param {string} [type] - the activity's resource type
+ * @param {string} [id] - the resource identifier, `<table>:<column>` for a table column
+ * @returns {string | null} the route with a trailing separator for the revision, or null when the type has no snapshot route
+ */
 export const getRevisionRouteForEntityType = (type?: string, id?: string): string | null => {
   switch (type) {
     case ActivityAuditResourceType.MODEL:
@@ -40,6 +52,16 @@ export const getRevisionRouteForEntityType = (type?: string, id?: string): strin
       return `/deployments/${id}/revision/`;
     case ActivityAuditResourceType.ADMIN_PROPERTIES:
       return `/admin-settings/revision/`;
+    case ActivityAuditResourceType.TABLE:
+      return `/tables/${id}/revision/`;
+    // A column has no snapshot endpoint of its own: it resolves to the owning
+    // table's snapshot at the same revision, which does contain the change.
+    case ActivityAuditResourceType.TABLE_COLUMN:
+      return `/tables/${getTableNameFromAnalyticsResourceId(id)}/revision/`;
+    case ActivityAuditResourceType.PIPELINE:
+      return `/pipelines/${id}/revision/`;
+    case ActivityAuditResourceType.SAVED_QUERY:
+      return `/saved-queries/${id}/revision/`;
     default:
       return null;
   }

--- a/apps/ai-dial-admin/src/utils/audit/tests/analytics-resource-id.spec.ts
+++ b/apps/ai-dial-admin/src/utils/audit/tests/analytics-resource-id.spec.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'vitest';
+import { getTableNameFromAnalyticsResourceId, isResourceIdInTableScope } from '../analytics-resource-id';
+
+describe('Audit :: getTableNameFromAnalyticsResourceId', () => {
+  test('returns the table half of a column identifier', () => {
+    expect(getTableNameFromAnalyticsResourceId('orders:total')).toBe('orders');
+  });
+
+  test('returns the whole value when the identifier carries no separator', () => {
+    expect(getTableNameFromAnalyticsResourceId('orders')).toBe('orders');
+  });
+
+  test('splits on the first separator when the column name contains one', () => {
+    expect(getTableNameFromAnalyticsResourceId('orders:total:net')).toBe('orders');
+  });
+
+  test('keeps an underscored table name whole', () => {
+    expect(getTableNameFromAnalyticsResourceId('my_orders:total')).toBe('my_orders');
+  });
+
+  test('returns an empty string for an empty identifier', () => {
+    expect(getTableNameFromAnalyticsResourceId('')).toBe('');
+  });
+
+  test('returns an empty string when the identifier starts with the separator', () => {
+    expect(getTableNameFromAnalyticsResourceId(':total')).toBe('');
+  });
+
+  test('returns undefined when no identifier is given', () => {
+    expect(getTableNameFromAnalyticsResourceId(undefined)).toBeUndefined();
+  });
+
+  test('returns undefined when called with no argument', () => {
+    expect(getTableNameFromAnalyticsResourceId()).toBeUndefined();
+  });
+});
+
+describe('Audit :: isResourceIdInTableScope', () => {
+  const tableName = 'orders';
+
+  test('accepts the table definition identifier itself', () => {
+    expect(isResourceIdInTableScope('orders', tableName)).toBe(true);
+  });
+
+  test('accepts a column of that table', () => {
+    expect(isResourceIdInTableScope('orders:total', tableName)).toBe(true);
+  });
+
+  test('accepts a column whose own name contains the separator', () => {
+    expect(isResourceIdInTableScope('orders:total:net', tableName)).toBe(true);
+  });
+
+  test('rejects a similarly named table that the contains filter also matches', () => {
+    expect(isResourceIdInTableScope('my_orders', tableName)).toBe(false);
+  });
+
+  test('rejects a column of a similarly named table that the contains filter also matches', () => {
+    expect(isResourceIdInTableScope('my_orders:total', tableName)).toBe(false);
+  });
+
+  test('rejects a table whose name merely starts with the table name', () => {
+    expect(isResourceIdInTableScope('orders_archive', tableName)).toBe(false);
+  });
+
+  test('rejects a column of a table whose name merely starts with the table name', () => {
+    expect(isResourceIdInTableScope('orders_archive:total', tableName)).toBe(false);
+  });
+
+  test('rejects an unrelated identifier', () => {
+    expect(isResourceIdInTableScope('conversations:role', tableName)).toBe(false);
+  });
+
+  test('rejects an empty identifier', () => {
+    expect(isResourceIdInTableScope('', tableName)).toBe(false);
+  });
+
+  test('rejects an empty table name rather than matching every identifier', () => {
+    expect(isResourceIdInTableScope('orders:total', '')).toBe(false);
+    expect(isResourceIdInTableScope(':total', '')).toBe(false);
+  });
+
+  test('returns false when the identifier is undefined', () => {
+    expect(isResourceIdInTableScope(undefined, tableName)).toBe(false);
+  });
+
+  test('returns false when the table name is undefined', () => {
+    expect(isResourceIdInTableScope('orders:total', undefined)).toBe(false);
+  });
+
+  test('returns false when called with no arguments', () => {
+    expect(isResourceIdInTableScope()).toBe(false);
+  });
+});

--- a/apps/ai-dial-admin/src/utils/audit/tests/deleted-parent-suppression.spec.ts
+++ b/apps/ai-dial-admin/src/utils/audit/tests/deleted-parent-suppression.spec.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  filterOutDeletedTableChildren,
+  getUnresolvedParentIds,
+  isChildOfDeletedTable,
+  ResolvedActivities,
+} from '@/src/utils/audit/deleted-parent-suppression';
+import { DialActivity } from '@/src/models/activity-audit';
+import { ActivityAuditResourceType, ActivityAuditType } from '@/src/types/activity-audit';
+
+const activity = (overrides: Partial<DialActivity> = {}): DialActivity =>
+  ({
+    activityId: 'activity-1',
+    activityType: ActivityAuditType.Delete,
+    resourceType: ActivityAuditResourceType.TABLE_COLUMN,
+    resourceId: 'orders:total',
+    epochTimestampMs: 1,
+    revision: 59,
+    ...overrides,
+  }) as DialActivity;
+
+const tableDelete = activity({
+  activityId: 'parent-delete',
+  activityType: ActivityAuditType.Delete,
+  resourceType: ActivityAuditResourceType.TABLE,
+  resourceId: 'orders',
+});
+
+const tableUpdate = activity({
+  activityId: 'parent-update',
+  activityType: ActivityAuditType.Update,
+  resourceType: ActivityAuditResourceType.TABLE,
+  resourceId: 'orders',
+});
+
+const resolved: ResolvedActivities = {
+  [tableDelete.activityId]: tableDelete,
+  [tableUpdate.activityId]: tableUpdate,
+};
+
+describe('Audit :: getUnresolvedParentIds', () => {
+  test('returns the parent identifier a row names when nothing is resolved yet', () => {
+    expect(getUnresolvedParentIds([activity({ parentActivityId: 'parent-delete' })], {})).toEqual(['parent-delete']);
+  });
+
+  test('returns each parent identifier once however many rows name it', () => {
+    const rows = [
+      activity({ activityId: 'c1', parentActivityId: 'p1' }),
+      activity({ activityId: 'c2', parentActivityId: 'p1' }),
+      activity({ activityId: 'c3', parentActivityId: 'p2' }),
+    ];
+
+    expect(getUnresolvedParentIds(rows, {})).toEqual(['p1', 'p2']);
+  });
+
+  test('skips a parent already resolved so it is never requested twice', () => {
+    const rows = [
+      activity({ activityId: 'c1', parentActivityId: 'parent-delete' }),
+      activity({ activityId: 'c2', parentActivityId: 'p-new' }),
+    ];
+
+    expect(getUnresolvedParentIds(rows, resolved)).toEqual(['p-new']);
+  });
+
+  test('skips rows that carry no parent identifier', () => {
+    const rows = [tableDelete, activity({ activityId: 'c1', parentActivityId: 'p1' })];
+
+    expect(getUnresolvedParentIds(rows, {})).toEqual(['p1']);
+  });
+
+  test('returns nothing for a page whose rows all name no parent, so no lookup is needed', () => {
+    expect(getUnresolvedParentIds([tableDelete, tableUpdate], {})).toEqual([]);
+  });
+
+  test('returns nothing for a page whose parents all arrived in the same page', () => {
+    const rows = [tableDelete, activity({ activityId: 'c1', parentActivityId: 'parent-delete' })];
+
+    expect(getUnresolvedParentIds(rows, resolved)).toEqual([]);
+  });
+
+  test('returns nothing for an empty page', () => {
+    expect(getUnresolvedParentIds([], resolved)).toEqual([]);
+  });
+});
+
+describe('Audit :: isChildOfDeletedTable', () => {
+  test('answers true for a column activity whose resolved parent is a table deletion', () => {
+    expect(isChildOfDeletedTable(activity({ parentActivityId: 'parent-delete' }), resolved)).toBe(true);
+  });
+
+  test('answers false for a column dropped from a table that still exists', () => {
+    expect(isChildOfDeletedTable(activity({ parentActivityId: 'parent-update' }), resolved)).toBe(false);
+  });
+
+  test('answers false for an activity that carries no parent identifier', () => {
+    expect(isChildOfDeletedTable(tableDelete, resolved)).toBe(false);
+  });
+
+  test('answers false when the parent is absent from the resolved activities', () => {
+    expect(isChildOfDeletedTable(activity({ parentActivityId: 'never-answered' }), resolved)).toBe(false);
+  });
+
+  test('answers false when nothing has been resolved at all', () => {
+    expect(isChildOfDeletedTable(activity({ parentActivityId: 'parent-delete' }), {})).toBe(false);
+  });
+
+  test('answers false when the parent is a deletion of something other than a table', () => {
+    const pipelineDelete = activity({
+      activityId: 'parent-pipeline',
+      activityType: ActivityAuditType.Delete,
+      resourceType: ActivityAuditResourceType.PIPELINE,
+    });
+
+    expect(
+      isChildOfDeletedTable(activity({ parentActivityId: 'parent-pipeline' }), {
+        [pipelineDelete.activityId]: pipelineDelete,
+      }),
+    ).toBe(false);
+  });
+
+  test('answers false when the parent is a table activity of any other type', () => {
+    [ActivityAuditType.Create, ActivityAuditType.Update, ActivityAuditType.Rollback].forEach((activityType) => {
+      const parent = activity({
+        activityId: 'parent-other',
+        activityType,
+        resourceType: ActivityAuditResourceType.TABLE,
+      });
+
+      expect(
+        isChildOfDeletedTable(activity({ parentActivityId: 'parent-other' }), { [parent.activityId]: parent }),
+      ).toBe(false);
+    });
+  });
+
+  test('keys on the parent alone, so a parent table deletion suppresses a child of any resource type', () => {
+    expect(
+      isChildOfDeletedTable(
+        activity({ resourceType: ActivityAuditResourceType.TABLE, parentActivityId: 'parent-delete' }),
+        resolved,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('Audit :: filterOutDeletedTableChildren', () => {
+  test('keeps the table deletion and drops every one of its column children', () => {
+    const rows = [
+      tableDelete,
+      activity({ activityId: 'c1', resourceId: 'orders:total', parentActivityId: 'parent-delete' }),
+      activity({ activityId: 'c2', resourceId: 'orders:id', parentActivityId: 'parent-delete' }),
+      activity({ activityId: 'c3', resourceId: 'orders:name', parentActivityId: 'parent-delete' }),
+    ];
+
+    expect(filterOutDeletedTableChildren(rows, resolved).map((row) => row.activityId)).toEqual(['parent-delete']);
+  });
+
+  test('keeps a column dropped from a living table alongside its parent update', () => {
+    const rows = [tableUpdate, activity({ activityId: 'c1', parentActivityId: 'parent-update' })];
+
+    expect(filterOutDeletedTableChildren(rows, resolved).map((row) => row.activityId)).toEqual(['parent-update', 'c1']);
+  });
+
+  test('keeps a child whose parent could not be resolved', () => {
+    const rows = [activity({ activityId: 'c1', parentActivityId: 'never-answered' })];
+
+    expect(filterOutDeletedTableChildren(rows, resolved).map((row) => row.activityId)).toEqual(['c1']);
+  });
+
+  test('preserves the order of the rows it keeps', () => {
+    const rows = [
+      activity({ activityId: 'a' }),
+      activity({ activityId: 'b', parentActivityId: 'parent-delete' }),
+      activity({ activityId: 'c', parentActivityId: 'parent-update' }),
+      activity({ activityId: 'd' }),
+    ];
+
+    expect(filterOutDeletedTableChildren(rows, resolved).map((row) => row.activityId)).toEqual(['a', 'c', 'd']);
+  });
+
+  test('returns every row when nothing has been resolved', () => {
+    const rows = [tableDelete, activity({ activityId: 'c1', parentActivityId: 'parent-delete' })];
+
+    expect(filterOutDeletedTableChildren(rows, {})).toEqual(rows);
+  });
+
+  test('returns an empty list for an empty page', () => {
+    expect(filterOutDeletedTableChildren([], resolved)).toEqual([]);
+  });
+});

--- a/apps/ai-dial-admin/src/utils/audit/tests/entity-audit-filters.spec.ts
+++ b/apps/ai-dial-admin/src/utils/audit/tests/entity-audit-filters.spec.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from 'vitest';
+
+import { ActivityAuditResourceType, ActivityAuditView } from '@/src/types/activity-audit';
+import { FilterOperatorDto } from '@/src/types/request';
+import { getEntityAuditFilters } from '@/src/utils/audit/entity-audit-filters';
+
+describe('getEntityAuditFilters', () => {
+  test('returns no filters when there is no entity', () => {
+    expect(getEntityAuditFilters(void 0, ActivityAuditResourceType.MODEL, ActivityAuditView.Config)).toEqual([]);
+    expect(getEntityAuditFilters(void 0, ActivityAuditResourceType.TABLE, ActivityAuditView.Analytics)).toEqual([]);
+  });
+
+  describe('Config and Deployments views', () => {
+    test('asks for the exact resource identifier and resource type pair', () => {
+      const filters = getEntityAuditFilters(
+        { name: 'gpt-4' },
+        ActivityAuditResourceType.MODEL,
+        ActivityAuditView.Config,
+      );
+
+      expect(filters).toEqual([
+        { column: 'resourceId', value: 'gpt-4', operator: FilterOperatorDto.EQUALS },
+        { column: 'resourceType', value: ActivityAuditResourceType.MODEL, operator: FilterOperatorDto.EQUALS },
+      ]);
+    });
+
+    test('builds the same pair for the Deployments view', () => {
+      const filters = getEntityAuditFilters(
+        { name: 'my-container' },
+        ActivityAuditResourceType.MCP_DEPLOYMENT,
+        ActivityAuditView.Deployments,
+      );
+
+      expect(filters).toEqual([
+        { column: 'resourceId', value: 'my-container', operator: FilterOperatorDto.EQUALS },
+        {
+          column: 'resourceType',
+          value: ActivityAuditResourceType.MCP_DEPLOYMENT,
+          operator: FilterOperatorDto.EQUALS,
+        },
+      ]);
+    });
+
+    test('builds the same pair when no view is given', () => {
+      const filters = getEntityAuditFilters({ name: 'gpt-4' }, ActivityAuditResourceType.MODEL);
+
+      expect(filters).toEqual([
+        { column: 'resourceId', value: 'gpt-4', operator: FilterOperatorDto.EQUALS },
+        { column: 'resourceType', value: ActivityAuditResourceType.MODEL, operator: FilterOperatorDto.EQUALS },
+      ]);
+    });
+
+    test('prefers the application scheme identifier over the name', () => {
+      const filters = getEntityAuditFilters(
+        { $id: 'scheme-id', name: 'scheme-name' },
+        ActivityAuditResourceType.APPLICATION_TYPE_SCHEMA,
+        ActivityAuditView.Config,
+      );
+
+      expect(filters[0]).toEqual({ column: 'resourceId', value: 'scheme-id', operator: FilterOperatorDto.EQUALS });
+    });
+
+    test('leaves the identifier undefined when the entity carries none, as it does today', () => {
+      const filters = getEntityAuditFilters({}, ActivityAuditResourceType.MODEL, ActivityAuditView.Config);
+
+      expect(filters[0]).toEqual({ column: 'resourceId', value: void 0, operator: FilterOperatorDto.EQUALS });
+    });
+  });
+
+  describe('Analytics view', () => {
+    test('asks for both table resource types and a substring match on the table name', () => {
+      const filters = getEntityAuditFilters(
+        { name: 'conversations' },
+        ActivityAuditResourceType.TABLE,
+        ActivityAuditView.Analytics,
+      );
+
+      expect(filters).toEqual([
+        { column: 'resourceType', value: 'Table,TableColumn', operator: FilterOperatorDto.INCLUDES },
+        { column: 'resourceId', value: 'conversations', operator: FilterOperatorDto.CONTAINS },
+      ]);
+    });
+
+    test('names the resource types from the resource-type enum', () => {
+      const filters = getEntityAuditFilters(
+        { name: 'orders' },
+        ActivityAuditResourceType.TABLE,
+        ActivityAuditView.Analytics,
+      );
+
+      expect(filters[0].value).toBe(`${ActivityAuditResourceType.TABLE},${ActivityAuditResourceType.TABLE_COLUMN}`);
+    });
+
+    test('ignores the entity type it is given, because the request carries two resource types', () => {
+      const filters = getEntityAuditFilters({ name: 'orders' }, void 0, ActivityAuditView.Analytics);
+
+      expect(filters).toEqual([
+        { column: 'resourceType', value: 'Table,TableColumn', operator: FilterOperatorDto.INCLUDES },
+        { column: 'resourceId', value: 'orders', operator: FilterOperatorDto.CONTAINS },
+      ]);
+    });
+  });
+});

--- a/apps/ai-dial-admin/src/utils/audit/tests/get-activity-audit-detail-data.spec.ts
+++ b/apps/ai-dial-admin/src/utils/audit/tests/get-activity-audit-detail-data.spec.ts
@@ -1,0 +1,527 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  activityAuditApi,
+  analyticsAuditApi,
+  containersApi,
+  deploymentAuditApi,
+  globalFirewallApi,
+  imagesApi,
+} from '@/src/app/api/api';
+import { DialActivity } from '@/src/models/activity-audit';
+import { AuditPageData } from '@/src/models/request';
+import { errorObjLog } from '@/src/server/logger';
+import { ActivityAuditResourceType, ActivityAuditType } from '@/src/types/activity-audit';
+import { FilterOperatorDto, SortDirectionDto } from '@/src/types/request';
+import { getActivityAuditDetailData } from '@/src/utils/audit/get-activity-audit-detail-data';
+import { TOKEN_MOCK } from '@/src/utils/tests/mock/api.mock';
+
+vi.mock('@/src/app/api/api');
+vi.mock('@/src/server/logger', () => ({
+  errorObjLog: vi.fn(),
+  errorLog: vi.fn(),
+  warnLog: vi.fn(),
+  infoLog: vi.fn(),
+}));
+
+const SORT_BY_TIME_DESC = [{ column: 'epochTimestampMs', direction: SortDirectionDto.DESC }];
+
+const EMPTY_PAGE: AuditPageData<DialActivity> = { total: 0, totalPages: 0, data: [] };
+
+const ADMIN_ACTIVITY: DialActivity = {
+  activityId: 'activity-admin',
+  activityType: ActivityAuditType.Update,
+  resourceType: ActivityAuditResourceType.MODEL,
+  resourceId: 'gpt-4',
+  epochTimestampMs: 1_700_000_000_000,
+  initiatedAuthor: 'Author',
+  initiatedEmail: 'author@epam.com',
+  revision: 5,
+};
+
+const DEPLOYMENT_ACTIVITY: DialActivity = {
+  ...ADMIN_ACTIVITY,
+  activityId: 'activity-deployment',
+  resourceType: ActivityAuditResourceType.MCP_DEPLOYMENT,
+  resourceId: 'mcp-runner',
+  revision: 3,
+};
+
+const IMAGE_ACTIVITY: DialActivity = {
+  ...ADMIN_ACTIVITY,
+  activityId: 'activity-image',
+  resourceType: ActivityAuditResourceType.MCP_IMAGE_DEFINITION,
+  resourceId: 'mcp-image',
+  revision: 2,
+};
+
+const FIREWALL_ACTIVITY: DialActivity = {
+  ...ADMIN_ACTIVITY,
+  activityId: 'activity-firewall',
+  resourceType: ActivityAuditResourceType.IMAGE_BUILD_DOMAIN_WHITELIST,
+  resourceId: 'global-whitelist',
+  revision: 4,
+};
+
+const ANALYTICS_ACTIVITY: DialActivity = {
+  ...ADMIN_ACTIVITY,
+  activityId: 'activity-analytics',
+  resourceType: ActivityAuditResourceType.TABLE_COLUMN,
+  resourceId: 'orders:total',
+  revision: 7,
+};
+
+const pageOf = (activities: DialActivity[]): AuditPageData<DialActivity> => ({
+  total: activities.length,
+  totalPages: 1,
+  data: activities,
+});
+
+/** A promise the test resolves by hand, so a call can be observed while it is still in flight. */
+const deferred = <T>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+};
+
+/** Lets every already-issued request settle, so a still-pending one is a real finding. */
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+const resolveAdminActivity = (activity: DialActivity = ADMIN_ACTIVITY) =>
+  vi.mocked(activityAuditApi.getActivityById).mockResolvedValue({ success: true, response: activity });
+
+const missAdminActivity = () =>
+  vi.mocked(activityAuditApi.getActivityById).mockResolvedValue({ success: false, response: void 0 });
+
+const missDeploymentActivity = () =>
+  vi.mocked(deploymentAuditApi.getActivityById).mockResolvedValue({ success: false, response: void 0 });
+
+const resolveDeploymentActivity = (activity: DialActivity) =>
+  vi.mocked(deploymentAuditApi.getActivityById).mockResolvedValue({ success: true, response: activity });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(activityAuditApi.getActivitiesList).mockResolvedValue(EMPTY_PAGE);
+  vi.mocked(deploymentAuditApi.getActivitiesList).mockResolvedValue(EMPTY_PAGE);
+  vi.mocked(analyticsAuditApi.getActivitiesList).mockResolvedValue(EMPTY_PAGE);
+  vi.mocked(activityAuditApi.getRevisionDetails).mockResolvedValue(null);
+  vi.mocked(containersApi.getRevisionDetails).mockResolvedValue(null);
+  vi.mocked(imagesApi.getRevisionDetails).mockResolvedValue(null);
+  vi.mocked(globalFirewallApi.getRevisionDetails).mockResolvedValue(null);
+  vi.mocked(analyticsAuditApi.getRevisionDetails).mockResolvedValue(null);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('getActivityAuditDetailData :: admin activities', () => {
+  test('Should resolve an admin activity without issuing the deployment or the analytics lookup', async () => {
+    vi.stubEnv('ANALYTICS_ENABLED', 'true');
+    resolveAdminActivity();
+    vi.mocked(activityAuditApi.getActivitiesList).mockResolvedValue(pageOf([{ ...ADMIN_ACTIVITY, revision: 9 }]));
+    vi.mocked(activityAuditApi.getRevisionDetails).mockResolvedValue({ name: 'gpt-4' });
+
+    const result = await getActivityAuditDetailData('activity-admin', TOKEN_MOCK);
+
+    expect(result.activity).toEqual(ADMIN_ACTIVITY);
+    expect(deploymentAuditApi.getActivityById).not.toHaveBeenCalled();
+    expect(analyticsAuditApi.getActivityById).not.toHaveBeenCalled();
+    expect(analyticsAuditApi.getRevisionDetails).not.toHaveBeenCalled();
+    expect(activityAuditApi.getActivitiesList).toHaveBeenCalledWith(1, 0, TOKEN_MOCK, SORT_BY_TIME_DESC, [
+      { column: 'resourceId', value: 'gpt-4', operator: FilterOperatorDto.EQUALS },
+    ]);
+    expect(activityAuditApi.getRevisionDetails).toHaveBeenCalledWith('/models/gpt-4/revision/5', TOKEN_MOCK);
+    expect(activityAuditApi.getRevisionDetails).toHaveBeenCalledWith('/models/gpt-4/revision/4', TOKEN_MOCK);
+    expect(activityAuditApi.getRevisionDetails).toHaveBeenCalledWith('/models/gpt-4/revision/9', TOKEN_MOCK);
+  });
+
+  test('Should issue the activities list and both revision snapshots concurrently', async () => {
+    resolveAdminActivity();
+    const pendingList = deferred<AuditPageData<DialActivity> | null>();
+    vi.mocked(activityAuditApi.getActivitiesList).mockReturnValue(pendingList.promise);
+
+    const pending = getActivityAuditDetailData('activity-admin', TOKEN_MOCK);
+    await tick();
+
+    // Both snapshots are in flight while the list request has not settled: serializing the chain
+    // would leave these at 0 until the list resolved.
+    expect(activityAuditApi.getActivitiesList).toHaveBeenCalledOnce();
+    expect(activityAuditApi.getRevisionDetails).toHaveBeenCalledTimes(2);
+
+    pendingList.resolve(EMPTY_PAGE);
+    await pending;
+
+    expect(activityAuditApi.getRevisionDetails).toHaveBeenCalledTimes(2);
+  });
+
+  test('Should request no snapshot before the first revision of a resource', async () => {
+    resolveAdminActivity({ ...ADMIN_ACTIVITY, revision: 0 });
+
+    const result = await getActivityAuditDetailData('activity-admin', TOKEN_MOCK);
+
+    expect(activityAuditApi.getRevisionDetails).toHaveBeenCalledOnce();
+    expect(activityAuditApi.getRevisionDetails).toHaveBeenCalledWith('/models/gpt-4/revision/0', TOKEN_MOCK);
+    expect(result.previousRevision).toBeNull();
+  });
+
+  test('Should request no snapshot for a resource type with no revision route', async () => {
+    resolveAdminActivity({ ...ADMIN_ACTIVITY, resourceType: 'UnknownResource' as ActivityAuditResourceType });
+
+    const result = await getActivityAuditDetailData('activity-admin', TOKEN_MOCK);
+
+    expect(activityAuditApi.getRevisionDetails).not.toHaveBeenCalled();
+    expect(result.activity).toBeTruthy();
+    expect(result.activityRevision).toBeNull();
+  });
+
+  test('Should return an empty result when a lookup fails', async () => {
+    vi.mocked(activityAuditApi.getActivityById).mockRejectedValue(new Error('backend is down'));
+
+    const result = await getActivityAuditDetailData('activity-admin', TOKEN_MOCK);
+
+    expect(result).toEqual({ activity: null, activityRevision: null, previousRevision: null, entity: void 0 });
+    expect(errorObjLog).toHaveBeenCalledOnce();
+  });
+});
+
+describe('getActivityAuditDetailData :: deployment activities', () => {
+  beforeEach(() => {
+    missAdminActivity();
+  });
+
+  test('Should resolve a container deployment activity without issuing the analytics lookup', async () => {
+    vi.stubEnv('ANALYTICS_ENABLED', 'true');
+    resolveDeploymentActivity(DEPLOYMENT_ACTIVITY);
+    vi.mocked(containersApi.getRevisionDetails).mockResolvedValue({ name: 'mcp-runner' });
+
+    const result = await getActivityAuditDetailData('activity-deployment', TOKEN_MOCK);
+
+    expect(result.activity).toEqual(DEPLOYMENT_ACTIVITY);
+    expect(result.activityRevision).toEqual({ name: 'mcp-runner' });
+    expect(containersApi.getRevisionDetails).toHaveBeenCalledWith('/deployments/mcp-runner/revision/3', TOKEN_MOCK);
+    expect(deploymentAuditApi.getActivitiesList).toHaveBeenCalledWith(1, 0, TOKEN_MOCK, SORT_BY_TIME_DESC, [
+      { column: 'resourceId', value: 'mcp-runner', operator: FilterOperatorDto.EQUALS },
+    ]);
+    expect(analyticsAuditApi.getActivityById).not.toHaveBeenCalled();
+    expect(analyticsAuditApi.getRevisionDetails).not.toHaveBeenCalled();
+    expect(analyticsAuditApi.getActivitiesList).not.toHaveBeenCalled();
+  });
+
+  test('Should resolve an image definition activity through the images client', async () => {
+    resolveDeploymentActivity(IMAGE_ACTIVITY);
+    vi.mocked(imagesApi.getRevisionDetails).mockResolvedValue({ name: 'mcp-image' });
+
+    const result = await getActivityAuditDetailData('activity-image', TOKEN_MOCK);
+
+    expect(result.activityRevision).toEqual({ name: 'mcp-image' });
+    expect(imagesApi.getRevisionDetails).toHaveBeenCalledWith('/images/definitions/mcp-image/revision/2', TOKEN_MOCK);
+    expect(containersApi.getRevisionDetails).not.toHaveBeenCalled();
+    expect(analyticsAuditApi.getRevisionDetails).not.toHaveBeenCalled();
+  });
+
+  test('Should resolve a global firewall activity through the firewall client and its resource-type filter', async () => {
+    resolveDeploymentActivity(FIREWALL_ACTIVITY);
+    vi.mocked(globalFirewallApi.getRevisionDetails).mockResolvedValue(['epam.com']);
+
+    const result = await getActivityAuditDetailData('activity-firewall', TOKEN_MOCK);
+
+    expect(result.activityRevision).toEqual({ domains: ['epam.com'] });
+    expect(globalFirewallApi.getRevisionDetails).toHaveBeenCalledWith(4, TOKEN_MOCK);
+    expect(deploymentAuditApi.getActivitiesList).toHaveBeenCalledWith(1, 0, TOKEN_MOCK, SORT_BY_TIME_DESC, [
+      {
+        column: 'resourceType',
+        value: ActivityAuditResourceType.IMAGE_BUILD_DOMAIN_WHITELIST,
+        operator: FilterOperatorDto.EQUALS,
+      },
+    ]);
+  });
+
+  test('Should discard an activity whose resource type no handler owns', async () => {
+    resolveDeploymentActivity({ ...DEPLOYMENT_ACTIVITY, resourceType: ActivityAuditResourceType.MODEL });
+
+    const result = await getActivityAuditDetailData('activity-deployment', TOKEN_MOCK);
+
+    expect(result.activity).toBeNull();
+    expect(containersApi.getRevisionDetails).not.toHaveBeenCalled();
+    expect(imagesApi.getRevisionDetails).not.toHaveBeenCalled();
+    expect(globalFirewallApi.getRevisionDetails).not.toHaveBeenCalled();
+  });
+});
+
+describe('getActivityAuditDetailData :: analytics activities', () => {
+  beforeEach(() => {
+    missAdminActivity();
+    missDeploymentActivity();
+  });
+
+  test('Should resolve an analytics activity after both existing lookups miss', async () => {
+    vi.stubEnv('ANALYTICS_ENABLED', 'true');
+    vi.mocked(analyticsAuditApi.getActivityById).mockResolvedValue({ success: true, response: ANALYTICS_ACTIVITY });
+    vi.mocked(analyticsAuditApi.getActivitiesList).mockResolvedValue(pageOf([{ ...ANALYTICS_ACTIVITY, revision: 11 }]));
+    vi.mocked(analyticsAuditApi.getRevisionDetails).mockImplementation((url) => Promise.resolve({ url }));
+
+    const result = await getActivityAuditDetailData('activity-analytics', TOKEN_MOCK);
+
+    expect(result.activity).toEqual(ANALYTICS_ACTIVITY);
+    expect(result.activityRevision).toEqual({ url: '/tables/orders/revision/7' });
+    expect(result.previousRevision).toEqual({ url: '/tables/orders/revision/6' });
+    expect(result.entity).toEqual({ url: '/tables/orders/revision/11' });
+    expect(analyticsAuditApi.getActivitiesList).toHaveBeenCalledWith(1, 0, TOKEN_MOCK, SORT_BY_TIME_DESC, [
+      { column: 'resourceId', value: 'orders:total', operator: FilterOperatorDto.EQUALS },
+    ]);
+    expect(activityAuditApi.getRevisionDetails).not.toHaveBeenCalled();
+    expect(containersApi.getRevisionDetails).not.toHaveBeenCalled();
+  });
+
+  test('Should fetch the current, previous and latest-revision snapshots with the two revisions in parallel', async () => {
+    vi.stubEnv('ANALYTICS_ENABLED', 'true');
+    vi.mocked(analyticsAuditApi.getActivityById).mockResolvedValue({ success: true, response: ANALYTICS_ACTIVITY });
+    const pendingList = deferred<AuditPageData<DialActivity> | null>();
+    vi.mocked(analyticsAuditApi.getActivitiesList).mockReturnValue(pendingList.promise);
+
+    const pending = getActivityAuditDetailData('activity-analytics', TOKEN_MOCK);
+    await tick();
+
+    expect(analyticsAuditApi.getActivitiesList).toHaveBeenCalledOnce();
+    expect(analyticsAuditApi.getRevisionDetails).toHaveBeenCalledTimes(2);
+
+    pendingList.resolve(pageOf([{ ...ANALYTICS_ACTIVITY, revision: 11 }]));
+    await pending;
+
+    expect(analyticsAuditApi.getRevisionDetails).toHaveBeenCalledTimes(3);
+    expect(analyticsAuditApi.getRevisionDetails).toHaveBeenLastCalledWith('/tables/orders/revision/11', TOKEN_MOCK);
+  });
+
+  test('Should render a snapshot the backend answers as absent as a null revision', async () => {
+    vi.stubEnv('ANALYTICS_ENABLED', 'true');
+    vi.mocked(analyticsAuditApi.getActivityById).mockResolvedValue({ success: true, response: ANALYTICS_ACTIVITY });
+    vi.mocked(analyticsAuditApi.getRevisionDetails).mockResolvedValue(null);
+
+    const result = await getActivityAuditDetailData('activity-analytics', TOKEN_MOCK);
+
+    expect(result.activity).toEqual(ANALYTICS_ACTIVITY);
+    expect(result.activityRevision).toBeNull();
+    expect(result.previousRevision).toBeNull();
+    expect(result.entity).toBeUndefined();
+    expect(errorObjLog).not.toHaveBeenCalled();
+  });
+
+  // `entity` is typed `BaseEntity | undefined`, and the only other test that reaches an undefined
+  // `entity` does so by never asking for it (no latest revision in the list). This one asks and is
+  // told the snapshot does not exist, which is the branch that used to leak a `null` past the type.
+  test('Should leave the entity undefined when the latest-revision snapshot does not exist', async () => {
+    vi.stubEnv('ANALYTICS_ENABLED', 'true');
+    vi.mocked(analyticsAuditApi.getActivityById).mockResolvedValue({ success: true, response: ANALYTICS_ACTIVITY });
+    vi.mocked(analyticsAuditApi.getActivitiesList).mockResolvedValue(pageOf([{ ...ANALYTICS_ACTIVITY, revision: 11 }]));
+    vi.mocked(analyticsAuditApi.getRevisionDetails).mockResolvedValue(null);
+
+    const result = await getActivityAuditDetailData('activity-analytics', TOKEN_MOCK);
+
+    expect(analyticsAuditApi.getRevisionDetails).toHaveBeenCalledWith('/tables/orders/revision/11', TOKEN_MOCK);
+    expect(result.entity).toBeUndefined();
+  });
+
+  test('Should issue no analytics lookup when ANALYTICS_ENABLED is unset', async () => {
+    vi.stubEnv('ANALYTICS_ENABLED', void 0);
+
+    const result = await getActivityAuditDetailData('activity-analytics', TOKEN_MOCK);
+
+    expect(analyticsAuditApi.getActivityById).not.toHaveBeenCalled();
+    expect(result.activity).toBeNull();
+  });
+
+  test('Should issue no analytics lookup when ANALYTICS_ENABLED is the string "false"', async () => {
+    vi.stubEnv('ANALYTICS_ENABLED', 'false');
+
+    const result = await getActivityAuditDetailData('activity-analytics', TOKEN_MOCK);
+
+    expect(analyticsAuditApi.getActivityById).not.toHaveBeenCalled();
+    expect(result.activity).toBeNull();
+  });
+});
+
+/**
+ * The chain probes three backends in turn, and only one of them is guaranteed to be configured on a
+ * given install: `DIAL_DEPLOYMENTS_API_URL` is optional and is not even listed in `.env.template`.
+ * An unset or unreachable host makes its client's `fetch` **reject**, which is a different event
+ * from the backend answering "I do not own this activity" — and a rejection at an earlier step must
+ * not decide the outcome of a later one. Every case here rejects a probe rather than resolving it
+ * with `success: false`, which is the distinction the rest of this suite never draws.
+ */
+describe('getActivityAuditDetailData :: a backend that rejects instead of answering', () => {
+  const FETCH_FAILED = new TypeError('fetch failed');
+
+  test('Should still resolve an analytics activity when the deployment lookup rejects', async () => {
+    vi.stubEnv('ANALYTICS_ENABLED', 'true');
+    missAdminActivity();
+    vi.mocked(deploymentAuditApi.getActivityById).mockRejectedValue(FETCH_FAILED);
+    vi.mocked(analyticsAuditApi.getActivityById).mockResolvedValue({ success: true, response: ANALYTICS_ACTIVITY });
+    vi.mocked(analyticsAuditApi.getRevisionDetails).mockImplementation((url) => Promise.resolve({ url }));
+
+    const result = await getActivityAuditDetailData('activity-analytics', TOKEN_MOCK);
+
+    expect(analyticsAuditApi.getActivityById).toHaveBeenCalledWith('activity-analytics', TOKEN_MOCK);
+    expect(result.activity).toEqual(ANALYTICS_ACTIVITY);
+    expect(result.activityRevision).toEqual({ url: '/tables/orders/revision/7' });
+    expect(result.previousRevision).toEqual({ url: '/tables/orders/revision/6' });
+  });
+
+  test('Should name the failing backend and the route it asked for when a lookup rejects', async () => {
+    vi.stubEnv('ANALYTICS_ENABLED', 'true');
+    missAdminActivity();
+    vi.mocked(deploymentAuditApi.getActivityById).mockRejectedValue(FETCH_FAILED);
+    vi.mocked(analyticsAuditApi.getActivityById).mockResolvedValue({ success: true, response: ANALYTICS_ACTIVITY });
+
+    await getActivityAuditDetailData('activity-analytics', TOKEN_MOCK);
+
+    expect(errorObjLog).toHaveBeenCalledOnce();
+    expect(errorObjLog).toHaveBeenCalledWith(
+      FETCH_FAILED,
+      'Activity lookup failed on the deployment manager backend: api/v1/activities/activity-analytics',
+    );
+  });
+
+  test('Should log nothing when a backend merely does not own the activity', async () => {
+    vi.stubEnv('ANALYTICS_ENABLED', 'true');
+    missAdminActivity();
+    missDeploymentActivity();
+    vi.mocked(analyticsAuditApi.getActivityById).mockResolvedValue({ success: true, response: ANALYTICS_ACTIVITY });
+
+    await getActivityAuditDetailData('activity-analytics', TOKEN_MOCK);
+
+    expect(errorObjLog).not.toHaveBeenCalled();
+  });
+
+  test('Should keep probing the later backends when the admin lookup rejects', async () => {
+    vi.stubEnv('ANALYTICS_ENABLED', 'true');
+    vi.mocked(activityAuditApi.getActivityById).mockRejectedValue(FETCH_FAILED);
+    missDeploymentActivity();
+    vi.mocked(analyticsAuditApi.getActivityById).mockResolvedValue({ success: true, response: ANALYTICS_ACTIVITY });
+
+    const result = await getActivityAuditDetailData('activity-analytics', TOKEN_MOCK);
+
+    expect(deploymentAuditApi.getActivityById).toHaveBeenCalledWith('activity-analytics', TOKEN_MOCK);
+    expect(result.activity).toEqual(ANALYTICS_ACTIVITY);
+    expect(errorObjLog).toHaveBeenCalledWith(
+      FETCH_FAILED,
+      'Activity lookup failed on the admin backend: api/v1/activities/activity-analytics',
+    );
+  });
+
+  test('Should resolve an admin activity even though the deployment backend is unreachable', async () => {
+    vi.stubEnv('ANALYTICS_ENABLED', 'true');
+    resolveAdminActivity();
+    vi.mocked(deploymentAuditApi.getActivityById).mockRejectedValue(FETCH_FAILED);
+
+    const result = await getActivityAuditDetailData('activity-admin', TOKEN_MOCK);
+
+    expect(result.activity).toEqual(ADMIN_ACTIVITY);
+    expect(deploymentAuditApi.getActivityById).not.toHaveBeenCalled();
+    expect(errorObjLog).not.toHaveBeenCalled();
+  });
+
+  test('Should keep the current snapshot when the previous-revision snapshot rejects', async () => {
+    vi.stubEnv('ANALYTICS_ENABLED', 'true');
+    missAdminActivity();
+    missDeploymentActivity();
+    vi.mocked(analyticsAuditApi.getActivityById).mockResolvedValue({ success: true, response: ANALYTICS_ACTIVITY });
+    vi.mocked(analyticsAuditApi.getRevisionDetails).mockImplementation((url) =>
+      url.endsWith('/6') ? Promise.reject(FETCH_FAILED) : Promise.resolve({ url }),
+    );
+
+    const result = await getActivityAuditDetailData('activity-analytics', TOKEN_MOCK);
+
+    expect(result.activity).toEqual(ANALYTICS_ACTIVITY);
+    expect(result.activityRevision).toEqual({ url: '/tables/orders/revision/7' });
+    expect(result.previousRevision).toBeNull();
+    expect(errorObjLog).toHaveBeenCalledWith(
+      FETCH_FAILED,
+      'Failed to fetch a revision snapshot for activity activity-analytics',
+    );
+  });
+
+  test('Should render both snapshots when the activities list rejects', async () => {
+    vi.stubEnv('ANALYTICS_ENABLED', 'true');
+    missAdminActivity();
+    missDeploymentActivity();
+    vi.mocked(analyticsAuditApi.getActivityById).mockResolvedValue({ success: true, response: ANALYTICS_ACTIVITY });
+    vi.mocked(analyticsAuditApi.getActivitiesList).mockRejectedValue(FETCH_FAILED);
+    vi.mocked(analyticsAuditApi.getRevisionDetails).mockImplementation((url) => Promise.resolve({ url }));
+
+    const result = await getActivityAuditDetailData('activity-analytics', TOKEN_MOCK);
+
+    expect(result.activity).toEqual(ANALYTICS_ACTIVITY);
+    expect(result.activityRevision).toEqual({ url: '/tables/orders/revision/7' });
+    expect(result.previousRevision).toEqual({ url: '/tables/orders/revision/6' });
+    expect(result.entity).toBeUndefined();
+    expect(errorObjLog).toHaveBeenCalledWith(
+      FETCH_FAILED,
+      'Failed to fetch the activity list for activity activity-analytics',
+    );
+  });
+});
+
+/**
+ * The scenarios behind this block are structural: every audit detail page resolves through this one
+ * module, and the two resolvers it replaced are gone. Nothing else in the suite renders these server
+ * pages, so a page reverted to a private resolver would be invisible without reading the source.
+ */
+describe('getActivityAuditDetailData :: page wiring', () => {
+  const RESOLVER_IMPORT =
+    /^import \{ getActivityAuditDetailData \} from '@\/src\/utils\/audit\/get-activity-audit-detail-data';$/m;
+  const APP_DIR = join(__dirname, '../../../app/[lang]');
+
+  const GLOBAL_PAGE = 'activity-audit/[id]/page.tsx';
+
+  const DEPLOYMENT_PAGES = [
+    'model-servings',
+    'mcp-containers',
+    'adapter-containers',
+    'application-containers',
+    'interceptor-containers',
+    'deployment-images',
+  ];
+
+  const ADMIN_PAGES = [
+    'models',
+    'adapters',
+    'applications',
+    'interceptors',
+    'roles',
+    'keys',
+    'routes',
+    'toolsets',
+    'application-runners',
+    'interceptor-templates',
+  ];
+
+  const readPage = (relativePath: string) => readFileSync(join(APP_DIR, relativePath), 'utf-8');
+
+  test('Should resolve the global detail page through the unified resolver', () => {
+    expect(readPage(GLOBAL_PAGE)).toMatch(RESOLVER_IMPORT);
+    expect(existsSync(join(APP_DIR, 'activity-audit/[id]/resolver.ts'))).toBe(false);
+  });
+
+  test.each(DEPLOYMENT_PAGES)('Should resolve the %s entity-namespaced page through the unified resolver', (route) => {
+    const page = readPage(`${route}/[id]/[subId]/page.tsx`);
+
+    expect(page).toMatch(RESOLVER_IMPORT);
+    expect(page).toContain('isEntityActivity');
+  });
+
+  test.each(ADMIN_PAGES)('Should resolve the %s entity-namespaced page through the unified resolver', (route) => {
+    const page = readPage(`${route}/[id]/[subId]/page.tsx`);
+
+    expect(page).toMatch(RESOLVER_IMPORT);
+    expect(page).toContain('isEntityActivity');
+  });
+
+  test('Should no longer ship the legacy admin-only resolver', () => {
+    expect(existsSync(join(__dirname, '../get-audit-activity-data.ts'))).toBe(false);
+  });
+});

--- a/apps/ai-dial-admin/src/utils/audit/tests/get-revision-route.spec.ts
+++ b/apps/ai-dial-admin/src/utils/audit/tests/get-revision-route.spec.ts
@@ -85,6 +85,40 @@ describe('Audit :: getRevisionRouteForEntityType', () => {
     expect(getRevisionRouteForEntityType(type, id)).toBe(`/deployments/${id}/revision/`);
   });
 
+  test('returns correct route for TABLE', () => {
+    expect(getRevisionRouteForEntityType(ActivityAuditResourceType.TABLE, 'orders')).toBe(`/tables/orders/revision/`);
+  });
+
+  test('returns the owning table route for TABLE_COLUMN', () => {
+    expect(getRevisionRouteForEntityType(ActivityAuditResourceType.TABLE_COLUMN, 'orders:total')).toBe(
+      `/tables/orders/revision/`,
+    );
+  });
+
+  test('returns correct route for PIPELINE', () => {
+    expect(getRevisionRouteForEntityType(ActivityAuditResourceType.PIPELINE, 'daily_rollup')).toBe(
+      `/pipelines/daily_rollup/revision/`,
+    );
+  });
+
+  test('returns correct route for SAVED_QUERY', () => {
+    expect(getRevisionRouteForEntityType(ActivityAuditResourceType.SAVED_QUERY, 'q1')).toBe(
+      `/saved-queries/q1/revision/`,
+    );
+  });
+
+  // Documents the URL each analytics route becomes once the resolver appends the revision
+  // and the analytics client prefixes `v1`. The prefix is asserted against the client in
+  // src/server/analytics/tests/audit-api.spec.ts; this pins only this function's half.
+  test.each([
+    [ActivityAuditResourceType.TABLE, 'orders', 7, 'v1/tables/orders/revision/7'],
+    [ActivityAuditResourceType.TABLE_COLUMN, 'orders:total', 7, 'v1/tables/orders/revision/7'],
+    [ActivityAuditResourceType.PIPELINE, 'daily_rollup', 3, 'v1/pipelines/daily_rollup/revision/3'],
+    [ActivityAuditResourceType.SAVED_QUERY, 'q1', 3, 'v1/saved-queries/q1/revision/3'],
+  ])('documents the analytics snapshot url composed for %s', (type, resourceId, revision, expected) => {
+    expect(`v1${getRevisionRouteForEntityType(type, resourceId)}${revision}`).toBe(expected);
+  });
+
   test('returns null for unknown type', () => {
     expect(getRevisionRouteForEntityType('UNKNOWN' as any, id)).toBeNull();
   });

--- a/openspec/changes/analytics-activity-audit/.openspec.yaml
+++ b/openspec/changes/analytics-activity-audit/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-08

--- a/openspec/changes/analytics-activity-audit/design.md
+++ b/openspec/changes/analytics-activity-audit/design.md
@@ -1,0 +1,768 @@
+# Design — analytics-activity-audit
+
+## Context
+
+See `proposal.md` — *Why* for motivation, and `<state>/changes/analytics-activity-audit/ba-review.md`
+for the near-duplicate analysis and the long-form open questions. This document covers only what the
+implementation needs decided.
+
+Five facts from the code and from the analytics backend's own specification shape everything below.
+They were read, not assumed:
+
+1. **`ActivityAuditList` branches on a boolean, not on the view.** `List.tsx:211` is
+   `isDeploymentsView ? getDeploymentActivities : getActivities`, and the same `isDeploymentsView`
+   boolean gates the row-class rule, the cell-click handler, the column set, and the
+   parent/child-aggregation bypass. A third view does not extend that shape.
+2. **`buildResourceTypeLabelMap` iterates the whole enum** (`formatters.ts:53`), so its map — and the
+   `contains` → `equals` narrowing that `expandResourceTypeFilter` performs from it
+   (`List/utils.tsx:26`) — is shared by the `Config` and `Deployments` views. Its existing tests
+   (`src/components/ActivityAudit/List/tests/utils.spec.tsx`, `resourceType label-aware filter
+   transform`) cover the mechanism but pin no specific label, so nothing currently fails if adding
+   enum members widens an existing needle from one match to two.
+3. **`BaseEntity` is entirely optional fields** (`name?`, `displayName?`, `description?`, `intro?`,
+   `topics?`, `createdAt?`, `updatedAt?`). An `AnalyticsTable` is not one, but `{ name, description }`
+   *is* a valid `BaseEntity`. So the `EntityAudit` reuse needs no cast, no widened prop, and no lie —
+   just a projection at the analytics call site.
+4. **A column activity is not a table activity.** The analytics backend's `AuditResourceMapper`
+   names a column `TableColumn` with `resourceId = "<table>:<column>"`, and its own spec states
+   outright, under *Activity feed listing → Filter by resource*, that filtering `resourceType eq Table`
+   + `resourceId eq <name>` returns "only activities for that table definition … and none for its
+   columns". Its *Child activities link to their parent* requirement further states that a revision
+   which changes a column but not the definition row produces a **parentless** `TableColumn` activity.
+5. **A `viewMode`-driven entity Audit tab resolves its row-click href through `auditResourceRoute`**
+   (`getAuditActivityHref`, `List/utils.tsx:184`), which returns `''` for an unregistered type. The
+   existing test `returns empty href for a resource type not registered in auditResourceRoute`
+   (`List/tests/utils.spec.tsx:392`, asserted with `ADMIN_PROPERTIES`) pins that, so a blanket
+   fallback there would break an existing assertion.
+6. **The diff engine silently drops an object-valued field it has no handler for.**
+   `compareObjectTypes` / `fillObjectTypes` (`View/utils/generate-diffs.ts:214, :293`) are chains of
+   `else if` over known key sets — `arrayParameterKeys`, `arrayStringParameterKeys`,
+   `arrayObjectParameterKeys`, `SOURCE`, `separateObjectParameterKeys` — with **no final `else`**. A
+   table snapshot's `columns` array, its `grain` / `partition_by` objects and its `ordering_key` /
+   `tag_order` arrays match none of them, so the generic path does not render them *badly*: it does
+   not render them at all. `createSectionFromDiffs` compounds this — it iterates a fixed list of
+   section names, so a bucket whose key is not in that list never reaches a renderer. This is why
+   the owner's requirement is a change to the engine and not a styling pass.
+7. **The engine already has the two mechanisms the owner's grouping needs.** Container environment
+   variables fan a repeated item out into numbered buckets (`metadata0`, `metadata1`, …) via
+   `compareMetadataEnvs`, are collected by `setObjectsArrayDiff`, and are rendered by `DiffSection`
+   as one accordion whose per-index blocks carry a `Variable N ` prefix. Container compute, scaling
+   and probe sections project an object to `FlatRow[]` and compare it through
+   `compareNestedFlatObject` (`View/utils/create-simple-diffs.ts:198`), which emits
+   `isCurrent ? MIRROR : REMOVED` and `isCurrent ? MIRROR : ADDED` — i.e. it already keeps a field
+   visible on the side where it does not exist, as a placeholder row. Together these are exactly
+   "one group per column, with added and removed entries still visible and marked".
+   One caveat that must **not** be copied: `compareMetadataEnvs` returns early when the compare side
+   has no rows (`generate-diffs.ts:433`), so an env var present only on side one emits nothing. That
+   is the failure mode the owner is objecting to; the analytics comparator must emit in both
+   directions.
+8. **Status is currently conveyed by row colour only.** `DIFF_ROW_CLASS_RULES`
+   (`src/constants/ag-grid.ts:129`) maps `DiffStatus` to background/border classes, and `DiffLegend`
+   shows counts against colour swatches labelled with the `Create` / `Update` / `Delete` button
+   strings. There is no text or ARIA statement of a row's or a group's status anywhere in the diff,
+   which is why the owner's "marked as such" needs `.claude/rules/a11y.md`'s grouping rule applied,
+   not just a class.
+9. **Every label the analytics diff needs already exists.** `AnalyticsTablesI18nKey`
+   (`src/constants/i18n.ts:2513`) already defines `Name`, `Description`, `Type`, `SourceTable`,
+   `Status`, `System`, `OrderingKey`, `PartitionColumn`, `Granularity`, `IdentityColumn`,
+   `VersionColumn`, `GrainKey`, `TagOrder`, `Columns`, `ColumnName`, `Tag`, `DisplayName`,
+   `ElementType`, `EnumValues`, `Nullable` and `Sensitive`. The diff needs no new field labels — only
+   the three status words and one group-heading pattern.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- One coherent replacement for the boolean fetcher branch, so a fourth backend later is an entry, not
+  another `if`.
+- An Audit tab on the table detail view that actually answers the questions in the ticket — who
+  dropped a column, who marked one sensitive.
+- A revision diff that answers the same questions on the detail page: the whole snapshot, grouped,
+  with the added and removed columns marked where they are (D11).
+- No change to what the `Config` and `Deployments` views do, and a test that proves the shared
+  resource-type filter did not shift under them.
+- No affordance anywhere in the audit capability that writes to a backend which does not own the
+  resource (D9).
+
+**Non-Goals** (design-level; the proposal's own Non-goals still hold)
+
+- **Rollback of any kind for analytics resources.** The analytics backend exposes no mutating audit
+  endpoint and no rollback route. Not buildable here; a disabled control would be worse than absence.
+  This now covers three affordances, not two — see D9.
+- **Guarding the `/tables/{name}` route itself.** The Audit tab is gated on the analytics flag and on
+  an active table status (D12); the route is not. Guarding it is a statement about the whole tables
+  feature, not about audit.
+- **Reshaping the diff for non-analytics resource types.** D10 adds an analytics branch to the diff
+  engine; the container, image, firewall and admin paths are untouched, and their row-level status
+  treatment is not revisited.
+
+**Reversed non-goal.** Earlier revisions of this design put analytics *diff readability* out of
+scope — "the diff must open and be correct; whether a `columns` array reads well is a follow-up".
+The owner has reversed that: every field of the snapshot must be shown, grouped where grouping
+helps, with added and removed entries marked as such. Diff presentation is therefore in scope and
+specified — see D10. What remains out of scope is any per-field formatting beyond labelling and
+grouping: no bespoke cell renderers, no type-aware value formatting for analytics fields.
+- **Splitting the change.** One change, one pull request. The batches below exist for parallel
+  dispatch, not for a PR split.
+- **Restructuring the tables feature onto the `View/` + `TabsContent/` entity pattern.** See D6.
+
+## Decisions
+
+### D1 — Where the spec delta lives: a new `activity-audit-analytics-view` capability
+
+The audit-page side of this change (the third view option, its fetcher, its labels, its rollback
+absence, its detail-page resolution) goes into a **new** capability spec,
+`openspec/specs/activity-audit-analytics-view/`, named to mirror `activity-audit-deployments-view`.
+The Analytics-**feature** side — the tables detail view's tab set and the Audit tab's content — goes
+into the analytics master spec, `openspec/specs/analytics/spec.md`, per `openspec/config.yaml`.
+
+*Alternatives rejected:*
+
+- **Amend `activity-audit-deployments-view` in place with the analytics requirements.** Rejected: it
+  puts requirements about analytics into a spec whose Purpose paragraph says it defines the
+  Deployments view, and it makes that spec grow a second subject every time a backend is added. Its
+  precedent argues the other way — deployments got its own capability rather than being folded into
+  the pre-existing audit specs.
+- **Put the audit-page analytics requirements into the analytics master spec.** Rejected: the master
+  spec covers the Analytics *feature* (its menu group, its tables, pipelines, queries, dashboards).
+  The `/activity-audit` page is the Audit feature; a reader looking for the audit view selector's
+  behavior would not find it under Analytics, and the config rule that keeps Analytics feature specs
+  consolidated is about the feature, not about every requirement containing the word.
+- **Move the selector's requirements to a new view-neutral capability and leave the deployments spec
+  to its own view.** Rejected as a bigger refactor than this change earns: it would mean a REMOVED +
+  ADDED pair across two capabilities to relocate text that is already correct. Only the one sentence
+  that literally becomes false is modified.
+
+Three existing requirements are `MODIFIED` because their text becomes false rather than merely
+incomplete: *View selector exposes a Deployments option* ("exactly these two views"),
+*`ActivityAuditList` accepts a `viewMode` prop…* (two modes enumerated), and *A single unified
+resolver loads activity audit detail for every page* (a two-step fallback chain enumerated). Nothing
+else in those specs is touched.
+
+Because a reader of the analytics master spec would otherwise never learn that part of the analytics
+audit story lives elsewhere, the master spec's new Audit-tab requirement opens with one
+cross-reference line naming `activity-audit-analytics-view` as the owner of the global page's
+`Analytics` view. That satisfies `openspec/config.yaml`'s consolidation rule at archive time without
+moving any requirement; the split itself is not reopened.
+
+The analytics master spec's *Table detail column schema management* requirement is deliberately **not**
+modified. It is ~40 lines of prose about the columns grid, and every statement in it stays true; the
+new *Table detail view is organized into Properties and Audit tabs* requirement scopes it additively
+by naming which tab its content now renders inside. Copying that block into a `MODIFIED` section to
+change one preposition would risk losing detail at archive time for no gain.
+
+### D2 — The fetcher ternary is replaced by a per-view lookup, not a third branch
+
+A new module `src/components/ActivityAudit/List/view-config.ts` exports
+`ACTIVITY_AUDIT_VIEW_CONFIG: Record<ActivityAuditView, ActivityAuditViewConfig>` with the per-view
+type in an adjacent `models.ts` (per `code-standards.md` — const values and types split). Each entry
+declares:
+
+| field | Config | Deployments | Analytics |
+|---|---|---|---|
+| `fetchActivities` | `getActivities` | `getDeploymentActivities` | `getAnalyticsActivities` |
+| `getColumns` | `getActivityAuditColumns` | `getDeploymentActivityAuditColumns` | `getAnalyticsActivityAuditColumns` |
+| `hasParentChildAggregation` | `true` | `false` | `false` |
+| `hasRollback` | `true` | `true` | `false` |
+| `isRowNavigable` | always | `isDeploymentManagerResource` | always |
+
+`List.tsx` reads `ACTIVITY_AUDIT_VIEW_CONFIG[effectiveViewType]` once and uses it everywhere
+`isDeploymentsView` is consulted today. The `Config` and `Deployments` entries are transcriptions of
+current behavior, so the two existing views are unchanged by construction, and `List.spec.tsx`'s
+existing view-aware tests are the regression check.
+
+*Alternatives rejected:* a nested ternary (`code-standards.md` forbids nesting, and it would need
+four more of them); a `switch` per call site (the same knowledge restated in five places, which is
+how the current boolean got out of step with itself); a strategy object passed in as a prop (pushes
+the decision to every caller and widens a shared component's props to fit one caller, which
+`use-don't-edit-shared-components` forbids).
+
+`Record<ActivityAuditView, …>` rather than `Partial<Record<…>>` is deliberate: adding a fourth enum
+member without an entry then fails to compile instead of falling through to `undefined` at runtime.
+
+**The `entity` short-circuit must yield to the view config.** `columnDefs`
+(`List.tsx:353-360`) returns early whenever `entity` is present, with
+`getActivityAuditColumns(t, openInNewTabForEntity, onOpenConfirmationModal, void 0, true)` — the
+`isSingleEntity` column set, which hides `Resource type` and `Resource identifier`, **plus** a
+Rollback row action. Leaving that branch first would break two specified scenarios at once (*A column
+activity states which column it refers to* and *No rollback action is offered*) while every unit test
+named in the surfaces task still passed. So the branch resolves through
+`ACTIVITY_AUDIT_VIEW_CONFIG[effectiveViewType]` like every other one: the config's `getColumns` and
+`hasRollback` decide, and `isSingleEntity` becomes an argument the `Config` and `Deployments` entries
+pass and the `Analytics` entry does not. Entity-mode row Rollback must survive for `Config` and
+`Deployments`, which is what the kept existing tests are for.
+
+### D3 — The table Audit tab shows the table **and its columns**
+
+The tab requests `resourceType in "Table,TableColumn"` + `resourceId co "<name>"` and then narrows
+client-side to rows whose `resourceId` is exactly `<name>` or starts with `<name>:`. The narrowing
+predicate is a pure function in `src/utils/audit/analytics-resource-id.ts`, unit-tested.
+
+This refines the proposal's phrasing ("filtered to this table's `(resourceType, resourceId)` pair").
+The reason is fact 4 above: that pair is specified by the analytics backend to return *no* column
+activities, so the literal reading produces an Audit tab that cannot answer either question the
+ticket names, while the backend deliberately models columns as children so a client can show them
+with their table. **EM/BA should veto this if the narrower reading was intended** — it is the one
+place where this design does not do what the proposal's sentence says.
+
+Why not something simpler:
+
+- **`resourceId eq <name>` only (the proposal's literal reading).** Rejected: hides column history;
+  see above.
+- **`resourceId co <name>` with no client-side narrowing.** Rejected: `co` is a substring match, so
+  the tab for `orders` would show rows belonging to `my_orders` — an audit surface showing another
+  resource's history is worse than one showing too little.
+- **Two paged requests merged in the datasource.** Rejected: merging two independently paged,
+  independently sorted streams into AG Grid's infinite row model is a correctness problem
+  (`lastRow`, ordering, dedupe) far larger than the feature.
+- **Reuse the `Config` view's parent/child child-fetch to pull columns in under their table.**
+  Rejected as insufficient rather than wrong: it only surfaces columns changed in the *same revision*
+  as a table change, and the backend's spec has an explicit scenario for the column-only revision
+  that produces no parent at all.
+
+Consequence for the tab's columns: because the list now carries two resource types, it uses the
+Analytics column set (`Resource type` and `Resource identifier` visible, no expander, no `Version`)
+rather than the `isSingleEntity` set that hides both — a row reading only "Update / 14:02 / ana@…"
+would not say *which column*. `ACTIVITY_AUDIT_COLUMNS` needs no edit: called with
+`view = Analytics, isSingleEntity = false` it already produces exactly that set.
+
+### D4 — Reuse `EntityAudit`; adapt at the call site
+
+The Audit tab renders `EntityAudit` with `entity={{ name: table.name, description: table.description }}`,
+`view={ApplicationRoute.AnalyticsTables}`, `viewMode={ActivityAuditView.Analytics}`. This is BA's Q5
+recommendation and I keep it, for two reasons beyond consistency:
+
+- `getAuditTabs(t, featureFlags, ApplicationRoute.AnalyticsTables)` already returns `[Activities]`
+  and nothing else — the route matches none of the telemetry branches — so the Activities-only rail
+  the deployment Audit tabs established comes for free, with **no edit to `getAuditTabs`**.
+- Fact 3 means the projection is a literal object, not a cast. The `AnalyticsTable → BaseEntity`
+  adaptation lives in one small component, `TableAudit.tsx`, which is the "adaptation at the call
+  site" the review demanded.
+
+`routeAuditResource` gains `[ApplicationRoute.AnalyticsTables]: ActivityAuditResourceType.TABLE` so
+`resolveEntityAuditType` resolves the entity type without a new branch.
+
+*Alternative rejected:* calling `ActivityAuditList` directly and skipping the single-item rail. It
+saves one visual element and costs the consistency every other Audit tab in the app has; and
+`ActivityAuditList`'s `entity` prop has the same `BaseEntity` typing, so it saves no adaptation
+either.
+
+### D5 — Row click in the Analytics view goes to the global detail page, in a new tab
+
+Both in the global Analytics view and in the table's Audit tab, a row opens
+`/activity-audit/{activityId}`. In the tab this is a per-view behavior (`view-config`'s
+`getEntityActivityHref`), **not** a general fallback inside `getAuditActivityHref`.
+
+**The row opens a new tab, and that is deliberate — do not "fix" it.** The first draft of this
+capability's spec said a row-body click navigates the *current* tab, and browser verification
+(item 7.1) found that it does not: `location.href` stays on the list and the detail page opens in a
+new tab. That is pre-existing shared behaviour of this list, not something this change introduced —
+the shipped `Config` view does the same, the row's own menu item is literally labelled
+`Open in a new tab`, and `onCellClicked` in `List.tsx` has always called `openInNewTab`
+(`onOpenInNewTab` → `window.open(url, '_blank')`, `src/utils/open-in-new-tab.ts:16`). This change
+touched only the navigability guard (`isDeploymentsView && !isDeploymentManagerResource(…)` →
+`viewConfig.isRowNavigable(…)`), never the navigation target. The owner's call was that the scenario
+moves and the code stays, so the requirement now states the new-tab behaviour for both entry points
+— the row body and the menu item — and names them separately so the two are not read as one.
+
+A future reader who finds the older, current-tab reading in a review comment or a stale spec should
+correct that text, not the component: making a row-body click navigate in place would change the
+`Config` and `Deployments` views for every user, which is out of scope for this change and was never
+asked for.
+
+*Alternatives rejected:* registering `Table → ApplicationRoute.AnalyticsTables` in
+`auditResourceRoute` would produce `/tables/{name}/{activityId}`, a route this change deliberately
+does not create (proposal Non-goal), i.e. a 404 on every row click. A blanket "if no namespaced route,
+fall back to the global page" inside `getAuditActivityHref` would change behavior for the
+Assets-Toolsets and Platform-Models Audit tabs, whose entity type is likewise unregistered, and would
+break the existing test named in fact 5 — an out-of-scope behavior change disguised as a default.
+
+### D6 — Tabs are added to `TableDetailView.tsx` as a shell; the body is extracted
+
+`TableDetailView.tsx` keeps its route wiring, its props, and ownership of all state (table, draft
+form, permissions, every modal). It renders, in order: the existing header (title, badges,
+description, **the whole action row, unchanged**), then a `DialTabs` strip, then the active tab's
+content, then the modals. The body it renders today — the read-only key summary plus the columns grid
+or the draft schema editor — moves verbatim into `TableProperties.tsx` (presentational, ~5 props).
+The Audit tab is `TableAudit.tsx` from D4.
+
+Header actions stay **above** the tab strip (BA's Q3 answer, accepted): Manage access and Delete are
+table-wide, and moving Add columns / Add rows / Connect into Properties would relocate controls for
+every user who never opens Audit, for no benefit. It also keeps the modal state where it already is.
+
+*Alternatives rejected:*
+
+- **Full house `View/` + `TabsContent/` restructure.** Rejected: the tables feature has no `View/`
+  directory, no etag/save/discard lifecycle, and no `originalEntity` handoff — the three things the
+  entity pattern exists to organize. Adopting the folder shape without the lifecycle would be
+  cargo-cult, it would rename the file every open PR touching this area conflicts on (issue #3977
+  edits `TableDetailView`), and it converts a reviewable diff into a move-plus-diff. The in-repo
+  precedent for a shell with an inline `activeTab === …` switch is `EntityAudit.tsx` itself.
+- **`DialTabs` bolted on with no extraction.** Rejected: it leaves a ~650-line component with two
+  unrelated bodies inline, which `components.md` §3 calls out directly.
+
+### D7 — The label-map blast radius is accepted, and pinned by a test
+
+Adding four enum members changes `buildResourceTypeLabelMap` for the `Config` and `Deployments`
+views too. That is accepted rather than scoped, because:
+
+- the map's values are **arrays** precisely so several enum members may share one label — the
+  structure was built to tolerate additions;
+- the four new labels (`Table`, `Table column`, `Pipeline`, `Saved query`) are equal to no existing
+  label, so no existing key is widened;
+- the residual risk is narrower than it looks: `expandResourceTypeFilter` narrows a `contains` needle
+  to `equals` only when exactly one label matches. If a new label makes some needle match two, that
+  needle degrades to the plain `contains` filter — still correct filtering, merely less narrow — and
+  it never resolves to the *wrong* type;
+- scoping the map per view would mean threading the active view through `getFormattedResourceType`,
+  the column definitions, and the filter transform: more code changed, in the very files the risk
+  lives in, than the risk warrants.
+
+The mitigation is a guard test in `src/constants/grid-columns/tests/formatters.spec.ts` pinning the
+single-match resolutions that other capabilities depend on — `global firewall` above all, since
+`global-firewall-audit-shortcut` requires that needle to reach one type.
+
+### D8 — The third detail-page fallback is gated on the analytics flag
+
+`getActivityAuditDetailData` gains `analyticsAuditApi.getActivityById` as a third and last fallback,
+issued **only** when analytics is enabled in the environment the resolver runs in (the resolver is
+server-side, so it reads the environment directly rather than the client `featureFlags`). Without the
+gate every non-admin activity's detail page would pay a third sequential round trip on an install
+that has no analytics at all.
+
+The check is `isValueTruthy(process.env.ANALYTICS_ENABLED)` — the helper in
+`src/utils/types.ts`, which is `value === 'true'` — and **not** a bare truthiness test on the
+variable. `layout.tsx:61` reads this same variable through that helper for
+`featureFlags.analyticsEnabled`, so a bare test would make the server resolver and the client flag
+disagree on any install that sets `ANALYTICS_ENABLED=false` explicitly: the string is truthy, so the
+resolver would call a backend the rest of the app treats as absent. The test covers both the unset
+and the `"false"` case for that reason.
+
+*Alternative rejected:* probing the three backends in parallel and taking the first hit. It would cut
+latency but issues two guaranteed-useless requests for every admin activity — the common case — and
+turns a `404` from an unrelated service into noise in every detail-page load.
+
+`getRevisionRouteForEntityType` gains the four analytics routes. `TableColumn` has no snapshot
+endpoint of its own, so it resolves to its owning table's snapshot at the same revision by splitting
+its `<table>:<column>` identifier — a snapshot that genuinely contains the column change, obtained
+with a documented route rather than invented shaping.
+
+### D9 — The detail page's `Rollback resource` button is suppressed by resource type
+
+`AuditView.tsx:221` renders the `Rollback resource` button for every activity whenever the viewer is
+not a read-only admin. There is no resource-type condition on it: `blockReason` is only ever set by
+`resolveDeploymentRollbackBlockReason`, and `resourceRollback` (`:133`) dispatches
+`isDeployment ? rollbackDeploymentEntity : rollbackEntityPerRevision` — so for an analytics activity
+it falls through to the **admin** backend's per-revision rollback, aimed at a resource that backend
+does not own. This is a third rollback affordance beyond the list's page-level button and the row
+menu, and suppressing it is the only reason the detail page is reachable at all for analytics.
+
+The condition is `isAnalyticsResource(activity.resourceType)` — the predicate the types task already
+creates — wrapped around the existing `!isReadOnlyAdmin` condition. Nothing else in `AuditView`
+changes: the confirmation popup, the notifications and the navigation after a successful rollback
+stay exactly as they are for the resource types that still offer it.
+
+*Alternatives rejected:*
+
+- **Render it disabled with a tooltip explaining that analytics has no rollback endpoint.** Rejected
+  for the same reason the proposal rejects it in the list: a disabled control advertises a capability
+  that does not exist and never will from this frontend.
+- **Set `blockReason` for analytics resource types and let the existing `disabled` path handle it.**
+  Rejected: same visible outcome as above, and it overloads a state that today means "this deployment
+  is mid-lifecycle, try again later" with "this can never work".
+- **Leave it and rely on the backend rejecting the call.** Rejected: the call goes to the *admin*
+  backend with an analytics resource id, so what it rejects — or worse, matches — is not predictable
+  from here.
+
+### D10 — The header's resource link resolves per resource type, and `auditResourceRoute` is left alone
+
+`View/Header/Header.tsx:25-30` builds `/{locale}${auditResourceRoute[resourceType]}/{resourceId}`
+unconditionally for any type outside three named exemptions, so an analytics activity gets
+`/en/undefined/orders`. All three analytics detail routes exist (`/tables/[id]`, `/pipelines/[name]`,
+`/queries/[id]`), so the answer is to resolve the link rather than to hide it.
+
+A new pure helper in `View/Header/utils.ts` — `getAuditResourceHref(resourceType, resourceId)` —
+returns the path or `undefined`: analytics types resolve through a small local
+`ANALYTICS_RESOURCE_ROUTE` map (`Table` and `TableColumn` → `ApplicationRoute.AnalyticsTables` with
+`getTableNameFromAnalyticsResourceId(resourceId)`, `Pipeline` → `AnalyticsPipelines`, `SavedQuery` →
+`AnalyticsQueries`), everything else through `auditResourceRoute` as today. `Header.tsx` renders the
+external-link button only when the helper returns a path, which also retires the `/en/undefined/...`
+link for any other unregistered type.
+
+**This is the fix that cannot be undone by accident, and that is the point.** The obvious one-line
+fix — `[TABLE]: ApplicationRoute.AnalyticsTables` in `auditResourceRoute` — has a second consumer:
+`getAuditActivityHref` (`List/utils.tsx:184`) reads the same map to build a row's `Open in new tab`
+href, so the entry would make every analytics row point at `/tables/{name}/{activityId}`, the
+entity-namespaced audit route D5 deliberately does not create. A developer fixing the header in
+isolation would silently undo D5 and ship a 404 on every row click, and no existing test would catch
+it. So: the map is not touched, a comment above it says why analytics is absent, and the existing
+`returns empty href for a resource type not registered in auditResourceRoute` test is extended with
+`Table` and `TableColumn` and a note naming D5. The guard lives on the *other* consumer, because
+that is the one a future edit would break.
+
+*Alternatives rejected:*
+
+- **Add the entry to `auditResourceRoute` and special-case `Table` inside `getAuditActivityHref`.**
+  Rejected: it puts the knowledge in two places and inverts the safe default — the map would then
+  contain a route that one of its two readers must remember to ignore.
+- **Suppress the header link for analytics types, as the three existing exemptions do.** Rejected as
+  a worse product answer for the same effort: the resource pages exist and the link is useful. Kept
+  as the fallback if the tables route is ever removed.
+- **Create the entity-namespaced routes so the map entry becomes correct.** Rejected: that is the
+  proposal's Non-goal, and it is a bigger change than the header link that motivates it.
+
+### D11 — The analytics revision diff: all fields, grouped, with added and removed marked
+
+This is the owner's reversal of the readability non-goal, and per fact 6 it is not a styling task:
+the fields the owner wants shown are the ones the generic engine drops on the floor. Four pieces:
+
+**1. An analytics branch in the builder.** `generateCurrentResource` gains an
+`isAnalyticsResource(type)` branch that delegates to a new module,
+`View/utils/analytics-diffs.ts`. That module owns three pure functions: a snapshot walker that
+projects any snapshot object to `FlatRow[]` (scalars as rows; nested objects flattened one row per
+leaf with a dotted parameter; scalar arrays joined **in declared order**, because `ordering_key` and
+`tag_order` mean their order); a `columnRows(column)` projector; and a `buildAnalyticsDiff` that
+fills the `properties` bucket from every non-`columns` field and one `columns:<name>` bucket per
+column name present in either revision, sorted by name. No hidden-key set: analytics resources have
+no `$type` / `id` / `createdAt` noise to suppress, and "show everything" is the requirement.
+Each bucket is compared with `compareNestedFlatObject` and filled with `fillNestedFlatObject` — the
+existing container compute/scaling/probe machinery, which already emits the MIRROR placeholder on
+the side a field is missing from. Fact 7's caveat applies: unlike `compareMetadataEnvs`, this
+comparator emits in both directions, so a removed column is never simply absent.
+
+**2. The section fan-out.** `EntityParameterKeys` gains `COLUMNS = 'columns'`, and
+`createSectionFromDiffs` gains an analytics branch beside the existing `setRolesDiffs` and
+`setObjectsArrayDiff` ones, collecting the `columns:<name>` buckets in name order into
+`sections.columns`. An `ANALYTICS_SECTION_ORDER` list is appended to the two existing ordered lists,
+so `properties` renders first and `columns` after it.
+
+**3. The group heading and the marker.** `ActivityAuditDiffSection` gains two optional fields,
+`label?: string` and `diffStatus?: DiffStatus`, threaded through `filterNotEmptySections` (which
+today discards everything but `current` / `compare`). `DiffSection` prefers `label` over its
+`EntityFieldsI18nKey[name]` title lookup for the per-index heading — generalizing the hardcoded
+`name === METADATA ? 'Variable N ' : ''` prefix it already has — and renders the status word beside
+it. Four new i18n keys on `CompareI18nKey`, the diff vocabulary's existing home: `Added`, `Removed`,
+`Changed`, and `ColumnGroup` (`'Column {name}'`). Field labels need nothing new (fact 9); the
+parameter formatter gains an `ANALYTICS_ROW_LABEL_KEYS` map beside the `CONTAINER_ROW_LABEL_KEYS` it
+already consults, and falls back to the raw field name as it does today — so a pipeline or
+saved-query field this repo does not model still renders, unlabelled rather than hidden.
+
+**4. Accessibility.** Per fact 8, status is colour-only today, and `.claude/rules/a11y.md` requires
+that a collection rendering different visual treatments per item kind expose the distinction with
+`role="group"` + `aria-label` on each item root. Each per-index block in `DiffSection` becomes that
+group, its accessible name carrying the column name and its status. The status word is also visible
+text, so the marker is not colour alone for a sighted user either. Scope discipline: this applies to
+the per-index group wrapper `DiffSection` already renders, for every section type — the row-level
+colour treatment of the container/image/admin diffs is not revisited, because doing that properly
+means a status column in every diff grid and that is its own change.
+
+**The filter's real label is `Changes only`.** The option beside `All parameters` in the diff view's
+`View` control is `ActivityAudit.Differences` = `Changes only`
+(`apps/ai-dial-admin/src/locales/en.ts`). An earlier draft of the delta called it `Diff only`, which
+is not a label the product has ever shown; browser verification (item 7.1) confirmed the shipped
+strings on a container activity's detail page. The control is pre-existing and this change neither
+renames nor moves it — the analytics groups simply flow through it. Any new text about it quotes
+`Changes only`.
+
+**The removed-column edge, recorded so it can be reversed cheaply.** A column present in the older
+revision and absent from the newer stays visible on both sides with a `Removed` marker, rather than
+disappearing from the newer side. Both revisions show the full column set; the difference is carried
+by the marker. This is the manager's default, stated to the owner and not contradicted. Reversing it
+is one branch in `buildAnalyticsDiff` (drop the group instead of emitting placeholders) and two
+scenarios; nothing else depends on it.
+
+*Alternatives rejected:*
+
+- **Register `columns` in `arrayObjectParameterKeys` and write a `compareColumns` beside
+  `compareUpstreams`.** Rejected: `compareObjectArray` dispatches on key name inside a function
+  shared by upstreams, defaults and env vars, and `columns` is a generic-enough name that an
+  analytics entry there would fire for any future resource with a `columns` field. The analytics
+  branch keys on the resource type, which is the thing that is actually true.
+- **One group for all columns, with the column name as a row inside it.** Rejected: it is the shape
+  the owner objected to. A ten-column table becomes ninety undifferentiated rows and "which column
+  changed" is back to reading colours.
+- **A dedicated analytics diff component instead of extending `DiffSection`.** Rejected: it
+  duplicates the accordion, the legend, the before/after pair and the `All parameters` /
+  `Changes only` filter, and it would drift from them. `DiffSection` already carries per-type title
+  resolution and a per-index prefix; analytics adds entries to those mechanisms rather than a
+  parallel renderer.
+- **Encode the column name in the bucket key and have `DiffSection` parse it out.** Rejected: it
+  makes the renderer parse a key format, and `setObjectsArrayDiff`'s `key.includes(sectionName)`
+  filter makes the format load-bearing in two places. Two optional fields on the section model say
+  the same thing in the type system.
+- **Type-aware value formatting for analytics fields** (rendering `enum_values` as chips, `nullable`
+  as a checkmark). Rejected as beyond the reversal: the owner asked for every field to be shown,
+  grouped and marked, not for per-field presentation. `formatValue` already handles the generic
+  cases.
+
+### D12 — The table Audit tab is gated on the client flag **and on an active status**; the route is not
+
+Two conditions, both in `TableDetailView`, and the tab strip renders only when both hold:
+
+1. `featureFlags.analyticsEnabled` (from `useAppContext`) is true;
+2. the table's status is active — `table.status === TableStatus.Active`, the `isActive` boolean the
+   component already computes for its header actions and its body branch.
+
+When either is false the component renders the Properties content directly — no tab strip, no Audit
+tab, no analytics activity request. One fallback for both conditions, not two.
+
+**The status condition is a reversal.** Earlier revisions of this design specified the opposite: both
+tabs present at every lifecycle status, on the reasoning that "a draft's history is as auditable as a
+live table's". The owner reversed it after checking the live analytics backend, and that check is the
+whole argument:
+
+- both `pending` tables in the stack report `column_count: 0` — a draft has no materialized columns;
+- an exact-match activity query (`resourceId eq <name>`) returns `total: 0` for each of them.
+
+So a draft table has **no** audit history at all — not "sometimes empty", empty in every observed
+case. A control that can never carry information is worse than its absence: it invites a click, costs
+a request, and answers nothing. `FAILED` and an absent `status` take the same branch, because the
+condition is `isActive`, not `!isPending`; a table whose materialization failed has no more history
+than one that never started, and treating an unreported status as inactive keeps this consistent with
+the body branch that already renders the draft editor in that case.
+
+**The falsifier, so a future reader knows the limit of the evidence.** If an `active` table can ever
+return to `pending`, hiding the tab conceals history exactly when it matters most — a table that lost
+its schema is the case an auditor most wants to read. That transition was **not** observed in the
+data and was **not** verified in the status-transition code; the evidence above is about tables that
+have never been materialized, and it does not extend to a table that was. If the transition turns out
+to exist, the fix is to widen condition 2 (to "active, or has ever been active") rather than to drop
+it, and the D12 scenarios are the two that change.
+
+*Alternatives rejected:*
+
+- **A tab strip with a single `Properties` tab on a draft table.** Rejected: a one-tab strip is chrome
+  with no function — nothing to switch to — and it costs vertical space on the very view (the draft
+  schema editor) that needs the most. It would also mean two distinct no-Audit renderings, one for the
+  flag and one for the status, where the product outcome is identical.
+- **Render the Audit tab disabled with a tooltip on a draft table.** Rejected for the same reason the
+  proposal rejects a disabled Rollback: a disabled control advertises something that does not exist
+  for this resource, and here the user cannot act to enable it except by materializing the table.
+- **Keep the tab at every status and let the empty grid state carry the message.** Rejected — this is
+  the reversed decision. It is defensible in the abstract and it is what the empty state exists for,
+  but it was measured: the tab is empty for *every* draft table, not for some, so the empty state
+  would be the only thing it ever showed.
+
+The earlier version of this design's Migration Plan claimed the change was inert with the flag off
+because "`/tables` is unreachable while the menu group is hidden". That is **false** and has been
+corrected: `src/app/[lang]/tables/[id]/page.tsx` reads only `ANALYTICS_PUBLIC_URL` and
+`ANALYTICS_FLIGHT_SQL_PUBLIC_URL`, `analyticsEnabled` is consumed in exactly one place today
+(`menu-configuration.tsx:267`), and a hidden menu item is not a route guard — a bookmark still opens
+the detail view. Without the tab condition, an analytics-disabled install would issue analytics
+activity requests from a page it still renders.
+
+*Alternative rejected:* guarding the route in `page.tsx` with a `notFound()` on
+`!isValueTruthy(process.env.ANALYTICS_ENABLED)`. It is arguably the more correct guard, and it is
+out of scope: it changes what the whole tables feature does when analytics is off, on every one of
+its routes, and it belongs to whoever owns that decision. Named here so the next reader knows it was
+considered rather than missed.
+
+### D13 — A child activity of a table `Delete` is not listed; the rule is keyed on the parent
+
+The owner's addition after the first pass: deleting a table floods the audit list, and the per-column
+child rows are to be hidden. This is one rule, applied in one place, and its narrowness is what makes
+it safe.
+
+**The evidence, checked against the live analytics backend rather than reasoned about.** Described as
+a shape, per the house rule that no record-specific data enters an OpenSpec artifact:
+
+- deleting one table produced exactly **one** parent `Table`/`Delete` activity and **one**
+  `TableColumn`/`Delete` activity per column of that table, all in the one revision, each child
+  carrying `parentActivityId` pointing at the parent;
+- the parent's own detail view already shows every one of them: the deleting revision has no snapshot
+  (`HTTP 404 revision_not_found` — the table is gone), the previous revision holds the table with all
+  of its columns, so D11's diff renders one `Removed` group per column. **The child rows carry no fact
+  the parent's view lacks**, and each child's own detail view is that same whole-table diff reached
+  from a row that names one column;
+- the rule separates noise from signal exactly, because a column `Delete` does **not** always sit
+  under a table `Delete`: a single column dropped from a living table is a `TableColumn`/`Delete`
+  whose parent is a `Table`/**`Update`**. That row stays, because "who dropped a column" is one of the
+  two questions the ticket names.
+
+**Why the parent's activity type is the only usable key.** Nothing on the child distinguishes the two
+cases — both are `TableColumn`/`Delete`, both carry a parent identifier, both name `<table>:<column>`.
+Sibling count does not distinguish them either (dropping every column one at a time would look
+identical). The distinguishing fact lives entirely on the parent, so the implementation has to hold
+the parent.
+
+**How the implementation gets the parent's `activityType`, which a child row does not carry.** A batch
+lookup on the same feed, mirroring the parent/child machinery `List.tsx` already runs for the `Config`
+view — which fetches *children* by `parentActivityId in <ids>` and caches them in a ref. The analytics
+suppression is its mirror image:
+
+1. every fetched row is cached by `activityId` first, so a parent that arrived in the same page costs
+   nothing — the common case, since a revision's activities share a timestamp and the feed's total
+   ordering is `epochTimestampMs desc, revision, activityId`;
+2. the still-unresolved `parentActivityId` values of that page are requested in **one** call,
+   `{ column: 'activityId', operator: 'in', value: ids.join(',') }`, with no other filter;
+3. rows whose resolved parent is `{ resourceType: Table, activityType: Delete }` are dropped before
+   the row buffer, at the same point the existing table-scope narrowing already drops rows.
+
+Three facts make step 2 safe, and all three were read rather than assumed:
+
+- **`activityId` is filterable.** The analytics backend's feed allow-list is
+  `AuditActivityService.PAGE_MAPPER`, and it binds `activityId` as `FilterableColumn.uuid("activityId")`.
+  A column outside that list is a `400 invalid_filter_column`, so this had to be checked, not guessed.
+- **`in` applies to a UUID column.** `PageEntityMapper.in(...)` splits the value on commas, trims each
+  member and coerces it through the column's own type; only `co`/`nc` (non-textual) and
+  `lt/gt/le/ge` (unordered) are rejected for a UUID.
+- **One request suffices per page.** A page holds at most `PAGE_SIZE` rows, hence at most `PAGE_SIZE`
+  distinct parent ids, so a single `PAGE_SIZE` request returns all of them. Do **not** copy the
+  children lookup's inner paging loop — that loop exists because one parent can have many children,
+  which is the opposite direction.
+
+**Where it belongs: the view, not the backend and not the resolver.** `ACTIVITY_AUDIT_VIEW_CONFIG`
+already declares the per-view facets (`hasParentChildAggregation`, `hasRollback`, `isRowNavigable`),
+and the analytics datasource already narrows its own feed (`isResourceIdInTableScope`). So this is one
+more declared facet — `hasDeletedParentSuppression`, true for `Analytics` only — plus a pure module
+under `src/utils/audit/`, plus the resolution step inside the existing buffer loop. No backend change
+is possible in this change and none is needed: the feed cannot express "whose parent is a delete" in
+one query, because filters are conjunctive over a single row's own columns with no join to the parent.
+
+**Fail-open, deliberately.** An unresolved parent leaves its child listed, and a failed resolution
+request leaves the whole page listed rather than failing the grid. Hiding a row on the absence of
+evidence is the failure mode an audit surface must not have; showing a redundant row is the one it can
+afford.
+
+*Alternatives rejected:*
+
+- **Turn on parent/child aggregation for the Analytics view** (`hasParentChildAggregation: true`, the
+  `Config` view's mechanism). Superseded by the owner. It keeps every child row and only nests it, so
+  the flood becomes an expander the reader still has to reason about, and it leaves the nonsensical
+  per-column detail page reachable from inside the group. It also costs a children lookup per page for
+  *every* parent, delete or not.
+- **Narrow a child column activity's diff to its own column** on the detail page. Superseded by the
+  owner, and it is the more expensive half of a two-mechanism answer: it needs a second shaping path
+  in the diff engine D11 just finished, and it does nothing about the list. The owner's rule is better
+  precisely because one rule removes the noise from the list **and** removes the nonsensical detail
+  page with it — the row that led there no longer exists.
+- **Suppress by resource type: hide `TableColumn`/`Delete` rows.** Rejected: it deletes the answer to
+  "who dropped a column", the case the manager measured on a living table. This is the mistake the
+  parent-keyed rule exists to avoid.
+- **Suppress by co-presence in the page** — hide a child whose parent `Table`/`Delete` row happens to
+  be in the same fetched page. Rejected: no request, but it is wrong under a page boundary, under a
+  non-default sort and under any column filter, and it fails *silently* and *intermittently*, which is
+  the worst shape a bug in an audit list can have.
+- **Do it in the server action or a new backend query.** Rejected: the feed cannot express it (no join
+  to the parent), so the server action would run the same two calls, one process further from the
+  buffer that needs the answer, and the `Config`/`Deployments` fetchers would have to grow a flag they
+  never use.
+
+*Residual risk, accepted:* **a deep link to a hidden child's detail URL still renders the whole-table
+`Removed` diff**, because only the list filters. I accept it, for four reasons. Nothing in the product
+links there any more — the row that produced the link is gone, so reaching it takes a pasted URL or an
+old bookmark. What it renders is *truthful*, merely redundant: it is the parent's diff, and the
+activity is a real one, so answering `404` for an activity the backend knows would be a worse lie than
+showing it. Blocking it means a second mechanism — a parent lookup inside
+`getActivityAuditDetailData`, on the detail page's critical path for every analytics activity — which
+is exactly the two-mechanism answer the owner's rule replaced. And it is cheaply reversible if it ever
+matters: the same pure predicate, applied server-side in the resolver, is the whole fix.
+
+*Falsifier, so a future reader knows the limit:* the rule hides **any** child of a table `Delete`, not
+only a `TableColumn` one. Today those are the same set — the analytics backend's parent rules give a
+`Table` activity exactly two kinds of child, `TableColumn` activities and bulk-bumped `Pipeline`
+activities, and the latter's parent is always a `version_column` repoint, i.e. a `Table` `Update`; a
+pipeline deleted because its target table was deleted is recorded with **no** parent at all. If the
+backend ever gives a table `Delete` a child of a kind whose state the table's own snapshot does not
+carry, this rule would hide it, and the fix is to narrow the predicate to `TableColumn` children.
+
+*Second residual, named because it looks like a bug:* filtering the `Resource type` column to
+`Table column` while a table delete is in range shows neither the children (suppressed) nor the parent
+(filtered out), so that deletion is invisible under that filter. That is what a filter does, and
+clearing it shows the parent row; no mitigation is specified.
+
+## Risks / Trade-offs
+
+- **D3 contradicts one sentence of the proposal.** → It is called out here and in the return, so EM
+  or BA can reverse it before dispatch. Reversing it deletes one util, one filter branch and three
+  scenarios; nothing else in the design depends on it.
+- **`ActivityAuditList` is on the regression surface of two shipped views, and D2 rewrites its
+  branching.** → The `Config` and `Deployments` entries in `view-config.ts` are transcriptions, the
+  existing `List.spec.tsx` view-aware tests are kept and must stay green, and the browser
+  verification task exercises both existing views, not only the new one. First place a mistake would
+  show: the Deployments view losing its flat rendering or its rollback row action.
+- **The `co` + client-side narrowing in D3 over-fetches** when many table names share a substring.
+  → Bounded by the page size and by how many such tables exist; the alternative (two merged streams)
+  is a correctness risk, and this one is only a throughput one. Would show first as a table Audit tab
+  that scrolls slowly on an install with dozens of similarly named tables.
+- **A `TableColumn` diff is the whole table's diff.** → Correct but broad: dropping one column is
+  shown as a change to the table's column set. With D11 that is now legible rather than invisible —
+  the dropped column is its own group carrying a `Removed` marker — but the page still shows the
+  whole table, not just the column named in the activity. First place a complaint would surface: a
+  reviewer opening a `TableColumn` activity and asking why the other nine columns are on screen.
+  Not narrowed deliberately: an audit reader needs the surrounding state to judge the change.
+- **D11 touches the diff engine that every resource type renders through.** `generateCurrentResource`,
+  `createSectionFromDiffs`, `filterNotEmptySections`, `DiffSection` and the parameter formatter are
+  shared by models, roles, containers, images and the firewall. → Every change is additive and keyed
+  on the analytics resource type or on a new optional field: a new branch, a new section-order list,
+  two optional model fields, one extra title source. The existing `generate-diffs`,
+  `create-simple-diffs`, `create-complex-diffs`, `domain-diffs` and `DiffReport/utils` specs are the
+  regression check and must stay green unmodified. First place a mistake would show: a container
+  detail page losing its Environment variables section, or the firewall diff losing its
+  added/removed domain rows.
+- **The `role="group"` wrapper lands on every section's per-index block, not only analytics ones.**
+  → That is the intended generalization (a11y.md's grouping rule applies to all of them), but it
+  changes the accessibility tree of shipped diff pages, so the existing `getByRole` queries in the
+  audit specs are where a break would surface first. The alternative — an analytics-only wrapper —
+  would mean two markup shapes for one component, which is worse.
+- **`AnalyticsTableColumn` is this repo's model of a column, and the snapshot is the backend's.** The
+  snapshot walker is written against whatever keys arrive, not against the interface, so a field the
+  backend adds later shows up unlabelled rather than being dropped. → If the model and the wire ever
+  disagree, the diff is right and the label is missing; that is the failure direction to prefer.
+- **Snapshots 404 legitimately.** The analytics backend answers `404 revision_not_found` for a table
+  whose creation predates its audit trail — so on an existing install, older tables will show an
+  empty comparison side. → Specified as an accepted outcome (render, don't error), and covered by a
+  scenario. If a reviewer sees an empty diff on a pre-existing table, that is the spec, not a bug.
+- **D13 adds a second request to some analytics pages.** A page containing rows with parents the
+  cache does not hold costs one extra `activityId in …` call before its rows reach the buffer. →
+  Bounded: at most one per page, none at all for a page whose rows have no parent or whose parents
+  arrived in the same page (the common case, since a revision's activities share a timestamp and the
+  feed's ordering is total). First place it would show: the analytics list feeling slower than the
+  `Deployments` one while scrolling through a range dense in schema patches.
+- **D13 changes how many rows a page yields, and the buffer loop is shared.** Suppression drops rows
+  before the row buffer, at the same point the entity-tab table-scope narrowing already does. → The
+  loop already refills until `endRow` and derives `lastRow` from the buffer, so the mechanism is
+  proven; but a mistake here shows as a short last page or an infinite refill, in the analytics view
+  first and in the table Audit tab second.
+- **`tsc` is red repo-wide (~205 pre-existing errors on `development`) and spec files are
+  eslint-ignored.** → Neither a green typecheck nor a clean lint proves anything about this change;
+  the quality-checks task compares error counts and relies on vitest for the real signal.
+- **D12's active-only condition rests on evidence about tables that were never materialized.** The
+  measurement (zero activities, zero columns for every `pending` table in the stack) says nothing
+  about a table that was active and returned to `pending`, and that transition was not verified in
+  the status-transition code. → If it exists, the Audit tab disappears from the table whose history
+  an auditor most needs. First place it would show: a user reporting that a table's audit history
+  vanished, or a `pending` table whose activity feed answers a non-zero `total`. The widening fix is
+  named in D12; nothing else in the change depends on the condition.
+- **Merge conflict with issue #3977 (Tables RBAC) in `TableDetailView.tsx`.** → D6 keeps the file in
+  place and moves the body rather than the header, so the header/permissions region #3977 edits is
+  the region least disturbed.
+- **This delta describes shared, pre-existing surfaces it does not own, and it was wrong about two of
+  them.** The row-body click's tab target (D5) and the diff filter's label (D11) were both written
+  from the change's own diff rather than from the shipped product, and browser verification caught
+  both. → The pattern to distrust is a sentence about a control this change does not touch: the
+  `View` selector's options, the row action menu's labels, the empty-state string. First place the
+  next one would show: a QA `fail` whose evidence is a screenshot of the app behaving reasonably.
+  One such is still open and deliberately unresolved — the empty grid renders AG Grid's default
+  `No Rows To Show`, while *Table with no recorded history* names the existing empty state without
+  quoting a string, so the scenario holds; adopting the localized `No Activities` label would be a
+  behaviour change and is not in this change.
+
+## Migration Plan
+
+None. No data migration, no new environment variable (`DIAL_ANALYTICS_API_URL` and `ANALYTICS_ENABLED`
+already exist in `.env.template`), no backend change, and no new route.
+
+With `ANALYTICS_ENABLED` unset or `false` the change is inert, but by three explicit conditions
+rather than by the route being unreachable:
+
+1. the `Analytics` option is absent from the `View` selector, so the global page issues no analytics
+   request (client flag, `useAppContext`);
+2. the detail-page resolver skips its third fallback (`isValueTruthy(process.env.ANALYTICS_ENABLED)`,
+   server-side — D8);
+3. the table detail view renders no tab strip and no Audit tab (client flag — D12; the same
+   condition also hides the tab on a non-active table whatever the flag says).
+
+Condition 3 is load-bearing and was previously assumed away: `/tables/{name}` has **no** feature-flag
+guard, so a bookmarked link renders the detail view on an analytics-disabled install. A hidden menu
+group is not a route guard. See D12.

--- a/openspec/changes/analytics-activity-audit/proposal.md
+++ b/openspec/changes/analytics-activity-audit/proposal.md
@@ -1,0 +1,175 @@
+# Extend Activity Audit to the analytics tables feature
+
+Issue: epam/ai-dial-admin-frontend#4450
+
+## Why
+
+The console has one activity-audit capability with three surfaces: the global list at
+`/activity-audit` with a `View:` selector (`ActivityAuditList`,
+`src/components/ActivityAudit/List/List.tsx`), a per-entity **Audit** tab
+(`src/components/EntityTabs/Audit/EntityAudit.tsx`), and a per-activity diff page at
+`/activity-audit/{activityId}` (`AuditView` + `src/utils/audit/get-activity-audit-detail-data.ts`).
+
+The Analytics **Tables** feature is outside all three. `src/components/Analytics/Tables/TableDetailView.tsx`
+(route `/tables/[id]`, `ApplicationRoute.AnalyticsTables`) is a single untabbed surface — header,
+key summary, column grid, and modals for Add columns / Add rows / Manage access / Connect. Who
+dropped a column, who marked one sensitive, who changed a table's access lists, and what the schema
+looked like before, is invisible in the console. `openspec/specs/analytics/spec.md` has no audit
+requirement, and `ActivityAuditResourceType` in `src/types/activity-audit.ts` has no analytics member.
+
+The gap is entirely in this frontend. The analytics backend (`DIAL_ANALYTICS_API_URL`) already
+records this history under its own `audit-trail` capability and already exposes it on a surface built
+to match this grid — it audits the table definition row, every column, and each pipeline and saved
+query, and its `POST /v1/activities` returns `{total, totalPages, data}` where each entry carries
+`activityId / activityType / resourceType / resourceId / epochTimestampMs / initiatedAuthor /
+initiatedEmail / revision / parentActivityId`. Those are the field names of `DialActivity`
+(`src/models/activity-audit.ts`) and the shape of `AuditPageData` (`src/models/request.ts`); its
+`{column, operator, value}` filters use `eq|ne|co|nc|lt|gt|le|ge|in`, which are the exact wire values
+of `FilterOperatorDto` (`src/types/request.ts`); its `activityType` values are `Create|Update|Delete`
+in PascalCase, and `GET /v1/tables/{name}/revision/{revision}` returns a snapshot the existing diff
+engine already knows how to walk. The console simply never calls any of it.
+
+Adding a second backend behind the same audit surface is a solved problem here, not new ground: the
+`Deployments` option in the view selector did exactly this for the deployment-manager backend
+(`openspec/specs/activity-audit-deployments-view/spec.md`), and the container/image Audit tabs reused
+`EntityAudit` with the Activities sub-tab only (`openspec/specs/activity-audit-deployments-tab/spec.md`).
+This change repeats that pattern a third time.
+
+## What Changes
+
+**Analytics activities are sourced.** A new `AnalyticsAuditApi` under `src/server/analytics/`, with
+the same two methods as `src/server/deployments/audit-api.ts` (`getActivitiesList`,
+`getActivityById`), constructed in `src/app/api/api.ts` on `process.env.DIAL_ANALYTICS_API_URL`
+beside the existing `analyticsDataApi`, and reached through a `getAnalyticsActivities` server action
+in `src/app/[lang]/activity-audit/actions.ts` alongside `getActivities` / `getDeploymentActivities`.
+`ActivityAuditResourceType` gains the resource types the analytics backend emits (`Table`, `TableColumn`, `Pipeline`,
+`SavedQuery`) with a predicate colocated beside the existing `isDeploymentManagerResource`.
+
+**The table detail view becomes tabbed** (ask 3). `TableDetailView` renders today's whole content
+under a **Properties** tab and gains an **Audit** tab that renders the existing `EntityAudit` with a
+fixed `viewMode`, so it shows the **Activities** sub-tab only and no view selector — the same
+arrangement the deployment Audit tabs already use. The list is filtered to this table's
+`(resourceType, resourceId)` pair, which `ActivityAuditList` already does from its `entity` /
+`entityType` props. No change to `EntityAudit`, `ActivityAuditList`, `TimeFilter`, or the audit grid.
+
+**The global audit list gains an Analytics option** (ask 4, and it is feasible — see below). The
+`View:` selector, currently `Config` / `Deployments` via `ActivityAuditView`, gains `Analytics`,
+sourced from `getAnalyticsActivities`. The `isDeploymentsView ? … : …` fetcher ternary in
+`List.tsx:211` becomes a per-view lookup rather than a nested ternary.
+
+**The Analytics option is gated on the analytics feature flag** (ask 4's second half). `EntityAudit`
+already takes `featureFlags` from `useAppContext` and hands them to `getAuditTabs`
+(`src/utils/tabs/utils.ts`), and `MENU_CONFIGURATION` already drops the whole Analytics menu group on
+`!featureFlags.analyticsEnabled` (`src/components/Menu/menu-configuration.tsx:267`) — the flag is set
+from `ANALYTICS_ENABLED` in `src/app/[lang]/layout.tsx:61`. This change reuses that flag: with
+analytics disabled the `Analytics` option is absent from the selector, no analytics fetch is issued,
+and the analytics rows never reach the grid. The gate is on the option, not on a post-fetch filter,
+so "not shown" and "not requested" are the same state.
+
+**Row click opens the existing diff page.** `getActivityAuditDetailData` already falls back from the
+admin backend to the deployment-manager backend and dispatches a snapshot fetcher per resource type;
+it gains analytics as a third fallback, with the snapshot read from
+`GET /v1/tables/{name}/revision/{revision}` via the existing `getRevisionRouteForEntityType` table.
+The generic diff engine renders a table snapshot as an ordinary object — no analytics-specific
+section shaping (unlike the container and firewall cases).
+
+**Rollback does not carry over, deliberately.** The analytics backend's audit-trail capability states that it exposes
+no endpoint which creates, edits or deletes an audit record, revision or snapshot, and there is no
+table-rollback route. So the row-action Rollback and the system-Rollback button are absent for
+analytics activities. The list already hides the system Rollback outside `ActivityAuditView.Config`
+(`List.tsx:529`), and `activity-audit-deployments-view` established hiding rollback affordances for a
+backend that does not support it. This is the one capability of today's audit that cannot be matched.
+
+**Sub-tabs that do not apply are absent.** `getAuditTabs` returns Dashboard / Traces / Conversations
+only for routes that name a DIAL deployment; those read request telemetry keyed by a deployment name
+(`Telemetry/Dashboard.tsx`, `UsageLog/UsageLog.tsx`, `src/utils/telemetry.ts`) and mean nothing for a
+catalog table. The analytics Audit tab is Activities-only, exactly as the container Audit tabs are.
+
+## Capabilities
+
+### New Capabilities
+
+None. Audit behavior belongs in the audit specs; analytics behavior belongs in the analytics master
+spec, per `openspec/config.yaml`.
+
+### Modified Capabilities
+
+- `analytics`: the master spec (`openspec/specs/analytics/spec.md`) gains the tables detail view's
+  tab set — Properties carrying today's content, Audit carrying the Activities list — and states that
+  the tab is present on an active table and hidden on a draft (pending) one, and requires no
+  permission beyond reading the table.
+- `activity-audit-deployments-view`: this spec owns the `View:` selector, the per-view column state
+  and the per-view rollback rules; its "View selector exposes a Deployments option" and "Rollback
+  affordances hidden in Deployments view" requirements have to account for a third option. SA decides
+  whether the delta amends it in place or whether the selector's requirements move to a
+  view-neutral home.
+
+*(The precise requirement/scenario wording is the architect's, not this proposal's.)*
+
+## Impact
+
+- **Shared component — `ActivityAuditList` (`src/components/ActivityAudit/List/List.tsx`)**: the
+  fetcher selection, the `ActivityAuditView` enum, the row-click and row-class predicates
+  (`isDeploymentManagerResource` today) and the `storageKey` for per-view AG Grid column state all
+  branch on the view. Every existing branch is `Config`-or-`Deployments`; a third value makes the
+  binary shape wrong rather than merely incomplete. Both existing views are on this component's
+  regression surface.
+- **Shared util — `buildResourceTypeLabelMap` / `getFormattedResourceType`
+  (`src/constants/grid-columns/formatters.ts`)**: the label map is built by iterating
+  `Object.values(ActivityAuditResourceType)`, so adding analytics members changes the map that the
+  Resource-type free-text filter uses **in every view**, including Config and Deployments. A new
+  member whose formatted label collides with an existing one would silently widen an existing view's
+  filter (the map's values are arrays for exactly that reason). This is the sharpest cross-cutting
+  risk in the change.
+- **Shared component — `EntityAudit` (`src/components/EntityTabs/Audit/EntityAudit.tsx`)**: gains a
+  call site, unmodified, provided a `viewMode` fixes the fetcher. Its `entity` prop is typed
+  `BaseEntity`; an `AnalyticsTable` (`src/models/analytics/table.ts`) is not one, so the adaptation
+  has to happen at the call site — per the house rule, no new prop on a shared component to fit one
+  caller.
+- **Shared util — `getActivityAuditDetailData` (`src/utils/audit/get-activity-audit-detail-data.ts`)**:
+  a third backend in the by-id fallback chain adds a request to the detail page's critical path for
+  every activity that is not an admin one. Its existing two-step fallback is already sequential.
+- **Feature component — `TableDetailView` (599 lines)**: restructured into a tab shell. Its header
+  actions (Manage access / Delete table / Add columns / Add rows / Connect) and its
+  draft-vs-active branch (`DraftSchemaEditor` vs the column `GridView`) both live in the body being
+  moved; where those actions sit relative to the tab strip is a design decision, not a requirements
+  one.
+- **New API client and server action**, no new API route: `src/server/analytics/` and
+  `src/app/[lang]/activity-audit/actions.ts`. No change to any backend.
+- **No new environment variable.** `DIAL_ANALYTICS_API_URL` and `ANALYTICS_ENABLED` already exist in
+  `.env.template`; `ANALYTICS_ENABLED` is already surfaced as `featureFlags.analyticsEnabled`.
+- **i18n**: new keys for the Analytics view-selector option (beside
+  `TelemetryI18nKey.ActivityViewConfig` / `ActivityViewDeployments`), the Properties/Audit tab labels
+  on the tables view (`TabsI18nKey.Properties` / `TabsI18nKey.Audit` already exist), and labels for
+  the new resource types.
+- **Contexts**: none. `AppContext` already carries the flag; `NotificationContext` is untouched.
+- **Authorization**: none added. The analytics backend authorizes its activity feed at exactly the bar reading the
+  catalog already requires, so anyone who can open a table's detail view can read its history.
+  `useAnalyticsTablePermissions` (`src/hooks/use-analytics-table-permissions.ts`) is not consulted for
+  the Audit tab.
+
+## Non-goals
+
+- **No rollback, revert or restore for analytics resources.** The analytics backend exposes no mutating audit endpoint
+  and no table-rollback route; this cannot be built in the frontend, and pretending otherwise with a
+  disabled control would be worse than its absence. If rollback is wanted it is a change to the analytics backend first.
+- **No Audit tab on Analytics → Pipelines or Analytics → Queries.** The analytics backend audits `Pipeline` and
+  `SavedQuery` too, so those tabs are cheap follow-ups once this lands, but the request names the
+  tables feature and each is its own detail-view restructure. Their activities do still appear in the
+  global Analytics view — the feed is not filtered down to tables, because hiding rows the backend
+  returned would make an audit surface quietly incomplete.
+- **No Dashboard / Traces / Conversations sub-tabs on the analytics Audit tab.** They report DIAL
+  request telemetry keyed by a deployment name and have no meaning for a catalog table.
+- **No analytics-specific diff rendering.** A table snapshot goes through the generic diff engine.
+  The bespoke section shaping that `activity-audit-deployments-detail` defines for containers, images
+  and the global firewall is not replicated; if a table's `columns` array reads poorly as a generic
+  diff, that is a follow-up.
+- **No entity-namespaced audit detail route** (`/tables/{name}/{activityId}`). Rows open the existing
+  global `/activity-audit/{activityId}` page. The deployment feature added namespaced routes in a
+  separate change; the same split applies here.
+- **No change to the Config or Deployments views' own behavior**, beyond the shared-code changes the
+  Impact section names.
+- **No new feature flag.** `ANALYTICS_ENABLED` is the gate; no separate audit toggle.
+- **No changes to the analytics backend.** Every endpoint this change calls already exists and is already specified.
+- **No change to what the audit list stores or how it pages.** Time filter, infinite row model,
+  column-state persistence and parent/child aggregation are reused as they are.

--- a/openspec/changes/analytics-activity-audit/specs/activity-audit-analytics-view/spec.md
+++ b/openspec/changes/analytics-activity-audit/specs/activity-audit-analytics-view/spec.md
@@ -1,0 +1,581 @@
+## Purpose
+
+Defines the `Analytics` view of the Activity Audit page and the analytics half of the audit detail
+page: how activities are sourced from the analytics backend (`POST /v1/activities` at
+`DIAL_ANALYTICS_API_URL`), which resource types it shows and how they are labelled, how the option is
+gated on the analytics feature flag, why no rollback affordance exists for it — in the list, in the
+row menu, and on the detail page — how a row resolves to a snapshot on the detail page, what the
+detail page's header offers for an analytics resource, how a revision snapshot is grouped and marked
+in the diff, the one activity the view does not list — a child of a deleted table, whose parent's own
+row and detail view already carry it — and the guard that keeps the shared resource-type filter of the
+`Config` and `Deployments` views unchanged.
+
+## ADDED Requirements
+
+### Requirement: Analytics view fetches activities from the analytics backend
+
+When the selected view is `Analytics`, the grid datasource SHALL call a `getAnalyticsActivities`
+server action, which forwards the request to `POST /v1/activities` at `DIAL_ANALYTICS_API_URL`. The
+request body SHALL carry `pageNumber`, `pageSize`, `sorts`, and `filters` in the same shape already
+sent to the admin and deployment-manager backends, and the response SHALL be read as
+`{ total, totalPages, data }` — the analytics backend already answers in exactly those shapes, with
+the same `{column, operator, value}` filter vocabulary (`eq`, `ne`, `co`, `nc`, `lt`, `gt`, `le`,
+`ge`, `in`), the same `{column, direction}` sorts, and the same activity fields (`activityId`,
+`activityType`, `resourceType`, `resourceId`, `epochTimestampMs`, `initiatedAuthor`,
+`initiatedEmail`, `revision`, `parentActivityId`).
+
+The selection of the fetcher SHALL be made from a single per-view lookup keyed by the active view
+rather than from a boolean condition, so that no view is reachable without an explicitly declared
+fetcher. The `Config` and `Deployments` views SHALL keep the exact fetchers they use today.
+
+A failed request SHALL leave the grid in its existing failure state and SHALL NOT raise a toast
+notification: the audit list is read-only and performs no action a success or error notification
+would describe.
+
+#### Scenario: Selecting the Analytics view triggers the analytics backend
+
+- **WHEN** the user switches the `View` dropdown to `Analytics`
+- **THEN** the next datasource call invokes `getAnalyticsActivities`
+- **AND** it does not invoke `getActivities` or `getDeploymentActivities`
+- **AND** the request payload carries `pageNumber`, `pageSize`, `sorts`, and `filters`
+
+#### Scenario: Existing views keep their fetchers
+
+- **WHEN** the active view is `Config`, and then `Deployments`
+- **THEN** the datasource invokes `getActivities`, and then `getDeploymentActivities`, respectively
+
+#### Scenario: Pagination on the Analytics view requests subsequent pages
+
+- **GIVEN** the Analytics view is active and the user scrolls past the first page boundary
+- **WHEN** AG Grid requests the next block
+- **THEN** `getAnalyticsActivities` is called with the incremented `pageNumber` and the same
+  sort/filter state
+
+### Requirement: Analytics option is gated on the analytics feature flag
+
+The `Analytics` option SHALL be present in the `View` dropdown only when `featureFlags.analyticsEnabled`
+is true — the same flag, set from `ANALYTICS_ENABLED`, that already removes the whole Analytics menu
+group. The gate SHALL be on the option itself, not on a filter applied to fetched rows, so that with
+analytics disabled no request is issued to the analytics backend at all.
+
+#### Scenario: Option absent when analytics is disabled
+
+- **GIVEN** `featureFlags.analyticsEnabled` is false
+- **WHEN** the user opens the `View` dropdown on `/activity-audit`
+- **THEN** the dropdown lists `Config` and `Deployments` only
+- **AND** no request is issued to the analytics activity feed
+
+#### Scenario: Option present when analytics is enabled
+
+- **GIVEN** `featureFlags.analyticsEnabled` is true
+- **WHEN** the user opens the `View` dropdown on `/activity-audit`
+- **THEN** the dropdown lists `Config`, `Deployments`, and `Analytics`
+
+### Requirement: Analytics view shows every resource type the feed returns
+
+The Analytics view SHALL display every activity the feed returns, whatever its `resourceType` —
+`Table`, `TableColumn`, `Pipeline`, and `SavedQuery`. It SHALL NOT narrow the feed by `resourceType`:
+a reader cannot tell an audit surface that hides rows from one that is empty, and the existing
+`Resource type` column filter already narrows it in one interaction.
+
+The one activity this view does not list is a child of a table `Delete` — see *A child activity of a
+deleted table is not listed*. That suppression is keyed on the **parent** activity and never on the
+child's own resource type, so a `TableColumn` activity remains a first-class row of this view whenever
+its parent is anything other than a table `Delete`.
+
+The view SHALL use the `Config` view's column set minus its row-expander column and minus the
+`Deployments` view's `Version` column, i.e. `Activity type`, `Resource type`, `Resource identifier`,
+`Time`, `Initiated`, `Activity ID`, `Parent ID`, with `Time` keeping its default descending sort.
+Every row this view lists SHALL be rendered flat, at the top level: the client-side parent/child
+aggregation the `Config` view applies SHALL NOT run, and a child activity's `Parent ID` cell SHALL
+show the parent activity identifier the backend supplied. Flat rendering and the suppression of a
+deleted table's children are separate rules — a child that is listed is listed flat, never nested
+under its parent.
+
+Saved column state SHALL be persisted under a key that names this view (`activity-audit:analytics`),
+so resizing a column here does not disturb the `Config` or `Deployments` column state.
+
+#### Scenario: Pipeline and saved-query rows are shown
+
+- **GIVEN** the feed returns activities with `resourceType` values `Table`, `TableColumn`,
+  `Pipeline`, and `SavedQuery`
+- **WHEN** the Analytics view renders the block
+- **THEN** a row is displayed for each of them
+
+#### Scenario: Rows render flat with their parent identifier
+
+- **GIVEN** the feed returns a `Table` activity whose `activityType` is `Update` — a table that still
+  exists — and a `TableColumn` activity that names it as its parent
+- **WHEN** the Analytics view renders the block
+- **THEN** both rows appear at the top level
+- **AND** no row-expander cell is rendered
+- **AND** the `TableColumn` row's `Parent ID` cell shows the `Table` row's activity identifier
+
+#### Scenario: Version column is not rendered
+
+- **WHEN** the Analytics view renders
+- **THEN** the grid does not render the `Version` column
+
+#### Scenario: Column state is kept apart from the other views
+
+- **GIVEN** the user has resized the `Resource identifier` column on the Analytics view
+- **WHEN** the user switches to the `Config` view
+- **THEN** the `Config` view's `Resource identifier` column keeps its own previously saved width
+
+### Requirement: A child activity of a deleted table is not listed
+
+Deleting a table records, in one revision, a `Delete` activity for the table definition and a `Delete`
+activity for **each** of its columns, every column activity carrying the table activity's identifier as
+its `parentActivityId`. Listing those children floods the audit list with one row per column and tells
+a reader nothing the parent does not: the deleting revision has no snapshot for the table, the
+previous revision holds the table with all of its columns, so the parent activity's own detail view
+already renders every column of it as removed. Each child's detail view renders that same whole-table
+diff, reached from a row that says only which column it was about.
+
+The Analytics view SHALL therefore NOT list an activity whose parent activity is a `Table` activity
+whose `activityType` is `Delete`. The parent `Delete` activity itself SHALL be listed. No other
+activity SHALL be suppressed on account of a parent:
+
+- an activity with no `parentActivityId` SHALL be listed;
+- an activity whose parent activity is a `Table` activity of any other activity type — a single column
+  dropped from, added to, or changed on a table that still exists — SHALL be listed, with its
+  `Parent ID` cell showing the parent identifier the backend supplied. "Who dropped a column" is one of
+  the questions this capability exists to answer, and those rows are the answer;
+- an activity whose parent activity cannot be resolved SHALL be listed. A row is hidden only on
+  positive evidence about its parent: an audit surface that hides a row it cannot account for is worse
+  than one that shows a redundant row.
+
+Parent activities SHALL be resolved from the same activity feed, by activity identifier, and that
+request SHALL NOT carry the grid's own column or time filters — it asks for named activities, not for a
+filtered page, and a column filter the reader applied would otherwise hide the very parent being
+resolved. A parent already resolved SHALL be reused for the rest of the same list pass rather than
+requested again, and a page carrying no unresolved parent identifier SHALL issue no resolution request
+at all.
+
+Suppression SHALL be applied to a page's rows before they enter the list's row buffer, so the buffer,
+the page boundaries and the end-of-list signal count only rows that are shown. A failure of the parent
+resolution SHALL leave that page's rows listed, SHALL NOT put the grid into its failure state, and
+SHALL NOT raise a notification.
+
+This is declared per view. The `Config` view — which aggregates children under their parent instead —
+and the `Deployments` view SHALL be unchanged: neither resolves parents, and neither suppresses a row.
+
+#### Scenario: Child column activities of a deleted table are absent while its Delete row is shown
+
+- **GIVEN** a revision in which a table with several columns was deleted
+- **AND** the feed answers it as one `Table` `Delete` activity and one `TableColumn` `Delete` activity
+  per column, each naming the table activity as its parent
+- **WHEN** the Analytics view renders the block
+- **THEN** the `Table` `Delete` row is displayed
+- **AND** no `TableColumn` row of that revision is displayed
+
+#### Scenario: A column dropped from a living table is still listed
+
+- **GIVEN** a revision in which one column was dropped from a table that still exists
+- **AND** the feed answers it as a `Table` `Update` activity and a `TableColumn` `Delete` activity
+  naming that table activity as its parent
+- **WHEN** the Analytics view renders the block
+- **THEN** both rows are displayed at the top level
+- **AND** the `TableColumn` row's `Parent ID` cell shows the `Table` row's activity identifier
+
+#### Scenario: The deleted table's own detail view still shows every removed column
+
+- **GIVEN** the `Table` `Delete` activity of a table that had several columns
+- **AND** the analytics backend answers the deleting revision's snapshot as not found and the previous
+  revision's snapshot with every column the table had
+- **WHEN** the user opens that activity's detail page
+- **THEN** the diff renders one column group per column of the previous revision
+- **AND** each of those groups states `Removed`
+- **AND** no column the table had is absent from the diff
+
+#### Scenario: A child whose parent cannot be resolved stays listed
+
+- **GIVEN** the feed returns a `TableColumn` activity carrying a `parentActivityId` that the parent
+  resolution does not answer for
+- **WHEN** the Analytics view renders the block
+- **THEN** that row is displayed
+
+#### Scenario: A page whose rows have no parent issues no resolution request
+
+- **GIVEN** a page of activities none of which carries a `parentActivityId`
+- **WHEN** the Analytics view renders the block
+- **THEN** no parent-resolution request is issued
+- **AND** every row of the page is displayed
+
+#### Scenario: The Config and Deployments views resolve no parents and suppress no rows
+
+- **WHEN** the active view is `Config`, and then `Deployments`
+- **THEN** no parent-resolution request is issued for either
+- **AND** each view lists exactly the rows it lists today
+
+### Requirement: Analytics resource types are labelled and localized
+
+`ActivityAuditResourceType` SHALL gain the members the analytics backend emits — `Table`,
+`TableColumn`, `Pipeline`, `SavedQuery` — and a predicate that answers whether a resource type is an
+analytics one, colocated with the existing resource-set predicates beside that enum. The
+`Resource type` column SHALL render each through the shared formatter as a localized singular label:
+`Table`, `Table column`, `Pipeline`, `Saved query`. Every label SHALL resolve through an i18n key
+present in the locale dictionary; the `Analytics` view-option label SHALL likewise be a new key
+alongside the existing `Config` and `Deployments` option labels.
+
+#### Scenario: Table column row displays its singular label
+
+- **WHEN** the grid receives an activity with `resourceType: "TableColumn"`
+- **THEN** the `Resource type` cell renders the localized `Table column` label
+- **AND** the key backing it exists in `apps/ai-dial-admin/src/locales/en.ts`
+
+#### Scenario: Saved query row displays its singular label
+
+- **WHEN** the grid receives an activity with `resourceType: "SavedQuery"`
+- **THEN** the `Resource type` cell renders the localized `Saved query` label
+
+#### Scenario: Analytics resource predicate answers for the four types and nothing else
+
+- **WHEN** the predicate is asked about `Table`, `TableColumn`, `Pipeline`, and `SavedQuery`
+- **THEN** it answers true for each
+- **AND** it answers false for `Model`, `McpDeployment`, `ImageBuildDomainWhitelist`, and for an
+  undefined resource type
+
+### Requirement: Adding analytics resource types does not change the Config or Deployments resource-type filter
+
+The `Resource type` free-text filter is expanded through a map built by iterating every member of
+`ActivityAuditResourceType` and keying by the lowercased formatted label, and it narrows a `contains`
+filter to an `equals` filter only when exactly one enum member matches. Adding the analytics members
+SHALL NOT change which enum member any label that resolved to a single member before this change
+resolves to, and SHALL NOT introduce a label that collides with an existing one.
+
+#### Scenario: Existing single-match label resolutions are unchanged
+
+- **WHEN** the resource-type label map is built after the analytics members are added
+- **THEN** the label `global firewall` still resolves to exactly `ImageBuildDomainWhitelist`
+- **AND** the image label resolves to exactly the set `AdapterImageDefinition`,
+  `ApplicationImageDefinition`, `InterceptorImageDefinition`, `McpImageDefinition`
+- **AND** the model-serving label resolves to exactly the set `NimDeployment`, `InferenceDeployment`
+- **AND** each of the four container labels resolves to exactly one member — respectively
+  `AdapterDeployment`, `ApplicationDeployment`, `InterceptorDeployment`, `McpDeployment`
+- **AND** no analytics label is equal to any pre-existing label
+
+#### Scenario: Global Firewall audit shortcut still narrows to one type
+
+- **GIVEN** the Global Firewall popup's `View in Activity Audit` link has applied its
+  `Resource type` `contains` filter
+- **WHEN** the request filters are built
+- **THEN** the filter is still narrowed to `{ column: "resourceType", operator: "eq", value: "ImageBuildDomainWhitelist" }`
+
+### Requirement: Rollback affordances are absent for analytics activities
+
+The analytics backend exposes no endpoint that creates, edits, or deletes an audit record, revision,
+or snapshot, and no table-, pipeline-, or saved-query-rollback route. There are three rollback
+affordances in the audit capability and all three SHALL be absent for an analytics activity:
+
+- the page-level `Rollback` button on the list SHALL not render while the Analytics view is active
+  (it is already restricted to the `Config` view);
+- the per-row action menu SHALL NOT offer a `Rollback` action for any Analytics view row, on the
+  global page or in an entity Audit tab;
+- the `Rollback resource` button on the audit **detail** page (`/activity-audit/{activityId}`) SHALL
+  NOT render when the activity's resource type is an analytics one. Today that button is conditional
+  only on the viewer not being a read-only admin, and its handler falls through to the admin
+  backend's per-revision rollback — a write aimed at a backend that does not own the resource.
+
+No disabled rollback control SHALL be rendered in place of any of them. The detail page's rollback
+button SHALL be unchanged for admin and deployment-manager activities, including its read-only-admin
+condition and its deployment lifecycle block reason.
+
+#### Scenario: No page-level rollback button
+
+- **WHEN** the user switches to the Analytics view
+- **THEN** the page-level `Rollback` button is not rendered
+
+#### Scenario: No per-row rollback action
+
+- **WHEN** the user opens the row action menu on any Analytics view row
+- **THEN** the menu offers `Open in a new tab`
+- **AND** the menu does not offer `Rollback`, enabled or disabled
+
+#### Scenario: No rollback button on an analytics activity's detail page
+
+- **GIVEN** a viewer who is not a read-only admin
+- **WHEN** the user opens `/activity-audit/{activityId}` for an activity whose `resourceType` is
+  `Table`, `TableColumn`, `Pipeline`, or `SavedQuery`
+- **THEN** the `Rollback resource` button is not rendered
+- **AND** no disabled rollback control is rendered in its place
+
+#### Scenario: The detail page's rollback button is unchanged for an admin activity
+
+- **GIVEN** a viewer who is not a read-only admin
+- **WHEN** the user opens the detail page for an activity whose `resourceType` is `Model`
+- **THEN** the `Rollback resource` button is rendered as it is today
+
+### Requirement: Analytics view rows open the global audit detail page
+
+For every resource type in the Analytics view, `/activity-audit/{activityId}` SHALL be reachable from
+a row by two entry points, and **both SHALL open it in a new browser tab**, leaving the list in the
+tab it is in: the row action menu's `Open in a new tab` item, and a click on the row body — anywhere
+outside the action menu and the row-expander cell. Opening in a new tab is the shared, pre-existing
+behaviour of this list, which the `Config` and `Deployments` views already have; this capability
+changes only which resource types are navigable at all, never the tab a row opens in. No analytics
+resource type SHALL remain a no-op row, and no entity-namespaced audit detail route
+(`/tables/{name}/{activityId}` and its siblings) SHALL be introduced by this capability.
+
+#### Scenario: Row body click opens the detail page in a new tab
+
+- **WHEN** the user clicks the row body — outside the action menu — on an Analytics view row whose
+  `activityId` is `abc-123`
+- **THEN** a new browser tab opens at `/activity-audit/abc-123`
+- **AND** the tab holding the list stays on `/activity-audit`
+
+#### Scenario: The row menu's Open in a new tab item opens the detail page
+
+- **WHEN** the user clicks `Open in a new tab` in the action menu of an Analytics view row whose
+  `activityId` is `abc-123`
+- **THEN** a new browser tab opens at `/activity-audit/abc-123`
+
+### Requirement: Audit detail page resolves analytics activities
+
+The unified audit-detail resolver SHALL resolve an activity that neither the admin backend nor the
+deployment-manager backend knows by asking the analytics backend
+(`GET /v1/activities/{activityId}`), as a third and last step of the existing fallback chain. That
+third request SHALL be issued only when the analytics feature is enabled in the environment the
+resolver runs in, so an installation without analytics pays no extra request on the detail page's
+critical path.
+
+The environment value SHALL be read through the same truthiness helper every other feature flag in
+this app is read through (`isValueTruthy`, `apps/ai-dial-admin/src/utils/types.ts`, which answers true
+only for the exact string `true`), not through a bare truthiness check on `process.env` — an
+installation that sets `ANALYTICS_ENABLED=false` explicitly is a disabled installation, and a bare
+check reads that string as enabled.
+
+When the activity resolves as an analytics one, the resolver SHALL fetch the current revision, the
+previous revision, and the latest-revision entity snapshot in parallel, as it already does for the
+other two backends, and return the same `{ activity, activityRevision, previousRevision, entity }`
+shape, which `AuditView` renders through the generic diff engine.
+
+#### Scenario: Analytics activity resolves after both existing lookups miss
+
+- **GIVEN** an `activityId` that the admin backend and the deployment-manager backend both answer as
+  unknown
+- **WHEN** the user opens `/activity-audit/{activityId}` and the analytics feature is enabled
+- **THEN** the resolver asks the analytics backend for that activity
+- **AND** the detail page renders the diff view for it
+
+#### Scenario: Admin and deployment activities are unaffected
+
+- **WHEN** the user opens the detail page for an activity the admin backend resolves
+- **THEN** neither the deployment-manager nor the analytics lookup is issued
+
+#### Scenario: No analytics lookup when the feature is disabled
+
+- **GIVEN** the analytics feature is disabled in the environment — `ANALYTICS_ENABLED` unset, or set
+  to the string `false`
+- **WHEN** the user opens the detail page for an activity neither existing backend resolves
+- **THEN** no request is issued to the analytics backend in either case
+- **AND** the page renders its existing not-found state
+
+### Requirement: Analytics snapshots are resolved per resource type
+
+The revision-route table SHALL resolve an analytics snapshot URL per resource type:
+`Table` → `v1/tables/{name}/revision/{revision}`; `Pipeline` →
+`v1/pipelines/{name}/revision/{revision}`; `SavedQuery` →
+`v1/saved-queries/{id}/revision/{revision}`. A `TableColumn` has no snapshot endpoint of its own; its
+resource identifier is `<table>:<column>`, so its snapshot SHALL be the owning table's snapshot at
+the same revision, resolved by taking the identifier's table half.
+
+A snapshot the backend answers as absent — the analytics backend answers `404`
+`revision_not_found` for a revision before the resource existed, at or after its deletion, or for a
+resource whose creation predates the audit trail — SHALL be treated as "no snapshot" and SHALL render
+the detail page without an error page and without a notification, exactly as the existing
+negative-revision case does.
+
+#### Scenario: Table snapshot route
+
+- **WHEN** a snapshot is requested for an activity with `resourceType: "Table"`, `resourceId: "orders"`,
+  and revision `7`
+- **THEN** the analytics backend is asked for `v1/tables/orders/revision/7`
+
+#### Scenario: Table column snapshot resolves through its table
+
+- **WHEN** a snapshot is requested for an activity with `resourceType: "TableColumn"`,
+  `resourceId: "orders:total"`, and revision `7`
+- **THEN** the analytics backend is asked for `v1/tables/orders/revision/7`
+
+#### Scenario: Pipeline and saved query snapshot routes
+
+- **WHEN** a snapshot is requested for an activity with `resourceType: "Pipeline"` and
+  `resourceId: "daily_rollup"`, and for one with `resourceType: "SavedQuery"` and `resourceId: "q1"`,
+  each at revision `3`
+- **THEN** the analytics backend is asked for `v1/pipelines/daily_rollup/revision/3` and
+  `v1/saved-queries/q1/revision/3` respectively
+
+#### Scenario: Missing snapshot renders without an error
+
+- **GIVEN** an analytics activity whose snapshot the backend answers as not found
+- **WHEN** the user opens its detail page
+- **THEN** the page renders with an empty side of the comparison
+- **AND** no error page and no error notification is shown
+
+### Requirement: The detail page header links an analytics resource to its own detail page
+
+The audit detail page's header renders an external-link control beside the resource identifier. Its
+target SHALL be resolved per resource type: `Table` and `TableColumn` to `/{locale}/tables/{table}` —
+a `TableColumn` identifier being `<table>:<column>`, its table half — `Pipeline` to
+`/{locale}/pipelines/{name}`, and `SavedQuery` to `/{locale}/queries/{id}`. The control SHALL render
+only when a target resolves; for a resource type with no known route it SHALL NOT render, rather than
+producing today's `/{locale}/undefined/{resourceId}`.
+
+This resolution SHALL NOT be implemented by adding analytics entries to the shared
+resource-type → route map that the audit list's `Open in a new tab` href also reads
+(`auditResourceRoute`, `apps/ai-dial-admin/src/constants/activity-audit.ts`). An entry there would
+make an analytics row's href `/tables/{name}/{activityId}` — an entity-namespaced audit detail route
+this change deliberately does not create, so every analytics row click would 404. The href builder
+SHALL keep returning an empty href for every analytics resource type, and a test SHALL pin that,
+naming the coupling, so a later fix to the header cannot silently reintroduce the broken route.
+
+#### Scenario: Header links a table activity to its table
+
+- **WHEN** the user opens the detail page for an `Update` activity with `resourceType: "Table"` and
+  `resourceId: "orders"`
+- **THEN** the header's external-link control opens `/en/tables/orders`
+
+#### Scenario: Header links a column activity to its table
+
+- **WHEN** the user opens the detail page for an activity with `resourceType: "TableColumn"` and
+  `resourceId: "orders:total"`
+- **THEN** the header's external-link control opens `/en/tables/orders`
+
+#### Scenario: Header omits the link when no target resolves
+
+- **WHEN** the user opens the detail page for an activity whose resource type has no route registered
+- **THEN** no external-link control is rendered beside the resource identifier
+- **AND** no link to a `/en/undefined/...` URL exists on the page
+
+#### Scenario: No entity-namespaced audit route is produced for an analytics resource type
+
+- **WHEN** the audit list builds a row href for an activity whose `resourceType` is `Table`
+- **THEN** the entity-namespaced href builder returns an empty href
+- **AND** no `/tables/{name}/{activityId}` URL is produced anywhere in the change
+
+### Requirement: An analytics revision diff shows every field of the snapshot
+
+The detail page renders an analytics revision through the shared diff engine. For an analytics
+resource type the engine SHALL emit a diff row for **every** field the snapshot carries, on both
+sides of the comparison, so a reader sees the full state of the resource with the changes located
+inside it. There SHALL be no hidden-key list for analytics resources — unlike the container and image
+resource types, which suppress `$type`, `id`, `createdAt` and `updatedAt` — and no field SHALL be
+dropped because the engine has no dedicated handler registered for its shape:
+
+- a scalar field renders as one row: its parameter and its value;
+- an object-valued field renders as one row per leaf, its parameter naming the path to that leaf
+  (`grain.grain_key`, `partition_by.granularity`);
+- an array of scalars renders as a single row whose value joins the elements **in the order the
+  snapshot lists them**. `ordering_key` and `tag_order` are ordered fields whose order is their
+  meaning; sorting them would render a reordering as no change at all.
+
+Each parameter SHALL be labelled through the localized field labels the tables feature already
+defines; a field with no label defined SHALL fall back to the snapshot's own field name rather than
+being hidden.
+
+#### Scenario: Every field of a table snapshot appears in the diff
+
+- **WHEN** the detail page renders a table revision whose snapshot carries `name`, `description`,
+  `type`, `source_table`, `status`, `ordering_key`, `partition_by`, `identity_column`,
+  `version_column` and `tag_order`
+- **THEN** the table-definition group displays a row for each of those fields
+- **AND** no field present in either snapshot is absent from the rendered diff
+
+#### Scenario: An ordered list field keeps the snapshot's order
+
+- **GIVEN** a table snapshot whose `ordering_key` lists `created_at` and then `id`
+- **WHEN** the detail page renders it
+- **THEN** the `ordering_key` row's value reads `created_at, id`
+- **AND** it is not re-sorted alphabetically
+
+#### Scenario: A pipeline or saved-query snapshot is rendered field by field
+
+- **WHEN** the detail page renders a `Pipeline` or a `SavedQuery` revision
+- **THEN** every field of that snapshot is displayed as a row in the definition group
+- **AND** no column group is rendered for it
+
+### Requirement: An analytics revision diff groups the definition and each column separately
+
+A table snapshot's fields SHALL be grouped: the table-definition fields — every field other than
+`columns` — under a single group, and the columns under a `Columns` section holding **one group per
+column**. A column group SHALL exist for every column name present in either revision, the groups
+SHALL be ordered by column name, and each SHALL list every attribute that column carries (`name`,
+`type`, `element_type`, `enum_values`, `nullable`, `tag`, `display_name`, `description`,
+`sensitive`).
+
+Each column group SHALL be headed by the name of the column it describes, so a reader can tell which
+column a group is about without reading its rows.
+
+#### Scenario: Each column is its own group headed by its name
+
+- **GIVEN** a table revision whose snapshot carries the columns `amount` and `total`
+- **WHEN** the detail page renders it
+- **THEN** the diff shows one group headed `Column amount` and one headed `Column total`
+- **AND** each lists that column's own attributes
+- **AND** the table-definition fields are shown in a separate group above them
+
+#### Scenario: Column groups are ordered by column name
+
+- **GIVEN** a table revision whose snapshot lists the columns `total`, `amount`, `id` in that order
+- **WHEN** the detail page renders it
+- **THEN** the column groups appear in the order `amount`, `id`, `total`
+
+### Requirement: Added and removed columns stay visible and are marked as such
+
+A column present in one revision and absent from the other SHALL remain visible on **both** sides of
+the comparison: the side that carries it shows its attribute rows marked as added or removed, and the
+opposite side shows the same group with placeholder rows. Both revisions therefore show the full
+column set and the difference is carried by the marker, not by an absence — a removed column is not
+simply missing from the newer revision's side.
+
+A column present in both revisions whose attributes differ SHALL have the differing rows marked as
+changed, and its unchanged rows SHALL still be displayed.
+
+The marker SHALL NOT be carried by colour alone. Each column group SHALL state its status in text
+beside the column name — `Added`, `Removed`, or `Changed` — and SHALL be exposed as a group whose
+accessible name carries both the column name and its status.
+
+The existing `All parameters` / `Changes only` control SHALL keep working over these groups: with
+`Changes only` selected, a group with no marked row SHALL not be rendered. (`Changes only` is the
+shipped label of that option — `ActivityAudit.Differences` in
+`apps/ai-dial-admin/src/locales/en.ts`; the control itself is pre-existing and this change does not
+rename or move it.)
+
+#### Scenario: A column added in this revision is marked as added
+
+- **GIVEN** a revision that adds the column `total` to the table `orders`
+- **WHEN** the user opens that activity's detail page
+- **THEN** the `Column total` group is shown on both sides of the comparison
+- **AND** on the side that carries the column its rows are marked as added
+- **AND** the group states `Added` beside the column name
+
+#### Scenario: A column removed in this revision stays visible and is marked as removed
+
+- **GIVEN** a revision that drops the column `legacy_id` from the table `orders`
+- **WHEN** the user opens that activity's detail page
+- **THEN** the `Column legacy_id` group is still shown on both sides of the comparison
+- **AND** it states `Removed` beside the column name
+- **AND** the group is not omitted from the side where the column no longer exists
+
+#### Scenario: A changed column attribute is marked as changed
+
+- **GIVEN** a revision that marks the column `email` of the table `orders` sensitive
+- **WHEN** the user opens that activity's detail page
+- **THEN** the `Column email` group states `Changed` beside the column name
+- **AND** its `sensitive` row is marked as changed
+- **AND** its unchanged rows are still displayed
+
+#### Scenario: The status of a column group is readable without colour
+
+- **GIVEN** the detail page of a revision that adds one column and drops another
+- **WHEN** the groups are inspected by accessible name
+- **THEN** each column group's accessible name carries the column's name and its status
+- **AND** the status is also shown as text, not only as a row colour
+
+#### Scenario: Changes only hides column groups with no change
+
+- **GIVEN** the detail page of a revision that changes one column of a table with several columns
+- **WHEN** the user selects `Changes only`
+- **THEN** only the changed column's group is rendered
+- **AND** selecting `All parameters` again renders every column group

--- a/openspec/changes/analytics-activity-audit/specs/activity-audit-deployments-tab/spec.md
+++ b/openspec/changes/analytics-activity-audit/specs/activity-audit-deployments-tab/spec.md
@@ -1,0 +1,95 @@
+## MODIFIED Requirements
+
+### Requirement: A single unified resolver loads activity audit detail for every page
+
+The codebase SHALL contain exactly one audit-detail resolver, located at
+`apps/ai-dial-admin/src/utils/audit/get-activity-audit-detail-data.ts`, exporting
+`getActivityAuditDetailData(activityId, token): Promise<ActivityAuditDetailData>`. Every audit detail
+page SHALL import from this module:
+
+- the global `/activity-audit/[id]/page.tsx`
+- the 6 deployment entity-namespaced `[subId]/page.tsx` wrappers (Model Servings, MCP / Adapter /
+  Application / Interceptor Containers, Deployment Images)
+- the 10 admin entity-namespaced `[subId]/page.tsx` pages (Models, Adapters, Applications,
+  Interceptors, Roles, Keys, Routes, Toolsets, ApplicationRunners, InterceptorTemplates)
+
+The resolver SHALL try `activityAuditApi.getActivityById` first, fall back to
+`deploymentAuditApi.getActivityById`, and then — only when the analytics feature is enabled in the
+environment it runs in — fall back to `analyticsAuditApi.getActivityById`. It SHALL dispatch via
+`pickActivityHandlers` to admin / image / firewall / container / analytics handlers, and fetch the
+current revision, previous revision, and the entity-context snapshot in parallel via `Promise.all`.
+It SHALL return `{ activity, activityRevision, previousRevision, entity }`.
+
+The legacy admin-only resolver at `apps/ai-dial-admin/src/utils/audit/get-audit-activity-data.ts`
+SHALL be deleted, and the prior route-folder resolver
+`apps/ai-dial-admin/src/app/[lang]/activity-audit/[id]/resolver.ts` SHALL no longer exist.
+
+#### Scenario: Global detail page uses the unified resolver
+
+- **GIVEN** the codebase after this change
+- **WHEN** the global `/activity-audit/[id]/page.tsx` file is read
+- **THEN** its activity resolution import resolves to `@/src/utils/audit/get-activity-audit-detail-data`
+- **AND** the prior `apps/ai-dial-admin/src/app/[lang]/activity-audit/[id]/resolver.ts` file no longer exists
+
+#### Scenario: Deployment entity-namespaced pages use the unified resolver
+
+- **GIVEN** any of the 6 deployment `[subId]/page.tsx` files
+- **WHEN** the file is read
+- **THEN** its activity resolution import resolves to `@/src/utils/audit/get-activity-audit-detail-data`
+- **AND** the page renders `<AuditView ... isEntityActivity />` with the resolved `{ activity, activityRevision, previousRevision, entity }`
+
+#### Scenario: Admin entity-namespaced pages use the unified resolver
+
+- **GIVEN** any of the 10 admin `[subId]/page.tsx` files (Models, Adapters, Applications, Interceptors, Roles, Keys, Routes, Toolsets, ApplicationRunners, InterceptorTemplates)
+- **WHEN** the file is read
+- **THEN** its activity resolution import resolves to `@/src/utils/audit/get-activity-audit-detail-data`
+- **AND** the legacy `getAuditActivityData` symbol from `@/src/utils/audit/get-audit-activity-data` is no longer referenced anywhere in the codebase
+
+#### Scenario: Admin audit-detail load benefits from parallel revision fetches
+
+- **GIVEN** an admin audit-detail page is opened (e.g. `/models/<id>/<activityId>`)
+- **WHEN** the resolver runs
+- **THEN** the current revision, previous revision, and activities list are fetched concurrently via `Promise.all` rather than sequentially
+
+#### Scenario: The analytics fallback is the last step and is skipped when the feature is off
+
+- **GIVEN** an activity the admin backend resolves
+- **WHEN** the resolver runs
+- **THEN** neither the deployment-manager nor the analytics lookup is issued
+- **AND** when neither existing backend resolves the activity and the analytics feature is disabled, no analytics lookup is issued either
+
+### Requirement: `ActivityAuditList` accepts a `viewMode` prop that fixes the fetcher and hides the toggle
+
+The `ActivityAuditList` component SHALL accept an optional `viewMode?: ActivityAuditView` prop. When
+the prop is provided, the component SHALL:
+
+- Use the supplied mode to select the fetcher and the column set from the single per-view lookup that
+  every view is resolved through (`Deployments` → `getDeploymentActivities`, `Config` →
+  `getActivities`, `Analytics` → `getAnalyticsActivities`).
+- Hide the view-type dropdown.
+- Ignore any internal state transitions of the view-type radio.
+
+When the prop is omitted, the component's behavior SHALL be unchanged from the existing global
+activity-audit page (local view-type state initialized to `Config`, dropdown rendered when no entity
+is present).
+
+#### Scenario: viewMode forces deployment-manager fetcher
+
+- **GIVEN** `ActivityAuditList` is rendered with `viewMode={ActivityAuditView.Deployments}`
+- **WHEN** AG Grid requests a row block
+- **THEN** the datasource invokes `getDeploymentActivities`
+- **AND** the `View` dropdown is not rendered
+
+#### Scenario: viewMode forces the analytics fetcher
+
+- **GIVEN** `ActivityAuditList` is rendered with `viewMode={ActivityAuditView.Analytics}`
+- **WHEN** AG Grid requests a row block
+- **THEN** the datasource invokes `getAnalyticsActivities`
+- **AND** the `View` dropdown is not rendered
+
+#### Scenario: Omitting viewMode preserves global page behavior
+
+- **GIVEN** `ActivityAuditList` is rendered on `/activity-audit` with no `viewMode` prop and no `entity` prop
+- **WHEN** the page loads
+- **THEN** the `View` dropdown is rendered with `Config` and `Deployments`, plus `Analytics` when the analytics feature is enabled
+- **AND** the initial fetcher is `getActivities` (Config view default)

--- a/openspec/changes/analytics-activity-audit/specs/activity-audit-deployments-view/spec.md
+++ b/openspec/changes/analytics-activity-audit/specs/activity-audit-deployments-view/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: View selector exposes a Deployments option
+
+The Activity Audit page SHALL render a `Deployments` option in the `View` dropdown alongside the
+existing `Config` option, and — when `featureFlags.analyticsEnabled` is true — an `Analytics` option
+alongside both (see the `activity-audit-analytics-view` capability for that view's own behavior). The
+dropdown SHALL offer exactly the views that have a fetcher behind them: `Config` and `Deployments`
+always, `Analytics` when the analytics feature is enabled — there SHALL be no disabled placeholder
+option for a view with no fetcher behind it. The default selection on initial page load SHALL remain
+`Config`. Selecting any offered option SHALL be available to all users including read-only admins.
+
+#### Scenario: Deployments option visible on initial render
+- **WHEN** the user opens `/activity-audit` for the first time with the analytics feature disabled
+- **THEN** the `View` dropdown shows exactly the options `Config` and `Deployments`
+- **AND** the dropdown value is `Config`
+
+#### Scenario: Analytics option joins the list when the analytics feature is enabled
+- **WHEN** the user opens `/activity-audit` for the first time with `featureFlags.analyticsEnabled` true
+- **THEN** the `View` dropdown shows exactly the options `Config`, `Deployments`, and `Analytics`
+- **AND** the dropdown value is `Config`
+
+#### Scenario: Read-only admin can switch to Deployments view
+- **WHEN** a read-only admin opens the View dropdown
+- **THEN** the `Deployments` option is enabled and selectable
+- **AND** the `Analytics` option, when offered, is likewise enabled and selectable

--- a/openspec/changes/analytics-activity-audit/specs/analytics/spec.md
+++ b/openspec/changes/analytics-activity-audit/specs/analytics/spec.md
@@ -1,0 +1,173 @@
+## ADDED Requirements
+
+### Requirement: Table detail view is organized into Properties and Audit tabs
+
+The table detail view (`/tables/{name}`) SHALL, for a table whose `status` is `ACTIVE`, present its
+content under a horizontal tab strip with exactly two tabs, **Properties** and **Audit**, in that
+order. `Properties` SHALL be the selected tab when the view is first opened.
+
+The view header — the table name, the lifecycle status badge, the kind tag, the system tag, the
+description row, and the whole header action row (Manage access, Delete table, Add columns, Add rows,
+Connect, and the draft **Save** action) — SHALL render **above** the tab strip and SHALL be unchanged
+by this reorganization: the same controls, in the same order, under the same permission and status
+conditions as before, visible whichever tab is selected. Every other element the "Table detail column
+schema management", "Define and materialize a table schema", and "Table detail row writes"
+requirements describe as being on the detail page — the read-only schema-metadata summary, the
+columns grid or the draft schema editor, and the modals those actions open — SHALL render inside the
+**Properties** tab where a tab strip is rendered, and directly beneath the header where it is not
+(see the status and feature-flag conditions below). Whichever of the two applies, that content SHALL
+be the same content, in the same order, as before this change.
+
+The Audit tab SHALL be offered **only** on a table whose `status` is `ACTIVE`. On a table at any other
+status — `PENDING` (Draft), `FAILED`, or a table whose status the backend does not report — the detail
+view SHALL render no tab strip and no Audit tab, SHALL render the Properties content directly, and
+SHALL issue no request to the analytics activity feed. A table that has not been materialized has no
+audit history for the tab to show: it has no columns, and the analytics activity feed returns zero
+activities for its name, so the tab could only ever be empty. On an `ACTIVE` table the Audit tab SHALL
+require no permission beyond the one that already allows reading the table, and SHALL NOT consult the
+per-table `write` / `modify` permissions.
+
+The tab strip SHALL therefore be rendered only when `featureFlags.analyticsEnabled` is true **and**
+the table's status is `ACTIVE`. With analytics disabled the detail view SHALL render the Properties
+content directly, with no tab strip and no Audit tab, and SHALL issue no request to the analytics
+activity feed — the same rendering as the non-`ACTIVE` case above. The route itself is not guarded —
+`/tables/{name}` renders whenever it is reached, today and after this change; hiding the Analytics
+menu group is not a route guard, so a bookmarked or pasted link still opens this view and the tab
+condition is what keeps an analytics-disabled installation from issuing an activity request. Guarding
+the route is a separate concern about the whole tables feature and is out of scope here.
+
+#### Scenario: Properties is the selected tab when the detail view opens
+
+- **WHEN** the user opens the detail view of a table whose `status` is `ACTIVE`
+- **THEN** a tab strip showing `Properties` and `Audit` is rendered
+- **AND** `Properties` is the selected tab
+- **AND** the read-only schema-metadata summary and the columns grid are shown beneath it
+
+#### Scenario: Header and its actions stay above the tab strip
+
+- **GIVEN** the detail view of a table whose `status` is `ACTIVE`
+- **WHEN** the user switches from `Properties` to `Audit`
+- **THEN** the table name, status badge, kind tag, description row, and every header action button
+  the user's permissions allow remain rendered above the tab strip, unchanged
+
+#### Scenario: Audit tab is hidden on a draft table
+
+- **GIVEN** a table whose `status` is `PENDING`
+- **WHEN** the user opens its detail view
+- **THEN** no tab strip and no `Audit` tab are rendered
+- **AND** the schema-metadata summary and the draft schema editor are shown directly, as they are
+  before this change
+- **AND** no request is issued to the analytics activity feed
+
+#### Scenario: Audit tab needs no permission beyond reading the table
+
+- **GIVEN** a table whose `status` is `ACTIVE`
+- **AND** a viewer whose per-table permissions report `write: false` and `modify: false`
+- **WHEN** the user opens the table detail view
+- **THEN** the `Audit` tab is present and selectable
+
+#### Scenario: Audit tab absent when analytics is disabled
+
+- **GIVEN** `featureFlags.analyticsEnabled` is false
+- **AND** a table whose `status` is `ACTIVE` — so the flag alone decides
+- **WHEN** the user reaches `/tables/{name}` by a direct link
+- **THEN** no tab strip and no `Audit` tab are rendered
+- **AND** the schema-metadata summary and the columns grid or draft schema editor are shown directly
+- **AND** no request is issued to the analytics activity feed
+
+### Requirement: Table Audit tab lists the table's own and its columns' activities
+
+The global Activity Audit page's own `Analytics` view — the third option in its `View` selector, its
+fetcher, its rollback absence, and how one of its rows resolves and renders on the audit detail page —
+is specified by the `activity-audit-analytics-view` capability. This requirement covers only the tab
+on the table detail view.
+
+The **Audit** tab SHALL render the shared entity audit surface with the Activities list as its only
+sub-tab — no Dashboard, Traces, or Conversations sub-tab, which report DIAL request telemetry keyed
+by a deployment name and have no meaning for a catalog table — and with no view-type selector.
+
+The list SHALL be sourced from the analytics backend (`POST /v1/activities` at
+`DIAL_ANALYTICS_API_URL`) and SHALL be narrowed to the table being viewed **and its columns**. The
+request SHALL carry a `resourceType` filter with the `in` operator and the value `Table,TableColumn`,
+and a `resourceId` filter with the `co` operator and the table's name. Because `co` is a substring
+match and the analytics backend names a column activity `<table>:<column>`, rows SHALL be narrowed
+client-side to those whose `resourceId` is exactly the table's name or begins with the table's name
+followed by `:`; a row belonging to any other table SHALL NOT be displayed.
+
+Because the list carries two resource types, the grid SHALL show the `Resource type` and
+`Resource identifier` columns, so a column activity states which column it refers to. Rows SHALL be
+listed flat, newest first, with no row-expander column.
+
+The tab renders the same `Analytics` view as the global page, so the suppression of a deleted table's
+child column activities (`activity-audit-analytics-view`, *A child activity of a deleted table is not
+listed*) applies here too. It is inert in practice — a deleted table has no detail view from which to
+open this tab — and it never touches a column dropped from the table being viewed, whose parent is a
+`Table` `Update`.
+
+The tab SHALL offer the same time-period filter `EntityAudit` already renders for other entities,
+initialized to the default period, and changing it SHALL re-request the list for the new range. The
+row action menu SHALL offer `Open in a new tab` and SHALL NOT offer `Rollback` — the analytics backend
+exposes no endpoint that writes an audit record, revision, or snapshot. A failed request SHALL leave
+the grid in its existing error/empty state and SHALL NOT raise a toast notification; this surface is
+read-only and performs no action a success or error notification would describe.
+
+#### Scenario: Request is narrowed to the table and its columns
+
+- **WHEN** the Audit tab is opened on the table named `conversations` and the grid requests its first
+  row block
+- **THEN** the analytics activity feed is requested with a `resourceType` filter
+  `{ operator: "in", value: "Table,TableColumn" }` and a `resourceId` filter
+  `{ operator: "co", value: "conversations" }`
+- **AND** the request is not sent to the admin backend or the deployment-manager backend
+
+#### Scenario: An activity belonging to a similarly named table is excluded
+
+- **GIVEN** the Audit tab is open on the table named `orders`
+- **AND** the feed response contains an activity with `resourceType: "TableColumn"` and
+  `resourceId: "my_orders:total"`
+- **WHEN** the grid renders the block
+- **THEN** that row is not displayed
+- **AND** a row with `resourceId: "orders"` and a row with `resourceId: "orders:total"` are both
+  displayed
+
+#### Scenario: A column activity states which column it refers to
+
+- **GIVEN** the Audit tab is open on the table named `orders`
+- **WHEN** the list contains an activity with `resourceType: "TableColumn"` and
+  `resourceId: "orders:total"`
+- **THEN** that row's `Resource type` cell reads the localized `Table column` label
+- **AND** its `Resource identifier` cell reads `orders:total`
+
+#### Scenario: Audit tab renders only the Activities sub-tab
+
+- **WHEN** the user selects the `Audit` tab
+- **THEN** the sub-tab rail lists `Activities` and nothing else
+- **AND** no `Config / Deployments / Analytics` view-type dropdown is rendered
+
+#### Scenario: Row click opens the global audit detail page
+
+- **GIVEN** the Audit tab lists an activity whose `activityId` is `abc-123`
+- **WHEN** the user clicks that row outside the action menu
+- **THEN** the browser opens `/activity-audit/abc-123` in a new tab, as the shared audit list already
+  does for every other view
+- **AND** no `/tables/{name}/{activityId}` URL is requested
+
+#### Scenario: No rollback action is offered
+
+- **WHEN** the user opens the row action menu on any row in the Audit tab
+- **THEN** the menu offers `Open in a new tab`
+- **AND** the menu does not offer `Rollback`
+
+#### Scenario: Table with no recorded history
+
+- **GIVEN** a table for which the analytics activity feed returns zero rows
+- **WHEN** the user opens the Audit tab
+- **THEN** the grid shows its existing empty state, with no error and no notification
+- **AND** the tab remains usable and the user can navigate away normally
+
+#### Scenario: Changing the time period re-requests the list
+
+- **GIVEN** the Audit tab is open
+- **WHEN** the user changes the time-period filter
+- **THEN** the next request to the analytics activity feed carries the updated
+  `epochTimestampMs` `ge` and `le` filters

--- a/openspec/changes/analytics-activity-audit/tasks.md
+++ b/openspec/changes/analytics-activity-audit/tasks.md
@@ -1,0 +1,435 @@
+# Tasks — analytics-activity-audit
+
+Every path below is relative to `apps/ai-dial-admin/`. Run vitest from that directory or `@/` will
+not resolve. Per `openspec/config.yaml`, unit tests for new and updated code are part of each task
+below and are named explicitly in it — a task is not done until the spec file it names passes.
+
+Notes for EM before dispatch:
+
+- **`TableDetailView.tsx` must keep its name and its path.** Issue #3977 (Tables RBAC) edits the same
+  file; design.md D6 deliberately extracts the body downward rather than moving the file, so the two
+  conflict on as little as possible. Do not "tidy" it into a `View/` folder.
+- Tasks 2.1 and 2.3 both touch shared audit code that the `Config` and `Deployments` views depend on.
+  The existing tests in `src/components/ActivityAudit/List/tests/` and
+  `src/constants/grid-columns/tests/formatters.spec.ts` are the regression check — they must be kept
+  and stay green, not rewritten to fit the new shape.
+- **Section 5 is the diff-presentation work the owner added after the first pass** (design.md D11).
+  It touches the diff engine every resource type renders through. The existing specs under
+  `src/components/ActivityAudit/View/utils/tests/` and
+  `src/components/ActivityAudit/View/DiffReport/tests/` are the regression check for containers,
+  images, roles and the firewall; keep them and keep them green.
+- Three files attract more than one task each and are therefore never in the same batch:
+  `List/List.tsx` (6.1 and 6.5; 6.1 also depends on 2.3's new modules),
+  `List/tests/utils.spec.tsx` (2.3 adds the analytics column block, 4.2 adds the D5 guard case) and
+  `List/tests/List.spec.tsx` (6.1 writes it, 6.4 extends it, 6.5 extends it again — in that order).
+- **6.5 is the owner's addition after the first implementation pass** (design.md D13): a table
+  `Delete`'s per-column child activities are not listed. It is numbered inside section 6 on purpose,
+  so the browser-verification task (7) and the quality-checks task (8) still come after every
+  implementation task without renumbering anything already done. It also means **7.1 needs a further
+  pass**: the verification round that ran before 6.5 existed could not have checked its scenarios.
+- Two scenarios were reworded after browser verification because the delta was wrong about the
+  shipped product, not because the code was: the row body opens the detail page in a **new** tab
+  (design.md D5), and the diff filter's option is labelled `Changes only`, never `Diff only`
+  (design.md D11). No behaviour requirement changed, and no source file needs to change for either.
+
+## 1. Analytics activity source and types
+
+- [x] 1.1 In `src/types/activity-audit.ts`, add `ActivityAuditView.Analytics = 'Analytics'`, add the
+      four resource types the analytics backend emits to `ActivityAuditResourceType` (`TABLE = 'Table'`,
+      `TABLE_COLUMN = 'TableColumn'`, `PIPELINE = 'Pipeline'`, `SAVED_QUERY = 'SavedQuery'`), and add an
+      `isAnalyticsResource` predicate backed by an `ANALYTICS_RESOURCE_TYPES` set, colocated with the
+      existing `isDeploymentManagerResource` / `isContainerDeploymentResource` predicates as
+      `activity-audit-deployments-detail`'s "Resource-type predicates colocated with the type enum"
+      requires. Extend `src/types/tests/activity-audit.spec.ts` with an `isAnalyticsResource` describe
+      block covering the four types, a deployment type, an admin type, and `undefined`. Verify with
+      `npx vitest run src/types/tests/activity-audit.spec.ts`.
+
+- [x] 1.2 Add `src/server/analytics/audit-api.ts` exporting `AnalyticsAuditApi extends BaseApi` with
+      `getActivitiesList(pageSize, pageNumber, token, sorts, filters)` (`POST v1/activities`),
+      `getActivityById(id, token)` (`GET v1/activities/{id}`) and
+      `getRevisionDetails(url, token)` (`GET v1{url}`) — the same three methods
+      `src/server/deployments/audit-api.ts` and `src/server/entities/activity-audit-api.ts` expose,
+      with the analytics `v1/` prefix rather than `api/v1/` (see `src/server/analytics/analytics-data-api.ts`
+      for the prefix convention). Register `analyticsAuditApi` in `src/app/api/api.ts` on
+      `process.env.DIAL_ANALYTICS_API_URL`, beside `analyticsDataApi`. Add `getAnalyticsActivities` to
+      `src/app/[lang]/activity-audit/actions.ts` alongside `getActivities` / `getDeploymentActivities`,
+      authenticating through `getUserToken` exactly as they do. Add
+      `src/server/analytics/tests/audit-api.spec.ts` asserting the called URL, the request body shape
+      (`pageNumber`, `pageSize`, `sorts`, `filters`), the parsed `{total, totalPages, data}` response and
+      the failure path; extend `src/app/[lang]/activity-audit/actions.spec.ts` with a case asserting
+      `getAnalyticsActivities` delegates to the client with the token. Verify with
+      `npx vitest run src/server/analytics/tests/audit-api.spec.ts "src/app/[lang]/activity-audit/actions.spec.ts"`.
+
+- [x] 1.3 In `src/constants/i18n.ts` and `src/locales/en.ts`, add every new i18n key this change
+      needs — the four for the view option and the new resource-type labels, and the four the analytics
+      revision diff needs for its column group headings and status markers (design.md D11). No field
+      labels are added: `AnalyticsTablesI18nKey` already defines every table and column field label the
+      diff uses, and `EntitiesI18nKey.Table` already exists for the `Table` resource-type label. This
+      task adds keys only; nothing consumes them until 2.1, 5.2 and 6.1.
+
+## 2. Shared audit utilities
+
+- [x] 2.1 In `src/constants/grid-columns/formatters.ts`, extend `getFormattedResourceType` so the four
+      analytics resource types return their localized labels (`Table` → `EntitiesI18nKey.Table`,
+      `TableColumn` → `EntitiesI18nKey.AnalyticsTableColumn`, `Pipeline` →
+      `EntitiesI18nKey.AnalyticsPipeline`, `SavedQuery` → `EntitiesI18nKey.AnalyticsSavedQuery`), adding
+      them to the existing `switch` rather than a new branch chain. Extend
+      `src/constants/grid-columns/tests/formatters.spec.ts` with a case per new type **and** the guard
+      test design.md D7 requires, naming its expected sets rather than asserting "unchanged": after the
+      additions the built label map still resolves `global firewall` to exactly
+      `[IMAGE_BUILD_DOMAIN_WHITELIST]`, the image label to exactly the four `*_IMAGE_DEFINITION`
+      members, the model-serving label to exactly `[NIM_DEPLOYMENT, INFERENCE_DEPLOYMENT]`, each of the
+      four container labels to exactly one member, and no analytics label equals any pre-existing label.
+      Verify with `npx vitest run src/constants/grid-columns/tests/formatters.spec.ts`.
+
+- [x] 2.2 Add `src/utils/audit/analytics-resource-id.ts` with two pure functions:
+      `getTableNameFromAnalyticsResourceId(resourceId)` (the part before the first `:`, or the whole
+      value when there is none) and `isResourceIdInTableScope(resourceId, tableName)` (true when
+      `resourceId` equals `tableName` or starts with `` `${tableName}:` ``). In
+      `src/utils/audit/get-revision-route.ts`, add the analytics cases to
+      `getRevisionRouteForEntityType`: `TABLE` → `` `/tables/${id}/revision/` ``, `TABLE_COLUMN` →
+      the same route built from `getTableNameFromAnalyticsResourceId(id)`, `PIPELINE` →
+      `` `/pipelines/${id}/revision/` ``, `SAVED_QUERY` → `` `/saved-queries/${id}/revision/` ``.
+      Add `src/utils/audit/tests/analytics-resource-id.spec.ts` (positive, no-separator, empty,
+      similarly-named-table, and `undefined` cases) and extend
+      `src/utils/audit/tests/get-revision-route.spec.ts` with the four new routes. Verify with
+      `npx vitest run src/utils/audit/tests/analytics-resource-id.spec.ts src/utils/audit/tests/get-revision-route.spec.ts`.
+
+- [x] 2.3 Replace the fetcher ternary at `src/components/ActivityAudit/List/List.tsx:211` with a
+      per-view lookup, per design.md D2: add `src/components/ActivityAudit/List/models.ts` with the
+      `ActivityAuditViewConfig` interface and `src/components/ActivityAudit/List/view-config.ts`
+      exporting `ACTIVITY_AUDIT_VIEW_CONFIG: Record<ActivityAuditView, ActivityAuditViewConfig>` whose
+      fields are `fetchActivities`, `getColumns`, `hasParentChildAggregation`, `hasRollback`,
+      `isRowNavigable` and `getEntityActivityHref` — the `Config` and `Deployments` entries being exact
+      transcriptions of today's behavior, including the entity-mode `isSingleEntity` column set and its
+      row Rollback action, which must survive for those two views. In
+      `src/components/ActivityAudit/List/utils.tsx` add `getAnalyticsActivityAuditColumns(t, open)`
+      returning `[...ACTIVITY_AUDIT_COLUMNS(t, ActivityAuditView.Analytics), ACTION_COLUMN([openInNewTab])]`
+      — no rollback action, and `ACTIVITY_AUDIT_COLUMNS` itself needs no edit, since that view value
+      already yields no expander, no `Version`, and a visible `Resource type` / `Resource identifier`
+      pair. Add `src/utils/audit/entity-audit-filters.ts` exporting
+      `getEntityAuditFilters(entity, entityType, view)`, returning today's
+      `resourceId eq` + `resourceType eq` pair for `Config` and `Deployments` and, for `Analytics`,
+      `resourceType in "Table,TableColumn"` + `resourceId co <table name>` per design.md D3. Add
+      `src/components/ActivityAudit/List/tests/view-config.spec.ts` (every enum member has an entry;
+      the `Config` and `Deployments` entries name today's fetchers and column factories; `Analytics`
+      has `hasRollback: false` and `hasParentChildAggregation: false`) and
+      `src/utils/audit/tests/entity-audit-filters.spec.ts`; extend
+      `src/components/ActivityAudit/List/tests/utils.spec.tsx` with a
+      `getAnalyticsActivityAuditColumns` block asserting the column ids and the absence of a rollback
+      action. Verify with
+      `npx vitest run src/components/ActivityAudit/List/tests/view-config.spec.ts src/components/ActivityAudit/List/tests/utils.spec.tsx src/utils/audit/tests/entity-audit-filters.spec.ts`.
+
+## 3. Audit detail resolution
+
+- [x] 3.1 In `src/utils/audit/get-activity-audit-detail-data.ts`, add analytics as the third and last
+      step of the `getActivityById` fallback chain, issued only when
+      `isValueTruthy(process.env.ANALYTICS_ENABLED)` — the helper from `@/src/utils/types`, which is
+      `value === 'true'` and is how `layout.tsx:61` reads this same variable. A bare truthiness check on
+      `process.env.ANALYTICS_ENABLED` reads the string `"false"` as enabled and would make this resolver
+      disagree with the client flag (design.md D8). Add an `analyticsHandlers` entry to
+      `pickActivityHandlers` using `filterByResourceId`, `makeRouteSnapshotFetcher(analyticsAuditApi)`
+      and `makeListActivities(analyticsAuditApi)`. Leave the admin and deployment branches untouched.
+      Add `src/utils/audit/tests/get-activity-audit-detail-data.spec.ts` covering: an admin activity
+      resolving with neither of the other two lookups issued; a deployment activity resolving with no
+      analytics lookup issued; an analytics activity resolving after both miss, with its current,
+      previous and latest-revision snapshots fetched in parallel; no analytics lookup when
+      `ANALYTICS_ENABLED` is unset **and** a second case with it set to the string `"false"`; and a
+      snapshot the backend answers as absent producing a `null` revision rather than a throw. Verify
+      with `npx vitest run src/utils/audit/tests/get-activity-audit-detail-data.spec.ts`.
+
+## 4. Audit detail page chrome
+
+Both tasks in this section fix controls in `src/components/ActivityAudit/View/**` that are
+unconditional on resource type today, and that the change's own scenarios require the analytics
+detail page to render past.
+
+- [x] 4.1 In `src/components/ActivityAudit/View/AuditView.tsx`, stop rendering the `Rollback resource`
+      button for analytics activities: the button at `:221` is conditional only on `!isReadOnlyAdmin`,
+      and `resourceRollback` (`:133`) falls through to `rollbackEntityPerRevision` against the **admin**
+      backend for a resource it does not own (design.md D9). Gate the button on
+      `!isAnalyticsResource(activity.resourceType)` in addition to the existing condition; render no
+      disabled control in its place; change nothing else — the confirmation popup, the notifications and
+      the post-rollback navigation stay as they are for the types that still offer it. Extend
+      `src/components/ActivityAudit/View/tests/AuditView.spec.tsx`, keeping every existing case, with:
+      no `Rollback resource` button for a `Table` and for a `TableColumn` activity given a non-read-only
+      viewer; the button still rendered for a `Model` activity given the same viewer; and no disabled
+      rollback control present in the analytics case. Verify with
+      `npx vitest run src/components/ActivityAudit/View/tests/AuditView.spec.tsx`.
+
+- [x] 4.2 Fix the header's resource external link for analytics activities, per design.md D10. In
+      `src/components/ActivityAudit/View/Header/utils.ts` add a pure
+      `getAuditResourceHref(resourceType, resourceId)` returning a path or `undefined`: analytics types
+      resolve through a local `ANALYTICS_RESOURCE_ROUTE` map (`TABLE` and `TABLE_COLUMN` →
+      `ApplicationRoute.AnalyticsTables` with `getTableNameFromAnalyticsResourceId(resourceId)` from
+      2.2, `PIPELINE` → `ApplicationRoute.AnalyticsPipelines`, `SAVED_QUERY` →
+      `ApplicationRoute.AnalyticsQueries`), every other type through `auditResourceRoute` as today, and
+      `undefined` when nothing resolves. In `src/components/ActivityAudit/View/Header/Header.tsx`, build
+      `openResourceInNewTab` from that helper and render the external-link `DialIconButton` only when it
+      returns a path — today an unregistered type produces `/{locale}/undefined/{resourceId}`.
+      **Do not add analytics entries to `auditResourceRoute`**: `getAuditActivityHref`
+      (`List/utils.tsx:184`) reads the same map, and an entry there would make every analytics row's
+      href `/tables/{name}/{activityId}`, the entity-namespaced route design.md D5 deliberately does not
+      create — a 404 on every row click, undoing D5 silently. Add a comment above `auditResourceRoute`
+      in `src/constants/activity-audit.ts` saying that, and extend the existing
+      `returns empty href for a resource type not registered in auditResourceRoute` case in
+      `src/components/ActivityAudit/List/tests/utils.spec.tsx` with `TABLE` and `TABLE_COLUMN`, naming
+      D5 in the test name so a later edit to the map fails here. Add
+      `src/components/ActivityAudit/View/Header/test/utils.spec.ts` cases for the four analytics types,
+      the `<table>:<column>` split and the unresolvable case, and extend
+      `src/components/ActivityAudit/View/Header/test/Header.spec.tsx` with: a `Table` activity's link
+      opening `/en/tables/orders`, a `TableColumn` activity with `resourceId` `orders:total` opening
+      `/en/tables/orders`, and no link button rendered for an activity whose type has no route. Verify
+      with `npx vitest run src/components/ActivityAudit/View/Header/test/utils.spec.ts src/components/ActivityAudit/View/Header/test/Header.spec.tsx src/components/ActivityAudit/List/tests/utils.spec.tsx`.
+
+## 5. Analytics revision diff
+
+Design.md D11 is the whole specification of this section; read it before starting. The reason it is
+engine work and not styling: `compareObjectTypes` / `fillObjectTypes` in `generate-diffs.ts` are
+`else if` chains over known key sets with no final `else`, and `createSectionFromDiffs` iterates a
+fixed list of section names — so a table snapshot's `columns`, `grain`, `partition_by`,
+`ordering_key` and `tag_order` are not rendered badly today, they are not rendered at all.
+
+- [x] 5.1 Add `src/components/ActivityAudit/View/utils/analytics-diffs.ts` with the pure builder for
+      an analytics snapshot diff: a snapshot walker projecting any snapshot object to `FlatRow[]`
+      (scalar → one row; nested object → one row per leaf with a dotted parameter such as
+      `grain.grain_key`; array of scalars → one row joining the elements **in the snapshot's order**,
+      never sorted, because `ordering_key` and `tag_order` mean their order); a `columnRows(column)`
+      projector emitting `name`, `type`, `element_type`, `enum_values`, `nullable`, `tag`,
+      `display_name`, `description`, `sensitive`; and a builder that fills the `properties` bucket from
+      every non-`columns` field and one `columns:<name>` bucket per column name present in **either**
+      revision, ordered by name. No hidden-key set — every field is shown. Compare each bucket with
+      `compareNestedFlatObject` and fill it with `fillNestedFlatObject` from
+      `View/utils/create-simple-diffs.ts`, which already emits the `MIRROR` placeholder on the side a
+      field is missing from; unlike `compareMetadataEnvs` (`generate-diffs.ts:433`) this builder must
+      emit in **both** directions, so a column present only on one side still produces a group on both.
+      Add `COLUMNS = 'columns'` to `EntityParameterKeys` in
+      `src/components/ActivityAudit/constants.ts`. In
+      `src/components/ActivityAudit/View/utils/generate-diffs.ts`, branch
+      `generateCurrentResource` to the new builder when `isAnalyticsResource(type)`, and add an
+      analytics branch to `createSectionFromDiffs` beside the existing `setRolesDiffs` /
+      `setObjectsArrayDiff` ones that collects the `columns:<name>` buckets in name order into
+      `sections.columns`, plus an `ANALYTICS_SECTION_ORDER` appended after the container and admin
+      orders. Every non-analytics resource type must take exactly the path it takes today. Add
+      `src/components/ActivityAudit/View/utils/tests/analytics-diffs.spec.ts` covering: every snapshot
+      field producing a row; a nested object flattened to dotted parameters; an ordered array joined in
+      declared order and not sorted; one bucket per column, name-ordered; a column present only in the
+      newer revision producing rows marked added on one side and placeholders on the other; the same for
+      a column present only in the older revision; a changed attribute marked changed with the column's
+      unchanged rows still emitted; and an empty/absent snapshot on one side. Extend
+      `src/components/ActivityAudit/View/utils/tests/generate-diffs.spec.ts` with the analytics branch
+      and a case proving a container snapshot's sections are unchanged. Verify with
+      `npx vitest run src/components/ActivityAudit/View/utils/tests/analytics-diffs.spec.ts src/components/ActivityAudit/View/utils/tests/generate-diffs.spec.ts`.
+
+- [x] 5.2 Render the grouped diff, per design.md D11 parts 3 and 4. In
+      `src/models/activity-audit.ts` add two optional fields to `ActivityAuditDiffSection` —
+      `label?: string` and `diffStatus?: DiffStatus` — and thread them through
+      `filterNotEmptySections` in `src/components/ActivityAudit/View/DiffReport/utils.ts`, which today
+      discards everything but `current` / `compare`. In
+      `src/components/ActivityAudit/View/DiffReport/DiffSection.tsx`, prefer a section entry's `label`
+      over the `EntityFieldsI18nKey[name]` title lookup for the per-index heading — generalizing the
+      existing `name === METADATA ? 'Variable N ' : ''` prefix — render the status word
+      (`CompareI18nKey.Added` / `Removed` / `Changed`) as visible text beside it, and wrap each
+      per-index block in a `role="group"` whose `aria-label` carries both the column name and the
+      status, as `.claude/rules/a11y.md` requires for a collection with per-item visual treatments.
+      Do not change the row-level colour treatment of any diff, and do not add a status column to the
+      grids. In `src/components/ActivityAudit/EntityGrid/constants.ts` add an exported
+      `ANALYTICS_ROW_LABEL_KEYS` map beside `CONTAINER_ROW_LABEL_KEYS` and consult it in
+      `formatParameter`, mapping each analytics field name to the `AnalyticsTablesI18nKey` label that
+      already exists for it; keep the existing fall-back to the raw field name so an unmapped field
+      renders unlabelled rather than being hidden. Add
+      `src/components/ActivityAudit/View/DiffReport/tests/DiffSection.spec.tsx` asserting: a labelled
+      section rendering its label as the per-index heading; the status word present as text; the group
+      queryable by role and accessible name carrying column name and status; an unlabelled section
+      still using the existing title lookup; and with `DiffView` set to diff-only, a section whose rows
+      carry no `diffStatus` not rendered while one that does is. Add
+      `src/components/ActivityAudit/EntityGrid/tests/constants.spec.ts` asserting the analytics label
+      map covers every field `columnRows` emits and every table-definition field, and extend
+      `src/components/ActivityAudit/View/DiffReport/tests/utils.spec.ts` with the label/status
+      pass-through. Verify with
+      `npx vitest run src/components/ActivityAudit/View/DiffReport/tests/DiffSection.spec.tsx src/components/ActivityAudit/View/DiffReport/tests/utils.spec.ts src/components/ActivityAudit/EntityGrid/tests/constants.spec.ts`.
+
+## 6. Surfaces
+
+- [x] 6.1 Rewire `src/components/ActivityAudit/List/List.tsx` onto `ACTIVITY_AUDIT_VIEW_CONFIG`:
+      replace `isDeploymentsView` at the datasource, the `rowClassRules`, `onCellClicked`, `columnDefs`
+      and the system-rollback condition with reads from the resolved view config. **The `entity`
+      short-circuit in `columnDefs` (`:353-360`) must resolve through the view config too** — today it
+      returns early with the `isSingleEntity` column set *and* a Rollback row action, which would break
+      *A column activity states which column it refers to* and *No rollback action is offered* while
+      every other test still passed (design.md D2). `Config` and `Deployments` entity mode keeps its
+      current columns and its row Rollback. Build the entity-mode filters through
+      `getEntityAuditFilters`; apply `isResourceIdInTableScope` to narrow rows before they enter the row
+      buffer when the view is `Analytics` and an entity is present; add the `Analytics` option to
+      `activityViewOptions` only when `useAppContext().featureFlags.analyticsEnabled` is true; use the
+      view's `getEntityActivityHref` so an `Analytics` row (in the tab as well as on the global page)
+      opens `/activity-audit/{activityId}` rather than an entity-namespaced URL; and make the
+      `storageKey` continue to derive from the active view so analytics column state lands under
+      `activity-audit:analytics`. Extend `src/components/ActivityAudit/List/tests/List.spec.tsx`,
+      keeping every existing case, with: the `Analytics` option present/absent by feature flag; the
+      analytics fetcher invoked under `viewMode={ActivityAuditView.Analytics}` and the dropdown hidden;
+      no page-level `Rollback` button in the Analytics view; **no Rollback row action in the analytics
+      entity view, and one still present in the `Config` entity view**; the entity-mode analytics
+      request carrying the `in` / `co` filter pair; a row for a similarly named table being excluded;
+      and the `Resource identifier` column present in the analytics entity view. Verify with
+      `npx vitest run src/components/ActivityAudit/List/tests/List.spec.tsx`.
+
+- [x] 6.2 Add `src/components/Analytics/Tables/TableAudit.tsx` — a component taking the
+      `AnalyticsTable` and rendering `EntityAudit` with
+      `entity={{ name: table.name, description: table.description }}` (a valid `BaseEntity`; do not cast
+      and do not widen `EntityAudit`'s props — design.md D4), `view={ApplicationRoute.AnalyticsTables}`
+      and `viewMode={ActivityAuditView.Analytics}`. In `src/constants/activity-audit.ts` add
+      `[ApplicationRoute.AnalyticsTables]: ActivityAuditResourceType.TABLE` to `routeAuditResource` so
+      `resolveEntityAuditType` resolves the tab's entity type with no new branch. Add
+      `src/components/Analytics/Tables/tests/TableAudit.spec.tsx` mocking `EntityAudit` and asserting
+      the three props it receives, including that the projected entity carries the table's name. Verify
+      with `npx vitest run src/components/Analytics/Tables/tests/TableAudit.spec.tsx`.
+
+- [x] 6.3 Turn `src/components/Analytics/Tables/TableDetailView.tsx` into the tab shell described in
+      design.md D6, without renaming or moving the file: keep every piece of state, every handler and
+      every modal where they are; keep the header (title, status badge, kind tag, system tag,
+      description row and the entire action row) above a new `DialTabs` strip carrying
+      `EntityViewTab.Properties` and `EntityViewTab.Audit` (labels `TabsI18nKey.Properties` /
+      `TabsI18nKey.Audit`, both of which already exist), with `Properties` selected initially; move the
+      read-only key summary and the `isActive ? <GridView …> : <DraftSchemaEditor …>` body verbatim into
+      a new presentational `src/components/Analytics/Tables/TableProperties.tsx`; render `TableAudit`
+      under the Audit tab. **Render the tab strip only when
+      `useAppContext().featureFlags.analyticsEnabled` is true AND the table is active** — that is, only
+      when `featureFlags.analyticsEnabled && isActive`, reusing the `isActive`
+      (`table.status === TableStatus.Active`) boolean the component already computes. When either
+      condition is false the view renders `TableProperties` directly, with no tab strip and no Audit
+      tab, so no analytics activity request is issued. Both halves matter for a different reason: a
+      draft table has no audit history at all (design.md D12 records the measurement), and
+      `src/app/[lang]/tables/[id]/page.tsx` has no feature-flag guard, so a bookmarked link reaches
+      this view on an analytics-disabled install and the flag half is the only gate there. Do not add
+      a guard to the route, and do not render a one-tab strip or a disabled Audit tab in the
+      non-active case. Split `src/components/Analytics/Tables/tests/TableDetailView.spec.tsx` so the
+      summary/grid cases move to a new `src/components/Analytics/Tables/tests/TableProperties.spec.tsx`
+      against the extracted component (assertions unchanged), and add to `TableDetailView.spec.tsx`:
+      `Properties` selected on open of an `ACTIVE` table, the header actions rendered while the `Audit`
+      tab is selected, **no tab strip and no `Audit` tab on a `PENDING` table with the draft schema
+      editor rendered directly and no analytics activity request issued**, the `Audit` tab present on
+      an `ACTIVE` table for a viewer whose permissions report `write: false, modify: false`, and no tab
+      strip and no `Audit` tab with `analyticsEnabled` false on an `ACTIVE` table. Verify with
+      `npx vitest run src/components/Analytics/Tables/tests/TableDetailView.spec.tsx src/components/Analytics/Tables/tests/TableProperties.spec.tsx`.
+
+- [x] 6.4 Close the one acceptance criterion the browser cannot reach, in
+      `src/components/ActivityAudit/List/tests/List.spec.tsx` only — no source file changes, and keep
+      every existing case. The local analytics feed carries no `Pipeline` or `SavedQuery` activity, so
+      *Pipeline and saved-query rows are shown* can never be observed in a browser on this stack; it
+      has to be a unit assertion or it is nothing. What exists today is two halves that never meet:
+      `renders a row for every resource type the analytics feed returns` (the same file) feeds a page
+      of all four resource types through `viewMode={ActivityAuditView.Analytics}` and asserts all four
+      reach the grid's `successCallback`, and `formatters.spec.ts` asserts
+      `getFormattedResourceType(PIPELINE|SAVED_QUERY, t)` resolves to
+      `EntitiesI18nKey.AnalyticsPipeline` / `AnalyticsSavedQuery` — but nothing asserts that a
+      `Pipeline` or `SavedQuery` row reaching the **analytics column set** renders its type. Join them:
+      in that test (or a sibling beside it) also pull the `resourceType` column out of
+      `lastColumnDefs()` and assert its `valueFormatter` resolves `PIPELINE` →
+      `EntitiesI18nKey.AnalyticsPipeline` and `SAVED_QUERY` → `EntitiesI18nKey.AnalyticsSavedQuery`,
+      the way the entity-tab block at `ActivityAuditList :: Analytics entity audit tab` already does
+      for `TABLE_COLUMN`. While in the file, rename the case currently called
+      `navigates to the global detail page on a row body click` to say what it actually asserts — that
+      the row body opens the detail page in a **new** tab (`window.open('/activity-audit/abc-123',
+      '_blank')`, which is what it already expects); its assertions do not change, only the name, which
+      contradicts the corrected scenario and is the sort of stale label that invites someone to
+      "fix" the component instead. Verify with
+      `npx vitest run src/components/ActivityAudit/List/tests/List.spec.tsx`.
+
+- [x] 6.5 Stop listing the per-column child activities of a table `Delete`, per design.md D13. **The
+      filtering belongs in the list, at view level — not in a server action, not in the detail
+      resolver, and not in a new backend query.** The analytics datasource already narrows its own
+      feed (`isResourceIdInTableScope`) and `ACTIVITY_AUDIT_VIEW_CONFIG` already declares the per-view
+      facets, so this is one more facet plus a pure module plus a step in the buffer loop.
+
+      **The crux — how a child's parent activity type is obtained.** A child row carries
+      `parentActivityId` and nothing about the parent, and nothing on the child distinguishes "column
+      of a deleted table" from "column dropped from a living table": both are `TableColumn` / `Delete`
+      with a parent. Do not try to infer it from the child, from the sibling count, or from whether
+      the parent happens to be in the same page. Resolve the parent, by mirroring the parent/child
+      machinery `List.tsx` already runs for the `Config` view (`:229-260`), in the other direction:
+      cache every fetched row by `activityId` in a ref first (a parent that arrived in the same page
+      then costs nothing), collect the page's still-unresolved `parentActivityId` values, and fetch
+      them in **one** call — `fetchActivities(PAGE_SIZE, 0, sorts, [{ column: 'activityId', operator:
+      FilterOperatorDto.INCLUDES, value: ids.join(',') }])` — carrying no other filter, because a
+      `Resource type` filter the reader applied would otherwise hide the parent being resolved.
+      `activityId` is on the analytics feed's filter allow-list and `in` is valid on it (design.md D13
+      names where that was read); a `400 invalid_filter_column` here would mean the allow-list moved.
+      **One request per page is enough** — a page holds at most `PAGE_SIZE` rows and therefore at most
+      `PAGE_SIZE` distinct parent ids. Do not copy the children lookup's inner paging loop; it exists
+      because one parent has many children, which is the opposite direction.
+
+      Files: add `src/utils/audit/deleted-parent-suppression.ts` with the pure half —
+      `getUnresolvedParentIds(rows, parents)` (distinct `parentActivityId` values not already in the
+      cache), `isChildOfDeletedTable(activity, parents)` (true only when the resolved parent's
+      `resourceType` is `TABLE` **and** its `activityType` is `Delete`) and
+      `filterOutDeletedTableChildren(rows, parents)`. Add `hasDeletedParentSuppression: boolean` to
+      `ActivityAuditViewConfig` in `src/components/ActivityAudit/List/models.ts` and set it in
+      `src/components/ActivityAudit/List/view-config.ts`: `true` for `Analytics`, `false` for `Config`
+      and `Deployments`. In `src/components/ActivityAudit/List/List.tsx`, add a parent cache ref
+      alongside `childrenCacheRef` (reset with it at `startRow === 0`) and, inside the existing
+      `while` loop when the facet is on, seed the cache from the page, resolve what is missing, and
+      filter the rows **before** they are pushed into `rowBufferRef` — at the same point
+      `analyticsTableScope` already filters them, so the refill-until-`endRow` and `lastRow` behaviour
+      is unchanged. Wrap the resolution call in its own `try`/`catch` that leaves the page's rows
+      listed: a failed lookup must not reach `params.failCallback()` and must not raise a
+      notification. An unresolved parent likewise leaves its child listed — a row is hidden only on
+      positive evidence about its parent.
+
+      Tests: add `src/utils/audit/tests/deleted-parent-suppression.spec.ts` (a child whose parent is
+      `Table`/`Delete` is dropped; one whose parent is `Table`/`Update` is kept; one with no
+      `parentActivityId` is kept; one whose parent is absent from the cache is kept; unresolved-id
+      collection is distinct and skips cached ids and rows with no parent). Extend
+      `src/components/ActivityAudit/List/tests/view-config.spec.ts` with the new facet's value for all
+      three views. Extend `src/components/ActivityAudit/List/tests/List.spec.tsx`, keeping every
+      existing case, with: a page of one `Table`/`Delete` plus several child `TableColumn`/`Delete`
+      rows reaching `successCallback` as the parent row only; a `Table`/`Update` plus its child
+      `TableColumn`/`Delete` both reaching it with the child's `parentActivityId` intact; a page whose
+      parents are all in the same page issuing **no** second fetch; a page with an unresolved parent
+      id issuing exactly one lookup call and still listing the child; a rejected lookup call listing
+      the page's rows rather than calling `failCallback`; and the `Config` and `Deployments` views
+      issuing no lookup and dropping no row. Verify with
+      `npx vitest run src/utils/audit/tests/deleted-parent-suppression.spec.ts src/components/ActivityAudit/List/tests/view-config.spec.ts src/components/ActivityAudit/List/tests/List.spec.tsx`.
+
+## 7. Browser verification
+
+- [x] 7.1 Run the `spec-browser-verify` skill against this change's browser-observable scenarios on a
+      local stack booted with `ANALYTICS_ENABLED=true` and `DIAL_ANALYTICS_API_URL` pointing at a
+      running analytics service that has at least one table with recorded history, including a revision
+      that added a column and one that dropped one. Verify: the `View` dropdown on `/activity-audit`
+      offering `Config`, `Deployments` and `Analytics`; the Analytics view rendering rows for more than
+      one resource type with no expander column, no `Version` column and no page-level `Rollback`
+      button; a row-body click opening `/activity-audit/{activityId}` **in a new tab** — the shared,
+      pre-existing behaviour of this list (design.md D5), with the list's own tab staying put; on that
+      page — no `Rollback resource` button, the header's resource link reaching the table's own page,
+      the diff showing every snapshot field with one group per column, an added column's group marked
+      `Added`, a dropped column's group still present and marked `Removed`, and the `View` control's
+      `Changes only` option (`All parameters` is the other; there is no option named `Diff only`)
+      hiding the unchanged column groups; the table
+      detail view opening on `Properties` with its header actions above the tab strip; the `Audit` tab
+      listing the table's own and its columns' activities with the `Resource identifier` column
+      populated; and — the regression half — the `Config` and `Deployments` views still behaving as they
+      do today, and a container audit detail page still rendering its Environment variables, Compute and
+      Autoscaling sections. Resolve every `fail` verdict before the change is complete; the flag-off
+      matrix stays with the unit tests in 3.1, 6.1 and 6.3.
+
+      **After 6.5 lands this task needs a further pass** for the three scenarios design.md D13 added,
+      which an earlier round could not have checked. Additional precondition: the analytics service
+      must hold a revision in which a whole table was deleted **and** a revision in which one column
+      was dropped from a table that still exists. Verify: the Analytics view listing that table's
+      `Delete` row with none of its per-column child rows; the dropped-column row still listed, with
+      its parent identifier in the `Parent ID` cell; and that `Delete` row's detail page still showing
+      one group per column of the previous revision, each marked `Removed`. The remaining D13
+      scenarios — an unresolvable parent, a page that issues no lookup, and the `Config` /
+      `Deployments` views issuing none — are network and fail-open assertions the booted stack cannot
+      produce, and stay with 6.5's unit tests.
+
+## 8. Quality checks
+
+- [x] 8.1 From `apps/ai-dial-admin/`, run `npx vitest run --coverage` and confirm the coverage gate in
+      `vitest.config.ts` is not regressed; from the repository root run `npm run lint` and
+      `npm run format`, and resolve any findings. Note for whoever runs this: `tsc` is red repo-wide
+      (~205 pre-existing errors on `development`) and `*.spec.tsx` files are eslint-ignored, so compare
+      typecheck error counts against `development` rather than expecting zero, and treat lint as a
+      statement about source files only. Anything this turns up is a new dispatch to the role that owns
+      the file, not an edit from this task.


### PR DESCRIPTION
**Description:**

Activity audit covered the admin backend and the deployment manager; the analytics tables feature was
outside all three of its surfaces, so who dropped a column, who marked one sensitive, and what a
table's schema looked like before were invisible in the console — even though the analytics backend
has recorded that history all along and the console simply never called it. This change adds a third
`Analytics` option to the audit view selector, gives the table detail view an **Audit** tab beside its
existing content, and makes the revision diff show every field of a table snapshot, grouped per column
and marked added / removed / changed. It reuses the existing audit stack rather than growing a
parallel one: the only genuinely new rendering code is a producer that turns an analytics snapshot
into the `ActivityAuditDiffSection[]` the diff renderer already consumes.

Issues:

- Issue #4450

**What a reviewer sees, in the product:**

- **A third `Analytics` option in the `View:` selector on `/activity-audit`**, gated on the analytics
  feature flag. The gate is on the option, not on a post-fetch filter — with analytics disabled the
  option is absent and no analytics request is issued at all.
- **The table detail view is tabbed**: `Properties` (today's content, selected on open) and `Audit`.
  The header and its whole action row stay above the tab strip, so nothing moves for a user who never
  opens `Audit`.
- **The revision diff shows the whole snapshot**, with the table definition grouped separately from
  each column, and added / removed / changed groups marked. A column removed by a revision stays
  visible carrying its marker rather than silently disappearing. Status is now readable without
  colour — each group is a `role="group"` whose accessible name carries the column name and the
  status, and the status word is visible text — which the previous diff was not.
- **Rollback is deliberately absent for analytics resources**, page-level and per-row. See below; this
  is the one part of today's audit that cannot be matched.

**Key Changes:**

- [src/components/ActivityAudit/List/view-config.ts](https://github.com/epam/ai-dial-admin-frontend/blob/feat/spread-activity-audit-to-analytics/apps/ai-dial-admin/src/components/ActivityAudit/List/view-config.ts) — new `ACTIVITY_AUDIT_VIEW_CONFIG: Record<ActivityAuditView, …>` replacing the `isDeploymentsView ? … : …` ternary and the four other places that boolean was consulted. A full `Record`, so a fourth view fails to compile rather than resolving `undefined` at runtime.
- [src/components/ActivityAudit/List/List.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/feat/spread-activity-audit-to-analytics/apps/ai-dial-admin/src/components/ActivityAudit/List/List.tsx) — rewired onto that config (datasource, row class rules, cell click, column defs including the entity short-circuit, system rollback); the flag-gated `Analytics` option; table-scope narrowing in the entity tab; the deleted-parent suppression step in the row buffer.
- [src/components/ActivityAudit/View/utils/analytics-diffs.ts](https://github.com/epam/ai-dial-admin-frontend/blob/feat/spread-activity-audit-to-analytics/apps/ai-dial-admin/src/components/ActivityAudit/View/utils/analytics-diffs.ts) + [View/utils/generate-diffs.ts](https://github.com/epam/ai-dial-admin-frontend/blob/feat/spread-activity-audit-to-analytics/apps/ai-dial-admin/src/components/ActivityAudit/View/utils/generate-diffs.ts) — the new snapshot producer, plus one analytics branch in the builder and one section fan-out beside the existing ones. Every other resource type takes exactly the path it takes today.
- [src/components/ActivityAudit/View/DiffReport/DiffSection.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/feat/spread-activity-audit-to-analytics/apps/ai-dial-admin/src/components/ActivityAudit/View/DiffReport/DiffSection.tsx) — the per-group heading now prefers an explicit label (generalizing the hardcoded `Variable N` prefix), renders the status as text, and wraps each per-index block in an addressable group.
- [src/components/ActivityAudit/View/AuditView.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/feat/spread-activity-audit-to-analytics/apps/ai-dial-admin/src/components/ActivityAudit/View/AuditView.tsx) — `Rollback resource` is no longer offered for an analytics activity. Nothing else about rollback changes.
- [src/components/ActivityAudit/View/Header/utils.ts](https://github.com/epam/ai-dial-admin-frontend/blob/feat/spread-activity-audit-to-analytics/apps/ai-dial-admin/src/components/ActivityAudit/View/Header/utils.ts) — the header's resource link resolves per resource type and the button renders only when a route exists; an unregistered type used to produce a `/{locale}/undefined/{id}` link.
- [src/utils/audit/get-activity-audit-detail-data.ts](https://github.com/epam/ai-dial-admin-frontend/blob/feat/spread-activity-audit-to-analytics/apps/ai-dial-admin/src/utils/audit/get-activity-audit-detail-data.ts) — analytics added as the third and last fallback, gated server-side on the analytics flag, **and** the defect fix described below.
- [src/utils/audit/deleted-parent-suppression.ts](https://github.com/epam/ai-dial-admin-frontend/blob/feat/spread-activity-audit-to-analytics/apps/ai-dial-admin/src/utils/audit/deleted-parent-suppression.ts) — the pure half of the "don't flood the list on a table delete" rule.
- [src/components/Analytics/Tables/TableDetailView.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/feat/spread-activity-audit-to-analytics/apps/ai-dial-admin/src/components/Analytics/Tables/TableDetailView.tsx) — becomes a tab shell. It keeps its name, its path, all of its state and all of its modals; the body moved down into `TableProperties`. The file was deliberately not restructured into a `View/` folder, to keep the conflict surface with issue #3977 (Tables RBAC) small.
- [src/server/analytics/audit-api.ts](https://github.com/epam/ai-dial-admin-frontend/blob/feat/spread-activity-audit-to-analytics/apps/ai-dial-admin/src/server/analytics/audit-api.ts) + [app/[lang]/activity-audit/actions.ts](https://github.com/epam/ai-dial-admin-frontend/blob/feat/spread-activity-audit-to-analytics/apps/ai-dial-admin/src/app/%5Blang%5D/activity-audit/actions.ts) — a new API client on the existing `DIAL_ANALYTICS_API_URL`, and one new server action. No new API route, no new environment variable, no backend change.
- [src/constants/grid-columns/formatters.ts](https://github.com/epam/ai-dial-admin-frontend/blob/feat/spread-activity-audit-to-analytics/apps/ai-dial-admin/src/constants/grid-columns/formatters.ts) — four new resource-type labels. This is shared by every view; see *Blast radius*.

**New Components:**

- `Analytics/Tables/TableProperties.tsx` — the table detail view's existing body (key summary, columns grid or draft schema editor), extracted verbatim as a presentational component.
- `Analytics/Tables/TableAudit.tsx` — renders the shared `EntityAudit` for a table, projecting the analytics table onto the `BaseEntity` shape at the call site rather than widening `EntityAudit`'s props.
- `ActivityAudit/List/view-config.ts` + `models.ts` — the per-view facet table.
- `ActivityAudit/View/utils/analytics-diffs.ts` — the snapshot → diff-section producer.
- `utils/audit/analytics-resource-id.ts`, `utils/audit/entity-audit-filters.ts`, `utils/audit/deleted-parent-suppression.ts` — pure helpers, each unit-tested on its own.
- `server/analytics/audit-api.ts` — `AnalyticsAuditApi`, the same three methods the deployment audit client exposes.

**Reuse — since it is this repository's first review question:**

`EntityAudit`, the `DiffReport` stack, the existing `getAuditTabs` and the container
Compute/Autoscaling diff machinery are reused, not reimplemented. `getAuditTabs` needed **no** edit —
the analytics route matches none of its telemetry branches, so it already returns an Activities-only
rail, exactly as the deployment Audit tabs get. The per-column groups are built with the same
`compareNestedFlatObject` / `fillNestedFlatObject` pair the container compute and autoscaling sections
already use, which is what keeps a field visible on the side it is missing from. The only new
rendering code is the producer named above.

**Deliberate absences, so they are not read as bugs:**

- **No rollback for analytics resources, anywhere.** The analytics backend exposes no endpoint that
  creates, edits or deletes an audit record, revision or snapshot, and there is no table-rollback
  route. Before this change the shared detail page rendered an *enabled* `Rollback resource` button
  for every resource type — for an analytics resource it would have dispatched against the admin
  backend, which does not own that resource. A disabled control with a tooltip was considered and
  rejected: it advertises a capability that cannot exist from this frontend.
- **The `Audit` tab is offered only on an active table.** A draft has no recorded activity at all, so
  the tab could only ever be empty; a control that can never carry information costs a click and a
  request and answers nothing. No one-tab strip and no disabled tab in that case — the Properties
  content renders directly.
- **Deleting a table does not flood the list.** Its per-column child activities are not listed, while
  the parent `Delete` row is — and that row's own detail view already shows every removed column as
  its own `Removed` group. The rule is keyed on the **parent's** activity type, which is the only
  thing that distinguishes the two cases: a column dropped from a living table has a `Table`/`Update`
  parent, and that row is still listed, because "who dropped a column" is one of the two questions
  this issue exists to answer. The rule fails open — an unresolved parent leaves its child listed, and
  a failed lookup leaves the whole page listed.

**Two pre-existing behaviours a reviewer might otherwise flag:**

- A **row body click opens the detail page in a new tab.** That is shared, shipped behaviour of this
  list — the `Config` view does the same and the row's own menu item is labelled `Open in a new tab`.
  This change touched the navigability guard, never the navigation target. Making it navigate in place
  would change the `Config` and `Deployments` views for every user.
- The diff view's filter option is **`Changes only`** (beside `All parameters`). There is no option
  named `Diff only`; an early draft of the spec said so and was corrected against the shipped product.

**Blast radius worth checking deliberately:**

- `buildResourceTypeLabelMap` iterates all resource types, so the `Resource type` filter in the
  **Config and Deployments** views changes too. Accepted rather than scoped — the map's values are
  arrays precisely so additions are tolerated — and pinned by a guard test that names the expected
  enum sets for the existing resolutions (the global-firewall needle above all) rather than asserting
  "unchanged". The test was mutation-checked.
- `List.tsx`'s branching was rewritten. The `Config` and `Deployments` entries in the view config are
  transcriptions of today's behaviour, including the entity-mode column set and its row Rollback,
  which had to survive. The existing view-aware cases in `List.spec.tsx` were kept, not rewritten to
  fit the new shape, and they are the regression check. First place a mistake would show: the
  Deployments view losing its flat rendering or its rollback row action.
- The diff engine gained an analytics branch, two optional fields on the section model and one extra
  title source. The container, image, role and firewall diffs are unchanged, and their existing specs
  under `View/utils/tests/` and `View/DiffReport/tests/` are the regression check.
- The `role="group"` wrapper lands on every section's per-index block, not only analytics ones. That
  is the intended generalization — the alternative is two markup shapes for one component — but it
  changes the accessibility tree of shipped diff pages.

**One defect found and fixed during verification** — it explains a diff in a file this feature does
not obviously touch. The audit detail page returned a 404 for **every** analytics activity: all three
backend lookups shared one `try`/`catch`, and an unconfigured upstream makes an earlier probe *reject*
rather than answer, aborting the chain before the analytics probe ran. Each probe is now isolated, and
a failure is logged with the backend and the route it was asked for — the page renders the same 404
for a genuine miss and for a failure, so the log is the only place the two are distinguishable.

**Verification:**

- The full suite passes and coverage is above every threshold in `vitest.config.ts`.
- Browser verification against a live local stack: **25 scenarios pass, 0 fail, 4 unverifiable** on
  this stack for environment reasons — no `Pipeline` or `SavedQuery` activity exists locally, no
  revision changes a column attribute with both snapshots present, and two of them need analytics
  *disabled*. Each of the four is backed by a unit test instead, deliberately rather than by omission.
- The regression half was verified in the browser too: the `Config` and `Deployments` audit views and
  a container audit detail page (Environment variables, Compute, Autoscaling sections) — all three
  pass.

**Out of scope, deliberately:**

- Rollback for analytics resources — it needs an analytics backend change first.
- Per-field readability of the analytics diff beyond grouping and markers: no bespoke cell renderers,
  no type-aware value formatting.
- An `Audit` tab on Analytics → Pipelines or Analytics → Queries. Their activities do appear in the
  global `Analytics` view; each detail view is its own restructure.
- Three pre-existing defects, each of which deserves its own ticket rather than being folded in:
  `DIAL_DEPLOYMENTS_API_URL` is missing from `.env.template`; the audit list wrapper carries an
  invented `role="activities"`; and `resourceRollback` decodes its response after raising the success
  toast, so one successful rollback can raise both a success and a failure notification.

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #4450)` (comma-separated list of issues)

