### PR TITLE
test(specs): use enum members where a bare string was standing in (part 3/4)

### DIFF
--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/tests/QueryBuilder.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/tests/QueryBuilder.spec.tsx
@@ -59,7 +59,7 @@ const FIELDS: AnalyticsEntityField[] = [
 
 const DEEP_JSON = JSON.stringify({
   entity: 'dial_usage_log',
-  mode: 'row',
+  mode: QueryMode.Row,
   filter: {
     op: 'and',
     args: [
@@ -72,7 +72,7 @@ const DEEP_JSON = JSON.stringify({
               {
                 op: 'eq',
                 args: [
-                  { type: 'field', name: 'project_id' },
+                  { type: QueryExprType.Field, name: 'project_id' },
                   { type: 'value', value_type: 'string', value: 'x' },
                 ],
               },
@@ -206,7 +206,11 @@ describe('QueryBuilder', () => {
     vi.mocked(translateSqlToQuery).mockResolvedValue({
       success: true,
       response: {
-        query: { entity: 'dial_usage_log', mode: 'row', select: [{ expr: { type: 'field', name: 'project_id' } }] },
+        query: {
+          entity: 'dial_usage_log',
+          mode: QueryMode.Row,
+          select: [{ expr: { type: QueryExprType.Field, name: 'project_id' } }],
+        },
       },
     });
     renderBuilder();
@@ -296,7 +300,11 @@ describe('QueryBuilder', () => {
     vi.mocked(translateSqlToQuery).mockResolvedValue({
       success: true,
       response: {
-        query: { entity: 'dial_usage_log', mode: 'row', select: [{ expr: { type: 'field', name: 'project_id' } }] },
+        query: {
+          entity: 'dial_usage_log',
+          mode: QueryMode.Row,
+          select: [{ expr: { type: QueryExprType.Field, name: 'project_id' } }],
+        },
       },
     });
     renderBuilder();
@@ -441,7 +449,7 @@ describe('QueryBuilder', () => {
 
     await user.click(screen.getByRole('button', { name: /QueryBuilder.Run/ }));
     const sent = vi.mocked(executeQuery).mock.calls[0][0] as StructuredQuery;
-    expect(sent.select).toEqual([{ expr: { type: 'field', name: 'project_id' } }]);
+    expect(sent.select).toEqual([{ expr: { type: QueryExprType.Field, name: 'project_id' } }]);
   });
 });
 
@@ -519,7 +527,7 @@ describe('QueryBuilder AI view', () => {
               {
                 op: 'eq',
                 args: [
-                  { type: 'field', name: 'project_id' },
+                  { type: QueryExprType.Field, name: 'project_id' },
                   { type: 'value', value_type: 'string', value: 'p1' },
                 ],
               },

--- a/apps/ai-dial-admin/src/components/Publications/Assets/Files/tests/FilesList.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Publications/Assets/Files/tests/FilesList.spec.tsx
@@ -1,15 +1,28 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, test } from 'vitest';
 import FilesList from '../FilesList';
+import { ActionType, PublicationFile } from '@/src/models/dial/publications';
 
 describe('FilesList', () => {
   test('renders grid with files', () => {
-    const files = [
-      { file: { name: 'file1.txt', path: '/path/file1.txt', extension: 'txt' } },
-      { file: { name: 'file2.pdf', path: '/path/file2.pdf', extension: 'pdf' } },
+    const files: PublicationFile[] = [
+      {
+        file: { name: 'file1.txt', path: '/path/file1.txt', extension: 'txt' },
+        sourceUrl: 'files/source/file1.txt',
+        targetUrl: 'files/public/file1.txt',
+        reviewUrl: 'files/review/file1.txt',
+        action: ActionType.DELETE,
+      },
+      {
+        file: { name: 'file2.pdf', path: '/path/file2.pdf', extension: 'pdf' },
+        sourceUrl: 'files/source/file2.pdf',
+        targetUrl: 'files/public/file2.pdf',
+        reviewUrl: 'files/review/file2.pdf',
+        action: ActionType.DELETE,
+      },
     ];
 
-    render(<FilesList files={files} action="download" />);
+    render(<FilesList files={files} action={ActionType.DELETE} />);
     expect(screen.getByRole('table')).toBeInTheDocument();
   });
 });

--- a/apps/ai-dial-admin/src/components/Runs/Compare/ExecutionResults/tests/ExecutionResultsTab.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Runs/Compare/ExecutionResults/tests/ExecutionResultsTab.spec.tsx
@@ -7,6 +7,7 @@ import { ExecutionResultsTabUiState } from '@/src/components/Runs/Compare/models
 import { createDefaultCompareViewTabState } from '@/src/components/Runs/Compare/use-compare-view-tab-state';
 
 import ExecutionResultsTab from '../ExecutionResultsTab';
+import { ExtractionResultStatus } from '@/src/models/evaluation/run';
 
 const getRunMock = vi.fn();
 const getTestCaseRunResultsMock = vi.fn();
@@ -27,6 +28,7 @@ vi.mock('@epam/ai-dial-ui-kit', async (importOriginal) => {
 const defaultRunProps = {
   primaryRunName: 'Run #316',
   comparedRunName: 'Run #317',
+  onlyMatchingTestCases: false,
 };
 
 const defaultDisplayPanelProps = {
@@ -64,6 +66,9 @@ const ControlledExecutionResultsTab: FC<
         executionResultsState={executionResultsState}
         setExecutionResultsState={setExecutionResultsState}
         {...props}
+        // after the spread: `props` is a `Partial`, so it would otherwise widen a required prop to
+        // `boolean | undefined`
+        onlyMatchingTestCases={props.onlyMatchingTestCases ?? false}
       />
     </div>
   );
@@ -98,7 +103,7 @@ describe('ExecutionResultsTab', () => {
             testCaseId: 'tc-1',
             responseStatusCode: 200,
             runIndex: 0,
-            executionStatus: 'SUCCESS',
+            executionStatus: ExtractionResultStatus.SUCCESS,
             testCaseName: 'Test Case 1',
             metricValues: {
               Accuracy: { precision: isPrimary ? 0.5 : 0.8 },
@@ -109,7 +114,7 @@ describe('ExecutionResultsTab', () => {
             testCaseId: 'tc-2',
             responseStatusCode: 200,
             runIndex: 1,
-            executionStatus: 'SUCCESS',
+            executionStatus: ExtractionResultStatus.SUCCESS,
             testCaseName: 'Test Case 2',
             metricValues: {
               Accuracy: { precision: 0.7 },
@@ -141,7 +146,7 @@ describe('ExecutionResultsTab', () => {
         testCaseId: 'tc-1',
         responseStatusCode: 200,
         runIndex: 0,
-        executionStatus: 'SUCCESS',
+        executionStatus: ExtractionResultStatus.SUCCESS,
         testCaseName: 'Test Case 1',
         metricValues: { Accuracy: { precision: 0.5 } },
       },
@@ -312,7 +317,7 @@ describe('ExecutionResultsTab', () => {
         testCaseName: 'Test Case 1',
         responseStatusCode: 200,
         runIndex: 0,
-        executionStatus: 'SUCCESS',
+        executionStatus: ExtractionResultStatus.SUCCESS,
         metricValues: { Accuracy: { precision: 0.5 } },
         _compared: null,
       },

--- a/apps/ai-dial-admin/src/components/Runs/Compare/HeatMap/utils/tests/build-heat-map-columns.spec.ts
+++ b/apps/ai-dial-admin/src/components/Runs/Compare/HeatMap/utils/tests/build-heat-map-columns.spec.ts
@@ -5,7 +5,7 @@ import { HEAT_MAP_VALUE_COL_MIN_WIDTH } from '@/src/components/Runs/Compare/Heat
 import { buildHeatMapColumns } from '@/src/components/Runs/Compare/HeatMap/utils/build-heat-map-columns';
 import { getHeatMapTestCaseColId } from '@/src/components/Runs/Compare/HeatMap/utils/heat-map-test-case-columns';
 import { CompareAnalyticsRow } from '@/src/components/Runs/View/models';
-import { AnalyticsResult } from '@/src/models/evaluation/run';
+import { AnalyticsResult, ExtractionResultStatus } from '@/src/models/evaluation/run';
 
 vi.mock('@/src/components/Runs/Compare/HeatMap/HeatMapTestCaseHeader', () => ({
   default: () => null,
@@ -26,7 +26,7 @@ const makeResult = (overrides: Partial<AnalyticsResult> = {}): AnalyticsResult =
   testCaseName: 'BLR',
   runIndex: 0,
   responseStatusCode: 200,
-  executionStatus: 'SUCCESS',
+  executionStatus: ExtractionResultStatus.SUCCESS,
   metricValues: {},
   ...overrides,
 });

--- a/apps/ai-dial-admin/src/components/Runs/Compare/HeatMap/utils/tests/build-heat-map-rows.spec.ts
+++ b/apps/ai-dial-admin/src/components/Runs/Compare/HeatMap/utils/tests/build-heat-map-rows.spec.ts
@@ -11,7 +11,7 @@ import {
 import { formatHeatMapTestCaseColId } from '@/src/components/Runs/Compare/HeatMap/utils/heat-map-test-case-columns';
 import { RUN_COMPARE_PRIMARY_INDEX, RUN_COMPARE_SECONDARY_INDEX } from '@/src/components/Runs/Compare/constants';
 import { CompareAnalyticsRow } from '@/src/components/Runs/View/models';
-import { AnalyticsResult } from '@/src/models/evaluation/run';
+import { AnalyticsResult, ExtractionResultStatus } from '@/src/models/evaluation/run';
 
 const makeResult = (overrides: Partial<AnalyticsResult> = {}): AnalyticsResult => ({
   id: 'result-1',
@@ -19,7 +19,7 @@ const makeResult = (overrides: Partial<AnalyticsResult> = {}): AnalyticsResult =
   testCaseName: 'Test Case 1',
   runIndex: 0,
   responseStatusCode: 200,
-  executionStatus: 'SUCCESS',
+  executionStatus: ExtractionResultStatus.SUCCESS,
   metricValues: {},
   ...overrides,
 });

--- a/apps/ai-dial-admin/src/components/Runs/Compare/HeatMap/utils/tests/heat-map-test-case-columns.spec.ts
+++ b/apps/ai-dial-admin/src/components/Runs/Compare/HeatMap/utils/tests/heat-map-test-case-columns.spec.ts
@@ -11,7 +11,7 @@ import {
   hasHeatMapMultiTurns,
 } from '@/src/components/Runs/Compare/HeatMap/utils/heat-map-test-case-columns';
 import { CompareAnalyticsRow } from '@/src/components/Runs/View/models';
-import { AnalyticsResult } from '@/src/models/evaluation/run';
+import { AnalyticsResult, ExtractionResultStatus } from '@/src/models/evaluation/run';
 
 const makeResult = (overrides: Partial<AnalyticsResult> = {}): AnalyticsResult => ({
   id: 'result-1',
@@ -19,7 +19,7 @@ const makeResult = (overrides: Partial<AnalyticsResult> = {}): AnalyticsResult =
   testCaseName: 'BLR',
   runIndex: 0,
   responseStatusCode: 200,
-  executionStatus: 'SUCCESS',
+  executionStatus: ExtractionResultStatus.SUCCESS,
   metricValues: {},
   ...overrides,
 });

--- a/apps/ai-dial-admin/src/components/Runs/Details/BottomDrawer/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/Runs/Details/BottomDrawer/tests/utils.spec.ts
@@ -1,15 +1,16 @@
 import { describe, expect, it } from 'vitest';
 
 import { MetricBindings } from '@/src/models/evaluation/metric';
-import { AnalyticsResult } from '@/src/models/evaluation/run';
+import { AnalyticsResult, ExtractionResultStatus } from '@/src/models/evaluation/run';
 
 import { buildComparisonSections, valuesAreEqual } from '../utils';
+import { MetricBindingType } from '@/src/types/evaluation';
 
 const makeResult = (overrides: Partial<AnalyticsResult> = {}): AnalyticsResult => ({
   id: 'r1',
   responseStatusCode: 200,
   runIndex: 0,
-  executionStatus: 'SUCCESS' as const,
+  executionStatus: ExtractionResultStatus.SUCCESS,
   execDurationMs: 1000,
   testCaseData: { input: 'hello' },
   extractedColumns: { answer: 'world' },
@@ -146,8 +147,8 @@ describe('buildComparisonSections', () => {
     const result = makeResult();
     const metricBindings: Record<string, MetricBindings> = {
       'eval.accuracy': {
-        configBindings: [{ property: 'model', source: { $type: 'Constant', value: 'gpt-4' } }],
-        inputBindings: [{ property: 'actual', source: { $type: 'Response', columnName: 'answer' } }],
+        configBindings: [{ property: 'model', source: { $type: MetricBindingType.Constant, value: 'gpt-4' } }],
+        inputBindings: [{ property: 'actual', source: { $type: MetricBindingType.Response, columnName: 'answer' } }],
       },
     };
     const sections = buildComparisonSections(
@@ -167,7 +168,7 @@ describe('buildComparisonSections', () => {
     const result = makeResult();
     const metricBindings: Record<string, MetricBindings> = {
       myMetric: {
-        configBindings: [{ property: 'model', source: { $type: 'Constant', value: 'gpt-4' } }],
+        configBindings: [{ property: 'model', source: { $type: MetricBindingType.Constant, value: 'gpt-4' } }],
         inputBindings: [],
       },
     };
@@ -190,7 +191,7 @@ describe('buildComparisonSections', () => {
     const metricBindings: Record<string, MetricBindings> = {
       myMetric: {
         configBindings: [],
-        inputBindings: [{ property: 'input', source: { $type: 'TestCase', columnName: 'Capital' } }],
+        inputBindings: [{ property: 'input', source: { $type: MetricBindingType.TestCase, columnName: 'Capital' } }],
       },
     };
     const sections = buildComparisonSections(
@@ -211,7 +212,9 @@ describe('buildComparisonSections', () => {
     const metricBindings: Record<string, MetricBindings> = {
       myMetric: {
         configBindings: [],
-        inputBindings: [{ property: 'actual_output', source: { $type: 'Response', columnName: 'answer' } }],
+        inputBindings: [
+          { property: 'actual_output', source: { $type: MetricBindingType.Response, columnName: 'answer' } },
+        ],
       },
     };
     const sections = buildComparisonSections(
@@ -231,7 +234,7 @@ describe('buildComparisonSections', () => {
     const result = makeResult();
     const metricBindings: Record<string, MetricBindings> = {
       myMetric: {
-        configBindings: [{ property: 'rubric', source: { $type: 'Constant' } }],
+        configBindings: [{ property: 'rubric', source: { $type: MetricBindingType.Constant } }],
         inputBindings: [],
       },
     };
@@ -253,13 +256,13 @@ describe('buildComparisonSections', () => {
     const pinned = makeResult({ id: 'b', metricValues: { myMetric: { score: 0.8 } } });
     const activeBindings: Record<string, MetricBindings> = {
       myMetric: {
-        configBindings: [{ property: 'model', source: { $type: 'Constant', value: 'gpt-4' } }],
+        configBindings: [{ property: 'model', source: { $type: MetricBindingType.Constant, value: 'gpt-4' } }],
         inputBindings: [],
       },
     };
     const pinnedBindings: Record<string, MetricBindings> = {
       myMetric: {
-        configBindings: [{ property: 'model', source: { $type: 'Constant', value: 'gpt-3.5' } }],
+        configBindings: [{ property: 'model', source: { $type: MetricBindingType.Constant, value: 'gpt-3.5' } }],
         inputBindings: [],
       },
     };
@@ -284,8 +287,8 @@ describe('buildComparisonSections', () => {
     const pinned = makeResult({ id: 'b', metricValues: {} });
     const metricBindings: Record<string, MetricBindings> = {
       myMetric: {
-        configBindings: [{ property: 'model', source: { $type: 'Constant', value: 'gpt-4' } }],
-        inputBindings: [{ property: 'actual', source: { $type: 'Response', columnName: 'answer' } }],
+        configBindings: [{ property: 'model', source: { $type: MetricBindingType.Constant, value: 'gpt-4' } }],
+        inputBindings: [{ property: 'actual', source: { $type: MetricBindingType.Response, columnName: 'answer' } }],
       },
     };
     const sections = buildComparisonSections(
@@ -311,8 +314,8 @@ describe('buildComparisonSections', () => {
     const pinned = makeResult({ id: 'b', metricValues: { myMetric: { score: 0.9 } } });
     const pinnedBindings: Record<string, MetricBindings> = {
       myMetric: {
-        configBindings: [{ property: 'model', source: { $type: 'Constant', value: 'gpt-4' } }],
-        inputBindings: [{ property: 'actual', source: { $type: 'Response', columnName: 'answer' } }],
+        configBindings: [{ property: 'model', source: { $type: MetricBindingType.Constant, value: 'gpt-4' } }],
+        inputBindings: [{ property: 'actual', source: { $type: MetricBindingType.Response, columnName: 'answer' } }],
       },
     };
     const sections = buildComparisonSections(
@@ -362,11 +365,11 @@ describe('buildComparisonSections', () => {
     const result = makeResult();
     const metricBindings: Record<string, MetricBindings> = {
       zMetric: {
-        configBindings: [{ property: 'p', source: { $type: 'Constant', value: 'v' } }],
+        configBindings: [{ property: 'p', source: { $type: MetricBindingType.Constant, value: 'v' } }],
         inputBindings: [],
       },
       aMetric: {
-        configBindings: [{ property: 'p', source: { $type: 'Constant', value: 'v' } }],
+        configBindings: [{ property: 'p', source: { $type: MetricBindingType.Constant, value: 'v' } }],
         inputBindings: [],
       },
     };
@@ -389,8 +392,8 @@ describe('buildComparisonSections', () => {
     const metricBindings: Record<string, MetricBindings> = {
       myMetric: {
         configBindings: [
-          { property: 'model', source: { $type: 'Constant', value: 'gpt-4' } },
-          { property: 'threshold', source: { $type: 'Constant', value: '0.5' } },
+          { property: 'model', source: { $type: MetricBindingType.Constant, value: 'gpt-4' } },
+          { property: 'threshold', source: { $type: MetricBindingType.Constant, value: '0.5' } },
         ],
         inputBindings: [],
       },
@@ -407,7 +410,7 @@ describe('buildComparisonSections', () => {
     const result = makeResult();
     const metricBindings: Record<string, MetricBindings> = {
       myMetric: {
-        configBindings: [{ property: 'model', source: { $type: 'Constant', value: 'gpt-4' } }],
+        configBindings: [{ property: 'model', source: { $type: MetricBindingType.Constant, value: 'gpt-4' } }],
         inputBindings: [],
       },
     };

--- a/apps/ai-dial-admin/src/components/Runs/View/tests/ExtractionResult.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Runs/View/tests/ExtractionResult.spec.tsx
@@ -8,6 +8,7 @@ import { SidebarPosition } from '@/src/components/Common/Sidebar/models';
 import { ExtractionResultTabUiState } from '../models';
 import ExtractionResultTab from '../ExtractionResult';
 import { createDefaultRunViewTabState } from '../use-run-view-tab-state';
+import { ExtractionResultStatus } from '@/src/models/evaluation/run';
 
 const mockShowSidebar = vi.fn();
 const mockCloseSidebar = vi.fn();
@@ -156,7 +157,7 @@ describe('ExtractionResultTab', () => {
               id: 'r1',
               responseStatusCode: 200,
               runIndex: 0,
-              executionStatus: 'SUCCESS',
+              executionStatus: ExtractionResultStatus.SUCCESS,
               testCaseName: 'Test Case 1',
             },
           ],

--- a/apps/ai-dial-admin/src/components/Toolsets/Auth/Sections/tests/OAuthSection.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Toolsets/Auth/Sections/tests/OAuthSection.spec.tsx
@@ -1,4 +1,9 @@
-import { ToolsetAuthSettings, ToolsetAuthStatus, ToolsetAuthType } from '@/src/models/dial/toolset';
+import {
+  ToolsetAuthSettings,
+  ToolsetAuthStatus,
+  ToolsetAuthType,
+  ToolsetCodeChallengeMethod,
+} from '@/src/models/dial/toolset';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, test, vi, beforeEach } from 'vitest';
 import { EntityPlaceholdersI18nKey, ToolsetI18nKey } from '@/src/constants/i18n';
@@ -29,7 +34,7 @@ describe('OAuthSection', () => {
       scopesSupported: ['scope1', 'scope2'],
       authorizationEndpoint: 'auth-endpoint',
       tokenEndpoint: 'token-endpoint',
-      codeChallengeMethod: 'S256',
+      codeChallengeMethod: ToolsetCodeChallengeMethod.S256,
     };
     render(<OAuthSection authSettings={authSettings} view={ApplicationRoute.Toolsets} />);
     expect(screen.getByPlaceholderText(EntityPlaceholdersI18nKey.ClientId)).toHaveValue('client-id');

--- a/apps/ai-dial-admin/src/utils/audit/tests/get-rollback-request.spec.ts
+++ b/apps/ai-dial-admin/src/utils/audit/tests/get-rollback-request.spec.ts
@@ -16,7 +16,7 @@ describe('getUpdateAction', () => {
     expect(getUpdateAction(ActivityAuditResourceType.APPLICATION_TYPE_SCHEMA).name).toBe('updateApplicationScheme');
   });
   test('returns null for unknown type', () => {
-    expect(getUpdateAction('Unknown')).toBeNull();
+    expect(getUpdateAction('Unknown' as ActivityAuditResourceType)).toBeNull();
   });
 });
 
@@ -34,7 +34,7 @@ describe('getCreateAction', () => {
     expect(getCreateAction(ActivityAuditResourceType.APPLICATION_TYPE_SCHEMA)?.name).toBe('createApplicationScheme');
   });
   test('returns null for unknown type', () => {
-    expect(getCreateAction('Unknown')).toBeNull();
+    expect(getCreateAction('Unknown' as ActivityAuditResourceType)).toBeNull();
   });
 });
 
@@ -52,6 +52,6 @@ describe('getDeleteAction', () => {
     expect(getDeleteAction(ActivityAuditResourceType.APPLICATION_TYPE_SCHEMA)?.name).toBe('removeApplicationScheme');
   });
   test('returns null for unknown type', () => {
-    expect(getDeleteAction('Unknown')).toBeNull();
+    expect(getDeleteAction('Unknown' as ActivityAuditResourceType)).toBeNull();
   });
 });


### PR DESCRIPTION
Third of four parts clearing the spec project's type errors (series in #4458). 32 places passed a bare
string where the type wants an enum member. Every value happened to match, so nothing failed — but the
assertion was no longer tied to the enum, so a rename would have slipped through exactly the way part 2's
deleted members did.

## Substitutions

| Spec had | Now |
| --- | --- |
| `executionStatus: 'SUCCESS'` (5 run/compare specs) | `ExtractionResultStatus.SUCCESS` |
| `$type: 'Constant' \| 'Response' \| 'TestCase'` (18 in the bottom-drawer spec) | `MetricBindingType.*` |
| `mode: 'row'`, `type: 'field'` | `QueryMode.Row`, `QueryExprType.Field` |
| `codeChallengeMethod: 'S256'` | `ToolsetCodeChallengeMethod.S256` |
| `action="download"` | `ActionType.DELETE` |
| `getUpdateAction('Unknown')` ×3 | `'Unknown' as ActivityAuditResourceType` |

`download` was never an `ActionType` member. The component only asks `isAddAction(action)`, so any non-add
value rendered the same thing and the case passed regardless — the literal was carrying no meaning.
`'Unknown'` is likewise not a member, and deliberately so: those cases assert the null-result path, so the
cast keeps the intent instead of inventing a member.

## Two literals stay

Inside `vi.mock` factories. vitest hoists those above the imports, so an enum reference there fails at
runtime with `Cannot access '__vi_import_N__' before initialization` — verified by doing it and watching
`ExtractionResult.spec.tsx` fail to load. Only the type-checked sites in those two files changed.

## Three follow-on fixes

Replacing a literal makes the compiler move to the next problem at the same site; three showed up and are
fixed here so the files land clean:

- the `PublicationFile[]` fixture in the files-list spec was missing `sourceUrl` / `targetUrl` /
  `reviewUrl` / `action`;
- `ExecutionResultsTab`'s harness never passed the required `onlyMatchingTestCases`, and its `Partial`
  props spread widened it to `boolean | undefined` — now defaulted after the spread, so a test can still
  override it.

## Verification

- Baseline **726 → 688**; zero literal-vs-enum errors left, and **no error newly surfaced anywhere** in
  the project (checked by diffing the full error set against the baseline).
- `npx vitest run` over the 10 touched specs: all pass.
- Pre-push gate (`npm run typecheck` + full suite with coverage) passed on push.

## Series

1. #4458 — mocks the compiler did not know were mocks (71)
2. #4459 — references to deleted or renamed members (40)
3. **this PR** — string literals where an enum member is required (32)
4. implicitly-`any` test variables (80)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
