### PR TITLE
feat(Eval/TestSuites): reduce metrics table filters and fix stepper valid state (Issues #4441, #4440, #4442)

### DIFF
--- a/apps/ai-dial-admin/src/components/Grid/CellRenderers/TagsCellRenderer.tsx
+++ b/apps/ai-dial-admin/src/components/Grid/CellRenderers/TagsCellRenderer.tsx
@@ -2,6 +2,7 @@
 
 import { FC, useCallback, useEffect, useRef, useState } from 'react';
 import classNames from 'classnames';
+import { mergeClasses } from '@/src/utils/merge-classes';
 
 interface Props {
   items: string[];
@@ -70,7 +71,7 @@ const TagsCellRenderer: FC<Props> = ({ items, tagClassName }) => {
     return () => observer.disconnect();
   }, [recalculateVisibleItems]);
 
-  const itemClassName = classNames(
+  const itemClassName = mergeClasses(
     'tiny bg-layer-3 rounded p-1 border border-primary whitespace-nowrap max-w-[200px] overflow-hidden',
     tagClassName,
   );

--- a/apps/ai-dial-admin/src/components/TestSuites/Metrics/AddMetric/AddMetricModal.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/Metrics/AddMetric/AddMetricModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FC, useCallback, useEffect, useMemo, useState } from 'react';
+import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
   DialLoader,
@@ -47,6 +47,7 @@ const AddMetricModal: FC<Props> = ({
   metricDeclarations,
 }) => {
   const t = useI18n();
+  const prevSelectedMetricIdRef = useRef<string>(undefined);
 
   const isEditMode = !!editingMetric;
   const [currentStepId, setCurrentStepId] = useState<string>(
@@ -113,9 +114,13 @@ const AddMetricModal: FC<Props> = ({
     ? t(TestSuitesI18nKey.ConditionSystemFunctionUnavailable)
     : undefined;
 
+  const newMetricSelected =
+    currentStepId === MetricStep.AddMetric && prevSelectedMetricIdRef.current !== selectedMetricId;
+
   const isStep1Valid = !!selectedMetricId;
   const isStep2Valid =
     !conditionError &&
+    !newMetricSelected &&
     (isJsonView
       ? true
       : validateMetricBindings(
@@ -151,6 +156,22 @@ const AddMetricModal: FC<Props> = ({
     }
   }, [condition, configBindings, inputBindings, metricName, onConfirm, selectedMetricDetails]);
 
+  const onMetricSelect = useCallback(
+    (metricId: string) => {
+      prevSelectedMetricIdRef.current = selectedMetricId;
+      setSelectedMetricId(metricId);
+    },
+    [selectedMetricId],
+  );
+
+  const onStepChange = useCallback(
+    (step: string) => {
+      if (step === MetricStep.Configuration) prevSelectedMetricIdRef.current = selectedMetricId;
+      setCurrentStepId(step);
+    },
+    [selectedMetricId],
+  );
+
   return (
     <DialPopup
       onClose={onClose}
@@ -170,7 +191,7 @@ const AddMetricModal: FC<Props> = ({
           <StepperModalButtons
             steps={steps}
             currentStep={steps.find((s) => s.id === currentStepId)}
-            onChangeStep={setCurrentStepId}
+            onChangeStep={onStepChange}
             onFinishClick={onFinishClick}
             onClose={onClose}
           />
@@ -178,13 +199,7 @@ const AddMetricModal: FC<Props> = ({
       }
     >
       <div className="h-full flex flex-col min-h-0 px-6 py-4">
-        {!isEditMode && (
-          <DialSteps
-            steps={steps}
-            currentStep={currentStepId}
-            onChangeStep={(step) => setCurrentStepId(step as MetricStep)}
-          />
-        )}
+        {!isEditMode && <DialSteps steps={steps} currentStep={currentStepId} onChangeStep={onStepChange} />}
 
         <div className={classNames('flex-1 min-h-0 overflow-auto', { 'mt-4': !isEditMode })}>
           {currentStepId === MetricStep.AddMetric && isMetricDeclarationsLoading && <DialLoader size={44} />}
@@ -194,7 +209,7 @@ const AddMetricModal: FC<Props> = ({
               metrics={metricDeclarations || []}
               selectedMetricId={selectedMetricId}
               columnOrder={metricColumnOrder}
-              onSelectMetric={setSelectedMetricId}
+              onSelectMetric={onMetricSelect}
               onChangeColumnOrder={setMetricColumnOrder}
             />
           )}

--- a/apps/ai-dial-admin/src/components/TestSuites/Metrics/AddMetric/AddMetricModal.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/Metrics/AddMetric/AddMetricModal.tsx
@@ -62,6 +62,8 @@ const AddMetricModal: FC<Props> = ({
   const [metricName, setMetricName] = useState<string | undefined>('');
   const [condition, setCondition] = useState<string>('');
 
+  const [metricColumnOrder, setMetricColumnOrder] = useState<string[]>([]);
+
   const [configBindings, setConfigBindings] = useState<MetricBinding[]>([]);
   const [inputBindings, setInputBindings] = useState<MetricBinding[]>([]);
   const [isJsonView, setIsJsonView] = useState(false);
@@ -191,7 +193,9 @@ const AddMetricModal: FC<Props> = ({
             <MetricSelection
               metrics={metricDeclarations || []}
               selectedMetricId={selectedMetricId}
+              columnOrder={metricColumnOrder}
               onSelectMetric={setSelectedMetricId}
+              onChangeColumnOrder={setMetricColumnOrder}
             />
           )}
 

--- a/apps/ai-dial-admin/src/components/TestSuites/Metrics/AddMetric/MetricSelection.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/Metrics/AddMetric/MetricSelection.tsx
@@ -2,10 +2,11 @@
 
 import { FC, useCallback, useMemo } from 'react';
 
-import { FirstDataRenderedEvent, GridOptions, RowSelectedEvent } from 'ag-grid-community';
+import { ColumnMovedEvent, FirstDataRenderedEvent, GridOptions, RowSelectedEvent } from 'ag-grid-community';
 
 import { TWO_LINE_ROW_HEIGHT } from '@/src/components/Grid/constants';
 import GridView from '@/src/components/Grid/GridView/GridView';
+import { applyColumnStateOrderToColDefs } from '@/src/components/Grid/utils';
 import { SINGLE_ROW_SELECTION_NO_CHECKBOX } from '@/src/constants/ag-grid';
 import { METRIC_SELECTION_COLUMNS } from '@/src/constants/grid-columns/grid-columns';
 import { EntitiesI18nKey, TabsI18nKey } from '@/src/constants/i18n';
@@ -15,13 +16,41 @@ import { Metric } from '@/src/models/evaluation/metric';
 interface Props {
   selectedMetricId?: string;
   metrics: Metric[];
+  columnOrder?: string[];
   onSelectMetric?: (metricId: string) => void;
+  onChangeColumnOrder?: (columnOrder: string[]) => void;
 }
 
-const MetricSelection: FC<Props> = ({ metrics, selectedMetricId, onSelectMetric }) => {
+const MetricSelection: FC<Props> = ({
+  metrics,
+  selectedMetricId,
+  columnOrder,
+  onSelectMetric,
+  onChangeColumnOrder,
+}) => {
   const t = useI18n();
 
-  const columnDefs = useMemo(() => METRIC_SELECTION_COLUMNS(t), [t]);
+  const columnDefs = useMemo(() => {
+    const defs = METRIC_SELECTION_COLUMNS(t);
+
+    return columnOrder?.length
+      ? applyColumnStateOrderToColDefs(
+          defs,
+          columnOrder.map((colId) => ({ colId })),
+        )
+      : defs;
+  }, [t, columnOrder]);
+
+  const onColumnMoved = useCallback(
+    (event: ColumnMovedEvent<Metric>) => {
+      if (!event.finished) {
+        return;
+      }
+
+      onChangeColumnOrder?.(event.api.getColumnState().map(({ colId }) => colId));
+    },
+    [onChangeColumnOrder],
+  );
 
   const onRowSelected = useCallback(
     (event: RowSelectedEvent<Metric>) => {
@@ -56,8 +85,9 @@ const MetricSelection: FC<Props> = ({ metrics, selectedMetricId, onSelectMetric 
       rowHeight: TWO_LINE_ROW_HEIGHT,
       onRowSelected,
       onFirstDataRendered,
+      onColumnMoved,
     }),
-    [onRowSelected, onFirstDataRendered],
+    [onRowSelected, onFirstDataRendered, onColumnMoved],
   );
 
   return (

--- a/apps/ai-dial-admin/src/components/TestSuites/Metrics/AddMetric/tests/AddMetricModal.spec.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/Metrics/AddMetric/tests/AddMetricModal.spec.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { ButtonsI18nKey, TestSuitesI18nKey } from '@/src/constants/i18n';
 import { Metric } from '@/src/models/evaluation/metric';
 import AddMetricModal from '../AddMetricModal';
+import { MetricStep } from '../constants';
 
 const mockGetMetricLatestVersion = vi.fn();
 const mockGetTestSuiteMetricDetailsWithSchema = vi.fn();
@@ -25,12 +26,18 @@ vi.mock('../utils', () => ({
   isReservedSystemFunctionCondition: (condition?: string) => condition?.trim() === 'name()',
 }));
 
+const REORDERED_COLUMNS = ['displayName', 'providerId', 'description', 'outups'];
+
 vi.mock('../MetricSelection', () => ({
-  default: ({ metrics, onSelectMetric }: any) => (
+  default: ({ metrics, columnOrder, onSelectMetric, onChangeColumnOrder }: any) => (
     <div role="region" aria-label="metric-selection">
       <span>{`metrics:${metrics?.length ?? 0}`}</span>
+      <span>{`columnOrder:${(columnOrder ?? []).join(',')}`}</span>
       <button type="button" onClick={() => onSelectMetric('metric-1')}>
         Select metric
+      </button>
+      <button type="button" onClick={() => onChangeColumnOrder(REORDERED_COLUMNS)}>
+        Reorder columns
       </button>
     </div>
   ),
@@ -68,7 +75,16 @@ vi.mock('@epam/ai-dial-ui-kit', () => ({
         {footer}
       </div>
     ) : null,
-  DialSteps: ({ currentStep }: any) => <nav aria-label="steps">{currentStep}</nav>,
+  DialSteps: ({ steps, currentStep, onChangeStep }: any) => (
+    <nav aria-label="steps">
+      {currentStep}
+      {steps.map((step: { id: string }) => (
+        <button key={step.id} type="button" onClick={() => onChangeStep(step.id)}>
+          {`go:${step.id}`}
+        </button>
+      ))}
+    </nav>
+  ),
   DialLoader: () => <div role="progressbar" aria-label="loading" />,
   DialNeutralButton: ({ label, onClick }: any) => (
     <button type="button" onClick={onClick}>
@@ -129,6 +145,27 @@ describe('AddMetricModal', () => {
     await waitFor(() => {
       expect(mockGetMetricLatestVersion).toHaveBeenCalledWith('metric-1');
     });
+  });
+
+  test('keeps the chosen column order when returning from configuration to metric selection', async () => {
+    const user = userEvent.setup();
+    const orderText = `columnOrder:${REORDERED_COLUMNS.join(',')}`;
+
+    render(
+      <AddMetricModal isModalOpen onClose={vi.fn()} onConfirm={vi.fn()} metricDeclarations={metricDeclarations} />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Reorder columns' }));
+
+    expect(screen.getByText(orderText)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: `go:${MetricStep.Configuration}` }));
+
+    expect(screen.queryByRole('region', { name: 'metric-selection' })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: `go:${MetricStep.AddMetric}` }));
+
+    expect(screen.getByText(orderText)).toBeInTheDocument();
   });
 
   test('renders edit mode without steps and loads metric details', async () => {

--- a/apps/ai-dial-admin/src/components/TestSuites/Metrics/AddMetric/tests/MetricSelection.spec.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/Metrics/AddMetric/tests/MetricSelection.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { ColDef, GridOptions, IRowNode, RowSelectedEvent } from 'ag-grid-community';
+import { ColDef, ColumnMovedEvent, ColumnState, GridOptions, IRowNode, RowSelectedEvent } from 'ag-grid-community';
 import { ComponentProps } from 'react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -24,6 +24,12 @@ vi.mock('@/src/components/Grid/GridView/GridView', () => ({
     return <section aria-label="metrics-grid" />;
   },
 }));
+
+const buildColumnMovedEvent = (columnState: ColumnState[], isFinished: boolean) =>
+  ({
+    finished: isFinished,
+    api: { getColumnState: () => columnState },
+  }) as unknown as ColumnMovedEvent<Metric>;
 
 const buildRowSelectedEvent = (metric: Metric, isSelected: boolean) => {
   const refreshCells = vi.fn();
@@ -170,6 +176,51 @@ describe('MetricSelection', () => {
     expect(setSelected).toHaveBeenCalledOnce();
     expect(setSelected).toHaveBeenCalledWith(true);
     expect(ensureNodeVisible).toHaveBeenCalledWith(nodes[1], 'middle');
+  });
+
+  test('reports the moved column order once the drag has finished', () => {
+    const onChangeColumnOrder = vi.fn();
+    renderMetricSelection({ onChangeColumnOrder });
+    const event = buildColumnMovedEvent(
+      [{ colId: 'displayName' }, { colId: 'providerId' }, { colId: 'description' }, { colId: 'outups' }],
+      true,
+    );
+
+    capturedGridProps?.additionalGridOptions?.onColumnMoved?.(event);
+
+    expect(onChangeColumnOrder).toHaveBeenCalledOnce();
+    expect(onChangeColumnOrder).toHaveBeenCalledWith(['displayName', 'providerId', 'description', 'outups']);
+  });
+
+  test('does not report an order while the column is still being dragged', () => {
+    const onChangeColumnOrder = vi.fn();
+    renderMetricSelection({ onChangeColumnOrder });
+
+    capturedGridProps?.additionalGridOptions?.onColumnMoved?.(buildColumnMovedEvent([{ colId: 'displayName' }], false));
+
+    expect(onChangeColumnOrder).not.toHaveBeenCalled();
+  });
+
+  test('restores a previously chosen column order', () => {
+    renderMetricSelection({ columnOrder: ['displayName', 'providerId', 'description', 'outups'] });
+
+    expect(capturedGridProps?.columnDefs?.map((col) => col.colId)).toEqual([
+      'displayName',
+      'providerId',
+      'description',
+      'outups',
+    ]);
+  });
+
+  test('falls back to the declared column order when none was chosen', () => {
+    renderMetricSelection({ columnOrder: [] });
+
+    expect(capturedGridProps?.columnDefs?.map((col) => col.colId)).toEqual([
+      'displayName',
+      'description',
+      'outups',
+      'providerId',
+    ]);
   });
 
   test('does not preselect anything when no metric is chosen yet', () => {

--- a/apps/ai-dial-admin/src/constants/grid-columns/grid-columns.tsx
+++ b/apps/ai-dial-admin/src/constants/grid-columns/grid-columns.tsx
@@ -1343,6 +1343,7 @@ export const METRIC_SELECTION_COLUMNS = (t: (key: string) => string): ColDef[] =
     field: 'displayName',
     colId: 'displayName',
     headerName: t(TestSuitesI18nKey.Metric),
+    lockPosition: 'left',
     cellRenderer: RadioNameCellRenderer,
     cellRendererParams: { groupName: METRIC_RADIO_GROUP_NAME },
     tooltipValueGetter: () => undefined,

--- a/apps/ai-dial-admin/src/constants/grid-columns/grid-columns.tsx
+++ b/apps/ai-dial-admin/src/constants/grid-columns/grid-columns.tsx
@@ -1353,6 +1353,7 @@ export const METRIC_SELECTION_COLUMNS = (t: (key: string) => string): ColDef[] =
 
       return displayName || name;
     },
+    ...evalStringFilter([GridFilterType.EQUALS, GridFilterType.NOT_EQUAL, GridFilterType.CONTAINS]),
   },
   {
     ...DESCRIPTION_COLUMN,
@@ -1361,6 +1362,7 @@ export const METRIC_SELECTION_COLUMNS = (t: (key: string) => string): ColDef[] =
     wrapText: true,
     tooltipValueGetter: () => undefined,
     minWidth: METRIC_DESCRIPTION_COLUMN_WIDTH,
+    ...evalStringFilter([GridFilterType.EQUALS, GridFilterType.NOT_EQUAL, GridFilterType.CONTAINS]),
   },
   {
     colId: 'outups',
@@ -1381,12 +1383,14 @@ export const METRIC_SELECTION_COLUMNS = (t: (key: string) => string): ColDef[] =
       tagClassName: '!border-accent-tertiary !bg-accent-tertiary-alpha',
     }),
     maxWidth: METRIC_OUTPUTS_COLUMN_WIDTH,
+    ...evalStringFilter([GridFilterType.EQUALS, GridFilterType.NOT_EQUAL, GridFilterType.CONTAINS]),
   },
   {
     field: 'providerId',
     colId: 'providerId',
     headerName: t(EntityFieldsI18nKey.provider),
     maxWidth: METRIC_PROVIDER_COLUMN_WIDTH,
+    ...evalStringFilter([GridFilterType.EQUALS, GridFilterType.NOT_EQUAL, GridFilterType.CONTAINS]),
   },
 ];
 

--- a/apps/ai-dial-admin/src/constants/grid-columns/grid-columns.tsx
+++ b/apps/ai-dial-admin/src/constants/grid-columns/grid-columns.tsx
@@ -1380,7 +1380,7 @@ export const METRIC_SELECTION_COLUMNS = (t: (key: string) => string): ColDef[] =
     },
     cellRendererParams: (params: { value: string[] }) => ({
       items: params.value,
-      tagClassName: '!border-accent-tertiary !bg-accent-tertiary-alpha',
+      tagClassName: 'border-accent-tertiary bg-accent-tertiary-alpha',
     }),
     maxWidth: METRIC_OUTPUTS_COLUMN_WIDTH,
     ...evalStringFilter([GridFilterType.EQUALS, GridFilterType.NOT_EQUAL, GridFilterType.CONTAINS]),


### PR DESCRIPTION
**Description:**

- fix metric table output tags colors
- lock position of metric table radio button column
- memo metric table position untill modal is closed
- reduce filter type options for metric table cols
- do not show valid state on metric Configuration step untill step is reviewed 

Issues:

- Issue #4441
- Issue #4440
- Issue #4442


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
