### PR TITLE
chore(config): cut unread tool output and resolve prettier config the way the CLI does

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -6,7 +6,7 @@
     },
     "playwright": {
       "command": "npx",
-      "args": ["@playwright/mcp@0.0.79", "--browser", "chrome"]
+      "args": ["@playwright/mcp@0.0.79", "--browser", "chrome", "--output-dir", ".playwright-mcp"]
     }
   }
 }

--- a/apps/ai-dial-admin/vitest.config.ts
+++ b/apps/ai-dial-admin/vitest.config.ts
@@ -28,10 +28,14 @@ export default defineConfig(() => ({
     threads: false,
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     exclude: [...configDefaults.exclude, '**/.next/**', '*.config.{ts,js}'],
-    reporters: ['default'],
+    // 'dot' prints one character per file and every failure in full; the default reporter prints a
+    // line per spec file (971 of them here), which is output nobody reads and agents pay for.
+    reporters: ['dot'],
     coverage: {
       include: ['src/**/*.{ts,tsx}'],
-      reporter: ['text', 'html', 'clover', 'json'],
+      // 'text-summary' is six lines; 'text' is one row per source file (2 950 of them here).
+      // The machine-readable reporters are untouched, so CI artifacts and thresholds are the same.
+      reporter: ['text-summary', 'html', 'clover', 'json'],
       reportsDirectory: '../../coverage/apps/ai-dial-admin',
       provider: 'v8' as const,
       thresholds: {

--- a/scripts/validate-agent-docs.mjs
+++ b/scripts/validate-agent-docs.mjs
@@ -156,7 +156,12 @@ const checkFormatting = async (src, file) => {
     resolveConfig: true,
   });
   if (info.ignored || !info.inferredParser) return; // prettier wouldn't format it
-  const config = (await prettier.resolveConfig(file)) ?? {};
+  // `editorconfig: true` is what the prettier CLI does by default, and the CLI is what
+  // `npm run format`, lint-staged and CI all run. Without it this gate resolves a different
+  // config than the repository's own formatter — printWidth 80 instead of the 120 that
+  // .editorconfig sets — so a line between 81 and 120 characters made the two contradict
+  // each other: whichever form satisfied one was rejected by the other.
+  const config = (await prettier.resolveConfig(file, { editorconfig: true })) ?? {};
   let formatted = false;
   try {
     formatted = await prettier.check(src, { ...config, filepath: file });


### PR DESCRIPTION
Three small tooling changes with one shared effect: less output nobody reads, and one gate that stops contradicting the formatter.

## vitest reporters

| | Before | After |
| --- | --- | --- |
| Test reporter | `default` — one line per spec file (**971**) | `dot` — one character per file, failures still printed in full |
| Coverage reporter | `text` — one row per source file (**2950**) | `text-summary` — six lines |

`html`, `clover` and `json` are untouched, so CI artifacts and coverage thresholds are unchanged. This is output cost paid on every run — by a person scrolling past it, and by an agent holding it in context.

## Prettier config resolution in the agent-docs validator

`prettier.resolveConfig` defaults to `editorconfig: false`. The prettier **CLI** — which `npm run format`, lint-staged and CI all run — defaults to `true`.

So the validator was checking against `printWidth: 80` while the repository actually formats at the `120` that `.editorconfig` sets. Any line between 81 and 120 characters could not satisfy both gates at once: format it the way the CLI wants and validation fails; satisfy validation and the next commit reformats it. Passing `editorconfig: true` makes the gate resolve exactly what the formatter resolves.

## Playwright MCP output directory

Pinned to `.playwright-mcp`, which `.gitignore` already covers (line 63), so traces and screenshots land in one ignored place instead of scattered through the working tree.

---

Independent of #4462 and #4463 — applies cleanly to `development` on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)