### PR TITLE
test(specs): give the vitest mocks their real types (part 1/4)

### DIFF
--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/utils/tests/result.spec.ts
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/utils/tests/result.spec.ts
@@ -1,3 +1,4 @@
+import { ColDef, ValueGetterFunc, ValueGetterParams } from 'ag-grid-community';
 import { describe, expect, test } from 'vitest';
 
 import {
@@ -8,6 +9,16 @@ import {
   renderCell,
 } from '@/src/components/Analytics/QueryBuilder/utils/result';
 import { StructuredQueryResult } from '@/src/models/analytics/query';
+
+// `ColDef.valueGetter` is `string | ValueGetterFunc`, so it cannot be called through the union.
+// Narrowing here fails loudly if a column stops carrying a getter, instead of silently skipping.
+const valueGetterOf = (column?: ColDef): ValueGetterFunc => {
+  const valueGetter = column?.valueGetter;
+  if (typeof valueGetter !== 'function') {
+    throw new Error(`column ${column?.field} has no valueGetter function`);
+  }
+  return valueGetter;
+};
 
 describe('renderCell', () => {
   test('blank for null/undefined', () => {
@@ -60,9 +71,9 @@ describe('getResultColumns', () => {
     };
     const dottedCol = getResultColumns(result).find((c) => c.field === 'test.test');
 
-    const value = dottedCol?.valueGetter?.({
+    const value = valueGetterOf(dottedCol)({
       data: { event_id: '1', 'test.test': 'test_value' },
-    } as Parameters<NonNullable<typeof dottedCol.valueGetter>>[0]);
+    } as ValueGetterParams);
 
     expect(value).toBe('test_value');
   });

--- a/apps/ai-dial-admin/src/components/ApplicationRunners/ConfigurationView/tests/Properties.spec.tsx
+++ b/apps/ai-dial-admin/src/components/ApplicationRunners/ConfigurationView/tests/Properties.spec.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { ComponentProps } from 'react';
+import { Mock, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import Properties from '../Properties';
 
@@ -51,6 +52,8 @@ vi.mock('../ExtendedProperties', () => ({
   default: ({ runner }: any) => <section aria-label="extended-properties">extended:{runner?.$id}</section>,
 }));
 
+type OnChangeRunner = NonNullable<ComponentProps<typeof Properties>['onChangeRunner']>;
+
 describe('ApplicationRunners :: ConfigurationView :: Properties', () => {
   const baseRunner = {
     $id: 'runner-1',
@@ -60,11 +63,11 @@ describe('ApplicationRunners :: ConfigurationView :: Properties', () => {
   } as any;
 
   const names = ['runner-1', 'runner-2'];
-  let onChangeRunner: ReturnType<typeof vi.fn>;
+  let onChangeRunner: Mock<OnChangeRunner>;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    onChangeRunner = vi.fn();
+    onChangeRunner = vi.fn<OnChangeRunner>();
   });
 
   test('renders editable controls when runner is mutable', () => {

--- a/apps/ai-dial-admin/src/components/Deployments/Fields/tests/ContainerBase.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Deployments/Fields/tests/ContainerBase.spec.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { ComponentProps } from 'react';
+import { Mock, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { Container } from '@/src/models/deployments/containers';
 import { CONTAINER_SOURCE_TYPE, CONTAINER_STATUS, CONTAINER_TYPE } from '@/src/types/deployments/containers';
@@ -32,6 +33,8 @@ vi.mock('@/src/components/BaseControls/Topics', () => ({
   ),
 }));
 
+type SetContainer = NonNullable<ComponentProps<typeof ContainerBase>['setContainer']>;
+
 describe('ContainerBase', () => {
   const baseContainer: Container = {
     $type: CONTAINER_TYPE.MCP,
@@ -45,11 +48,11 @@ describe('ContainerBase', () => {
     topics: ['existing-topic'],
   };
 
-  let setContainer: ReturnType<typeof vi.fn>;
+  let setContainer: Mock<SetContainer>;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    setContainer = vi.fn();
+    setContainer = vi.fn<SetContainer>();
   });
 
   test('renders TopicsControl in non-modal mode', () => {

--- a/apps/ai-dial-admin/src/components/EntityHeaderControls/Wrappers/tests/SimpleButtonsWrapper.spec.tsx
+++ b/apps/ai-dial-admin/src/components/EntityHeaderControls/Wrappers/tests/SimpleButtonsWrapper.spec.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { describe, expect, test, vi } from 'vitest';
 
 import SimpleButtonsWrapper from '@/src/components/EntityHeaderControls/Wrappers/SimpleButtonsWrapper';
+import { AssetsFolderContext } from '@/src/context/assets/AssetsFolderContext';
 import { ButtonsI18nKey } from '@/src/constants/i18n';
 import { ApplicationRoute } from '@/src/types/routes';
 
@@ -38,7 +39,9 @@ const openDeleteModal = async () => {
 describe('SimpleButtonsWrapper :: getAssetContext forwarding', () => {
   test('forwards getAssetContext to DeleteConfirmationModal when provided', async () => {
     const fetchFiles = vi.fn();
-    const getAssetContext = vi.fn(() => ({ fetchFiles, filePath: 'platform/' }));
+    // The fake carries only what the wrapper forwards; the cast happens once, here.
+    const assetContext = { fetchFiles, filePath: 'platform/' } as unknown as AssetsFolderContext;
+    const getAssetContext = vi.fn<() => AssetsFolderContext>(() => assetContext);
 
     render(<SimpleButtonsWrapper {...baseProps} getAssetContext={getAssetContext} />);
 

--- a/apps/ai-dial-admin/src/components/EntityTabs/JsonEditor/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/EntityTabs/JsonEditor/tests/utils.spec.ts
@@ -1,12 +1,14 @@
 import { JSONEditorError, JSONEditorErrorNotification } from '@/src/types/editor';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { Mock, beforeEach, describe, expect, test, vi } from 'vitest';
 import { clearResolvedErrors, mergeWithIgnoredFields } from '../utils';
 
+type RemoveNotification = Parameters<typeof clearResolvedErrors>[1];
+
 describe('clearResolvedErrors', () => {
-  let mockRemoveNotification: ReturnType<typeof vi.fn>;
+  let mockRemoveNotification: Mock<RemoveNotification>;
 
   beforeEach(() => {
-    mockRemoveNotification = vi.fn();
+    mockRemoveNotification = vi.fn<RemoveNotification>();
   });
 
   test('should remove notification when error is resolved', () => {

--- a/apps/ai-dial-admin/src/components/ExportConfig/AddEntities/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/ExportConfig/AddEntities/tests/utils.spec.ts
@@ -8,7 +8,7 @@ import { DEPLOYMENT_IMAGE_DEP } from '@/src/utils/entities/get-export-deps';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 vi.mock('@/src/components/AddEntitiesTab/utils');
 
-const mockGetAvailableEntities = AddEntitiesUtils.getAvailableEntities;
+const mockGetAvailableEntities = vi.mocked(AddEntitiesUtils.getAvailableEntities);
 
 describe('Export Config Utils :: getButtonTitle', () => {
   const mockTranslate = (v: string) => v;
@@ -171,7 +171,7 @@ describe('Export Config Utils :: getAvailableData', () => {
 
     const selectedTopics = ['topic1'];
 
-    mockGetAvailableEntities.mockReturnValue(['filtered']);
+    mockGetAvailableEntities.mockReturnValue([{ name: 'filtered' }]);
 
     const result = getAvailableData(EntityType.MODEL, tabData, customExportData, 'MODEL', selectedTopics);
 
@@ -179,7 +179,7 @@ describe('Export Config Utils :: getAvailableData', () => {
       [entity('m3', MenuI18nKey.Models, ['topic1'])],
       [entity('m1', MenuI18nKey.Models, ['topic1', 'topic2'])],
     );
-    expect(result).toEqual(['filtered']);
+    expect(result).toEqual([{ name: 'filtered' }]);
   });
 
   test('should return all available MODEL entities when selectedTopics is empty', () => {
@@ -190,9 +190,9 @@ describe('Export Config Utils :: getAvailableData', () => {
       MODEL: [entity('m3', MenuI18nKey.Models, ['topic1'])],
     };
 
-    const selectedTopics = [];
+    const selectedTopics: string[] = [];
 
-    mockGetAvailableEntities.mockReturnValue(['filtered']);
+    mockGetAvailableEntities.mockReturnValue([{ name: 'filtered' }]);
 
     const result = getAvailableData(EntityType.MODEL, tabData, customExportData, 'MODEL', selectedTopics);
 
@@ -200,7 +200,7 @@ describe('Export Config Utils :: getAvailableData', () => {
       [entity('m3', MenuI18nKey.Models, ['topic1'])],
       [entity('m1', MenuI18nKey.Models, ['topic1', 'topic2'])],
     );
-    expect(result).toEqual(['filtered']);
+    expect(result).toEqual([{ name: 'filtered' }]);
   });
 
   test('should filter and return available APPLICATION entities based on selected topics', () => {
@@ -213,7 +213,7 @@ describe('Export Config Utils :: getAvailableData', () => {
 
     const selectedTopics = ['topic1'];
 
-    mockGetAvailableEntities.mockReturnValue(['filtered-apps']);
+    mockGetAvailableEntities.mockReturnValue([{ name: 'filtered-apps' }]);
 
     const result = getAvailableData(EntityType.APPLICATION, tabData, customExportData, 'APPLICATION', selectedTopics);
 
@@ -221,7 +221,7 @@ describe('Export Config Utils :: getAvailableData', () => {
       [entity('a3', MenuI18nKey.Applications, ['topic1'])],
       [entity('a1', MenuI18nKey.Applications, ['topic1'])],
     );
-    expect(result).toEqual(['filtered-apps']);
+    expect(result).toEqual([{ name: 'filtered-apps' }]);
   });
 
   test('should return all available APPLICATION entities when selectedTopics is empty', () => {
@@ -232,9 +232,9 @@ describe('Export Config Utils :: getAvailableData', () => {
       APPLICATION: [entity('a3', MenuI18nKey.Applications, ['topic1'])],
     };
 
-    const selectedTopics = [];
+    const selectedTopics: string[] = [];
 
-    mockGetAvailableEntities.mockReturnValue(['filtered-apps']);
+    mockGetAvailableEntities.mockReturnValue([{ name: 'filtered-apps' }]);
 
     const result = getAvailableData(EntityType.APPLICATION, tabData, customExportData, 'APPLICATION', selectedTopics);
 
@@ -242,7 +242,7 @@ describe('Export Config Utils :: getAvailableData', () => {
       [entity('a3', MenuI18nKey.Applications, ['topic1'])],
       [entity('a1', MenuI18nKey.Applications, ['topic1'])],
     );
-    expect(result).toEqual(['filtered-apps']);
+    expect(result).toEqual([{ name: 'filtered-apps' }]);
   });
 
   test('should filter and return available TOOLSET entities based on selected topics', () => {
@@ -255,7 +255,7 @@ describe('Export Config Utils :: getAvailableData', () => {
 
     const selectedTopics = ['topic1'];
 
-    mockGetAvailableEntities.mockReturnValue(['filtered-toolsets']);
+    mockGetAvailableEntities.mockReturnValue([{ name: 'filtered-toolsets' }]);
 
     const result = getAvailableData(EntityType.TOOLSET, tabData, customExportData, 'TOOLSET', selectedTopics);
 
@@ -263,7 +263,7 @@ describe('Export Config Utils :: getAvailableData', () => {
       [entity('t3', MenuI18nKey.Toolsets, ['topic1'])],
       [entity('t1', MenuI18nKey.Toolsets, ['topic1'])],
     );
-    expect(result).toEqual(['filtered-toolsets']);
+    expect(result).toEqual([{ name: 'filtered-toolsets' }]);
   });
 
   test('should return all available TOOLSET entities when selectedTopics is empty', () => {
@@ -274,9 +274,9 @@ describe('Export Config Utils :: getAvailableData', () => {
       TOOLSET: [entity('t3', MenuI18nKey.Toolsets, ['topic1'])],
     };
 
-    const selectedTopics = [];
+    const selectedTopics: string[] = [];
 
-    mockGetAvailableEntities.mockReturnValue(['filtered-toolsets']);
+    mockGetAvailableEntities.mockReturnValue([{ name: 'filtered-toolsets' }]);
 
     const result = getAvailableData(EntityType.TOOLSET, tabData, customExportData, 'TOOLSET', selectedTopics);
 
@@ -284,7 +284,7 @@ describe('Export Config Utils :: getAvailableData', () => {
       [entity('t3', MenuI18nKey.Toolsets, ['topic1'])],
       [entity('t1', MenuI18nKey.Toolsets, ['topic1'])],
     );
-    expect(result).toEqual(['filtered-toolsets']);
+    expect(result).toEqual([{ name: 'filtered-toolsets' }]);
   });
 
   test('should handle APPLICATION_TYPE_SCHEMA entities with selected topics', () => {
@@ -297,7 +297,7 @@ describe('Export Config Utils :: getAvailableData', () => {
 
     const selectedTopics = ['topic1'];
 
-    mockGetAvailableEntities.mockReturnValue(['filtered-schemas']);
+    mockGetAvailableEntities.mockReturnValue([{ name: 'filtered-schemas' }]);
 
     const result = getAvailableData(
       EntityType.APPLICATION_TYPE_SCHEMA,
@@ -311,7 +311,7 @@ describe('Export Config Utils :: getAvailableData', () => {
       [entity('schema2', MenuI18nKey.ApplicationRunners, ['topic2'])],
       [entity('schema1', MenuI18nKey.ApplicationRunners, ['topic1'])],
     );
-    expect(result).toEqual(['filtered-schemas']);
+    expect(result).toEqual([{ name: 'filtered-schemas' }]);
   });
 
   test('should return empty array when no data is available for APPLICATION_TYPE_SCHEMA', () => {

--- a/apps/ai-dial-admin/src/components/ExportConfig/Preview/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/ExportConfig/Preview/tests/utils.spec.ts
@@ -17,13 +17,13 @@ beforeEach(() => {
 describe('Export Config Utils :: getPreviewTabs', () => {
   test('should return tabs and convertedData correctly with roles, keys, applicationRunners, and models', () => {
     const mockEntities: any[] = [{ id: 'e1' }, { id: 'e2' }, { id: 'e3' }];
-    entitiesUtils.getApplicationsForEntitiesGrid.mockReturnValue([]);
-    entitiesUtils.getModelsForEntitiesGrid.mockReturnValue(mockEntities);
-    entitiesUtils.getRolesForEntitiesGrid.mockReturnValue([{ id: 'e1' }]);
-    entitiesUtils.getKeysForEntitiesGrid.mockReturnValue([{ id: 'e1' }, { id: 'e1' }]);
-    entitiesUtils.getRoutesForEntitiesGrid.mockReturnValue([]);
-    entitiesUtils.getToolsetsForEntitiesGrid.mockReturnValue([]);
-    entitiesUtils.getRunnersForEntitiesGrid.mockReturnValue([{ id: 'e1' }]);
+    vi.mocked(entitiesUtils.getApplicationsForEntitiesGrid).mockReturnValue([]);
+    vi.mocked(entitiesUtils.getModelsForEntitiesGrid).mockReturnValue(mockEntities);
+    vi.mocked(entitiesUtils.getRolesForEntitiesGrid).mockReturnValue([{ id: 'e1' }]);
+    vi.mocked(entitiesUtils.getKeysForEntitiesGrid).mockReturnValue([{ id: 'e1' }, { id: 'e1' }]);
+    vi.mocked(entitiesUtils.getRoutesForEntitiesGrid).mockReturnValue([]);
+    vi.mocked(entitiesUtils.getToolsetsForEntitiesGrid).mockReturnValue([]);
+    vi.mocked(entitiesUtils.getRunnersForEntitiesGrid).mockReturnValue([{ id: 'e1' }]);
 
     const data = {
       roles: [{ id: 'role1' }],
@@ -56,10 +56,10 @@ describe('Export Config Utils :: getPreviewTabs', () => {
   });
 
   test('should not add tabs for empty categories', () => {
-    entitiesUtils.getApplicationsForEntitiesGrid.mockReturnValue([]);
-    entitiesUtils.getModelsForEntitiesGrid.mockReturnValue([]);
-    entitiesUtils.getRoutesForEntitiesGrid.mockReturnValue([]);
-    entitiesUtils.getToolsetsForEntitiesGrid.mockReturnValue([]);
+    vi.mocked(entitiesUtils.getApplicationsForEntitiesGrid).mockReturnValue([]);
+    vi.mocked(entitiesUtils.getModelsForEntitiesGrid).mockReturnValue([]);
+    vi.mocked(entitiesUtils.getRoutesForEntitiesGrid).mockReturnValue([]);
+    vi.mocked(entitiesUtils.getToolsetsForEntitiesGrid).mockReturnValue([]);
 
     const data = {
       roles: [],
@@ -76,7 +76,7 @@ describe('Export Config Utils :: getPreviewTabs', () => {
 
   test('should handle interceptors and files correctly', () => {
     const mockEntities = [{ id: 'int1' }];
-    entitiesUtils.getInterceptorsForEntitiesGrid.mockReturnValue(mockEntities);
+    vi.mocked(entitiesUtils.getInterceptorsForEntitiesGrid).mockReturnValue(mockEntities);
     const data = {
       interceptors: [{ id: 'int1' }],
       files: [{ id: 'file1' }],
@@ -99,7 +99,7 @@ describe('Export Config Utils :: getPreviewTabs', () => {
     };
 
     const mockEntities = [{ id: 'adapter1' }];
-    entitiesUtils.getAdaptersForEntitiesGrid.mockReturnValue(mockEntities);
+    vi.mocked(entitiesUtils.getAdaptersForEntitiesGrid).mockReturnValue(mockEntities);
 
     const { tabs, convertedData } = getPreviewTabs(data, false, ExportFormat.ADMIN, t);
 
@@ -114,7 +114,7 @@ describe('Export Config Utils :: getPreviewTabs', () => {
     };
 
     const mockEntities = [{ id: 'interceptorRunner1' }];
-    entitiesUtils.getInterceptorTemplatesForEntitiesGrid.mockReturnValue(mockEntities);
+    vi.mocked(entitiesUtils.getInterceptorTemplatesForEntitiesGrid).mockReturnValue(mockEntities);
 
     const { tabs, convertedData } = getPreviewTabs(data, false, ExportFormat.ADMIN, t);
 
@@ -126,10 +126,10 @@ describe('Export Config Utils :: getPreviewTabs', () => {
   test('should merge entities from applications and routes as well', () => {
     const mockEntitiesFromApplications = [{ id: 'app1' }];
     const mockEntitiesFromRoutes = [{ id: 'route1' }];
-    entitiesUtils.getApplicationsForEntitiesGrid.mockReturnValue(mockEntitiesFromApplications);
-    entitiesUtils.getModelsForEntitiesGrid.mockReturnValue([]);
-    entitiesUtils.getRoutesForEntitiesGrid.mockReturnValue(mockEntitiesFromRoutes);
-    entitiesUtils.getToolsetsForEntitiesGrid.mockReturnValue([]);
+    vi.mocked(entitiesUtils.getApplicationsForEntitiesGrid).mockReturnValue(mockEntitiesFromApplications);
+    vi.mocked(entitiesUtils.getModelsForEntitiesGrid).mockReturnValue([]);
+    vi.mocked(entitiesUtils.getRoutesForEntitiesGrid).mockReturnValue(mockEntitiesFromRoutes);
+    vi.mocked(entitiesUtils.getToolsetsForEntitiesGrid).mockReturnValue([]);
 
     const data = {
       applications: [{ id: 'application1' }],

--- a/apps/ai-dial-admin/src/components/InterceptorTemplates/Properties/tests/ExtendedProperties.spec.tsx
+++ b/apps/ai-dial-admin/src/components/InterceptorTemplates/Properties/tests/ExtendedProperties.spec.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { ComponentProps } from 'react';
+import { Mock, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import ExtendedProperties from '../ExtendedProperties';
 
@@ -48,6 +49,8 @@ vi.mock('@/src/components/BaseControls/Topics', () => ({
   ),
 }));
 
+type OnChange = NonNullable<ComponentProps<typeof ExtendedProperties>['onChange']>;
+
 describe('InterceptorTemplates :: ExtendedProperties', () => {
   const template = {
     name: 'template-1',
@@ -57,11 +60,11 @@ describe('InterceptorTemplates :: ExtendedProperties', () => {
     topics: ['old-topic'],
   } as any;
 
-  let onChange: ReturnType<typeof vi.fn>;
+  let onChange: Mock<OnChange>;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    onChange = vi.fn();
+    onChange = vi.fn<OnChange>();
   });
 
   test('renders all sections and passes immutable mode to base properties', () => {

--- a/apps/ai-dial-admin/src/components/Roles/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/Roles/tests/utils.spec.ts
@@ -150,20 +150,23 @@ describe('getDefaultPlaceholder', () => {
 });
 
 describe('isResetToDefaultHidden', () => {
-  const mockApi = {
+  // The fakes stay in their own object so they keep their `Mock` type; the cast to `GridApi` happens
+  // once, where the fake is handed to the function under test.
+  const gridApi = {
     getCellValue: vi.fn(),
     getColumn: vi.fn(),
-  } as unknown as GridApi;
+  };
+  const mockApi = gridApi as unknown as GridApi;
 
   const mockNode: IRowNode = { data: {} } as IRowNode;
 
   test('should return true when both invitationTtl and maxAcceptedUsers are falsy', () => {
-    mockApi.getCellValue.mockImplementation(({ colKey }: { colKey: string }) => {
+    gridApi.getCellValue.mockImplementation(({ colKey }: { colKey: string }) => {
       if (colKey === 'invitationTtl') return undefined;
       if (colKey === 'maxAcceptedUsers') return undefined;
     });
 
-    mockApi.getColumn.mockImplementation((colKey: string) => {
+    gridApi.getColumn.mockImplementation((colKey: string) => {
       if (colKey === 'invitationTtl') return 'invitationTtl';
       if (colKey === 'maxAcceptedUsers') return 'maxAcceptedUsers';
       return {} as Column;
@@ -174,12 +177,12 @@ describe('isResetToDefaultHidden', () => {
   });
 
   test('should return false when invitationTtl is truthy', () => {
-    mockApi.getCellValue.mockImplementation(({ colKey }: { colKey: string }) => {
+    gridApi.getCellValue.mockImplementation(({ colKey }: { colKey: string }) => {
       if (colKey === 'invitationTtl') return '3600';
       if (colKey === 'maxAcceptedUsers') return undefined;
     });
 
-    mockApi.getColumn.mockImplementation((colKey: string) => {
+    gridApi.getColumn.mockImplementation((colKey: string) => {
       if (colKey === 'invitationTtl') return 'invitationTtl';
       if (colKey === 'maxAcceptedUsers') return 'maxAcceptedUsers';
       return {} as Column;
@@ -190,12 +193,12 @@ describe('isResetToDefaultHidden', () => {
   });
 
   test('should return false when maxAcceptedUsers is truthy', () => {
-    mockApi.getCellValue.mockImplementation(({ colKey }: { colKey: string }) => {
+    gridApi.getCellValue.mockImplementation(({ colKey }: { colKey: string }) => {
       if (colKey === 'invitationTtl') return undefined;
       if (colKey === 'maxAcceptedUsers') return '10';
     });
 
-    mockApi.getColumn.mockImplementation((colKey: string) => {
+    gridApi.getColumn.mockImplementation((colKey: string) => {
       if (colKey === 'invitationTtl') return 'invitationTtl';
       if (colKey === 'maxAcceptedUsers') return 'maxAcceptedUsers';
       return {} as Column;
@@ -206,12 +209,12 @@ describe('isResetToDefaultHidden', () => {
   });
 
   test('should return false when both invitationTtl and maxAcceptedUsers are truthy', () => {
-    mockApi.getCellValue.mockImplementation(({ colKey }: { colKey: string }) => {
+    gridApi.getCellValue.mockImplementation(({ colKey }: { colKey: string }) => {
       if (colKey === 'invitationTtl') return '3600';
       if (colKey === 'maxAcceptedUsers') return '10';
     });
 
-    mockApi.getColumn.mockImplementation((colKey: string) => {
+    gridApi.getColumn.mockImplementation((colKey: string) => {
       if (colKey === 'invitationTtl') return 'invitationTtl';
       if (colKey === 'maxAcceptedUsers') return 'maxAcceptedUsers';
       return {} as Column;
@@ -223,20 +226,23 @@ describe('isResetToDefaultHidden', () => {
 });
 
 describe('isSetNoLimitsHidden', () => {
-  const mockApi = {
+  // The fakes stay in their own object so they keep their `Mock` type; the cast to `GridApi` happens
+  // once, where the fake is handed to the function under test.
+  const gridApi = {
     getCellValue: vi.fn(),
     getColumn: vi.fn(),
-  } as unknown as GridApi;
+  };
+  const mockApi = gridApi as unknown as GridApi;
 
   const mockNode: IRowNode = { data: {} } as IRowNode;
 
   test('should return true when both invitationTtl and maxAcceptedUsers are falsy', () => {
-    mockApi.getCellValue.mockImplementation(({ colKey }: { colKey: string }) => {
+    gridApi.getCellValue.mockImplementation(({ colKey }: { colKey: string }) => {
       if (colKey === 'invitationTtl') return undefined;
       if (colKey === 'maxAcceptedUsers') return undefined;
     });
 
-    mockApi.getColumn.mockImplementation((colKey: string) => {
+    gridApi.getColumn.mockImplementation((colKey: string) => {
       if (colKey === 'invitationTtl') return 'invitationTtl';
       if (colKey === 'maxAcceptedUsers') return 'maxAcceptedUsers';
       return {} as Column;
@@ -247,12 +253,12 @@ describe('isSetNoLimitsHidden', () => {
   });
 
   test('should return true when invitationTtl is UNLIMITED_VALUE and maxAcceptedUsers is UNLIMITED_ACCEPTED_USERS', () => {
-    mockApi.getCellValue.mockImplementation(({ colKey }: { colKey: string }) => {
+    gridApi.getCellValue.mockImplementation(({ colKey }: { colKey: string }) => {
       if (colKey === 'invitationTtl') return UNLIMITED_VALUE;
       if (colKey === 'maxAcceptedUsers') return UNLIMITED_ACCEPTED_USERS;
     });
 
-    mockApi.getColumn.mockImplementation((colKey: string) => {
+    gridApi.getColumn.mockImplementation((colKey: string) => {
       if (colKey === 'invitationTtl') return 'invitationTtl';
       if (colKey === 'maxAcceptedUsers') return 'maxAcceptedUsers';
       return {} as Column;
@@ -263,12 +269,12 @@ describe('isSetNoLimitsHidden', () => {
   });
 
   test('should return false when invitationTtl is truthy and maxAcceptedUsers is falsy', () => {
-    mockApi.getCellValue.mockImplementation(({ colKey }: { colKey: string }) => {
+    gridApi.getCellValue.mockImplementation(({ colKey }: { colKey: string }) => {
       if (colKey === 'invitationTtl') return '3600';
       if (colKey === 'maxAcceptedUsers') return undefined;
     });
 
-    mockApi.getColumn.mockImplementation((colKey: string) => {
+    gridApi.getColumn.mockImplementation((colKey: string) => {
       if (colKey === 'invitationTtl') return 'invitationTtl';
       if (colKey === 'maxAcceptedUsers') return 'maxAcceptedUsers';
       return {} as Column;
@@ -279,13 +285,12 @@ describe('isSetNoLimitsHidden', () => {
   });
 
   test('should return false when invitationTtl is falsy and maxAcceptedUsers is truthy', () => {
-    mockApi.getCellValue.mockImplementation(({ colKey }: { colKey: string }) => {
-      if (colKey === 'invitationTtl') return '3600';
+    gridApi.getCellValue.mockImplementation(({ colKey }: { colKey: string }) => {
       if (colKey === 'invitationTtl') return undefined;
       if (colKey === 'maxAcceptedUsers') return '10';
     });
 
-    mockApi.getColumn.mockImplementation((colKey: string) => {
+    gridApi.getColumn.mockImplementation((colKey: string) => {
       if (colKey === 'invitationTtl') return 'invitationTtl';
       if (colKey === 'maxAcceptedUsers') return 'maxAcceptedUsers';
       return {} as Column;
@@ -296,12 +301,12 @@ describe('isSetNoLimitsHidden', () => {
   });
 
   test('should return false when both invitationTtl and maxAcceptedUsers are truthy but do not match UNLIMITED_VALUE', () => {
-    mockApi.getCellValue.mockImplementation(({ colKey }: { colKey: string }) => {
+    gridApi.getCellValue.mockImplementation(({ colKey }: { colKey: string }) => {
       if (colKey === 'invitationTtl') return '3600';
       if (colKey === 'maxAcceptedUsers') return '10';
     });
 
-    mockApi.getColumn.mockImplementation((colKey: string) => {
+    gridApi.getColumn.mockImplementation((colKey: string) => {
       if (colKey === 'invitationTtl') return 'invitationTtl';
       if (colKey === 'maxAcceptedUsers') return 'maxAcceptedUsers';
       return {} as Column;

--- a/apps/ai-dial-admin/src/components/TestSuites/utils/tests/columns.spec.ts
+++ b/apps/ai-dial-admin/src/components/TestSuites/utils/tests/columns.spec.ts
@@ -1,3 +1,4 @@
+import { ColDef, ValueGetterFunc, ValueGetterParams } from 'ag-grid-community';
 import { ReactElement } from 'react';
 import { describe, expect, test, vi } from 'vitest';
 import { getTestCaseColumns, getSchemaFieldGridColumns, getValidityStatusColumn } from '../columns';
@@ -7,6 +8,15 @@ import { EXPANDER_COLUMN_CEL_ID } from '@/src/constants/ag-grid';
 import { BasicI18nKey } from '@/src/constants/i18n';
 import { TestCaseItemType } from '@/src/types/evaluation';
 import { GridRowType } from '@/src/types/grid-row-type';
+
+// `ColDef.valueGetter` is `string | ValueGetterFunc`, so it cannot be called through the union.
+const valueGetterOf = (column?: ColDef): ValueGetterFunc => {
+  const valueGetter = column?.valueGetter;
+  if (typeof valueGetter !== 'function') {
+    throw new Error(`column ${column?.field} has no valueGetter function`);
+  }
+  return valueGetter;
+};
 
 const makeSchema = (name: string, type: TestCaseItemType = TestCaseItemType.STRING): TestCaseSchema => ({
   name,
@@ -132,9 +142,9 @@ describe('getTestCaseColumns', () => {
     const promptColumn = result.find((column) => column.field === 'prompt');
 
     expect(promptColumn).toBeDefined();
-    expect(promptColumn?.valueGetter?.({ data: { prompt: 'fallback value', data: undefined } } as never)).toBe(
-      'fallback value',
-    );
+    expect(
+      valueGetterOf(promptColumn)({ data: { prompt: 'fallback value', data: undefined } } as ValueGetterParams),
+    ).toBe('fallback value');
   });
 });
 

--- a/apps/ai-dial-admin/src/constants/grid-columns/tests/conversations-trace-columns.spec.ts
+++ b/apps/ai-dial-admin/src/constants/grid-columns/tests/conversations-trace-columns.spec.ts
@@ -1,4 +1,4 @@
-import { ColDef, ColGroupDef, ColumnState, ValueFormatterParams } from 'ag-grid-community';
+import { ColDef, ColGroupDef, ColumnState, ValueFormatterFunc, ValueFormatterParams } from 'ag-grid-community';
 import { describe, expect, test } from 'vitest';
 
 import { applyColumnStateOrderToGroupedColDefs } from '@/src/components/Grid/utils';
@@ -76,8 +76,17 @@ const columns = (schemaFields: AnalyticsEntityField[] = ALL_FIELDS): ColDef[] =>
 
 const column = (fieldName: string): ColDef => columns().find((col) => col.field === fieldName) as ColDef;
 
+// `ColDef.valueFormatter` is `string | ValueFormatterFunc`, so it cannot be called through the union.
+const valueFormatterOf = (column: ColDef): ValueFormatterFunc => {
+  const { valueFormatter } = column;
+  if (typeof valueFormatter !== 'function') {
+    throw new Error(`column ${column.field} has no valueFormatter function`);
+  }
+  return valueFormatter;
+};
+
 const format = (fieldName: string, value: unknown): string =>
-  column(fieldName).valueFormatter?.({ value } as ValueFormatterParams) as string;
+  valueFormatterOf(column(fieldName))({ value } as ValueFormatterParams);
 
 const groups = (schemaFields: AnalyticsEntityField[] = ALL_FIELDS): ColGroupDef[] =>
   CONVERSATIONS_TRACE_COLUMN_GROUPS(t, schemaFields);


### PR DESCRIPTION
First of four parts clearing the spec project's type errors. `tsc` has never run over `*.spec.ts(x)` in
this repo — vitest strips types through esbuild and eslint ignores spec files — so 726 real errors
accumulated there. They were categorised by risk; this PR takes the 71 in the riskiest bucket: values the
compiler did not know were mocks.

That class matters because a mis-shaped stub still satisfies a green assertion. The exemplar this series
was born from: a test read `HopEventType.Error` after that member was deleted, the comparison became
`undefined === undefined`, and it passed vacuously.

## Four shapes, four fixes

| Shape | Fix |
| --- | --- |
| `entitiesUtils.getX.mockReturnValue(...)` — a namespace import of a `vi.mock`ed module keeps the real signature | `vi.mocked(...)`, per `.claude/rules/testing.md` §5 |
| A fake cast straight to `GridApi` / `AssetsFolderContext` loses its `Mock` type | fakes keep their own object; the cast happens once, where the fake meets the code under test |
| A bare `vi.fn()` is `Mock<Procedure \| Constructable>` and does not fit a typed callback prop | `vi.fn<T>()` with `T` derived from the consumer — `ComponentProps<typeof X>['onChange']`, `Parameters<typeof fn>[1]` |
| `ColDef.valueGetter` / `valueFormatter` are `string \| Func` unions, so calling through the union is an error | a local `valueGetterOf` / `valueFormatterOf` narrows and throws if the column stops carrying the function |

Typing the mocks immediately forced two fixtures to become real: `getAvailableEntities` returns
`EntitiesGridData[]`, and the spec was feeding it `string[]`.

## One real test bug surfaced

`Roles/tests/utils.spec.ts` had two `if`s on the same condition inside one mock:

```ts
if (colKey === 'invitationTtl') return '3600';
if (colKey === 'invitationTtl') return undefined;   // dead
```

The test named *"invitationTtl is falsy and maxAcceptedUsers is truthy"* was therefore exercising the
both-truthy path. Now it does what its name says; the expectation is unchanged and still passes.

## Deliberately left

- 5 `TS2352` casts in `ExportConfig/AddEntities/tests/utils.spec.ts`. Real cause: `getButtonTitle` types
  `selectedTab` as `EntityType`, while its own `entityTypeToMenuKey` map also holds
  `DeploymentExportEntityType` and `DEPLOYMENT_IMAGE_DEP` keys — the signature is narrower than the
  function. Widening it is a source change and belongs to the cast part.
- 4 stale Monaco marker fixtures in `EntityTabs/JsonEditor` (fixture part).
- `FormData.entries()` errors in `Publications/View` — the repo's `lib` lacks `dom.iterable`; one-line
  infra fix, its own part.

## Verification

- Spec-project baseline **726 → 655** (`tsc -p tsconfig.spec.json`, measured with the jest-dom `types` fix
  from #4457 applied; without it the phantom-matcher noise hides all of these).
- Every touched file is at **0** errors except the deliberate leftovers above.
- `npx vitest run` over the 11 touched specs: **228 tests pass**.
- Pre-push gate (`npm run typecheck` + full suite with coverage) passed on push.

## Series

1. **this PR** — mocks the compiler did not know were mocks (71)
2. references to deleted or renamed members (40)
3. string literals where an enum member is required (32)
4. implicitly-`any` test variables (80)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
