### PR TITLE
test(specs): stop asserting on deleted and renamed members (part 2/4)

### DIFF
--- a/apps/ai-dial-admin/src/app/[lang]/assets-applications/actions.spec.ts
+++ b/apps/ai-dial-admin/src/app/[lang]/assets-applications/actions.spec.ts
@@ -128,7 +128,7 @@ describe('Assets application :: server actions', () => {
     const result = await updateApp(
       {
         folderId: 'public',
-        applicationProperties: { key: 'value' },
+        application_properties: { key: 'value' },
         defaults: { key: 'value' },
         nodeType: DialFileNodeType.FOLDER,
         path: 'test',
@@ -144,7 +144,7 @@ describe('Assets application :: server actions', () => {
       {
         folderId: undefined,
         nodeType: DialFileNodeType.FOLDER,
-        applicationProperties: { key: 'value' },
+        application_properties: { key: 'value' },
         defaults: { key: 'value' },
         path: undefined,
         version: undefined,

--- a/apps/ai-dial-admin/src/components/ActivityAudit/Rollback/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/ActivityAudit/Rollback/tests/utils.spec.ts
@@ -58,7 +58,7 @@ describe('getSystemRollbackColumns', () => {
   });
 
   test('returns empty array for unknown type', () => {
-    const cols = getSystemRollbackColumns(ActivityAuditResourceType.UNKNOWN as any, t);
+    const cols = getSystemRollbackColumns('UnknownResourceType' as ActivityAuditResourceType, t);
     expect(cols).toEqual([]);
   });
 });

--- a/apps/ai-dial-admin/src/components/ActivityAudit/View/utils/tests/compare-helpers.spec.ts
+++ b/apps/ai-dial-admin/src/components/ActivityAudit/View/utils/tests/compare-helpers.spec.ts
@@ -55,7 +55,7 @@ describe('Activity audit :: generateStringFromObject', () => {
 
   test('should correctly handle character-based pricing when translator is provided', () => {
     const pricing = {
-      unit: PricingType.Character,
+      unit: PricingType.CharWithoutWhitespace,
       rate: 0.001,
     };
 
@@ -88,7 +88,7 @@ describe('Activity audit :: convertPricing', () => {
 
   test('should format character-based pricing correctly (unit = Character)', () => {
     const pricing = {
-      unit: PricingType.Character,
+      unit: PricingType.CharWithoutWhitespace,
       input: 0.002,
       output: 0.003,
     };
@@ -99,7 +99,7 @@ describe('Activity audit :: convertPricing', () => {
 
   test('should multiply numeric values by 1,000,000 only when unit is Token', () => {
     const tokenPricing = { unit: PricingType.Token, rate: 0.001 };
-    const charPricing = { unit: PricingType.Character, rate: 0.001 };
+    const charPricing = { unit: PricingType.CharWithoutWhitespace, rate: 0.001 };
 
     const tokenResult = convertPricing(tokenPricing, t);
     const charResult = convertPricing(charPricing, t);
@@ -138,7 +138,7 @@ describe('Activity audit :: convertPricing', () => {
 
   test('should handle string values gracefully in non-token mode', () => {
     const pricing = {
-      unit: PricingType.Character,
+      unit: PricingType.CharWithoutWhitespace,
       currency: 'USD',
     };
 

--- a/apps/ai-dial-admin/src/components/AddEntitiesTab/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/AddEntitiesTab/tests/utils.spec.ts
@@ -228,7 +228,7 @@ describe('Add Entities tab :: getAvailableEntities ', () => {
   });
 
   test('Should return filtered data', () => {
-    const existing = [{ key: 'key', type: MenuI18nKey.Key, route: ApplicationRoute.Keys }];
+    const existing = [{ key: 'key', type: MenuI18nKey.Keys, route: ApplicationRoute.Keys }];
     const result = getAvailableEntities(existing, [
       { name: 'model', type: MenuI18nKey.Models, route: ApplicationRoute.Models },
       { name: 'application', type: MenuI18nKey.Applications, route: ApplicationRoute.Applications },

--- a/apps/ai-dial-admin/src/components/Analytics/ConversationsTrace/tests/ConversationsListNavigation.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/ConversationsTrace/tests/ConversationsListNavigation.spec.tsx
@@ -20,10 +20,10 @@ vi.mock('@/src/components/Grid/GridView/GridView', () => ({
   },
 }));
 
-const leafColumns = (columns: Column[]): ColDef<ConversationRow>[] =>
-  columns.flatMap((column) =>
-    'children' in column ? leafColumns(column.children as Column[]) : [column as ColDef<ConversationRow>],
-  );
+// Deliberately not `ColDef<ConversationRow>`: a leaf can be a composed column (the rating cell) whose
+// `field` is not a key of the row, and the row-typed `field` would make that comparison impossible.
+const leafColumns = (columns: Column[]): ColDef[] =>
+  columns.flatMap((column) => ('children' in column ? leafColumns(column.children as Column[]) : [column as ColDef]));
 
 const CHAT_ID = 'conversations/eRxsos/chathub-claude4__E2E';
 

--- a/apps/ai-dial-admin/src/components/Analytics/Pipelines/Enrich/tests/use-enrich-form.spec.ts
+++ b/apps/ai-dial-admin/src/components/Analytics/Pipelines/Enrich/tests/use-enrich-form.spec.ts
@@ -60,7 +60,7 @@ const allTables = [enrichment, otherEnrichment, sourceTable, otherSource];
 
 const renderForm = (params?: Parameters<typeof useEnrichForm>[0]) => renderHook(() => useEnrichForm(params));
 
-type Form = { current: ReturnType<typeof usePipelineForm> };
+type Form = { current: ReturnType<typeof useEnrichForm> };
 
 const fillRequired = async (result: Form) => {
   act(() =>

--- a/apps/ai-dial-admin/src/components/ExportConfig/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/ExportConfig/tests/utils.spec.ts
@@ -117,7 +117,7 @@ describe('Export Config Utils :: getComponents', () => {
 
   test('Should return components for custom core config', () => {
     const res = getComponents(ExportType.Custom, {
-      [EntityType.ENTITIES]: [
+      entities: [
         { name: 'Model', type: MenuI18nKey.Models, dependencies: [EntityType.ROLE] },
         { name: 'Application', type: MenuI18nKey.Applications, dependencies: [EntityType.ROLE] },
         { name: 'Route', type: MenuI18nKey.Routes, dependencies: [EntityType.ROLE] },
@@ -137,7 +137,7 @@ describe('Export Config Utils :: getComponents', () => {
 
   test('Should return tabs for custom core config with correct dependencies', () => {
     const res = getComponents(ExportType.Custom, {
-      [EntityType.ENTITIES]: [{ name: 'Model', type: MenuI18nKey.Models, dependencies: [EntityType.APPLICATION] }],
+      entities: [{ name: 'Model', type: MenuI18nKey.Models, dependencies: [EntityType.APPLICATION] }],
     });
 
     expect(res).toEqual([

--- a/apps/ai-dial-admin/src/components/ImportConfig/ConfigurationPreview/ConfigurationPreview.utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/ImportConfig/ConfigurationPreview/ConfigurationPreview.utils.spec.ts
@@ -26,6 +26,10 @@ const makeItem = (importAction: string, next: Partial<BaseEntity>, prev?: Partia
   prev: prev as BaseEntity,
 });
 
+// `getConfigurationPreview` types its buckets as `BaseEntity[]`, which has no `id`; these fixtures track
+// identity by one, so read it through the record shape instead of pretending the field is on the type.
+const idOf = (entity?: BaseEntity): unknown => (entity as { id?: unknown } | undefined)?.id;
+
 describe('ConfigurationPreview.utils', () => {
   const t = (v: string) => v;
   const compare = () => void 0;
@@ -80,11 +84,11 @@ describe('ConfigurationPreview.utils', () => {
     expect(prevData[EntityType.MODEL].length).toBe(previewData[EntityType.MODEL].length);
     expect(prevData[EntityType.APPLICATION].length).toBe(previewData[EntityType.APPLICATION].length);
 
-    expect(prevData[EntityType.MODEL][0]?.id).toBe(1);
-    expect(prevData[EntityType.APPLICATION][0]?.id).toBe(2);
+    expect(idOf(prevData[EntityType.MODEL][0])).toBe(1);
+    expect(idOf(prevData[EntityType.APPLICATION][0])).toBe(2);
 
-    expect(previewData[EntityType.MODEL][0].id).toBe(1);
-    expect(previewData[EntityType.APPLICATION][0].id).toBe(2);
+    expect(idOf(previewData[EntityType.MODEL][0])).toBe(1);
+    expect(idOf(previewData[EntityType.APPLICATION][0])).toBe(2);
 
     expect(prevData[EntityType.ROUTE]).toEqual([]);
   });
@@ -102,8 +106,8 @@ describe('ConfigurationPreview.utils', () => {
 
     expect(previewData[EntityType.MODEL]).toHaveLength(1);
     expect(previewData[EntityType.ROLE]).toHaveLength(1);
-    expect(previewData[EntityType.MODEL][0].id).toBe(1);
-    expect(previewData[EntityType.ROLE][0].id).toBe(2);
+    expect(idOf(previewData[EntityType.MODEL][0])).toBe(1);
+    expect(idOf(previewData[EntityType.ROLE][0])).toBe(2);
   });
 
   test('getConfigurationPreview handles empty config correctly with prevData', () => {
@@ -134,11 +138,11 @@ describe('ConfigurationPreview.utils', () => {
     expect(prevData[EntityType.MODEL].length).toBe(previewData[EntityType.MODEL].length);
     expect(prevData[EntityType.ROLE].length).toBe(previewData[EntityType.ROLE].length);
 
-    expect(prevData[EntityType.MODEL][0]?.id).toBe(1);
-    expect(prevData[EntityType.ROLE][0]?.id).toBe(2);
+    expect(idOf(prevData[EntityType.MODEL][0])).toBe(1);
+    expect(idOf(prevData[EntityType.ROLE][0])).toBe(2);
 
-    expect(previewData[EntityType.MODEL][0].id).toBe(1);
-    expect(previewData[EntityType.ROLE][0].id).toBe(2);
+    expect(idOf(previewData[EntityType.MODEL][0])).toBe(1);
+    expect(idOf(previewData[EntityType.ROLE][0])).toBe(2);
 
     expect(prevData[EntityType.ROUTE]).toEqual([]);
   });
@@ -160,7 +164,7 @@ describe('ConfigurationPreview.utils', () => {
   test('getActionClassName returns correct class', () => {
     expect(getActionClassName(ImportConfigurationAction.CREATE)).toBe('bg-accent-primary');
     expect(getActionClassName(ImportConfigurationAction.UPDATE)).toBe('bg-orange-400');
-    expect(getActionClassName(ImportConfigurationAction.OTHER)).toBe('bg-controls-disable');
+    expect(getActionClassName(ImportConfigurationAction.SKIP)).toBe('bg-controls-disable');
   });
 
   test('getComponentColDefs returns correct columns for MODEL', () => {

--- a/apps/ai-dial-admin/src/components/Publications/View/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/Publications/View/tests/utils.spec.ts
@@ -187,7 +187,7 @@ describe('getCorrectPublication', () => {
 
     expect(result.applicationResources).toHaveLength(1);
     expect(result.applicationResources![0].applicationResource.defaults).toEqual({});
-    expect(result.applicationResources![0].applicationResource.applicationProperties).toEqual({});
+    expect(result.applicationResources![0].applicationResource.application_properties).toEqual({});
   });
 
   it('should handle publication with undefined applicationResources', () => {
@@ -197,6 +197,6 @@ describe('getCorrectPublication', () => {
 
     expect(result.applicationResources).toHaveLength(1);
     expect(result.applicationResources![0].applicationResource.defaults).toEqual({});
-    expect(result.applicationResources![0].applicationResource.applicationProperties).toEqual({});
+    expect(result.applicationResources![0].applicationResource.application_properties).toEqual({});
   });
 });

--- a/apps/ai-dial-admin/src/components/Publications/View/utils.ts
+++ b/apps/ai-dial-admin/src/components/Publications/View/utils.ts
@@ -32,7 +32,7 @@ export const getCorrectPublication = (publication: ApplicationPublication): Publ
         applicationResource: {
           ...publication.applicationResources?.[0]?.applicationResource,
           defaults,
-          applicationProperties,
+          application_properties: applicationProperties,
         },
       },
     ],

--- a/apps/ai-dial-admin/src/components/SourceField/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/SourceField/tests/utils.spec.ts
@@ -212,7 +212,9 @@ describe('buildContainerSelection', () => {
     expect(result.source?.containerId).toBe('app-container');
     expect(result.source?.completionEndpointPath).toBeTruthy();
     expect(result.endpoint).toBe('');
-    expect(result.baseEndpoint).toBe('');
+    // `buildContainerSelection` clears all three endpoint shapes in one object, so a model carries the
+    // adapter's `baseEndpoint` too — the model type does not declare it.
+    expect((result as Record<string, unknown>).baseEndpoint).toBe('');
   });
 
   test('default (Interceptors): writes containerId, clears endpoint, no completionEndpointPath', () => {

--- a/apps/ai-dial-admin/src/utils/api/tests/create-stream-request.spec.ts
+++ b/apps/ai-dial-admin/src/utils/api/tests/create-stream-request.spec.ts
@@ -34,7 +34,7 @@ describe('Utils :: api :: streamRequest', () => {
     const mockStream = createMockReadableStream();
     const mockResponse = new Response(mockStream);
 
-    (sendRequest as vi.Mock).mockResolvedValue(mockResponse);
+    vi.mocked(sendRequest).mockResolvedValue(mockResponse);
 
     const response = await streamRequest(mockUrl, mockFileName, mockToken, true);
 
@@ -48,7 +48,7 @@ describe('Utils :: api :: streamRequest', () => {
     const mockStream = createMockReadableStream();
     const mockResponse = new Response(mockStream);
 
-    (sendRequest as vi.Mock).mockResolvedValue(mockResponse);
+    vi.mocked(sendRequest).mockResolvedValue(mockResponse);
 
     const response = await streamRequest(mockUrl, mockFileName, mockToken, false);
 
@@ -63,7 +63,7 @@ describe('Utils :: api :: streamRequest', () => {
     // try/catch swallowed into a promise that never resolves — hanging any caller awaiting it.
     const mockStream = createMockReadableStream();
     const mockResponse = new Response(mockStream);
-    (sendRequest as vi.Mock).mockResolvedValue(mockResponse);
+    vi.mocked(sendRequest).mockResolvedValue(mockResponse);
 
     const response = await streamRequest(mockUrl, 'Brand™.txt', mockToken, false);
 
@@ -110,7 +110,7 @@ describe('Utils :: api :: streamRequest', () => {
 
   describe('streamRequest error handling', () => {
     test('returns promise resolving to null on error', async () => {
-      (sendRequest as vi.Mock).mockImplementation(() => {
+      vi.mocked(sendRequest).mockImplementation(() => {
         throw new Error('fail');
       });
       const promise = streamRequest('url', 'file.txt', { access_token: 'token' }, true);

--- a/apps/ai-dial-admin/src/utils/files/tests/folder.spec.ts
+++ b/apps/ai-dial-admin/src/utils/files/tests/folder.spec.ts
@@ -321,7 +321,7 @@ describe('Folder Utils :: findFolderSiblings', () => {
       },
       {
         path: '/root/file1.txt',
-        nodeType: DialFileNodeType.FILE,
+        nodeType: DialFileNodeType.ITEM,
       },
     ],
   };
@@ -358,7 +358,7 @@ describe('Folder Utils :: findFolderSiblings', () => {
         },
         {
           path: '/parent/fileA.txt',
-          nodeType: DialFileNodeType.FILE,
+          nodeType: DialFileNodeType.ITEM,
         },
       ],
     };
@@ -383,7 +383,7 @@ describe('Folder Utils :: findFolderChildren', () => {
           },
           {
             path: '/root/folder1/file1.txt',
-            nodeType: DialFileNodeType.FILE,
+            nodeType: DialFileNodeType.ITEM,
           },
         ],
       },
@@ -412,11 +412,11 @@ describe('Folder Utils :: findFolderChildren', () => {
       items: [
         {
           path: '/files/fileA.txt',
-          nodeType: DialFileNodeType.FILE,
+          nodeType: DialFileNodeType.ITEM,
         },
         {
           path: '/files/fileB.md',
-          nodeType: DialFileNodeType.FILE,
+          nodeType: DialFileNodeType.ITEM,
         },
       ],
     };

--- a/apps/ai-dial-admin/src/utils/tests/download.spec.ts
+++ b/apps/ai-dial-admin/src/utils/tests/download.spec.ts
@@ -1,10 +1,10 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { MockInstance, afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { downloadFile } from '../download';
 
 const mockUrl = 'blob:http://example.com/fake-blob';
 describe('Utils :: downloadFile', () => {
-  let createObjectURLSpy: vi.SpyInstance;
-  let revokeObjectURLSpy: vi.SpyInstance;
+  let createObjectURLSpy: MockInstance;
+  let revokeObjectURLSpy: MockInstance;
 
   beforeEach(() => {
     global.URL.createObjectURL = vi.fn(() => mockUrl);

--- a/apps/ai-dial-admin/src/utils/tests/publications.spec.ts
+++ b/apps/ai-dial-admin/src/utils/tests/publications.spec.ts
@@ -37,7 +37,7 @@ describe('getModalsTranslations', () => {
   });
 
   test('returns prompt publication unpublish translations', () => {
-    const result = getModalsTranslations(ApplicationRoute.PromptPublications, ActionType.REMOVE);
+    const result = getModalsTranslations(ApplicationRoute.PromptPublications, ActionType.DELETE);
     expect(result).toEqual({
       ApproveModalTitle: PublicationsI18nKey.PromptUnpublishApproveModalTitle,
       DeclineModalTitle: PublicationsI18nKey.PromptUnpublishDeclineModalTitle,
@@ -55,7 +55,7 @@ describe('getModalsTranslations', () => {
   });
 
   test('returns file publication unpublish translations', () => {
-    const result = getModalsTranslations(ApplicationRoute.FilePublications, ActionType.REMOVE);
+    const result = getModalsTranslations(ApplicationRoute.FilePublications, ActionType.DELETE);
     expect(result).toEqual({
       ApproveModalTitle: PublicationsI18nKey.FileUnpublishApproveModalTitle,
       DeclineModalTitle: PublicationsI18nKey.FileUnpublishDeclineModalTitle,
@@ -73,7 +73,7 @@ describe('getModalsTranslations', () => {
   });
 
   test('returns application publication unpublish translations', () => {
-    const result = getModalsTranslations(ApplicationRoute.ApplicationPublications, ActionType.REMOVE);
+    const result = getModalsTranslations(ApplicationRoute.ApplicationPublications, ActionType.DELETE);
     expect(result).toEqual({
       ApproveModalTitle: PublicationsI18nKey.ApplicationUnpublishApproveModalTitle,
       DeclineModalTitle: PublicationsI18nKey.ApplicationUnpublishDeclineModalTitle,
@@ -91,7 +91,7 @@ describe('getModalsTranslations', () => {
   });
 
   test('returns toolset publication unpublish translations', () => {
-    const result = getModalsTranslations(ApplicationRoute.ToolsetPublications, ActionType.REMOVE);
+    const result = getModalsTranslations(ApplicationRoute.ToolsetPublications, ActionType.DELETE);
     expect(result).toEqual({
       ApproveModalTitle: PublicationsI18nKey.ToolsetUnpublishApproveModalTitle,
       DeclineModalTitle: PublicationsI18nKey.ToolsetUnpublishDeclineModalTitle,


### PR DESCRIPTION
Second of four parts clearing the spec project's type errors (see #4458 for the series). This one takes
the 40 errors where a spec named a member that no longer exists — the class that produced the motivating
bug, because a missing enum member is `undefined` at runtime and a comparison against it still passes.

## What the members turned out to be

| Spec said | Reality | Effect while it went unchecked |
| --- | --- | --- |
| `ActionType.REMOVE` | `DELETE` | 4 modal cases called `getModalsTranslations(route, undefined)` and landed in the unpublish branch by accident |
| `PricingType.Character` | `CharWithoutWhitespace` | the "character pricing" cases only proved *not Token* — the same branch `undefined` takes |
| `DialFileNodeType.FILE` | `ITEM` | 5 file fixtures carried `nodeType: undefined` |
| `MenuI18nKey.Key` | `Keys` | — |
| `ImportConfigurationAction.OTHER` | `SKIP` | asserted the fallback class via a member that never existed |
| `EntityType.ENTITIES` | a plain `entities` bucket key | the bucket was keyed `undefined`; the key is only a fallback for entries whose `type` does not map |
| `ActivityAuditResourceType.UNKNOWN as any` | `'UnknownResourceType' as ActivityAuditResourceType` | intent kept, invented member gone |
| `ReturnType<typeof usePipelineForm>` | `useEnrichForm` | the fixture type resolved to an error type and checked nothing |
| `vi.SpyInstance`, `as vi.Mock` | `MockInstance`, `vi.mocked(...)` | `vi` is a value, not a namespace |

## A real source bug surfaced

`getCorrectPublication` reads `application_properties` off the resource and wrote the normalised result
back as **`applicationProperties`** — a key `DialApplicationResource` does not have, hidden by the
`as Publication` cast at the end:

```ts
const applicationProperties = { ...resource.application_properties };
return { ...resource, defaults, applicationProperties };   // ← wrong key
```

So the function's whole purpose — defaulting those two objects to `{}` — never reached the field
consumers read (`ParametersTab` reads `application_properties`, which stayed `undefined` and relied on its
own `|| {}`). Fixed in `Publications/View/utils.ts`; the spec now asserts the real key and passes.
`updateApp`'s spec had the same camel/snake confusion in its payload, where it was proving only that an
unknown extra key gets forwarded.

## Two type-model mismatches, recorded where they belong

- `getConfigurationPreview` types its buckets `BaseEntity[]`, which has no `id`, while the fixtures track
  identity by one → a local `idOf` reads it through the record shape instead of pretending otherwise.
- `buildContainerSelection` clears `endpoint`, `configurationEndpoint` and `baseEndpoint` in one object,
  so a model does carry the adapter's field → the assertion goes through the record shape.
- `ColDef<ConversationRow>` cannot express the composed rating column, whose `field` is not a row key; the
  leaf-column helper drops the row generic. That comparison was `TS2367` "unintentional" before, i.e. it
  could never have matched had the types been right.

## Verification

- Baseline **726 → 687**; zero `TS2551` / `TS2304` / `TS2367` / `TS2561` / `TS2503` and no
  `does not exist on type 'typeof …'` left in the project.
- `npx vitest run` over the 14 touched specs: **all pass** (181 in the last batch plus the 4 enum files'
  160 and the actions spec's 25).
- One error converts rather than disappears: `assets-applications/actions.spec.ts` swaps a `TS2561` on the
  misspelled key for the `TS2345` behind it — that fixture is missing required `DialApplicationResource`
  fields, which is the fixture part's work.
- Pre-push gate (`npm run typecheck` + full suite with coverage) passed on push, which also covers the
  source change.

## Series

1. #4458 — mocks the compiler did not know were mocks (71)
2. **this PR** — references to deleted or renamed members (40)
3. string literals where an enum member is required (32)
4. implicitly-`any` test variables (80)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
