### PR TITLE
feat(analytics/Tables): show an ACTIVE table's definition as a read-only JSON view (Issue #4499)

### DIFF
--- a/apps/ai-dial-admin/src/components/Analytics/Tables/TableDetailView.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/TableDetailView.tsx
@@ -15,6 +15,7 @@ import {
   DialNeutralButton,
   DialPrimaryButton,
   DialTabs,
+  ElementSize,
   PopupSize,
 } from '@epam/ai-dial-ui-kit';
 import { IconPlugConnected } from '@tabler/icons-react';
@@ -30,7 +31,11 @@ import {
 import ColumnRowsEditor from '@/src/components/Analytics/Tables/ColumnRowsEditor';
 import ConnectPanel from '@/src/components/Analytics/Tables/ConnectPanel/ConnectPanel';
 import { isEnrichmentRead } from '@/src/components/Analytics/Tables/ConnectPanel/connect-snippets';
-import { buildDraftDocument, splitDraftDocument } from '@/src/components/Analytics/Tables/draft-document';
+import {
+  buildDraftDocument,
+  formatDraftDocument,
+  splitDraftDocument,
+} from '@/src/components/Analytics/Tables/draft-document';
 import EditColumnPopup from '@/src/components/Analytics/Tables/EditColumnPopup';
 import TableAccessPanel from '@/src/components/Analytics/Tables/TableAccessPanel';
 import TableAudit from '@/src/components/Analytics/Tables/TableAudit';
@@ -47,6 +52,7 @@ import {
   parseRowsJson,
   toTableColumns,
 } from '@/src/components/Analytics/Tables/utils';
+import CopyButton from '@/src/components/Common/CopyButton/CopyButton';
 import JsonEditorBase from '@/src/components/Common/JsonEditorBase/JsonEditorBase';
 import ChangedEntityButtons from '@/src/components/EntityHeaderControls/Buttons/ChangedEntityButtons';
 import { showEditorErrorNotifications } from '@/src/components/EntityHeaderControls/Buttons/utils';
@@ -202,6 +208,10 @@ const TableDetailView: FC<Props> = ({ name, initialTable, apiBaseUrl, flightUri 
       const res = await defineTableSchema(name, dto);
       if (res.success) {
         showNotification(getSuccessNotification(t(AnalyticsTablesI18nKey.TableActive)));
+        // Before the reload, not after: the refreshed table reads ACTIVE, where the same toggle means
+        // the read-only definition view, and an author who just materialized belongs on the live column
+        // surface (design.md D1). Resetting first leaves no commit in which ACTIVE meets an open editor.
+        setIsEditorEnabled(false);
         await reload();
         return true;
       }
@@ -247,9 +257,10 @@ const TableDetailView: FC<Props> = ({ name, initialTable, apiBaseUrl, flightUri 
 
   // Seeded on the first entry only. The document is the sole holder of hand-authored JSON — the column
   // form cannot represent `description`, `tag_order` or a pasted pass-through member — so re-seeding on
-  // a later entry would silently discard it.
+  // a later entry would silently discard it. An ACTIVE table's view reads `storedDocument` and never
+  // `draftDocument`, so seeding there would only be dead state for `isDocumentChanged` to compare.
   const onToggleEditor = () => {
-    if (!draftDocument) setDraftDocument(buildDraftDocument(table, draft.buildDto()));
+    if (!isActive && !draftDocument) setDraftDocument(buildDraftDocument(table, draft.buildDto()));
     setIsEditorEnabled((prev) => !prev);
   };
 
@@ -400,9 +411,47 @@ const TableDetailView: FC<Props> = ({ name, initialTable, apiBaseUrl, flightUri 
     />
   );
 
-  // The two authoring surfaces are mutually exclusive; the editor is reachable only on a draft, so the
-  // active table's tabbed body below never sees it.
+  // The draft's two authoring surfaces are mutually exclusive: the toggle swaps the column-by-column
+  // surface for the editable document and back.
   const draftSurface = isEditorEnabled ? draftEditor : properties;
+
+  // The same object the memo at the top produced, handed over by reference: EntityJsonEditor keeps the
+  // last `entity` it saw and remounts Monaco for any object that is not identical to it, so a
+  // re-derivation, a clone or a spread here would remount on every parent render (design.md D3).
+  // Read-only here is a rule, not a structure: `setDraftDocument` is in scope at this call site, so
+  // nothing but discipline stops a writer prop being added. `readonly` alone is not enough — passing
+  // `setSelectedEntity`, `setIsChanged` or `onChangeText` would make this surface editable (design.md D5).
+  const definitionJson = (
+    <div className="flex min-h-0 flex-1 flex-col overflow-auto">
+      <EntityJsonEditor entity={storedDocument} readonly />
+    </div>
+  );
+
+  // A full JSON.stringify of the definition, re-derived only when the memoized document itself
+  // changes — not on every one of this view's many unrelated re-renders (design.md D6).
+  const copyValue = useMemo(() => formatDraftDocument(storedDocument), [storedDocument]);
+
+  const tabbedBody = (
+    <>
+      <div className="mb-6">
+        <DialTabs tabs={tabs} activeTab={activeTab} onClick={(tab) => setActiveTab(tab as EntityViewTab)} />
+      </div>
+      {activeTab === EntityViewTab.Properties && properties}
+      {activeTab === EntityViewTab.Audit && (
+        <div className="flex min-h-0 flex-1 flex-col">
+          <TableAudit table={table} />
+        </div>
+      )}
+    </>
+  );
+
+  // With analytics disabled the Properties content is the whole body — no tab strip, and no Audit tab to
+  // issue an analytics activity request from.
+  const activeBody = featureFlags.analyticsEnabled ? tabbedBody : properties;
+  // The read-only document takes over the whole body, tab strip included, so nothing of the page is left
+  // reachable behind it. `activeTab` is untouched, which is what brings the reader back to the tab they
+  // were on when the toggle goes off.
+  const activeSurface = isEditorEnabled ? definitionJson : activeBody;
 
   return (
     <div className="flex flex-col flex-1 min-h-0 w-full bg-layer-2 rounded p-4 relative">
@@ -424,7 +473,10 @@ const TableDetailView: FC<Props> = ({ name, initialTable, apiBaseUrl, flightUri 
           </div>
           {/* shrink-0 keeps the actions at their natural width, so no description length can squeeze a
               button label onto a second line; the title next to them truncates instead. */}
-          {(canDelete || canWrite || canModify || canManageRoles || (isActive && canConnect)) && (
+          {/* `isActive` alone, not `isActive && canConnect`: on an active table the JSON-editor toggle
+              is always in the container, so an enrichment with no source table viewed by a caller with
+              no permissions still gets a header. Every other child keeps its own gate. */}
+          {(isActive || canDelete || canWrite || canModify || canManageRoles) && (
             <div className="flex shrink-0 items-center gap-4">
               {isChangeBarShown ? (
                 <ChangedEntityButtons
@@ -466,6 +518,20 @@ const TableDetailView: FC<Props> = ({ name, initialTable, apiBaseUrl, flightUri 
                           iconBefore={<IconPlugConnected size={18} />}
                         />
                       )}
+                      {/* After the primary Connect, not before it: Connect stays the last action, but the
+                          toggle — and, while it is on, the copy control beside it — is now the last
+                          control. Not permission-gated here: on an active table it opens a read-only view
+                          of the stored definition and writes nothing, and a system table, which reports
+                          {write:false, modify:false} to everyone, is the one whose definition is most often
+                          read as a document. */}
+                      {isActive && isEditorEnabled && (
+                        <CopyButton
+                          valueLabel={t(AnalyticsTablesI18nKey.JsonDefinition)}
+                          value={copyValue}
+                          size={ElementSize.Small}
+                        />
+                      )}
+                      <JsonToggle isEditorEnabled={isEditorEnabled} onToggleEditor={onToggleEditor} />
                     </>
                   ) : (
                     canModify && <JsonToggle isEditorEnabled={isEditorEnabled} onToggleEditor={onToggleEditor} />
@@ -481,24 +547,7 @@ const TableDetailView: FC<Props> = ({ name, initialTable, apiBaseUrl, flightUri 
         {table.description && <DialEllipsisTooltip text={table.description} className="text-primary dial-small" />}
       </div>
 
-      {/* One fallback for both conditions: with analytics disabled, or on a table that is not active,
-          the Properties body is the whole view — no tab strip, and no Audit tab to issue an analytics
-          activity request from. */}
-      {featureFlags.analyticsEnabled && isActive ? (
-        <>
-          <div className="mb-6">
-            <DialTabs tabs={tabs} activeTab={activeTab} onClick={(tab) => setActiveTab(tab as EntityViewTab)} />
-          </div>
-          {activeTab === EntityViewTab.Properties && properties}
-          {activeTab === EntityViewTab.Audit && (
-            <div className="flex min-h-0 flex-1 flex-col">
-              <TableAudit table={table} />
-            </div>
-          )}
-        </>
-      ) : (
-        draftSurface
-      )}
+      {isActive ? activeSurface : draftSurface}
 
       {confirmOpen && (
         <DialConfirmationPopup

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/draft-document.ts
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/draft-document.ts
@@ -52,3 +52,7 @@ export const splitDraftDocument = (
     schema: { ...unpackGrain(grain), ...rest } as DraftSchemaDto,
   };
 };
+
+// Mirrors the serialization `EntityJsonEditor` uses to render the document (JsonEditor.tsx:90), so
+// the copied text matches the displayed text character for character.
+export const formatDraftDocument = (document: DraftTableDocument): string => JSON.stringify(document, null, 4);

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/tests/TableDetailView.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/tests/TableDetailView.spec.tsx
@@ -10,7 +10,13 @@ import {
   updateTableSchema,
 } from '@/src/app/[lang]/tables/actions';
 import TableDetailView from '@/src/components/Analytics/Tables/TableDetailView';
-import { ActionMenuOperationI18nKey, AnalyticsTablesI18nKey, ButtonsI18nKey, TabsI18nKey } from '@/src/constants/i18n';
+import {
+  ActionMenuOperationI18nKey,
+  AnalyticsTablesI18nKey,
+  ButtonsI18nKey,
+  EntitiesI18nKey,
+  TabsI18nKey,
+} from '@/src/constants/i18n';
 import { AnalyticsFieldType } from '@/src/models/analytics/entity';
 import { AnalyticsTable, AnalyticsTableType, TableStatus } from '@/src/models/analytics/table';
 
@@ -32,10 +38,27 @@ vi.mock('@/src/components/Analytics/Tables/TableAudit', () => ({
   },
 }));
 
-// Monaco is heavy and not meaningful in jsdom — assert on the value/onChange contract instead.
+// Monaco is heavy and not meaningful in jsdom — assert on the value/onChange contract instead. The
+// read-only document view and an editable mount (Add-rows, the draft editor) can be on screen in the
+// same tree, so `options.readOnly` — forwarded by EntityJsonEditor — is the only thing that tells them
+// apart; hence the distinct label, with `rows-json` kept on the editable mount so the existing Add-rows
+// assertions keep finding it unchanged.
 vi.mock('@/src/components/Common/JsonEditorBase/JsonEditorBase', () => ({
-  default: ({ value, onChange }: { value?: string; onChange: (v?: string) => void }) => (
-    <textarea aria-label="rows-json" value={value} onChange={(e) => onChange(e.target.value)} />
+  default: ({
+    value,
+    onChange,
+    options,
+  }: {
+    value?: string;
+    onChange: (v?: string) => void;
+    options?: { readOnly?: boolean };
+  }) => (
+    <textarea
+      aria-label={options?.readOnly ? 'definition-json' : 'rows-json'}
+      readOnly={options?.readOnly}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
   ),
 }));
 
@@ -883,5 +906,224 @@ describe('TableDetailView tabs', () => {
     expect(auditPropsSpy).not.toHaveBeenCalled();
     // The Properties body is the whole view instead.
     expect(screen.getByText(/^columns:/)).toBeInTheDocument();
+  });
+});
+
+// The read-only definition view's own disclosure/copy/read-only behavior used to be covered by a
+// standalone wrapper component's own spec; that wrapper is now inlined into this header/body, and its
+// cases live here instead. The header control is a `DialSwitch` (see JsonToggle), which renders both a
+// `switch`-role wrapper with no accessible name of its own and a real `checkbox`-role input that
+// carries the on/off state and the click target — so every query below goes through the checkbox, not
+// a button. There is no toolbar heading over the document — the labelled toggle is what names the
+// surface — so presence of the read-only editor is asserted through its own mock label
+// (`definition-json`, see the JsonEditorBase mock above) rather than a heading.
+describe('TableDetailView JSON definition view', () => {
+  const jsonToggle = () => screen.getByRole('checkbox');
+  const copyControlName = `copy ${AnalyticsTablesI18nKey.JsonDefinition}`;
+
+  test('is present on an ACTIVE table for a caller with no permissions', () => {
+    setPerms({});
+    render(<TableDetailView name="dial_usage_log" initialTable={table()} apiBaseUrl="" flightUri="" />);
+
+    expect(jsonToggle()).toBeInTheDocument();
+    expect(screen.getByText(EntitiesI18nKey.JSONEditor)).toBeInTheDocument();
+  });
+
+  test('is present on an ACTIVE table when analytics is disabled', () => {
+    featureFlags.analyticsEnabled = false;
+    render(<TableDetailView name="dial_usage_log" initialTable={table()} apiBaseUrl="" flightUri="" />);
+
+    expect(jsonToggle()).toBeInTheDocument();
+  });
+
+  // With analytics off, `isActive` still picks the read-only surface, never the editable draft editor —
+  // the latent path a widened body-ternary could otherwise fall through to (design.md D1).
+  test('turning the toggle on with analytics disabled shows the read-only document, not the editable draft editor', async () => {
+    const user = userEvent.setup();
+    featureFlags.analyticsEnabled = false;
+    render(<TableDetailView name="dial_usage_log" initialTable={table()} apiBaseUrl="" flightUri="" />);
+
+    await user.click(jsonToggle());
+
+    expect(screen.getByLabelText('definition-json')).toBeInTheDocument();
+    expect(screen.queryByText(/^columns:/)).not.toBeInTheDocument();
+  });
+
+  test('turning the toggle on removes the tab strip and the columns grid and mounts the read-only editor', async () => {
+    const user = userEvent.setup();
+    render(<TableDetailView name="dial_usage_log" initialTable={table()} apiBaseUrl="" flightUri="" />);
+
+    await user.click(jsonToggle());
+
+    expect(screen.queryByRole('tab')).not.toBeInTheDocument();
+    expect(screen.queryByText(/^columns:/)).not.toBeInTheDocument();
+    expect(screen.getByLabelText('definition-json')).toBeInTheDocument();
+  });
+
+  test('turning the toggle off restores the tab strip with the previously selected tab (Audit) still selected', async () => {
+    const user = userEvent.setup();
+    render(<TableDetailView name="dial_usage_log" initialTable={table()} apiBaseUrl="" flightUri="" />);
+
+    await user.click(screen.getByRole('tab', { name: TabsI18nKey.Audit }));
+    await user.click(jsonToggle());
+    await user.click(jsonToggle());
+
+    expect(screen.getByRole('tab', { selected: true })).toHaveTextContent(TabsI18nKey.Audit);
+    expect(screen.getByText('table-audit')).toBeInTheDocument();
+  });
+
+  // `user.type`/`user.paste` walk through this library's own editable-element check, which reads the
+  // native `readOnly` DOM property our mock now forwards (`options.readOnly` — see the mock above) —
+  // so this exercises the real wiring, not a hand-rolled substitute for it.
+  test('rejects typing and pasting into the read-only document', async () => {
+    const user = userEvent.setup();
+    render(<TableDetailView name="dial_usage_log" initialTable={table()} apiBaseUrl="" flightUri="" />);
+
+    await user.click(jsonToggle());
+    const editor = screen.getByLabelText('definition-json') as HTMLTextAreaElement;
+    const original = editor.value;
+
+    await user.type(editor, 'broken');
+    expect(editor.value).toBe(original);
+
+    await user.paste('also broken');
+    expect(editor.value).toBe(original);
+  });
+
+  test('the toggle is the last header control, after every action, whether the JSON view is on or off', async () => {
+    const user = userEvent.setup();
+    render(<TableDetailView name="dial_usage_log" initialTable={table()} apiBaseUrl="" flightUri="" />);
+
+    const assertToggleIsLast = () => {
+      [
+        AnalyticsTablesI18nKey.ManageAccess,
+        AnalyticsTablesI18nKey.DeleteTable,
+        AnalyticsTablesI18nKey.AddColumns,
+        AnalyticsTablesI18nKey.AddRows,
+        AnalyticsTablesI18nKey.Connect,
+      ].forEach((name) => {
+        const action = screen.getByRole('button', { name });
+        // The toggle follows every other action in document order — i.e. it renders after, not before —
+        // which is what distinguishes this from a presence-only check that would pass under the old order.
+        expect(action.compareDocumentPosition(jsonToggle()) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+      });
+    };
+
+    assertToggleIsLast();
+
+    await user.click(jsonToggle());
+
+    assertToggleIsLast();
+    const connect = screen.getByRole('button', { name: AnalyticsTablesI18nKey.Connect });
+    const copy = screen.getByRole('button', { name: copyControlName });
+    // The copy control sits between Connect and the toggle, not merely somewhere in the header.
+    expect(connect.compareDocumentPosition(copy) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(copy.compareDocumentPosition(jsonToggle()) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  test('offers no copy-definition control while the JSON view is off, including after it has been toggled on and off', async () => {
+    const user = userEvent.setup();
+    render(<TableDetailView name="dial_usage_log" initialTable={table()} apiBaseUrl="" flightUri="" />);
+
+    expect(screen.queryByRole('button', { name: copyControlName })).not.toBeInTheDocument();
+
+    await user.click(jsonToggle());
+    await user.click(jsonToggle());
+
+    expect(screen.queryByRole('button', { name: copyControlName })).not.toBeInTheDocument();
+  });
+
+  test('offers no copy-definition control on a PENDING table whose own JSON editor is open', async () => {
+    const user = userEvent.setup();
+    render(
+      <TableDetailView
+        name="dial_usage_log"
+        initialTable={table({ status: TableStatus.Pending })}
+        apiBaseUrl=""
+        flightUri=""
+      />,
+    );
+
+    await user.click(jsonToggle());
+
+    expect(screen.queryByRole('button', { name: copyControlName })).not.toBeInTheDocument();
+  });
+
+  // `userEvent.click` does not reach `CopyButton`'s icon-only variant in jsdom — established across five
+  // isolated probes in `qa/review-batch-4-round-1.md` §1: the event reaches the DOM node and a bare
+  // ui-kit `DialIconButton` responds fine, but `CopyButton`'s own click wiring does not survive the
+  // synthetic pointer sequence. `fireEvent.click` is used deliberately here, not as a shortcut around it.
+  test('the copy control writes the whole displayed document to the clipboard', async () => {
+    const user = userEvent.setup();
+    // Spied after `userEvent.setup()`, which installs a clipboard of its own over any earlier stub —
+    // same pattern as `ResultValueCell.spec.tsx`.
+    const writeText = vi.spyOn(navigator.clipboard, 'writeText');
+    render(<TableDetailView name="dial_usage_log" initialTable={table()} apiBaseUrl="" flightUri="" />);
+
+    await user.click(jsonToggle());
+    const editor = screen.getByLabelText('definition-json') as HTMLTextAreaElement;
+
+    fireEvent.click(screen.getByRole('button', { name: copyControlName }));
+
+    expect(writeText).toHaveBeenCalledWith(editor.value);
+  });
+
+  test('coexists with Manage access, Delete table, Add columns, Add rows and Connect, on or off', async () => {
+    const user = userEvent.setup();
+    render(<TableDetailView name="dial_usage_log" initialTable={table()} apiBaseUrl="" flightUri="" />);
+
+    const assertActionsPresent = () =>
+      [
+        AnalyticsTablesI18nKey.ManageAccess,
+        AnalyticsTablesI18nKey.DeleteTable,
+        AnalyticsTablesI18nKey.AddColumns,
+        AnalyticsTablesI18nKey.AddRows,
+        AnalyticsTablesI18nKey.Connect,
+      ].forEach((name) => expect(screen.getByRole('button', { name })).toBeInTheDocument());
+
+    assertActionsPresent();
+
+    await user.click(jsonToggle());
+
+    assertActionsPresent();
+  });
+
+  test('offers no Save, Discard or changed-entity header, and issues no table write, while the toggle is on', async () => {
+    const user = userEvent.setup();
+    render(<TableDetailView name="dial_usage_log" initialTable={table()} apiBaseUrl="" flightUri="" />);
+
+    await user.click(jsonToggle());
+
+    expect(screen.queryByRole('button', { name: ButtonsI18nKey.Save })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: ButtonsI18nKey.Discard })).not.toBeInTheDocument();
+    expect(updateTable).not.toHaveBeenCalled();
+    expect(defineTableSchema).not.toHaveBeenCalled();
+    expect(updateTableSchema).not.toHaveBeenCalled();
+  });
+
+  // The draft's own JSON editor (opened via the same toggle, on a non-active table) is the one write path
+  // that legitimately runs through this toggle: a successful save materializes the table, and the design
+  // requires the reader land back on the live column surface with the toggle off, never on the read-only
+  // document view (design.md D1, assumption 2 in aiem-senior-3.1's return).
+  test("a successful save from a draft's JSON editor leaves the now-ACTIVE table on its live column surface with the toggle off", async () => {
+    const user = userEvent.setup();
+    vi.mocked(updateTable).mockResolvedValue({ success: true });
+    vi.mocked(defineTableSchema).mockResolvedValue({ success: true });
+    const columns = [{ source_name: 'event_id', name: 'event_id', type: AnalyticsFieldType.Uuid }];
+    const pendingTable = table({ status: TableStatus.Pending, ordering_key: ['event_id'], columns });
+    // Not an enrichment, so the grain-key lookup effect never calls `getTable`; its only caller here is
+    // `reload()`, which this stands in for the backend re-fetch after a successful materialize.
+    vi.mocked(getTable).mockResolvedValue(table({ status: TableStatus.Active, columns }));
+
+    render(<TableDetailView name="dial_usage_log" initialTable={pendingTable} apiBaseUrl="" flightUri="" />);
+
+    await user.click(jsonToggle());
+    const editor = screen.getByLabelText('rows-json') as HTMLTextAreaElement;
+    const document = JSON.parse(editor.value);
+    fireEvent.change(editor, { target: { value: JSON.stringify({ ...document, description: 'materialized' }) } });
+    await user.click(screen.getByRole('button', { name: ButtonsI18nKey.Save }));
+
+    expect(await screen.findByText(/^columns:/)).toBeInTheDocument();
+    expect(jsonToggle()).not.toBeChecked();
   });
 });

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/tests/TableDraftJsonEditor.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/tests/TableDraftJsonEditor.spec.tsx
@@ -150,11 +150,19 @@ describe('TableDetailView — entering the JSON editor on a draft', () => {
     expect(screen.getByRole('switch')).toBeInTheDocument();
   });
 
-  test('offers no toggle on an ACTIVE table', () => {
+  test('offers the JSON toggle on an ACTIVE table, but never the authoring editor', async () => {
+    const user = userEvent.setup();
     renderView(sourceDraft({ status: TableStatus.Active }));
 
-    expect(screen.queryByRole('switch')).not.toBeInTheDocument();
+    expect(screen.getByRole('switch')).toBeInTheDocument();
     expect(queryArea()).not.toBeInTheDocument();
+
+    await openEditor(user);
+
+    // The toggle swaps in the read-only stored definition, not the draft's editable document: no Save
+    // ever appears for an ACTIVE table, toggled or not.
+    expect(area()).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: ButtonsI18nKey.Save })).not.toBeInTheDocument();
   });
 
   test('activating the editor replaces the column-by-column surface', async () => {

--- a/apps/ai-dial-admin/src/components/Analytics/Tables/tests/draft-document.spec.ts
+++ b/apps/ai-dial-admin/src/components/Analytics/Tables/tests/draft-document.spec.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'vitest';
 
-import { buildDraftDocument, splitDraftDocument } from '@/src/components/Analytics/Tables/draft-document';
+import {
+  buildDraftDocument,
+  formatDraftDocument,
+  splitDraftDocument,
+} from '@/src/components/Analytics/Tables/draft-document';
+import { buildDraftSchemaDto, createDraftSchemaForm } from '@/src/components/Analytics/Tables/utils';
 import { AnalyticsFieldType } from '@/src/models/analytics/entity';
 import {
   AnalyticsTable,
@@ -9,6 +14,7 @@ import {
   DraftSchemaDto,
   DraftTableDocument,
   PartitionGranularity,
+  TableStatus,
 } from '@/src/models/analytics/table';
 
 const columns = [{ source_name: 'ts', name: 'ts', type: AnalyticsFieldType.Timestamp }];
@@ -60,6 +66,136 @@ describe('buildDraftDocument', () => {
     expect(document).not.toHaveProperty('partition_by');
     expect(document).not.toHaveProperty('identity_column');
     expect(document).not.toHaveProperty('version_column');
+  });
+});
+
+describe('buildDraftDocument — composed the way an ACTIVE table document is built (design.md D7)', () => {
+  test("a source table's document is the write shape, not the GET response", () => {
+    const table: AnalyticsTable = {
+      name: 'orders',
+      type: AnalyticsTableType.Source,
+      status: TableStatus.Active,
+      system: false,
+      permissions: { write: true, modify: true },
+      column_count: 2,
+      description: 'Orders table',
+      tag_order: ['pii'],
+      columns: [
+        { source_name: 'ts', name: 'ts', type: AnalyticsFieldType.Timestamp },
+        { source_name: 'id', name: 'id', type: AnalyticsFieldType.String },
+      ],
+      ordering_key: ['ts'],
+      partition_by: { column: 'ts', granularity: PartitionGranularity.Day },
+      identity_column: 'id',
+      version_column: 'ts',
+    };
+
+    const document = buildDraftDocument(table, buildDraftSchemaDto(createDraftSchemaForm(table), table.type));
+
+    expect(document).toEqual({
+      columns: [
+        { source_name: 'ts', name: 'ts', type: AnalyticsFieldType.Timestamp, nullable: false },
+        { source_name: 'id', name: 'id', type: AnalyticsFieldType.String, nullable: false },
+      ],
+      ordering_key: ['ts'],
+      partition_by: { column: 'ts', granularity: PartitionGranularity.Day },
+      identity_column: 'id',
+      version_column: 'ts',
+      description: 'Orders table',
+      tag_order: ['pii'],
+    });
+    ['status', 'system', 'permissions', 'column_count', 'name', 'type', 'source_table', 'grain'].forEach((key) =>
+      expect(document).not.toHaveProperty(key),
+    );
+  });
+
+  test('a source table with no scan-metadata pair omits both identity_column and version_column', () => {
+    const table: AnalyticsTable = {
+      name: 'orders',
+      type: AnalyticsTableType.Source,
+      columns: [{ source_name: 'ts', name: 'ts', type: AnalyticsFieldType.Timestamp }],
+      ordering_key: ['ts'],
+    };
+
+    const document = buildDraftDocument(table, buildDraftSchemaDto(createDraftSchemaForm(table), table.type));
+
+    expect(document).not.toHaveProperty('identity_column');
+    expect(document).not.toHaveProperty('version_column');
+  });
+
+  test("an enrichment table's document carries its enrichment members and no source-only member", () => {
+    const table: AnalyticsTable = {
+      name: 'order_flags',
+      type: AnalyticsTableType.Enrichment,
+      status: TableStatus.Active,
+      source_table: 'orders',
+      description: 'Order flags',
+      tag_order: ['finance'],
+      columns: [{ source_name: 'flag', name: 'flag', type: AnalyticsFieldType.Boolean }],
+      grain: { grain_key: 'order_id', cardinality: Cardinality.ZeroOrOne },
+    };
+
+    const document = buildDraftDocument(table, buildDraftSchemaDto(createDraftSchemaForm(table), table.type));
+
+    expect(document).toEqual({
+      columns: [{ source_name: 'flag', name: 'flag', type: AnalyticsFieldType.Boolean, nullable: false }],
+      grain_key: 'order_id',
+      cardinality: Cardinality.ZeroOrOne,
+      description: 'Order flags',
+      tag_order: ['finance'],
+    });
+    ['ordering_key', 'partition_by', 'identity_column', 'version_column', 'source_table', 'grain'].forEach((key) =>
+      expect(document).not.toHaveProperty(key),
+    );
+  });
+
+  test('a column renamed after materialization keeps both source_name and name and carries its stored metadata', () => {
+    const table: AnalyticsTable = {
+      name: 'orders',
+      type: AnalyticsTableType.Source,
+      columns: [
+        {
+          source_name: 'cust_id',
+          name: 'customer_id',
+          type: AnalyticsFieldType.String,
+          tag: 'pii',
+          display_name: 'Customer ID',
+          description: 'Renamed after materialization',
+          sensitive: true,
+        },
+      ],
+    };
+
+    const document = buildDraftDocument(table, buildDraftSchemaDto(createDraftSchemaForm(table), table.type));
+
+    expect(document.columns).toEqual([
+      {
+        source_name: 'cust_id',
+        name: 'customer_id',
+        type: AnalyticsFieldType.String,
+        nullable: false,
+        tag: 'pii',
+        display_name: 'Customer ID',
+        description: 'Renamed after materialization',
+        sensitive: true,
+      },
+    ]);
+    expect(document.columns[0]).not.toHaveProperty('element_type');
+    expect(document.columns[0]).not.toHaveProperty('enum_values');
+  });
+
+  test('formatDraftDocument renders the same 4-space JSON the JSON view displays', () => {
+    const table: AnalyticsTable = {
+      name: 'orders',
+      type: AnalyticsTableType.Source,
+      description: 'Orders table',
+      tag_order: ['pii'],
+      columns: [{ source_name: 'ts', name: 'ts', type: AnalyticsFieldType.Timestamp }],
+    };
+
+    const document = buildDraftDocument(table, buildDraftSchemaDto(createDraftSchemaForm(table), table.type));
+
+    expect(formatDraftDocument(document)).toBe(JSON.stringify(document, null, 4));
   });
 });
 

--- a/apps/ai-dial-admin/src/constants/i18n.ts
+++ b/apps/ai-dial-admin/src/constants/i18n.ts
@@ -2663,6 +2663,7 @@ export enum AnalyticsTablesI18nKey {
   ConnectEnrichmentColumns = 'AnalyticsTables.ConnectEnrichmentColumns',
   WriteProgrammatically = 'AnalyticsTables.WriteProgrammatically',
   AddRowsPurpose = 'AnalyticsTables.AddRowsPurpose',
+  JsonDefinition = 'AnalyticsTables.JsonDefinition',
 }
 
 export enum AnalyticsPipelinesI18nKey {

--- a/apps/ai-dial-admin/src/locales/en.ts
+++ b/apps/ai-dial-admin/src/locales/en.ts
@@ -2973,6 +2973,7 @@ export default {
     WriteProgrammatically: 'Write rows programmatically',
     AddRowsPurpose:
       'Inserts rows by hand — useful for checking that the schema accepts what you expect. Ongoing ingestion goes through the table’s row endpoint.',
+    JsonDefinition: 'JSON definition',
   },
   ConversationsTrace: {
     Title: 'Conversations',

--- a/openspec/changes/add-active-table-json-view/.openspec.yaml
+++ b/openspec/changes/add-active-table-json-view/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-09

--- a/openspec/changes/add-active-table-json-view/design.md
+++ b/openspec/changes/add-active-table-json-view/design.md
@@ -1,0 +1,709 @@
+# Design — a read-only JSON view of an ACTIVE table's definition
+
+Read this in slices. Every section names, in its first line, the files it governs; find yours by
+grepping for its path.
+
+**Revision note 1 (placement reworked).** The first version of this design put the document in a
+collapsible section inside the Properties body (`§D1`, and `§D8` reasoned from it). The owner saw it
+running and rejected it: one thin disclosure row among a full column grid, which he could not find.
+His instruction was that it be *the same JSON editor as on the draft screen, the only difference
+being that nothing inside it can be changed*. `§D1` and `§D8` were replaced; `§D2`, `§D10` and `§D11`
+were revised to match; `§D3`, `§D4`, `§D5`, `§D6`, `§D7` and `§D9` survived unchanged in substance.
+
+**Revision note 2 (the surface loses its toolbar; the toggle becomes the last control).** The owner
+saw the reworked placement running and asked for three things, in his order:
+
+1. drop the **"JSON definition" heading** — the surface is reached by a toggle that already names it;
+2. put the **copy control in the header, beside the JSON-editor toggle**;
+3. **swap the toggle and Connect** — the toggle becomes the header's rightmost control.
+
+Two consequences are not cosmetic and are decided here rather than absorbed. Revision 3 destroys the
+"primary action last" clause that `§D1` was written to preserve, so `§D6a` supersedes that clause,
+states the successor rule and names what the divergence costs against the one sibling toolbar that
+still follows it. Revisions 1 and 2 together empty `TableDefinitionJson.tsx` of everything but one
+element, so `§D2` decides its fate: **it is deleted and the editor is rendered inline in
+`TableDetailView.tsx`.**
+
+Sections replaced by revision 2: `§D1` (points 2 and 6), `§D2`, `§D6`, plus the new `§D6a`. Revised
+to match: `§D3`, `§D5`, `§D9`, `§D10`, `§D11` and the risk list. Unchanged: `§D4`, `§D7`, `§D8`.
+
+**One decided question, recorded so it is not reopened:** the copy control is offered **only while
+the JSON view is on**, not permanently. A permanent control in the header would copy a document that
+is not on screen, and it would contradict the delta's own "offered with the document". The owner
+settled this; a later change that wants a permanent copy has to argue against that sentence.
+
+**One correction to a fact this design asserted, measured by the implementer of 3.1 and folded in
+below (`§D1`, "What was verified in code"):** `hasJsonErrors` is **not** `!isActive`-gated.
+
+## Context
+
+Files: `apps/ai-dial-admin/src/components/Analytics/Tables/TableDetailView.tsx`,
+`apps/ai-dial-admin/src/components/Analytics/Tables/draft-document.ts`, and
+`apps/ai-dial-admin/src/components/Analytics/Tables/TableDefinitionJson.tsx` — which **this change
+creates and then deletes again**: it exists in the working tree from item 2.1 and `§D2` removes it.
+
+This change is built on top of PR #4492's branch (`feat/4488-table-draft-json-editor`), so everything
+`add-table-draft-schema-json-editor` shipped is already in the tree. Four facts from it decide most of
+this design:
+
+- `storedDocument` (`TableDetailView.tsx:133`) is `buildDraftDocument(table, draft.baselineDto)`,
+  memoized on `[table, draft.baselineDto]`, and is already computed for **every** table, `ACTIVE`
+  included. Nothing new has to be derived.
+- The draft arrangement this change now copies is three lines of `TableDetailView.tsx`: the header
+  control at `:474` (`canModify && <JsonToggle isEditorEnabled={…} onToggleEditor={…} />`), the whole-body
+  swap at `:408` (`const draftSurface = isEditorEnabled ? draftEditor : properties;`), and the editor
+  itself at `:381-390`.
+- `EntityJsonEditor` (`components/EntityTabs/JsonEditor/JsonEditor.tsx`) takes `readonly` and forces
+  `options.readOnly` on its Monaco instance (`:138`), and `setSelectedEntity` is optional (`:21`). A
+  read-only caller therefore needs no new prop on a shared component.
+- `apps/ai-dial-admin/src/app/[lang]/tables/[id]/page.tsx:35-37` already wraps the view in
+  `SaveValidationContextProvider`, which `EntityJsonEditor` requires unconditionally. **No provider
+  work is in scope.**
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Give an `ACTIVE` table the draft screen's arrangement, read-only: a header toggle that swaps the body
+  for the definition as one JSON document.
+- Make that document copyable in one action, with the confirmation announced.
+- Reach every caller who can open the detail page — no permission gate, and no feature-flag gate.
+- Change no *authoring* behaviour of the `ACTIVE` branch and none of the draft branch.
+
+**Non-Goals**
+
+- Any write from this surface (the proposal's Non-goals are binding).
+- Any change to `Common/CopyButton`, `EntityJsonEditor`, `EntityHeaderControls/JsonToggle` or
+  `Common/Accordion`. They are shared; the house rule is to use them, not to grow them for one caller.
+- Any change to `openspec/changes/add-table-draft-schema-json-editor/**` — that directory belongs to an
+  open PR and stays byte-identical to HEAD.
+
+## Decisions
+
+### D1 — Placement: the draft's header toggle and whole-body swap, on an ACTIVE table, read-only
+
+Files: `apps/ai-dial-admin/src/components/Analytics/Tables/TableDetailView.tsx`,
+`apps/ai-dial-admin/src/components/Analytics/Tables/TableDefinitionJson.tsx`.
+
+The `ACTIVE` header gains the **same** `JsonToggle` the draft header carries, and turning it on replaces
+the **whole body** — the Properties/Audit tab strip included — with the read-only document. Turning it
+off restores the body exactly as it was. Five concrete points, all in `TableDetailView.tsx`:
+
+1. **The control is `EntityHeaderControls/JsonToggle`, used unchanged.** It is a ui-kit `DialSwitch`
+   labelled `EntitiesI18nKey.JSONEditor` with `switchId="jsonEditor"`
+   (`EntityHeaderControls/JsonToggle/JsonToggle.tsx:41-46`). The label reads "JSON editor" on both
+   statuses, which is right: it names the surface being switched to, the surface is the same Monaco
+   editor, and it is the owner's own word for it. The hardcoded `switchId` is safe because a table is
+   either `ACTIVE` or a draft, so only one instance is ever mounted. Reusing it also inherits the
+   component's tablet/mobile behaviour for free, so the two statuses stay visually identical.
+2. **It renders in the `isActive` arm of the header ternary, last — after Connect's block, in source
+   order, which is also the rendered order.** *(Revision 3.)* The row reads Manage access, Delete
+   table, Add columns, Add rows, Connect, **copy JSON definition** (only while the view is on),
+   **JSON-editor toggle**. No CSS `order-*` is involved: source order is rendered order, which is what
+   item 3.1's implementer already established when it declined the first version's "before Connect in
+   the rendered row" phrasing. `§D6a` supersedes the consolidated spec's "primary action last" clause
+   and states what replaces it.
+3. **It is not permission-gated**, per BA's ruling and the delta. That forces one more edit: the
+   header's action container is currently gated on
+   `(canDelete || canWrite || canModify || canManageRoles || (isActive && canConnect))` (`:430`). An
+   `ACTIVE` enrichment with no source table, viewed by a caller with no permissions, would render no
+   container and therefore no toggle. The guard becomes
+   `(isActive || canDelete || canWrite || canModify || canManageRoles)`: on an `ACTIVE` table the
+   container always has at least the toggle in it. **Verified by item 3.1, child by child: the
+   widening reveals nothing** — every child keeps its own gate, the dropped `(isActive && canConnect)`
+   term is subsumed by `isActive`, and for a non-`ACTIVE` table the guard is arithmetically identical
+   to the old one. The only newly reachable render is the container itself, holding the toggle alone.
+4. **The body swap is status-aware.** The current body is
+   `featureFlags.analyticsEnabled && isActive ? <tabbed> : draftSurface`. It becomes: on an `ACTIVE`
+   table, `isEditorEnabled ? definitionJson : (featureFlags.analyticsEnabled ? <tabbed> : properties)`;
+   on a draft, `draftSurface` unchanged. With analytics off, the toggle swaps the un-tabbed Properties
+   body for the document — the same control, the same meaning, one branch fewer on screen.
+5. **`onToggleEditor` must not seed a draft document on an `ACTIVE` table.** It currently seeds
+   `draftDocument` on first entry (`:251-254`). Guard it: `if (!isActive && !draftDocument) …`. The
+   read-only surface reads `storedDocument`, never `draftDocument`, so nothing on the `ACTIVE` branch
+   needs the seed, and a seeded `draftDocument` there would be dead state that `isDocumentChanged`
+   (`:135`) compares for no reason.
+
+6. **The copy control sits in the same arm, immediately before the toggle, gated on
+   `isActive && isEditorEnabled`.** *(Revision 2.)* Its props are `§D6`'s, unchanged; what changes is
+   the file it lives in. Two properties of this slot are worth stating because they are the reason it
+   is not merely acceptable but better than the toolbar it replaces: the control is present exactly
+   when the document is, without a second visibility rule to keep in sync; and because the **toggle**
+   is the control that persists and the **copy** is the one that mounts and unmounts, keyboard focus
+   after a toggle-off is still on a control that exists. Had the order been reversed — toggle then
+   copy — turning the view off would unmount the element to the right of the focused one, which is
+   harmless, but turning it *on* would insert a control between the focused toggle and its
+   neighbours, which is the shuffle this order avoids. No live region is needed for the appearance:
+   `JsonToggle` is a `DialSwitch`, so the state change that causes it is already announced as the
+   switch's own checked state.
+
+**What was verified in code by item 3.1's implementer, so it is fact rather than inference.** Readers
+of `isEditorEnabled` in `TableDetailView.tsx` are exactly five — `hasJsonErrors`, `onTryToSave`,
+`draftSurface`, `disableSave` and the toggle — with no sixth, and no other component reads it.
+Two corrections to what this section claimed:
+
+- **`hasJsonErrors` is NOT `!isActive`-gated.** It is `isEditorEnabled && Boolean(jsonErrors?.length)`,
+  and the read-only editor **does** register markers: `readonly` only sets Monaco's `readOnly` option,
+  while `onValidateJSON → setJsonErrors` runs regardless. What is gated is its **sole** consumer,
+  `isChangeBarShown` (`!isActive && canModify && …`). So the safety comes from that consumer, not from
+  the expression itself. The conclusion — one boolean can carry both meanings — stands; the reasoning
+  behind it was wrong and is corrected here so a later change does not rely on a gate that is not there.
+- **`draftSurface` was reachable on an `ACTIVE` table** before edit 4, on the analytics-off path.
+  Without edit 4 an analytics-off install would have got the *editable* draft editor on a materialized
+  table. That is why edit 4 is not cosmetic.
+
+**The materialize interaction, which is a real defect if it is missed.** `reload()` calls `setTable`
+without remounting, and nothing resets `isEditorEnabled`. Today that is invisible, because the `ACTIVE`
+branch ignores `isEditorEnabled` entirely. Under this placement it stops being invisible: an author who
+saves a `PENDING` table from its JSON editor would land, the moment the refreshed table reads `ACTIVE`,
+on the read-only JSON view — while the consolidated spec says "On success the view SHALL refresh
+showing the table `ACTIVE` with its live column surface"
+(`openspec/specs/analytics/tables/spec.md:502`). So `onDefineSchema` (`:200-212`) sets
+`setIsEditorEnabled(false)` on success. One line, and it also fixes the same latent oddity that exists
+today on an analytics-off install.
+
+**The reset sits before `await reload()`, deliberately** — established by item 3.1 and recorded so it
+is not "tidied" later. An effect keyed on `table.status` could only run after the `setTable` commit,
+so it would necessarily render one committed frame of ACTIVE-plus-open-editor: exactly the state the
+spec forbids. Resetting first makes the intermediate state (still `PENDING`, editor off) a surface the
+reader may legitimately see. The failure branch is untouched: a rejected schema request leaves the
+author in the editor with their document.
+
+**What happens to the Audit tab while the editor is on, and how the reader gets back.** The tab strip
+is unmounted with the rest of the body, so Audit is not reachable until the toggle is switched off. The
+toggle stays in the header in both states — `JsonToggle` renders its switch whether or not
+`isEditorEnabled` — so the way back is always on screen, one click, in the place the reader just
+clicked. `activeTab` is React state that the toggle never touches, so switching off returns the reader
+to the tab they were on, Audit included. The cost is that `TableAudit` unmounts and remounts across a
+visit to the JSON view, re-issuing its activity request; that is the same cost a tab switch already
+has, and it is why the change bar and the tab state are the only things this surface must not disturb.
+
+**Alternative rejected — make the JSON view the Properties tab's content and leave the tab strip
+standing.** It keeps Audit reachable without toggling off, which is its one genuine advantage, and it
+is small. Four costs outweigh it: (a) the same control would mean "swap the whole body" on a draft and
+"swap one tab's content" on an `ACTIVE` table — two behaviours for one switch, which is the class of
+thing the owner has just rejected once; (b) with `ANALYTICS_ENABLED` off there is no tab strip at all,
+so the control would have to swap the whole body anyway — a third behaviour; (c) the reader would see a
+tab strip whose selected tab reads "Properties" above a JSON document, which mislabels the surface;
+(d) the editor would be squeezed under a strip it has nothing to do with, which is a smaller version of
+the visibility complaint that caused this rework.
+
+**Alternative rejected — a collapsible section inside the Properties body.** This is what shipped and
+what the owner rejected on sight; it is recorded here so it is not re-proposed. Its arguments were
+reachability with analytics off (which point 4 above satisfies just as well) and collision-freedom with
+two unmerged deltas (which `§D8` now handles head-on). Neither survives contact with the fact that a
+disclosure row below a keys summary and above a full-height grid is, in practice, invisible.
+
+**Alternative rejected — a third tab beside Properties and Audit.** `analytics/spec.md`, the Analytics
+root index shared by every Analytics detail page, specifies "exactly two tabs, `Properties` and
+`Audit`". A tables-only third tab degrades a shared index, and it would also disappear with the strip
+when `ANALYTICS_ENABLED` is off.
+
+**What would change this decision.** If the Audit tab turns out to be something readers want *while*
+comparing a definition, the tab-content variant becomes worth its costs — but that is a request for
+two surfaces at once, and it should be designed as one (a split view), not by weakening this toggle.
+
+### D2 — `TableDefinitionJson.tsx` is deleted; the read-only editor is rendered inline
+
+Files: `apps/ai-dial-admin/src/components/Analytics/Tables/TableDefinitionJson.tsx` (**deleted**),
+`apps/ai-dial-admin/src/components/Analytics/Tables/tests/TableDefinitionJson.spec.tsx` (**deleted**),
+`apps/ai-dial-admin/src/components/Analytics/Tables/TableDetailView.tsx` (gains the inline surface).
+
+*(Revised by revision 2. The previous version of this section specified a toolbar with an `<h3>`
+heading and the copy control; revisions 1 and 2 remove both.)*
+
+**The question the owner asked, answered plainly.** With the heading gone (revision 1) and the copy
+control in the header (revision 2), the component's whole body would be:
+
+```tsx
+<div className="flex min-h-0 flex-1 flex-col overflow-auto">
+  <EntityJsonEditor entity={document} readonly />
+</div>
+```
+
+That does not earn a file. It is a `'use client'` module, six imports, a `Props` interface whose only
+member is passed straight through, a default export and a spec file — around one element of a shared
+component. Three things decide it:
+
+1. **Its sibling is already inline.** The draft's editable editor is a plain const in
+   `TableDetailView.tsx` (`draftEditor`, `:387-396`) with exactly this markup and one prop different
+   (`setSelectedEntity` instead of `readonly`). Extracting one of two identically shaped surfaces and
+   not the other is a worse arrangement than leaving both where they are, and it invites the next
+   reader to wonder what the asymmetry means.
+2. **`.claude/rules/components.md` §3 extracts for size or for unrelated concerns.** Neither applies
+   to a pass-through. The rule that does apply is the same file's "keep the component simple; logic
+   lives elsewhere" — and there is no logic here at all.
+3. **`§D3`'s by-reference rule gets shorter.** `storedDocument` goes from its `useMemo` straight into
+   `EntityJsonEditor` in the same file, with no prop hop in between where a clone could be introduced.
+
+So `TableDetailView.tsx` gains, beside `draftEditor`:
+
+```tsx
+const definitionJson = (
+  <div className="flex min-h-0 flex-1 flex-col overflow-auto">
+    <EntityJsonEditor entity={storedDocument} readonly />
+  </div>
+);
+```
+
+Tailwind theme tokens only; no hex, no stock palette. The fixed `h-[320px]` box the collapsible
+version used is long gone — this surface owns the body and takes its height.
+
+**What the deletion costs, and why it is affordable.** `TableDetailView.tsx` grows by about five
+lines, in a file two changes in flight both touch — a merge-conflict surface, but a five-line one in a
+region (`:376-416`) that only this change edits. And `tests/TableDefinitionJson.spec.tsx` goes with
+the component: of its cases, the copy ones move to the header's spec anyway (revision 2), the heading
+one dies (revision 1), and the single remaining case — typing into the editor leaves it unchanged —
+moves to `TableDetailView.spec.tsx` (`§D10`). One case does not keep a spec file alive for a component
+that no longer exists.
+
+**Alternative rejected — keep the component with `Props { document }` unchanged.** Cheapest in churn:
+item 2.1 becomes a small deletion inside a file that already exists, and item 2.2 loses two cases
+instead of the whole file. It also keeps `TableDetailView.tsx` from growing. Rejected because the
+churn saved is one-off and the wrapper is permanent: every later reader pays the cost of opening a
+file to find one element, and the asymmetry with `draftEditor` never resolves itself. If the read-only
+surface ever grows something of its own — a diff against another environment, a download action — the
+extraction is three lines away and can be made then, on evidence.
+
+**Alternative rejected — keep the component and move the copy control back into it.** That is
+revision 2 undone; it is the owner's call, not a design trade-off, and `§D6` records why the header
+slot is also the better one.
+
+**Alternative rejected — a "read-only" badge or a reworded heading.** Recorded from the previous
+version because it is the obvious response to revision 1: Monaco's read-only mode is not visually
+loud, so a label saying so is tempting. It is not free — the same i18n key is the copy control's
+`valueLabel`, so "JSON definition (read-only)" would become the accessible name "copy JSON definition
+(read-only)" and the toast "JSON definition (read-only) Copied successfully" — and revision 1 removed
+the heading precisely because the toggle already names the surface. The absence of Save/Discard and
+Monaco's own read-only behaviour are the signals. If readers turn out to try typing, a distinct key
+is the cheap follow-up.
+
+**Alternative rejected — `Common/Accordion`.** Moot twice over now, but recorded because the first
+version examined it: it renders children while collapsed behind a `hidden` class
+(`Accordion.tsx:89-98`), so Monaco would have mounted on every page load, and its toggle carries no
+`aria-expanded`/`aria-controls` (`:69-79`).
+
+### D3 — The document object is passed by reference; nothing re-derives it
+
+File: `apps/ai-dial-admin/src/components/Analytics/Tables/TableDetailView.tsx`.
+
+`TableDetailView` hands its existing memoized `storedDocument` (`:133`) straight to
+`<EntityJsonEditor entity={storedDocument} readonly />` — since `§D2` deletes the wrapper component,
+there is now no hop at all. It must not be rebuilt, cloned or spread on the
+way. `EntityJsonEditor` re-creates its Monaco model whenever `entity` is not *identically* the object it
+last saw (`JsonEditor.tsx:86-92`, and the note at `TableDetailView.tsx:376-380`): a fresh object per
+render means a remount per render. Read-only makes that less visible than in the draft editor — there
+is no cursor to throw away — but a remount per parent render is still wrong, and jsdom cannot catch it.
+One derivation, one owner, passed by reference. A short call-site comment saying so is warranted;
+nothing in the types protects it.
+
+Under the reworked placement the hop through `TableProperties` is gone, and under `§D2` the hop
+through `TableDefinitionJson` is gone too — the memo and the editor are now three lines apart in one
+file, which removes every place this rule could have been broken by accident.
+
+**Do not confuse the two representations.** `formatDraftDocument(storedDocument)` (`§D4`) is the copy
+control's `value` — a string. `EntityJsonEditor` takes the **object**. Passing the formatted string to
+the editor, or re-parsing the string back into an object for it, both break this rule.
+
+### D4 — The copied text comes from a pure formatter in `draft-document.ts`
+
+Files: `apps/ai-dial-admin/src/components/Analytics/Tables/draft-document.ts`,
+`apps/ai-dial-admin/src/components/Analytics/Tables/TableDefinitionJson.tsx`. **Implemented already;
+unaffected by the rework.**
+
+The spec requires the clipboard to hold *the text the view displays*, character for character.
+`EntityJsonEditor` serializes with `JSON.stringify(entity, null, 4)` (`JsonEditor.tsx:90`), so the copy
+uses the same formatting:
+
+```ts
+export const formatDraftDocument = (document: DraftTableDocument): string => /* 4-space JSON */;
+```
+
+beside the two functions that already own this document's shape contract, with a comment naming
+`JsonEditor.tsx:90` as the format it mirrors. Pure, deterministic and feature-local, which is where
+`.claude/rules/utils.md` puts it.
+
+**Alternative rejected — reading the text out of the Monaco model.** It would guarantee identity with
+what is displayed, but it needs a ref into a shared component that exposes none. A pure formatter plus
+a unit test asserting equality with `JSON.stringify(doc, null, 4)` is the cheaper guarantee.
+
+### D5 — Read-only is `readonly` plus the absence of `setSelectedEntity`
+
+File: `apps/ai-dial-admin/src/components/Analytics/Tables/TableDetailView.tsx` (the inline
+`definitionJson` of `§D2`; this section governed `TableDefinitionJson.tsx` before revision 2).
+
+`<EntityJsonEditor entity={storedDocument} readonly />` — no `setSelectedEntity`, no `setIsChanged`,
+no `onChangeText`. Both halves matter: `readonly` makes Monaco reject input, and omitting
+`setSelectedEntity` means that even if input somehow arrived, `onChangeJSON` (`JsonEditor.tsx:94-114`)
+has nowhere to write it. Note that now the editor is inline in `TableDetailView`, "nowhere to write
+it" is a statement about the props, not about the file: `setDraftDocument` is in scope at that call
+site and must not be passed. That is the one thing the deleted wrapper made structurally impossible
+and inlining makes merely a rule — it is called out in the task for that reason.
+
+Two consequences to know rather than to handle:
+
+- The editor registers with `SaveValidationContext` through `useJsonEditorValidation()` and deregisters
+  on unmount (`JsonEditor.tsx:58-77`). On an `ACTIVE` table the change bar is gated on `!isActive`
+  (`TableDetailView.tsx:140`), so nothing this editor reports can raise Save or Discard.
+- The document is serialized from an object, so it is always valid JSON and the editor's validation can
+  never produce a marker.
+
+### D6 — The copy confirmation rides the existing notification container, which **is** announced
+
+Files: `apps/ai-dial-admin/src/components/Analytics/Tables/TableDetailView.tsx` (**the control now
+renders here, in the header** — revision 2; it was in `TableDefinitionJson.tsx`'s toolbar before),
+`apps/ai-dial-admin/src/components/Common/CopyButton/CopyButton.tsx` (used unchanged),
+`apps/ai-dial-admin/src/components/Notification/NotificationPortal.tsx` (read, not changed).
+
+**The slot, and the gate.** `{isActive && isEditorEnabled && <CopyButton … />}`, rendered immediately
+before the `JsonToggle` in the `isActive` arm of the header (`§D1` point 6). The `isActive` half of
+the gate matters as much as the other: a draft's header carries the same toggle, and the copy control
+must not follow it there — the draft's document is editable and unsaved, so a copy of it would be a
+copy of something the table does not hold.
+
+**`value` is memoized.** `formatDraftDocument(storedDocument)` is a full `JSON.stringify` of the
+definition, and `TableDetailView` re-renders on every one of its many local state flags (popup open
+flags, the tab, the access panel). Wrap it: `useMemo(() => formatDraftDocument(storedDocument),
+[storedDocument])`. This is the case `.claude/rules/components.md` §8 means by "where render cost
+matters" — a table with hundreds of columns re-serialized on every popup toggle — and it is not
+indiscriminate memoization, because the input is itself a memo with a stable identity.
+
+`.claude/rules/a11y.md` requires verifying that the notification container is itself announced when a
+result is surfaced only through `NotificationContext`. **Verified, not assumed:**
+`NotificationPortal.tsx:15` renders the list inside `<div role="status" aria-live="polite" …>` portalled
+into `document.body`. That is a polite live region, distinct from `CopyButton`'s own accessible name
+(`copy ${valueLabel}`, `CopyButton.tsx:26`), which the copy does not change. **So no local live region
+is needed and none is added** — a second region here would double-announce every copy in the console.
+
+`CopyButton` is used as it stands, in its **icon-only** variant: `valueLabel={t(AnalyticsTablesI18nKey.JsonDefinition)}`,
+`value={copyText}` (the memo above), `size={ElementSize.Small}`, and it no-ops unless **both**
+`value` and `valueLabel` are given (`CopyButton.tsx:29`). **`buttonLabel` is deliberately not passed**,
+and the reason was **measured on this change**, by a real render plus an isolated probe of the two
+variants at `CopyButton.tsx:35-51`: with `buttonLabel` the component renders a ui-kit
+`DialNeutralButton` and hands it `aria-label={copyLabel}`, but **`DialNeutralButton` discards a
+caller-supplied `aria-label`**, so the accessible name collapses to the visible label alone — "Copy".
+Without `buttonLabel` it renders a ui-kit `DialIconButton`, which honours the attribute, and the name is
+`copy <valueLabel>` exactly as `CopyButton.tsx:26` intends. The delta's scenario **The copy control is
+offered with the document** requires a control "whose accessible name states that it copies the table's
+JSON definition", and "Copy" does not state that. The trade-off is accepted rather than hidden: the
+icon-only control carries **no visible text label**, so sighted discoverability rests on the copy glyph
+and its position in the toolbar, and everything else rests on the accessible name.
+
+Rejected alternatives: adding a prop to the shared `CopyButton` so the neutral variant could carry a
+distinct name — a new prop on a `Common/*` component to fit one caller; patching the ui-kit component —
+vendor internals are out of scope per `.claude/rules/a11y.md`; and relaxing the scenario to accept
+"Copy", which drops the requirement instead of meeting it. Note that the discarded `aria-label` is a
+**ui-kit gap affecting every call site in this repository that passes `buttonLabel` to `CopyButton`**.
+Fixing it belongs upstream.
+
+One honest limitation, recorded rather than fixed: the container mounts only while at least one
+notification exists (`NotificationContext.tsx:57`). A live region inserted together with its content is
+announced by current browser/AT combinations but is a weaker construction than a region that is always
+present. Fixing it means changing a shared provider used by the whole console — out of scope here.
+
+### D6a — Superseding "the primary action last", and what that costs
+
+File: `openspec/changes/add-active-table-json-view/specs/analytics/tables/spec.md`, the `MODIFIED`
+block on **`### Requirement: Table detail gates edits by per-table permissions`**. The target lives in
+`openspec/specs/analytics/tables/spec.md:215`, its order bullet at `:225` and its scenario at `:271`.
+
+*(New in revision 2. The previous `§D1` chose the slot **before** Connect precisely so this clause
+would survive verbatim. Revision 3 removes that option, so the clause is superseded rather than
+preserved.)*
+
+**Superseded, verbatim as it stands in the consolidated spec (`:225`):**
+
+> - Header actions SHALL be ordered **Manage access, Delete table, Add columns, Add rows, Connect** —
+>   the primary action last, where the header's primary action already sits. A not-yet-`ACTIVE` table
+>   shows neither Connect nor the two Add buttons, and shows **Save** in their place — see "Define and
+>   materialize a table schema".
+
+**And its scenario, verbatim (`:271-274`):**
+
+> #### Scenario: Header actions follow the fixed order
+>
+> - **WHEN** the detail header renders for a user with every permission on an `ACTIVE` table
+> - **THEN** the actions appear in the order Manage access, Delete table, Add columns, Add rows, Connect
+
+**What replaces it.** The order becomes **Manage access, Delete table, Add columns, Add rows,
+Connect, copy JSON definition, JSON-editor toggle** — the toggle last, after the primary Connect, the
+copy control immediately before it and present only while the JSON view is on. Connect remains the
+header's only primary action and remains the last **action**; it is no longer the last **control**.
+
+**What the clause was protecting, taken seriously before rewriting it.** Two things, and they are not
+the same:
+
+1. *Exactly one primary action per header.* This is stated separately, in `### Requirement: Table
+   detail Connect panel` (`:873`): "**Connect** SHALL be the header's primary action, so an `ACTIVE`
+   table always presents exactly one primary action whatever the viewer's permissions are." That
+   sentence makes **no positional claim**, so it is untouched by this change and stays true — worth
+   saying because it is the requirement a reader would expect to have to modify and does not. The
+   scenario "Add actions keep a fixed emphasis" (`:244-248`), whose second THEN is "**Connect** is the
+   only primary action in the header", likewise survives verbatim.
+2. *Positional consistency: the emphasized control terminates the row.* This is the part that dies,
+   and it is a real convention, not a local accident. The only other place in the consolidated specs
+   that fixes a control order for this console states the same shape:
+   `openspec/specs/analytics/query-builder/spec.md:57` — "…then right-aligned the query's own
+   actions — Edit, Discard, and Save — followed by **Copy and the Run primary action**." The query
+   page therefore puts **Copy immediately before the primary**, and the primary last. This change
+   inverts both: the primary is not last, and Copy comes **after** it.
+
+**The cost, accepted and named.** A reader who learns the console's toolbar grammar on the query page
+(`/queries/[id]`) does not carry it to a table detail header. Two surfaces, two orders, no rule
+distinguishing them from the outside — the divergence is exactly one page wide today, and it will read
+as an inconsistency in review. It is accepted because the owner asked for it after seeing both, and
+because the toggle is genuinely a different kind of control from Run and Connect: it changes what the
+page shows rather than doing something, and it is the control the reader must find again to get back.
+
+**The successor rule, so the next addition is not a guess.** "Primary last" was doing work beyond
+aesthetics: it told whoever added a header control where to put it. Deleting it without a replacement
+would leave the next author with a precedent to imitate and no rule. The replacement, written into the
+`MODIFIED` bullet: **actions on the table come before Connect; controls that act on the view come
+after it, in the order they were added.** Under that rule the copy control is a view control (it
+copies what the view shows) and sits after Connect, and a hypothetical future "Export definition"
+that hits the service would sit before it.
+
+**Alternative rejected — keep "primary last" and put the toggle before Connect.** This is what `§D1`
+originally chose, for exactly this reason. Rejected because the owner instructed otherwise after
+seeing it, and because "do not silently delete a rule" is satisfied by superseding it here rather than
+by refusing the instruction.
+
+**Alternative rejected — move Connect out of the primary style so nothing is "primary last" to
+violate.** It would make the order question vanish, and it is worse on every other axis: it
+contradicts `:873`'s "exactly one primary action", it demotes the page's actual primary task
+(connecting a client to the table) for the sake of a layout rule, and it is scope this change was
+not asked for.
+
+**Alternative rejected — also reorder the query page so both match.** Consistency restored, at the
+price of changing a page this change has no business in, on no request, with its own spec, tests and
+review. If the inconsistency proves to matter, that is the follow-up — and it should be argued as a
+console-wide toolbar convention, not smuggled in here.
+
+### D7 — Confirmed: the baseline is faithful for a materialized table
+
+Files read, not changed: `apps/ai-dial-admin/src/components/Analytics/Tables/use-draft-schema-form.ts`,
+`apps/ai-dial-admin/src/components/Analytics/Tables/utils.ts`.
+
+The proposal flagged this as unconfirmed. It is true, so it is a footnote rather than a task:
+
+- `baselineDto` is `buildDraftSchemaDto(createDraftSchemaForm(table), table.type)`
+  (`use-draft-schema-form.ts:110`), i.e. derived from `table` alone, not from the live form — so it is
+  the *stored* definition at all times, on an `ACTIVE` table as much as on a draft.
+- `createDraftSchemaForm` → `toColumnRows` (`utils.ts:100-113`) carries every per-column member the
+  model declares: `source_name`, `name`, `type`, `element_type`, `enum_values`, `tag`, `display_name`,
+  `description`, `nullable`, `sensitive`. `buildDraftSchemaDto` → `toTableColumns` (`utils.ts:211-232`)
+  re-emits all of them, omitting the blank ones — matching the draft editor's "absent rather than
+  present and empty" rule.
+- **A post-materialization rename is carried correctly.** The rename changes the exposed `name` while
+  `source_name` keeps the physical name, and the two travel separately through both functions.
+- An enrichment's grain key is a hidden physical column and is never in `table.columns`
+  (`TableDetailView.tsx:338`), but `grain_key` reaches the document from `table.grain.grain_key`
+  (`utils.ts:122`), so nothing is lost.
+
+The one member the document does not carry is an enrichment's `source_table`, which the proposal
+already accepted as a create-time identity field.
+
+### D8 — Sequencing: three MODIFIED requirements, and an archive order nothing enforces
+
+File: `openspec/changes/add-active-table-json-view/specs/analytics/tables/spec.md`.
+
+**This replaces the first version's `§D8`, which argued the delta was ADDED-only *by placement*. That
+reasoning is void: a header control on an `ACTIVE` table is exactly what those requirements said would
+not exist.** The delta now carries a `## MODIFIED Requirements` section with three entries.
+
+1. **`### Requirement: Table detail gates edits by per-table permissions`** — lives in
+   `openspec/specs/analytics/tables/spec.md:215`, so this one modifies a target that really exists. It
+   gains a bullet for the toggle's permission rule and its order bullet gains an entry: *Manage access,
+   Delete table, Add columns, Add rows, JSON-editor toggle, Connect*. Its scenario "Header actions
+   follow the fixed order" (`:271`) and "A system table still offers Connect" (`:260`) are amended with
+   it.
+2. **`### Requirement: JSON editor for a table draft`** — lives **only** in PR #4492's unmerged delta
+   (`openspec/changes/add-table-draft-schema-json-editor/specs/analytics/tables/spec.md:3`). Two
+   statements in it become false under this placement, and both are superseded here. Verbatim, as they
+   stand in that delta:
+   - prose: *"The toggle SHALL NOT be offered on an `ACTIVE` table, whose schema is patched through the
+     scoped add/drop/rename/update surface instead."*
+   - scenario clause, under "The editor toggle takes over the draft surface": *"**AND** on an `ACTIVE`
+     table no such toggle is offered"*
+
+   The replacement distinguishes the authoring editor from the read-only view rather than forbidding
+   both, which is what BA's Impact section asked for.
+3. **`### Requirement: A changed table draft's header offers Discard and Save`** — same file, `:109`.
+   Two more statements, verbatim:
+   - prose: *"Nothing about an `ACTIVE` table SHALL change. The changed-entity header SHALL NOT be
+     presented there, and that view's own actions — Add columns, Add rows, Connect — SHALL be presented
+     exactly as today."*
+   - `#### Scenario: An ACTIVE table's header is untouched` (`:177`), whose title asserts the
+     untouched-ness the header no longer has. It is retitled "An ACTIVE table's header offers neither
+     Discard nor Save" and its second THEN names the added toggle.
+
+   Read strictly, that scenario's own THEN clauses stay true — the five named actions *are* presented
+   exactly as before; a sixth control is added beside them. It is modified anyway, on EM's decision,
+   because the title states something broader than its clauses do and a reader will believe the title.
+
+**Each MODIFIED block carries its requirement whole — every paragraph and every scenario — not just the
+sentences that changed.** An archive fold replaces the named requirement with the block's contents, so a
+partial copy would silently delete the other nine or ten scenarios of a requirement this change barely
+touches. That is the whole risk of entries 2 and 3, and it is why they are long.
+
+**The ordering constraint, and the fact that nothing enforces it.** Entries 2 and 3 name requirements
+that reach `openspec/specs/analytics/tables/spec.md` only when **#4492 merges and is archived**. So:
+
+> **#4492 (`add-table-draft-schema-json-editor`) MUST merge and be archived before this change is
+> archived.** Archiving this one first folds two MODIFIED blocks against requirements that do not exist,
+> and then #4492's archive would fold its *original* wording back over them — restoring both false
+> statements with no diff to show for it.
+
+`openspec validate --strict` will **not** catch a violation. That was measured on this very change: a
+delta whose `## MODIFIED Requirements` block targeted `### Requirement: JSON editor for a table draft`,
+absent from every consolidated spec, validated clean — `Change 'add-active-table-json-view' is valid`,
+exit 0. The CLI checks the delta's own structure, not the existence of the target. The ordering is a
+**human** constraint; it is repeated at the top of `tasks.md` and in its archive note, which is where
+someone archiving would actually read it.
+
+Editing #4492's own delta instead was not available: a third push to that branch would dismiss its
+approval for the third time, which is precisely why the owner asked for a separate change.
+
+### D9 — i18n
+
+Files: `apps/ai-dial-admin/src/constants/i18n.ts`, `apps/ai-dial-admin/src/locales/en.ts`.
+**Implemented already; unaffected by the rework.**
+
+One key, and **it survives revision 1**. `AnalyticsTablesI18nKey` (`i18n.ts:2528`) carries
+`JsonDefinition = 'AnalyticsTables.JsonDefinition'`, and the `AnalyticsTables` block in `en.ts`
+(`:2815`) carries `JsonDefinition: 'JSON definition'`. Revision 1 removed the `<h3>` heading that was
+one of its two uses; **the other use is load-bearing and stays**: it is the copy control's
+`valueLabel`, which is what produces the accessible name "copy JSON definition" (`§D6`) and the toast
+"JSON definition Copied successfully" (`CopyButton.tsx:26,31`). Removing the key would leave the
+control announcing a bare "copy" and the toast unnamed, which the delta's scenarios forbid. **Item 1.2
+therefore stands as done and must not be reverted.** The English is not reworded (see `§D2`'s rejected
+"read-only" wording). The toggle needs no key of its own: `JsonToggle` supplies
+`EntitiesI18nKey.JSONEditor`.
+
+### D10 — Where each scenario is proved
+
+Files: `apps/ai-dial-admin/src/components/Analytics/Tables/tests/draft-document.spec.ts`,
+`.../tests/TableDetailView.spec.tsx`. Note what is **not** here, and why: `TableProperties.spec.tsx`
+reverts with `TableProperties.tsx`, and `TableDefinitionJson.spec.tsx` is **deleted** with the
+component (`§D2`), so `TableDetailView.spec.tsx` is now the only file that proves the surface.
+
+- **`draft-document.spec.ts`** — the document's shape and the copy text: the source members, the
+  enrichment members, the per-column metadata and the rename (`§D7`), and
+  `formatDraftDocument(doc) === JSON.stringify(doc, null, 4)`. **Already written and green (13 cases);
+  neither the placement rework nor revisions 1-3 reach it.**
+- **`TableDetailView.spec.tsx`** — everything else. Grouped by what it proves:
+  - *The header.* The toggle is present on an `ACTIVE` table for a caller with no permissions
+    (`setPerms({})`, the pattern at `:867`); present with `featureFlags.analyticsEnabled` false (the
+    flag is flipped at `:877`); the five existing header actions are unaffected; and **the rendered
+    order puts the toggle last, after Connect** — assert on the DOM order of the accessible names
+    within the header container, not on presence alone, because presence would pass under the old
+    order too.
+  - *The copy control.* Absent while the view is off; present once it is on, queryable by the
+    accessible name `CopyButton` derives from `valueLabel` (`copy AnalyticsTables.JsonDefinition`, the
+    mocked `t()` returning the key); positioned between Connect and the toggle; and activating it
+    writes the whole formatted document to `navigator.clipboard.writeText`. Absent again after the
+    view is toggled off, and absent on a `PENDING` table whose own editor is open. Use
+    `fireEvent.click`, not `userEvent.click`: QA established empirically
+    (`qa/review-batch-4-round-1.md` §1) that `userEvent` does not reach `CopyButton`'s icon-only
+    variant in jsdom, and that `CopyButton.spec.tsx` has always used `fireEvent` for the same reason.
+  - *The body.* Turning the toggle on removes the tab strip and the columns grid and shows the
+    document; turning it off restores the strip on the tab that was selected, Audit included; no Save,
+    no Discard and no changed-entity header appear while the view is on, and `updateTable`,
+    `defineTableSchema` and `updateTableSchema` are never called from it (the file mocks the actions
+    module wholesale at `:48`).
+  - *Read-only observed as behaviour* — the one case inherited from the deleted
+    `TableDefinitionJson.spec.tsx`: type into the editor and assert the value is unchanged.
+  - *The materialize transition.* A successful save from a *draft's* JSON editor leaves the
+    now-`ACTIVE` table on its live column surface with the toggle off.
+
+**The `JsonEditorBase` mock has to change, and this is the one trap in the file.** It currently reads
+(`:42-46`):
+
+```tsx
+vi.mock('@/src/components/Common/JsonEditorBase/JsonEditorBase', () => ({
+  default: ({ value, onChange }: { value?: string; onChange: (v?: string) => void }) => (
+    <textarea aria-label="rows-json" value={value} onChange={(e) => onChange(e.target.value)} />
+  ),
+}));
+```
+
+It does **not** forward `options.readOnly`, and it hardcodes one label — so with the read-only editor
+mounted in the body the Add-rows popup's textarea and the definition's textarea would be
+indistinguishable, and the read-only assertion could not be written at all. The mock must accept
+`options` and derive both from it: `readOnly={options?.readOnly}`, and an `aria-label` that differs
+between the two mounts (`options?.readOnly` is the discriminator — `EntityJsonEditor` sets it only
+under `readonly`). Existing assertions on `rows-json` must keep working, so the editable mount keeps
+that label.
+
+**The awkward assertion, called out so it is not quietly dropped.** The materialize case needs
+`defineTableSchema` to resolve successfully and the subsequent `getTable` to answer with an `ACTIVE`
+table, both from the same already-mocked module. If the existing harness cannot express that, the
+honest fallback is to assert the toggle's own state after the save rather than the surface behind
+it — but say so; do not drop the case.
+
+### D11 — Browser verification: required by the criterion, waived by the owner on this run
+
+Applying the house criterion honestly, most scenarios in this delta are browser-observable: their THEN
+clauses describe an element present or absent, or text shown. The verification task is therefore
+required and stays in `tasks.md` as item 4.1. What goes into the browser is a separate, much smaller
+question, and the owner's instruction is critical paths only. This change crosses **no** backend
+boundary and **no** route — the document is derived client-side from data the page already has. Two
+scenarios still cross a boundary every unit test mocks away:
+
+- **"The view cannot be edited"** — every unit test replaces Monaco with a textarea. Whether the real
+  Monaco instance honours `options.readOnly`, and whether it renders at all inside a body-height flex
+  container (the classic zero-height blank editor), is unprovable in jsdom. The rework raises this one's
+  value: the container changed from a fixed 320px box to a flex-filled body.
+- **"Copying places the whole displayed document on the clipboard"** — jsdom has no clipboard;
+  `navigator.clipboard.writeText` is asserted as a spy. The real write, and the notification container
+  actually appearing, exist only in a browser. Revision 2 moves the control into the header, which
+  does not change what the browser is for here, but a pass should now also glance at whether an
+  icon-only copy button reads as an affordance beside a switch and a primary button — that is a
+  judgement no unit test makes.
+
+Everything else — the document's shape, the permission independence, the flag independence, the body
+swap, the absence of write requests — is unit-test territory and is not sent.
+
+**On this run the owner waived the browser pass**: his local backend is down and he chose to ship
+without it rather than bring it up. The task is kept, not dropped, and the waiver is recorded in
+`plan.json` under `browser_verification.waiver` so a later run can pick the two scenarios up unchanged.
+
+## Risks / Trade-offs
+
+- **Audit is unreachable while the JSON view is on** (`§D1`). One click gets it back and the selected
+  tab survives, but a reader who wants both at once cannot have them. This is the trade this placement
+  makes, and it is the first thing to revisit if it bites.
+- **`isEditorEnabled` now means two different things depending on `status`.** One boolean, two
+  meanings — the authoring surface on a draft, the read-only surface on an `ACTIVE` table. The
+  materialize reset (`§D1`) exists precisely because those two meanings meet at the moment a draft
+  becomes active. A later change that introduces another status transition in place, or that lets an
+  `ACTIVE` table revert, has to think about this flag again. Splitting it into two states would remove
+  the hazard and duplicate the toggle wiring; it is not worth it for one transition, but that is the
+  assumption most likely to be invalidated.
+- **The header-order requirement is now modified by two changes in flight.** #4492 does not touch it, so
+  today there is no conflict — but a third change that adds a header action on this page would collide
+  with this delta, and openspec would not say so.
+- **The copy text and the displayed text are kept identical by convention, not by construction**
+  (`§D4`). `formatDraftDocument` mirrors `JsonEditor.tsx:90`. If a future change to the shared editor
+  alters its indentation, the copy silently diverges; the unit test pins our side, nothing pins theirs.
+- **The notification container mounts with its first notification** (`§D6`). If an AT combination is
+  ever found not to announce it, every copy control in the console is affected, not just this one.
+- **A second editor instance on the page.** `EntityJsonEditor` registers with `SaveValidationContext`.
+  On an `ACTIVE` table nothing consumes those errors (`§D5`), but if a later change makes the `ACTIVE`
+  branch reach for `jsonErrors`, this editor becomes one of its sources.
+- **The archive order is unenforced** (`§D8`). The only protection is that it is written where an
+  archiver reads.
+- **Inlining the read-only editor puts `setDraftDocument` in scope at its call site** (`§D2`, `§D5`).
+  The deleted wrapper made "the editor has nowhere to write" structurally true; inline it is a rule a
+  future edit can break in one line, and `readonly` would keep the surface looking correct while the
+  draft document silently changed underneath. The task states it explicitly and the spec's "no save
+  path" case is the net that would catch it.
+- **The header order diverges from the query page** (`§D6a`). One page wide today. If a third surface
+  is added, the console needs a stated toolbar convention rather than two precedents.
+- **The copy control is icon-only and now sits among labelled buttons** (`§D6`). In the deleted
+  toolbar it was the only control in its row; in the header it competes with Manage access, Delete
+  table, Add columns, Add rows and Connect, all of which carry visible text. Its accessible name is
+  correct (that is why `buttonLabel` is omitted), but sighted discoverability now rests entirely on
+  the copy glyph. This is the first thing to look at if readers report not finding the copy.
+- **The copy text is serialized on render unless the memo of `§D6` is kept.** Easy to lose in a later
+  refactor, invisible when it happens, and proportional to the table's column count.

--- a/openspec/changes/add-active-table-json-view/proposal.md
+++ b/openspec/changes/add-active-table-json-view/proposal.md
@@ -1,0 +1,250 @@
+## Why
+
+Copying an analytics table's definition from one environment to another needs a source and a target.
+The target side now exists: a `PENDING`/`FAILED` table's detail view can be authored as one JSON
+document. The source side does not. Once a table is `ACTIVE`, the console shows its definition only as
+rendered UI — the columns grid, the keys panel, the status badge, the tag chips — and there is no way
+to read the definition **as a document**. An operator who wants to stand the same table up on another
+environment either re-types every column into the target's form, or leaves the console entirely and
+issues `GET /v1/tables/{name}` from a REST client to get something pasteable. Both are worse than the
+console being able to show what it already holds: `TableDetailView.tsx:133` computes
+`buildDraftDocument(table, draft.baselineDto)` as `storedDocument` for **every** table, `ACTIVE`
+included, and then never surfaces it on the materialized branch.
+
+Reaching for a REST client is not only inconvenient, it produces the wrong text. A `GET` response is
+the read shape, not the write shape: it carries members the write path rejects or reshapes, so the
+copy has to be pruned by hand before it will paste. The console is the one place that already knows
+the difference.
+
+## What Changes
+
+- **An `ACTIVE` table's detail view makes its definition readable as JSON, read-only.** The document
+  is rendered through the shared `EntityJsonEditor`
+  (`apps/ai-dial-admin/src/components/EntityTabs/JsonEditor/JsonEditor.tsx`), which already takes a
+  `readonly` prop and forces its Monaco instance read-only — no new prop on a shared component for
+  this caller.
+- **The document shown is the paste-ready shape, not the raw `GET` body.** It is
+  `buildDraftDocument(table, schema)` (`Analytics/Tables/draft-document.ts`) — the kind-specific
+  schema body (`columns`, `ordering_key`, `partition_by`, `identity_column`, `version_column` for a
+  source table; `columns`, `grain_key`, `cardinality` for an enrichment) plus `description` and
+  `tag_order`. That is the identical shape a `PENDING` table's JSON editor seeds, which is what turns
+  the copy into a round trip: read it here, paste it there, nothing to prune or reshape.
+
+  Showing the raw `GET /v1/tables/{name}` body instead would add `status`, `system`, `permissions`,
+  `column_count`, `name`, `type`, `source_table` and the nested `grain` object — members the paste
+  transform (`splitDraftDocument`, same file) drops or unpacks anyway, most of which the page already
+  states elsewhere (the status badge, the system chip, the kind tag, the columns grid), and the rest
+  of which is environment-local and therefore noise in a comparison between two environments. The one
+  genuine loss is an enrichment's `source_table`. That is acceptable: it is a create-time identity
+  field, and the target environment supplies it on its own create screen either way — it is not part
+  of what the draft editor accepts.
+- **The document is taken to the clipboard in one action.** A copy control is offered with the
+  document and puts the whole of it on the clipboard, confirming the copy in a way assistive
+  technology announces. The feature exists so an operator can carry the definition to another
+  environment; a read-only pane without it leaves the primary action as a click-drag selection over a
+  document that scrolls, which is the interaction this change is meant to remove.
+- **The view is ungated.** Anyone who can open the table's detail page can read it. It mutates
+  nothing; **Connect**, the other non-mutating affordance in the same header, is already shown
+  regardless of permission; and system tables — which report `permissions {write: false,
+  modify: false}` to everyone — are exactly the tables an operator most often wants to copy. Gating
+  the read on a write permission would withhold it precisely where it is most useful.
+- **Read-only is observable, not merely intended.** Typing or pasting into the view leaves the content
+  unchanged; no Save, no Discard and no changed-entity header appear in any state a reader can reach;
+  and no `updateTable` and no `defineTableSchema` request is ever issued from this view. The last of
+  those is the one that fails if someone later wires a save path through this surface, which is why it
+  is stated as behaviour rather than as intent.
+- **Where the view is reached from is deliberately left open.** A third tab beside Properties and
+  Audit, or a toggle in the header, each satisfies the requirement below; it is written so that either
+  does. The architect chooses — see Impact.
+- **Nothing else on the `ACTIVE` branch moves.** Manage access, Delete table, Add columns, Add rows,
+  Connect, the per-column edit/drop and inline-rename actions and `EditTableMetadataPopup` all behave
+  exactly as they do today.
+
+## Acceptance Scenarios
+
+Stated here in the proposal's own words, as the behaviour a spec delta will formalize during the
+specification phase.
+
+### Requirement: A read-only JSON view of a materialized table
+
+For an `ACTIVE` table, the detail view SHALL make the table's document reachable without leaving the
+page, rendered read-only. The document SHALL be the same one a draft editor seeds — the schema body
+for the table's kind plus `description` and `tag_order` — so that the source and the target of a
+cross-environment copy present the identical shape. The view SHALL be reachable by any caller who can
+open the table's detail page, since it performs no write; it SHALL offer no way to change the table;
+and it SHALL leave the `ACTIVE` view's existing actions exactly as they are. This requirement does
+**not** fix *where* on the screen the view is reached from — any placement that satisfies the
+scenarios below is acceptable.
+
+#### Scenario: The document is the paste-ready shape, not the GET response
+
+- **WHEN** a reader reaches the JSON view of an `ACTIVE` source table
+- **THEN** it shows `columns`, `ordering_key`, `partition_by`, `description` and `tag_order` — plus
+  `identity_column` and `version_column` when the stored definition declares them — and none of
+  `status`, `system`, `permissions`, `column_count`, `name`, `type`, `source_table`, nor a nested
+  `grain` object
+- **AND** on an `ACTIVE` enrichment table it shows `columns`, `grain_key`, `cardinality`, `description`
+  and `tag_order`, and no source-only member
+
+#### Scenario: The document pastes into another environment's draft with no editing
+
+- **WHEN** the reader copies the document shown for an `ACTIVE` table and pastes it into the JSON
+  editor of a `PENDING` table of the same kind on another environment
+- **THEN** the pasted text is already the shape that editor seeds, so no member has to be removed,
+  renamed or unpacked by hand before Save
+
+#### Scenario: A caller with no write or modify permission still sees it
+
+- **WHEN** the detail view of an `ACTIVE` table renders for a caller the table reports
+  `permissions {write: false, modify: false}` for — which is every caller on a system table
+- **THEN** the JSON view is reachable, on the same reasoning that already keeps **Connect** available
+  to that caller
+- **AND** no permission-gated action appears alongside it
+
+#### Scenario: The view cannot be edited
+
+- **WHEN** a caller with every permission reaches the JSON view of an `ACTIVE` table and types or
+  pastes into it
+- **THEN** the document's content is unchanged
+
+#### Scenario: No save path exists from an ACTIVE table's JSON view
+
+- **WHEN** the JSON view is shown on an `ACTIVE` table, in any state a reader can put it in
+- **THEN** neither Save nor Discard is offered, the changed-entity header is never presented, and no
+  `updateTable` and no `defineTableSchema` request is issued from this view
+
+#### Scenario: The ACTIVE view's own actions are unaffected
+
+- **WHEN** the detail view of an `ACTIVE` table renders for a caller with every permission
+- **THEN** Manage access, Delete table, Add columns, Add rows and Connect are all still offered, each
+  behaving exactly as before, whether or not the JSON view is the surface on screen
+
+### Requirement: The document is copyable to the clipboard in one action
+
+Wherever the read-only view presents the document, a control SHALL be offered with it that places
+that same document — the paste-ready shape of the requirement above, in full — on the clipboard, and
+the result SHALL be confirmed by a `polite` live-region announcement kept separate from the control's
+own accessible name (`.claude/rules/a11y.md`, "Status feedback for dynamic content"; a notification
+container that is itself announced satisfies this). Like the requirement above, this one does **not**
+fix where the control sits or by what mechanism the announcement is carried — only that the control
+is offered with the document and that the outcome is observable.
+
+#### Scenario: The copy control is offered wherever the document is
+
+- **WHEN** a reader reaches the JSON view of an `ACTIVE` table, under any placement of that view
+- **THEN** a control whose accessible name states that it copies is offered together with the document
+- **AND** it is offered to every caller the view itself is offered to, including one the table reports
+  `permissions {write: false, modify: false}` for
+
+#### Scenario: Copying places the whole displayed document on the clipboard
+
+- **WHEN** the reader activates that control
+- **THEN** the clipboard holds the entire document the view displays — the paste-ready shape of the
+  requirement above, complete, whatever part of it is scrolled into view and whatever the editor's own
+  selection happens to be
+- **AND** pasting it into a `PENDING` table's JSON editor of the same kind needs no member removed,
+  renamed or unpacked, exactly as when the text is taken by hand
+
+#### Scenario: The copy is announced to assistive technology
+
+- **WHEN** the copy succeeds
+- **THEN** a confirmation is announced politely through a live region distinct from the control's own
+  accessible name, which is unchanged by the copy
+- **AND** the reader is not required to see a transient visual cue to know the copy happened
+
+## Capabilities
+
+### Modified Capabilities
+
+- `analytics/tables`:
+  - **"Table detail gates edits by per-table permissions"** (`openspec/specs/analytics/tables/spec.md:215`)
+    — the read-only view is a non-mutating affordance on an `ACTIVE` table that is deliberately **not**
+    permission-gated, on the same reasoning that requirement already applies to **Connect** ("shown
+    regardless of permission"). If the chosen placement is a header control, that requirement's fixed
+    header-action order gains an entry.
+  - The requirement above, "A read-only JSON view of a materialized table", is **added** to the same
+    capability.
+  - So is "The document is copyable to the clipboard in one action", which has no meaning apart from
+    that view and travels with it.
+
+### New Capabilities
+
+None — this extends the table detail surface `analytics/tables` already specifies.
+
+## Impact
+
+**Code** (read, not designed here — component shape and file layout are SA's):
+
+- `apps/ai-dial-admin/src/components/Analytics/Tables/TableDetailView.tsx` — the `isActive` branch is
+  where the view lands. **The document already exists in the component**: `storedDocument`
+  (`TableDetailView.tsx:133`) is `buildDraftDocument(table, draft.baselineDto)` and is computed for
+  every table today, `ACTIVE` included, so the view needs no new derivation. **Unconfirmed and for SA
+  to confirm**: whether `useDraftSchemaForm`'s baseline is faithful for a *materialized* table — in
+  particular that each column's `display_name`, `description`, `sensitive` and tag survive into it,
+  and what a column renamed after materialization contributes (the exposed name is what a fresh
+  definition in the target environment wants; the physical source name is target-local).
+- `apps/ai-dial-admin/src/components/Analytics/Tables/draft-document.ts` — `buildDraftDocument` and
+  `splitDraftDocument` are the existing shape contract; no backend contract changes, no new request.
+- `apps/ai-dial-admin/src/components/EntityTabs/JsonEditor/JsonEditor.tsx:138` — `EntityJsonEditor`
+  already takes `readonly` and forces the Monaco instance read-only, so no shared component gains a
+  prop for this caller.
+- `apps/ai-dial-admin/src/components/Common/CopyButton/CopyButton.tsx` — the shared copy control this
+  console already uses: it writes with `navigator.clipboard.writeText`, takes its accessible name from
+  `valueLabel`, and raises the confirmation through `NotificationContext`
+  (`getCopyToClipboardNotification`). The copy requirement therefore adds **no new file and no new
+  dependency** — it reuses this component as it stands. What SA does have to confirm is the a11y half:
+  that the notification container is itself announced, which is what `.claude/rules/a11y.md` requires
+  of any result surfaced only through `NotificationContext`.
+
+**Placement — open, and the architect's call.** An `ACTIVE` table renders a Properties/Audit tab strip
+when analytics is enabled (`TableDetailView.tsx:487-500`), while the draft screen instead swaps its
+whole body from a header `JsonToggle` (`TableDetailView.tsx:449-471`). Both satisfy the requirements
+above, and so does either placement of the copy control that travels with the document. Two
+consequences differ by placement, and each is a finding, not a decision:
+
+- **Header placement** touches the consolidated spec's fixed header-action order
+  (`openspec/specs/analytics/tables/spec.md:225`, and its scenario at `:271`), which would gain an
+  entry.
+- **Tab placement** inherits the `featureFlags.analyticsEnabled` gate at `TableDetailView.tsx:487`. A
+  Tables page is itself analytics-gated, so this is probably moot — SA should confirm rather than
+  inherit the gate by accident.
+
+**Sequencing against `add-table-draft-schema-json-editor` — a finding for the architect, not solved
+here.** Two requirements in *that* change's delta
+(`openspec/changes/add-table-draft-schema-json-editor/specs/analytics/tables/spec.md`) contradict this
+one:
+
+- `### Requirement: JSON editor for a table draft` states "The toggle SHALL NOT be offered on an
+  `ACTIVE` table" — false under **either** placement once an `ACTIVE` table has a JSON surface; the
+  sentence needs to distinguish the authoring toggle from the read-only view rather than forbid both.
+- `#### Scenario: An ACTIVE table's header is untouched` — still true under tab placement, false under
+  header placement.
+
+Neither of those requirements is in `openspec/specs/analytics/tables/spec.md` yet. They arrive there
+only when PR #4492 merges and that change is archived. **This change's delta therefore cannot modify a
+requirement that does not exist in the consolidated spec**, and the ordering — whether this change
+waits for that archive, or its delta is written against the consolidated spec and the collision
+reconciled at archive time — is the architect's problem to solve. Nothing in this change may be
+written into `add-table-draft-schema-json-editor`: that change is finished and its PR carries an
+approval a further push would dismiss.
+
+**Spec** — the requirements above go into `openspec/specs/analytics/tables/spec.md` via this change's
+delta; no other capability's spec is touched.
+
+## Non-goals
+
+- **Any editing of an `ACTIVE` table.** This puts a **read-only** view on a materialized table and
+  nothing more. Out of scope: any write issued from it — no Save, no Discard, no changed-entity
+  header — and any full-object write for an `ACTIVE` table, which the service does not offer anyway
+  (it has only the scoped `PATCH /v1/tables/{name}/schema` add/drop/rename/update). Also out of scope:
+  any change to **Add columns**, **Add rows** or **Connect**, to the per-column edit/drop and
+  inline-rename actions, or to `EditTableMetadataPopup` — every existing `ACTIVE` editing surface
+  behaves exactly as it does today.
+- **The draft/failed branch.** The JSON editor on a `PENDING`/`FAILED` table is
+  `add-table-draft-schema-json-editor`'s subject and is untouched here.
+- **Comparing two environments' documents in the console.** This view makes the copy possible;
+  diffing, syncing or promoting a table between environments is a different feature.
+- **Bulk export of multiple tables.** Single table, single document.
+- **Restoring the members the paste-ready shape omits.** `source_table` in particular is not carried;
+  the target environment's create screen asks for it. Adding it back would mean showing the read shape,
+  which is the thing this change deliberately does not do.

--- a/openspec/changes/add-active-table-json-view/specs/analytics/tables/spec.md
+++ b/openspec/changes/add-active-table-json-view/specs/analytics/tables/spec.md
@@ -1,0 +1,327 @@
+## ADDED Requirements
+
+### Requirement: An ACTIVE table's definition is readable as JSON
+
+For a table whose `status` is `ACTIVE`, the table detail view SHALL offer among the header's actions the **same JSON-editor toggle a draft offers**, and activating it SHALL replace the view's whole body — the Properties/Audit tab strip included — with the table's stored definition rendered as a JSON document, **read-only**. The only difference from the draft's arrangement SHALL be that nothing inside the document can be changed. Toggling the control off SHALL restore the body as it was, on the tab the reader had selected; the toggle SHALL stay in the header while the document is shown, so the way back is visible at all times and no other surface of the page is reachable behind it.
+
+The document SHALL be the **paste-ready write shape**, not the `GET /v1/tables/{name}` read body: the schema body for the table's kind — for a **source** `columns`, `ordering_key`, `partition_by`, and `identity_column`/`version_column` when the stored definition declares them; for an **enrichment** `columns`, `grain_key`, `cardinality` — plus the catalog metadata `description` and `tag_order`. It SHALL carry none of `status`, `system`, `permissions`, `column_count`, `name`, `type`, `source_table`, nor a nested `grain` object. It SHALL be the identical document a `PENDING`/`FAILED` table's JSON editor seeds ("JSON editor for a table draft"), so a definition read here pastes into that editor on another environment with no member removed, renamed or unpacked. Each declared column SHALL carry the metadata the stored definition holds for it — its physical `source_name`, its exposed `name`, `type`, `nullable`, and `element_type`, `enum_values`, `tag`, `display_name`, `description` and `sensitive` where they are set — so that a column renamed after materialization contributes both names and the target environment reproduces the rename rather than losing it.
+
+The toggle SHALL be offered on every `ACTIVE` table to every caller who can open its detail page:
+
+- whatever the table reports for `permissions.write` and `permissions.modify` — including a system table, which reports `{write: false, modify: false}` to everyone — on the same reasoning that already keeps **Connect** free of a permission gate ("Table detail gates edits by per-table permissions"); and
+- whatever `ANALYTICS_ENABLED` reports: with analytics disabled the detail view renders the Properties content as the whole body and no tab strip, and the toggle SHALL swap that body for the document just the same.
+
+The JSON view SHALL offer no way to change the table. Its editor SHALL reject typing and pasting; no **Save**, no **Discard** and no changed-entity header SHALL be presented in any state a reader can reach from it; and no table write SHALL be issued from it — neither `updateTable` (`PUT /v1/tables/{name}`) nor `defineTableSchema` (`POST /v1/tables/{name}/schema`) nor `updateTableSchema` (`PATCH /v1/tables/{name}/schema`). Because the view is read-only there are no form fields to validate and no request to report on, so it raises no success or error notification of its own; the only notification it can produce is the copy confirmation specified in "The displayed definition is copyable in one action".
+
+A save that materializes a draft **from its JSON editor** SHALL leave the reader on the live column surface of the now-`ACTIVE` table, not on the read-only JSON view: after a successful `defineTableSchema` the toggle SHALL be off, so that "Define and materialize a table schema" — "the view SHALL refresh showing the table `ACTIVE` with its live column surface" — keeps holding now that the same control has a meaning on an `ACTIVE` table.
+
+Every existing affordance of the `ACTIVE` detail view — Manage access, Delete table, Add columns, Add rows, Connect, the per-column edit/drop and inline-rename actions — SHALL behave exactly as before. The JSON-editor toggle SHALL be the **last** control of the header row, after the primary **Connect** (see "Table detail gates edits by per-table permissions"). It is a view switch rather than an action on the table, and it is the one control that persists across the swap and that the reader returns to, so it sits at the end of the row where the actions stop. **Connect** remains the header's only primary action; it is no longer the header's last control. That is the same slot the toggle occupies on a draft, where it is also the row's last control.
+
+#### Scenario: The JSON-editor toggle is offered in an ACTIVE table's header
+
+- **WHEN** the detail view of an `ACTIVE` table renders
+- **THEN** the header offers the same JSON-editor toggle a draft's header offers, as the last control of the row, after **Connect**
+- **AND** activating it shows the table's stored definition as a read-only JSON document
+
+#### Scenario: Opening the JSON view replaces the whole body
+
+- **WHEN** a reader activates the toggle on an `ACTIVE` table whose body is showing the Properties/Audit tab strip
+- **THEN** the document takes over the body, the tab strip is no longer rendered, and neither the columns grid nor the Audit tab's content is on screen
+- **AND** the toggle is still in the header, showing that the JSON view is the active surface
+
+#### Scenario: Closing the JSON view restores the tab the reader was on
+
+- **WHEN** a reader on the **Audit** tab of an `ACTIVE` table opens the JSON view and then toggles it off
+- **THEN** the tab strip is rendered again with **Audit** still selected and its content shown
+- **AND** the same holds for the **Properties** tab
+
+#### Scenario: A source table's document is the write shape, not the GET response
+
+- **WHEN** a reader opens the JSON view on an `ACTIVE` source table whose stored definition declares columns, an ordering key, a partition and a scan-metadata pair
+- **THEN** the document shows `columns`, `ordering_key`, `partition_by`, `identity_column`, `version_column`, `description` and `tag_order`
+- **AND** it shows none of `status`, `system`, `permissions`, `column_count`, `name`, `type`, `source_table`, nor a nested `grain` object
+- **AND** on a source table whose scan-metadata pair is unset, neither `identity_column` nor `version_column` is present
+
+#### Scenario: An enrichment table's document carries its enrichment members
+
+- **WHEN** a reader opens the JSON view on an `ACTIVE` enrichment table
+- **THEN** the document shows `columns`, `grain_key`, `cardinality`, `description` and `tag_order`
+- **AND** it shows no source-only member — no `ordering_key`, no `partition_by`, no `identity_column`, no `version_column` — and no `source_table`
+
+#### Scenario: A column's stored metadata survives into the document
+
+- **WHEN** a reader opens the JSON view on an `ACTIVE` table one of whose columns was renamed after materialization and carries a tag, a display name, a description and the sensitive flag
+- **THEN** that column appears with both its physical `source_name` and its exposed `name`, and with its `tag`, `display_name`, `description` and `sensitive` as stored
+- **AND** a member the stored definition does not set is absent from that column rather than present and empty
+
+#### Scenario: The document is the shape a draft editor seeds
+
+- **WHEN** the document shown for an `ACTIVE` table is compared with the document a `PENDING` table of the same kind seeds its JSON editor with
+- **THEN** the two are built from the same shape, so the text read here needs no member removed, renamed or unpacked before it is saved from that editor
+
+#### Scenario: A caller with no write or modify permission still sees it
+
+- **WHEN** the detail view of an `ACTIVE` table renders for a caller the table reports `permissions {write: false, modify: false}` for — which is every caller on a system table
+- **THEN** the JSON-editor toggle is offered and opens the document
+- **AND** no permission-gated action appears alongside it
+
+#### Scenario: The JSON view is reachable with analytics disabled
+
+- **WHEN** the detail view of an `ACTIVE` table renders with `ANALYTICS_ENABLED` off, so that no Properties/Audit tab strip is rendered and the Properties content is the whole body
+- **THEN** the JSON-editor toggle is offered, and activating it replaces that body with the document
+
+#### Scenario: The view cannot be edited
+
+- **WHEN** a caller with every permission opens the JSON view of an `ACTIVE` table and types or pastes into the document
+- **THEN** the document's content is unchanged
+
+#### Scenario: No save path exists from an ACTIVE table's JSON view
+
+- **WHEN** the JSON view is shown on an `ACTIVE` table, in any state a reader can put it in
+- **THEN** neither Save nor Discard is offered, the changed-entity header is never presented, and no `updateTable`, `defineTableSchema` or `updateTableSchema` request is issued from it
+
+#### Scenario: The ACTIVE view's own actions are unaffected
+
+- **WHEN** the detail view of an `ACTIVE` table renders for a caller with every permission
+- **THEN** Manage access, Delete table, Add columns, Add rows and Connect are all still offered, each behaving exactly as before, whether the JSON view is on or off
+- **AND** **Connect** is still the header's only primary action, though it is no longer the header's last control — the JSON-editor toggle follows it
+
+#### Scenario: Materializing a draft from the JSON editor lands on the live column surface
+
+- **WHEN** an author saves a `PENDING` table from its JSON editor and the schema request succeeds, so the refreshed table is `ACTIVE`
+- **THEN** the body shows the live column surface of the now-`ACTIVE` table, not the read-only JSON view
+- **AND** the toggle is off, so the reader turns it on again to read the definition as a document
+
+#### Scenario: A not-yet-materialized table is untouched
+
+- **WHEN** the detail view of a `PENDING` or `FAILED` table renders
+- **THEN** the toggle authors the draft exactly as before — it opens the editable JSON editor, not a read-only view — and the column-by-column schema-definition surface, the changed-entity header and the toggle's own `canModify` gate are all as before
+
+### Requirement: The displayed definition is copyable in one action
+
+While the read-only JSON view of an `ACTIVE` table is shown, a copy control SHALL be offered **in the header**, immediately before the JSON-editor toggle that opened the view, so it is reachable without scrolling the document and sits beside the control the reader just used. Its accessible name SHALL state that it copies and name the value it copies, and that name SHALL be unchanged by a copy. The control SHALL be shown **only while the document is** — it copies what is displayed, so it has no meaning when nothing is, and a permanent control in the header would offer to copy a document that is not on screen.
+
+The read-only view itself SHALL carry no toolbar and no heading of its own: it is reached by a labelled toggle that names the surface, and the copy control travels with that toggle, so the whole body below the header is the document.
+
+Activating the control SHALL place the **entire** document on the clipboard — the same text the read-only view displays, character for character including its indentation, whatever part of the document is scrolled into view and whatever the editor's own selection happens to be. The control SHALL be offered to every caller the view itself is offered to, including one the table reports `permissions {write: false, modify: false}` for.
+
+A successful copy SHALL be confirmed by a notification raised through the console's notification container, which is itself a polite live region (`role="status"`, `aria-live="polite"`) distinct from the control's own accessible name, so the outcome is announced without the reader having to see a transient visual cue. The change SHALL introduce no new error path: a clipboard write the browser rejects is the shared copy control's existing behaviour and raises no notification.
+
+#### Scenario: The copy control is offered with the document
+
+- **WHEN** a reader opens the JSON view of an `ACTIVE` table
+- **THEN** a control whose accessible name states that it copies the table's JSON definition is offered in the header, between **Connect** and the JSON-editor toggle
+- **AND** it is offered to every caller the view is offered to, including one the table reports `permissions {write: false, modify: false}` for
+
+#### Scenario: The copy control is absent while the JSON view is off
+
+- **WHEN** the detail view of an `ACTIVE` table renders with the JSON view off, and again after a reader turns the view on and then off
+- **THEN** no copy-definition control is present in the header in either case, and the JSON-editor toggle is still the header's last control
+- **AND** on a `PENDING` or `FAILED` table no copy-definition control is present in any state, whether that table's own JSON editor is open or closed
+
+#### Scenario: Copying places the whole displayed document on the clipboard
+
+- **WHEN** the reader activates that control
+- **THEN** the clipboard holds the entire document the view displays — the paste-ready shape, complete and identically formatted — whatever part of it is scrolled into view and whatever the editor's own selection is
+
+#### Scenario: The copy is announced to assistive technology
+
+- **WHEN** the copy succeeds
+- **THEN** a confirmation naming the copied value is announced politely through the console's notification container, a live region distinct from the control's own accessible name
+- **AND** the control's accessible name is unchanged by the copy
+
+## MODIFIED Requirements
+
+### Requirement: Table detail gates edits by per-table permissions
+
+The table detail view (`components/Analytics/Tables/TableDetailView.tsx`) SHALL gate its mutating affordances independently:
+
+- **Manage access** SHALL be shown only when `canManageRoles` (`FULL_ADMIN` and non-system).
+- **Delete table** SHALL be shown only when `canDelete` (`FULL_ADMIN` and non-system).
+- **Connect** SHALL be shown regardless of permission, as the header's primary action, for every `ACTIVE` **source** table and for every `ACTIVE` **enrichment** table whose payload names a source table (see "Table detail Connect panel").
+- The **JSON-editor toggle** SHALL be shown on every `ACTIVE` table regardless of permission, because there it opens a read-only view of the stored definition and writes nothing (see "An ACTIVE table's definition is readable as JSON"); on a `PENDING`/`FAILED` table it SHALL be shown only when `canModify`, because there it authors the schema (see "JSON editor for a table draft"). It follows that an `ACTIVE` table always presents at least one header action, whatever the viewer's permissions are and whether or not Connect can be offered for it.
+- **Add rows** SHALL NOT be offered for an **enrichment** table whatever its `write` permission reports: those rows come from the enrichment process, so a hand-written insert is not a path this UI offers.
+- For an `ACTIVE` table, **Add columns** (schema evolution) and **Add rows** (inserting rows) SHALL each be offered as its own standalone header button — **not** as items of a shared dropdown. **Add columns** SHALL be shown only when `canModify` and **Add rows** only when `canWrite`; when neither permission is held, neither button renders. Both SHALL render as neutral actions, never primary and never dependent on whether the other is present, so each keeps the same appearance whatever the viewer's other permissions are. **Add rows** is deliberately not the emphasized way to put data in the table — see "Table detail row writes".
+- Per-column **edit/drop** (grid action column), **inline column rename**, column-metadata edits, and **description edits** SHALL be shown only when `canModify`.
+- Header controls SHALL be ordered **Manage access, Delete table, Add columns, Add rows, Connect, copy JSON definition, JSON-editor toggle** — the **JSON-editor toggle last**, after the primary **Connect**, with the copy-definition control immediately before the toggle and present only while the JSON view is on (see "The displayed definition is copyable in one action"). **Connect** remains the header's only primary action, and it remains the last **action**; it is no longer the last control, because the two controls that follow it act on the view rather than on the table. The rule that replaces "primary action last" is therefore: **actions on the table come before Connect, view controls after it**, so a later header addition has a rule to follow rather than a precedent to guess at. A not-yet-`ACTIVE` table shows neither Connect nor the two Add buttons, and shows **Save** in their place — see "Define and materialize a table schema"; its own JSON-editor toggle is likewise the last control of its row, where no primary action precedes it.
+
+Because the backend reports `permissions {false,false}` for system tables, the write/modify-gated affordances (Add rows, Add columns, per-column edit/drop, inline rename, description edits) hide for system tables without a separate check. **Manage access** and **Delete table** are gated on `FULL_ADMIN`, which the backend does not scope per-table, so each carries its own explicit `!table.system` check. The JSON-editor toggle is deliberately outside that set on an `ACTIVE` table: it mutates nothing, and a system table is exactly the table whose definition an operator most often needs to read as a document.
+
+#### Scenario: Write-capable, not modify-capable
+
+- **WHEN** a table reports `permissions {write:true, modify:false}`
+- **THEN** the header shows an **Add rows** button and no **Add columns** button, and the per-column action column and inline rename are absent
+
+#### Scenario: Modify-capable, not write-capable
+
+- **WHEN** a table reports `permissions {write:false, modify:true}`
+- **THEN** the schema-edit affordances and per-column action column are present, and the header shows an **Add columns** button and no **Add rows** button
+
+#### Scenario: Neither capability hides the Add dropdown entirely
+
+- **WHEN** a table reports `permissions {write:false, modify:false}`
+- **THEN** neither **Add columns** nor **Add rows** is rendered, and no **Add** dropdown is rendered in their place either
+
+#### Scenario: Add actions keep a fixed emphasis
+
+- **WHEN** a table reports both permissions, and separately when it reports only one
+- **THEN** **Add columns** and **Add rows** each render as a neutral action whenever present, and neither is promoted to primary by the other's absence
+- **AND** **Connect** is the only primary action in the header
+
+#### Scenario: Delete stays admin-only
+
+- **WHEN** a non-system table reports edit permissions but the user is not `FULL_ADMIN`
+- **THEN** the "Delete table" button is absent
+
+#### Scenario: Manage access is hidden for a system table even for a full admin
+
+- **WHEN** a `FULL_ADMIN` opens a system table's detail page
+- **THEN** the "Manage access" button is absent
+
+#### Scenario: A system table still offers Connect
+
+- **WHEN** a user opens an `ACTIVE` system table's detail page
+- **THEN** **Connect** is present while **Add rows**, **Add columns**, **Manage access**, and **Delete table** are all absent
+- **AND** the JSON-editor toggle is present, since it writes nothing
+
+#### Scenario: An enrichment table offers Connect but never Add rows
+
+- **WHEN** a user opens an `ACTIVE` enrichment table's detail page and its payload names a source table
+- **THEN** **Connect** is present as the header's primary action
+- **AND** no **Add rows** action is present, whatever the table's `write` permission reports
+
+#### Scenario: Header actions follow the fixed order
+
+- **WHEN** the detail header renders for a user with every permission on an `ACTIVE` table
+- **THEN** the controls appear in the order Manage access, Delete table, Add columns, Add rows, Connect, JSON-editor toggle — the toggle last, after the primary Connect
+- **AND** with the JSON view on, the copy-definition control appears between Connect and the toggle, leaving the toggle last
+
+#### Scenario: A not-yet-active table shows Save in their place
+
+- **WHEN** the detail header renders for a `PENDING` or `FAILED` table and the user has `canModify`
+- **THEN** **Save** is shown, and none of **Connect**, **Add columns**, or **Add rows** is
+
+### Requirement: JSON editor for a table draft
+
+For a table that is not yet materialized (`status` `PENDING` or `FAILED`) and that the caller may modify, the table detail view SHALL offer a JSON-editor toggle among the header's ordinary actions while the draft has no unsaved changes — once either surface has been edited the toggle is withdrawn with the header's other ordinary actions, as "A changed table draft's header offers Discard and Save" specifies — and the two authoring surfaces SHALL be mutually exclusive: while the editor is the active surface the column-by-column schema-definition surface SHALL NOT be rendered, and toggling the editor off SHALL restore it. The **authoring** editor specified here SHALL NOT be offered on an `ACTIVE` table, whose schema is patched through the scoped add/drop/rename/update surface instead; the same toggle on an `ACTIVE` table's header opens the **read-only** view specified in "An ACTIVE table's definition is readable as JSON", which authors nothing and submits nothing.
+
+The edited document SHALL be the schema body the column form would submit for the table's kind — for a **source** `columns`, `ordering_key`, `partition_by`, `identity_column`, `version_column`; for an **enrichment** `columns`, `grain_key`, `cardinality` — plus the table's catalog metadata `description` and `tag_order`, which the column form presents no field for. A member the column form would omit (an unset partition, an unset scan-metadata pair) SHALL be absent from the seeded document rather than present and empty.
+
+The document SHALL be seeded **once**, when the editor is first opened, from the current column-form state and the table's stored `description`/`tag_order`. It SHALL NOT be re-seeded thereafter — not on a re-render, and not on a later entry into the editor — so an in-progress document is never silently replaced. The single action that does re-seed it is **Discard**, specified in "A changed table draft's header offers Discard and Save"; nothing else replaces the author's document. After the first seed the two surfaces hold independent state: an edit to the document SHALL NOT change the column form, and an edit to the column form SHALL NOT change the document.
+
+Two consequences of the toggle's withdrawal, stated because they bound what the two paragraphs above can be observed to mean. A later entry into the editor is reachable only from an **unchanged** draft — once either surface has been edited the toggle is gone — so seeding once and re-seeding from the stored state are indistinguishable on every reachable path, and the seed-once rule is a statement about the implementation rather than an observable one. For the same reason the two surfaces can never be visited in sequence after a change, so their independence is observable only in what a save from each surface submits: "Saving from the column form sends only the schema request" and "A successful save sends the metadata update before the schema" are what pin it.
+
+While the editor is the active surface, the column form's own completeness rules (at least one valid column, a non-empty ordering key, a complete-or-absent scan-metadata pair, a non-empty grain key, no invalid column row) SHALL NOT gate Save. The only client-side gate SHALL be that the document parses as JSON, reported by the editor's own parse markers: with markers present, Save SHALL send neither request and SHALL surface the parse errors as notifications. No client-side validation of the document's *content* SHALL be performed — an incomplete or otherwise unacceptable document is a service rejection (the data-access service parses request bodies strictly and answers 422 on an unknown property or a missing required field), and that rejection SHALL be shown as-is.
+
+#### Scenario: The editor toggle takes over the draft surface
+
+- **WHEN** the detail view of a `PENDING` or `FAILED` table renders for a caller who may modify it
+- **THEN** a JSON-editor toggle is offered among the header's ordinary actions, and activating it replaces the column-by-column schema-definition surface with the JSON document
+- **AND** on an `ACTIVE` table the same toggle offers no authoring surface at all — it opens the read-only view of the stored definition, from which no save is reachable
+
+#### Scenario: A source draft's document is its schema plus catalog metadata
+
+- **WHEN** the editor is first opened for a source draft whose column form declares columns, an ordering key and a partition, and whose scan-metadata pair is unset
+- **THEN** the seeded document carries `columns`, `ordering_key`, `partition_by`, `description` and `tag_order`
+- **AND** it carries neither `identity_column` nor `version_column`, and no `grain_key` or `cardinality`
+
+#### Scenario: An enrichment draft's document is its schema plus catalog metadata
+
+- **WHEN** the editor is first opened for an enrichment draft whose column form declares columns and a grain key
+- **THEN** the seeded document carries `columns`, `grain_key`, `cardinality`, `description` and `tag_order`
+- **AND** it carries none of `ordering_key`, `partition_by`, `identity_column`, `version_column`
+
+#### Scenario: An in-progress document survives a re-render
+
+- **WHEN** the author has edited the document and the surrounding view re-renders from an unrelated state change
+- **THEN** the editor still shows the author's edited document, not a fresh seed
+
+#### Scenario: Opening the editor and leaving it does not change what the column form submits
+
+- **WHEN** the author opens the editor on an unchanged draft, makes no edit, toggles the editor off, then edits the column form and saves
+- **THEN** the draft still reads as unchanged while the editor is open and after it is closed, so the toggle stays offered throughout
+- **AND** the save sends `defineTableSchema` alone, carrying the column form's own body and no `updateTable`
+
+#### Scenario: The column form's completeness rules do not gate Save in the editor
+
+- **WHEN** the editor is the active surface, the author has edited the document, and it parses but omits a member the column form requires — a source document with no `ordering_key`
+- **THEN** the Save the changed header offers is enabled, and submitting it sends the requests, so the service's answer decides the outcome
+
+#### Scenario: A document that does not parse blocks the save
+
+- **WHEN** the editor is the active surface, the document carries parse-error markers, and the author submits Save
+- **THEN** neither the metadata request nor the schema request is sent, and the parse errors are surfaced as notifications
+
+### Requirement: A changed table draft's header offers Discard and Save
+
+For a table that is not yet materialized (`status` `PENDING` or `FAILED`) and that the caller may modify, the detail view SHALL adopt this console's changed-entity header convention, which every other entity view already follows: while the draft has unsaved changes the header's ordinary actions give way to **Discard** and **Save**.
+
+A draft SHALL be treated as **changed** when either authoring surface differs from the table's stored state:
+
+- the **column-by-column surface**, when the schema body it would submit differs from the schema body the table's stored definition yields — so a `PENDING` table whose form has not been touched and a `FAILED` table freshly seeded from its stored definition are both *unchanged*;
+- the **JSON document**, when it differs from the document that same stored state seeds.
+
+While the JSON editor is the active surface, unresolved parse markers SHALL additionally count as changed, because a marker suppresses the parse and the last successfully parsed document therefore cannot be compared — leaving the header in its ordinary state would offer no way out of a broken document but to fix it.
+
+While the draft is changed the header SHALL present **Discard** and **Save**, and SHALL withdraw its ordinary actions — **Manage access**, **Delete table** and the JSON-editor toggle. Discard SHALL be confirmed through this console's shared discard confirmation before it takes effect. Both actions SHALL be presented only to a caller who may modify the table; a caller who may only view, delete or manage access SHALL never see them, and SHALL keep whichever ordinary actions its permissions already allow.
+
+While the draft is **unchanged** the header SHALL present its ordinary actions — **Manage access**, **Delete table** and the JSON-editor toggle — and SHALL offer **neither Save nor Discard**, exactly as this console's convention behaves on every other entity view. Save is therefore reachable only while the draft is changed. One consequence is accepted deliberately: an untouched `FAILED` draft SHALL NOT be re-submittable as-is — its author must first make an edit that either surface registers as a change.
+
+Save's **disabled** state SHALL follow the active surface, and SHALL be the convention's:
+
+- from the **column-by-column surface**, Save SHALL be disabled while that surface's own completeness rules are unmet — the rules "Define and materialize a table schema" states;
+- from the **JSON editor**, Save SHALL NOT be disabled; its only client-side gate SHALL be the parse markers "JSON editor for a table draft" specifies.
+
+Save SHALL send from each surface exactly the requests that surface already sends: "Saving a table draft as metadata then schema" in the editor, `defineTableSchema` alone from the column form.
+
+**Discard** SHALL restore both surfaces to the table's stored state: the column form to the values the stored definition seeds, and — if a document has been seeded — the JSON document to the document that stored state yields. Any parse markers and the notifications they raised SHALL be cleared first, so a stale marker cannot hold the changed header up on its own. The active surface SHALL NOT change: an author who discards while the editor is open stays in the editor, looking at the restored document.
+
+No **authoring** behaviour of an `ACTIVE` table SHALL change. The changed-entity header SHALL NOT be presented there, and that view's own actions — Add columns, Add rows, Connect — SHALL be presented exactly as today. The one control that view's header gains is the read-only JSON-view toggle of "An ACTIVE table's definition is readable as JSON": it is not an authoring surface, it never marks the table changed, and neither Save nor Discard is reachable from it.
+
+#### Scenario: Editing the JSON document swaps the header's actions
+
+- **WHEN** the JSON editor is the active surface on a modifiable draft and the author edits the document
+- **THEN** the header offers Discard and Save
+- **AND** Manage access, Delete table and the JSON-editor toggle are no longer offered
+
+#### Scenario: Editing the column form swaps the header's actions
+
+- **WHEN** the author changes a value on a modifiable draft's column-by-column surface
+- **THEN** the header offers Discard and Save, and Manage access, Delete table and the JSON-editor toggle are no longer offered
+
+#### Scenario: An untouched draft keeps its ordinary header actions
+
+- **WHEN** a modifiable draft renders and neither surface has been edited
+- **THEN** the header offers Manage access, Delete table and the JSON-editor toggle
+- **AND** it offers neither Save nor Discard
+
+#### Scenario: An untouched FAILED draft offers no Save
+
+- **WHEN** the detail view of a `FAILED` table renders for a caller who may modify it, both surfaces seeded from the table's stored definition and neither edited
+- **THEN** no Save action is offered, so the stored definition cannot be re-submitted until an edit makes the draft changed
+
+#### Scenario: Unresolved parse markers hold the changed header up
+
+- **WHEN** the JSON editor is the active surface and the document carries parse-error markers
+- **THEN** the header offers Discard and Save even though the last successfully parsed document is unchanged
+
+#### Scenario: Discard restores both surfaces to the stored state
+
+- **WHEN** the draft is changed and the author confirms Discard
+- **THEN** the column form shows the values the table's stored definition seeds, the JSON document shows the document that stored state yields, the editor is still the active surface if it was, and the header returns to its ordinary actions
+
+#### Scenario: Discard is confirmed before it takes effect
+
+- **WHEN** the author activates Discard on a changed draft
+- **THEN** a discard confirmation is presented, and dismissing it leaves both surfaces and the header as they were
+
+#### Scenario: The changed header is offered only to a caller who may modify
+
+- **WHEN** a draft's detail view renders for a caller who may delete or manage access but may not modify
+- **THEN** neither Discard nor Save is offered in any state, and the actions that caller's permissions do allow are presented as before
+
+#### Scenario: An ACTIVE table's header offers neither Discard nor Save
+
+- **WHEN** the detail view of an `ACTIVE` table renders for a caller with full permissions
+- **THEN** no Discard action and no Save action is offered, in any state that view can be put in — the read-only JSON view included
+- **AND** Manage access, Delete table, Add columns, Add rows and Connect are presented exactly as before this change, alongside the read-only JSON-view toggle

--- a/openspec/changes/add-active-table-json-view/tasks.md
+++ b/openspec/changes/add-active-table-json-view/tasks.md
@@ -1,0 +1,205 @@
+## 0. Read this before dispatching or archiving
+
+**State of the work, so nothing finished is re-dispatched.** This list has been revised twice. Read
+the state column before you dispatch anything.
+
+| Item | State |
+|---|---|
+| 1.1, 1.2, 1.3 | **Done. Untouched by every revision.** 1.2 in particular is still needed — see below. |
+| 2.1, 2.2 | **Done, then superseded.** The files they produced are **deleted** by 3.3. Do not re-run them and do not re-create the component. |
+| 3.1 | **Done.** Its header/body wiring stands; 3.3 revises the header's order and the body's contents. |
+| 3.2 | **Dispatched.** Whatever state it returned in, 3.4 owns both spec files afterwards and is written not to assume their content. |
+| 3.3, 3.4 | **The remaining work.** |
+| 4.1 | Browser verification — **waived by the owner on this run**, task and waiver both kept. |
+| 5.1 | Quality checks — not run since the rework. |
+
+**Revision 2 — the owner's three instructions, after seeing the reworked placement running.**
+
+1. **Drop the "JSON definition" heading** from the read-only surface. The surface is reached by a
+   toggle that already names it.
+2. **Move the copy control into the header**, beside the JSON-editor toggle — offered only while the
+   JSON view is on.
+3. **Swap the toggle and Connect**: the JSON-editor toggle becomes the header's rightmost control.
+
+Two consequences are decided in `design.md`, not left to the implementer:
+
+- **`AnalyticsTablesI18nKey.JsonDefinition` survives revision 1. Item 1.2 stands as done and must
+  NOT be reverted.** Only the `<h3>` goes. The key is still the copy control's `valueLabel`, which is
+  what produces the accessible name "copy JSON definition" and the toast "JSON definition Copied
+  successfully" (`design.md` §D9). Deleting the key would break two delta scenarios.
+- **`TableDefinitionJson.tsx` is deleted** and the read-only editor is rendered inline in
+  `TableDetailView.tsx`, beside the draft editor it mirrors. With the heading gone and the copy
+  control in the header it would be a wrapper around one element (`design.md` §D2). Its spec file
+  goes with it; its one surviving case moves to `TableDetailView.spec.tsx`.
+- **The consolidated spec's "the primary action last" clause is superseded, not deleted.**
+  `design.md` §D6a quotes the superseded wording, states the replacement (actions before Connect,
+  view controls after it) and names what it costs against `analytics/query-builder`, the one sibling
+  toolbar that still puts the primary last with Copy before it.
+
+**Reverts that must not be lost.** `TableProperties.tsx` (reverted to HEAD inside 3.1, confirmed
+clean) and `tests/TableProperties.spec.tsx` (3.2's, re-checked by 3.4). A half-revert leaves the tree
+red.
+
+**Archive order — a hard dependency, and nothing enforces it.**
+`add-table-draft-schema-json-editor` (PR #4492) **must merge and be archived before this change is
+archived.** Two of the three `## MODIFIED Requirements` blocks in this change's delta name
+requirements that reach `openspec/specs/analytics/tables/spec.md` only through that archive. Archiving
+this one first folds them against nothing, and #4492's later archive then restores the superseded
+wording with no diff to show for it. `openspec validate --strict` does **not** catch this — measured
+on this change, exit 0 on an absent MODIFIED target. `design.md` §D8 has the detail. Nothing in this
+change may be written into `openspec/changes/add-table-draft-schema-json-editor/`, which must stay
+byte-identical to HEAD.
+
+## 1. The document's text and its label — DONE, unaffected by every revision
+
+Design: `design.md` §D4 (formatter), §D9 (i18n). Listed so the plan stays one-to-one, not so they are
+run again.
+
+- [x] 1.1 Add `formatDraftDocument(document: DraftTableDocument): string` to
+      `apps/ai-dial-admin/src/components/Analytics/Tables/draft-document.ts`, returning
+      `JSON.stringify(document, null, 4)`, with a comment naming
+      `apps/ai-dial-admin/src/components/EntityTabs/JsonEditor/JsonEditor.tsx:90` as the serialization
+      it must mirror. Pure and exported; no other change to that file.
+- [x] 1.2 Add the surface's label. In `apps/ai-dial-admin/src/constants/i18n.ts`,
+      `AnalyticsTablesI18nKey` gains `JsonDefinition = 'AnalyticsTables.JsonDefinition',`; in
+      `apps/ai-dial-admin/src/locales/en.ts`, the `AnalyticsTables` block gains
+      `JsonDefinition: 'JSON definition',`. **Revision 1 removed the heading, not the key — this item
+      stands as done and must not be reverted.** The key is the copy control's `valueLabel`, hence the
+      accessible name "copy JSON definition" and the toast "JSON definition Copied successfully"
+      (`design.md` §D9). Not reworded.
+- [x] 1.3 Unit-test the document and the copy text in
+      `apps/ai-dial-admin/src/components/Analytics/Tables/tests/draft-document.spec.ts` — 13 cases,
+      green. Placement-independent by construction: it composes the pure functions and renders nothing.
+
+## 2. The read-only surface — DONE, then superseded by revision 2
+
+Both items were implemented and are green. Revisions 1 and 2 empty the component they produced, and
+`design.md` §D2 deletes it. They stay in the list so the plan reads one-to-one and nobody re-creates
+the file; **item 3.3 removes both files.**
+
+- [x] 2.1 Rewrote `apps/ai-dial-admin/src/components/Analytics/Tables/TableDefinitionJson.tsx` as the
+      full-body read-only surface (root flex-fill, toolbar with the `<h3>` heading and the copy
+      control, editor wrapper). **Superseded — the file is deleted by 3.3.** Do not re-run.
+- [x] 2.2 Rewrote `apps/ai-dial-admin/src/components/Analytics/Tables/tests/TableDefinitionJson.spec.tsx`
+      for that surface. **Superseded — the file is deleted by 3.3.** Its cases do not vanish: the copy
+      ones move to the header's spec, the heading one dies with the heading, and the read-only-typing
+      one moves to `TableDetailView.spec.tsx` in 3.4.
+
+## 3. The placement
+
+Design: `design.md` §D1 (the five header/body edits, the materialize reset, and the copy control's
+slot in point 6), §D2 (the deletion and the inline editor), §D3 (pass the document by reference), §D5
+(read-only props), §D6 (the copy control), §D6a (the superseded order clause), §D10 (where each
+scenario is proved).
+
+- [x] 3.1 Moved the surface into the header/body arrangement and reverted `TableProperties.tsx`.
+      **Done.** `git diff --stat` on `TableProperties.tsx` prints nothing; `tsc -p tsconfig.app.json`
+      exits 0. Three facts it established in code, which 3.3 must not re-derive and must not
+      contradict: `isEditorEnabled` has exactly five readers and no sixth; `hasJsonErrors` is **not**
+      `!isActive`-gated (only its sole consumer `isChangeBarShown` is, and the read-only editor does
+      register markers); and the reset in `onDefineSchema` sits **before** `await reload()`
+      deliberately, so no frame of ACTIVE-plus-open-editor is ever committed. Leave all three alone.
+- [x] 3.2 Re-aimed the two existing specs (`tests/TableProperties.spec.tsx` reverted,
+      `tests/TableDetailView.spec.tsx` re-aimed at the header toggle and the body). **Dispatched
+      before revision 2 landed**, so some of what it wrote — an assertion that the toggle sits
+      *before* Connect, and one on the toolbar heading — is now wrong. Item 3.4 owns both files
+      afterwards and is written not to assume their content. Do not re-dispatch this item.
+- [x] 3.3 Apply the owner's three revisions to the header and delete the wrapper component. **Three
+      files, one item** — deleting the component while `TableDetailView.tsx` still imports it leaves
+      the tree red, so they land together.
+      - **Delete** `apps/ai-dial-admin/src/components/Analytics/Tables/TableDefinitionJson.tsx` and
+        `apps/ai-dial-admin/src/components/Analytics/Tables/tests/TableDefinitionJson.spec.tsx`
+        (`design.md` §D2), and remove the import of the component from `TableDetailView.tsx`.
+      - In `apps/ai-dial-admin/src/components/Analytics/Tables/TableDetailView.tsx`:
+        (a) **render the read-only editor inline**, replacing
+        `const definitionJson = <TableDefinitionJson document={storedDocument} />;` with the
+        `<div className="flex min-h-0 flex-1 flex-col overflow-auto"><EntityJsonEditor entity={storedDocument} readonly /></div>`
+        of `design.md` §D2 — mirroring `draftEditor` a few lines above it. Keep the §D3 by-reference
+        comment at the new call site. **Pass no `setSelectedEntity`, no `setIsChanged`, no
+        `onChangeText`**: `setDraftDocument` is now in scope at that call site and passing it would
+        make a read-only surface write the draft document (`design.md` §D5).
+        (b) **Move the `JsonToggle` to the end of the `isActive` arm** of the header, after the
+        Connect block, so the rendered row reads Manage access, Delete table, Add columns, Add rows,
+        Connect, JSON-editor toggle. Source order is rendered order — no CSS `order-*`. Update the
+        comment above it, which currently says it is the last neutral action before the primary.
+        (c) **Add the copy control immediately before the toggle**, gated
+        `isActive && isEditorEnabled`: the existing `Common/CopyButton/CopyButton` with
+        `valueLabel={t(AnalyticsTablesI18nKey.JsonDefinition)}`, `size={ElementSize.Small}`, **no**
+        `buttonLabel` (`design.md` §D6 — the labelled variant loses its `aria-label`, so do not add
+        one), and `value` from a `useMemo(() => formatDraftDocument(storedDocument), [storedDocument])`.
+        The `isActive` half of the gate is load-bearing: a draft's header carries the same toggle and
+        must not gain a copy control.
+        Everything else in the file stays as 3.1 left it. Do not add a prop to `CopyButton`,
+        `EntityJsonEditor` or `EntityHeaderControls/JsonToggle`. Do not touch
+        `tests/TableDetailView.spec.tsx` here — it goes red and 3.4 is what fixes it.
+      - Check with `npx tsc -p tsconfig.app.json --noEmit` from `apps/ai-dial-admin/` (exit 0 — the
+        app typecheck is green on this tree and a red one is yours) and
+        `npx eslint src/components/Analytics/Tables/TableDetailView.tsx`.
+- [x] 3.4 Re-aim `apps/ai-dial-admin/src/components/Analytics/Tables/tests/TableDetailView.spec.tsx`
+      at the revised header and body. **Read the file first — item 3.2 wrote against the previous
+      order and the deleted toolbar, so treat its content as a starting point, not as a premise.**
+      Assertions, per `design.md` §D10:
+      - *Header order.* The toggle is the **last** control of the header row, after Connect — assert
+        on the DOM order of accessible names within the header container, not on presence alone,
+        because presence passes under the old order too. The five existing actions are all still
+        rendered. The toggle is present for a caller with no permissions (`setPerms({})`) and with
+        `featureFlags.analyticsEnabled` false.
+      - *Copy control.* Absent while the view is off; present once it is on, between Connect and the
+        toggle, queryable by the accessible name `copy AnalyticsTables.JsonDefinition` (the mocked
+        `t()` returns the key); activating it writes the whole formatted document to
+        `navigator.clipboard.writeText`; absent again after the view is toggled off; absent on a
+        `PENDING` table whose own JSON editor is open. Use `fireEvent.click`, not `userEvent.click` —
+        `qa/review-batch-4-round-1.md` §1 established that `userEvent` does not reach `CopyButton`'s
+        icon-only variant in jsdom.
+      - *Body.* Turning the toggle on removes the tab strip and the columns grid and shows the
+        document; turning it off restores the strip with the previously selected tab still selected,
+        Audit included; no Save, no Discard and no changed-entity header while the view is on, and
+        `updateTable`, `defineTableSchema` and `updateTableSchema` are never called from it.
+      - *Read-only as behaviour* — the case inherited from the deleted `TableDefinitionJson.spec.tsx`:
+        type into the editor and assert the value is unchanged.
+      - *Materialize.* A successful save from a draft's JSON editor leaves the now-`ACTIVE` table on
+        its live column surface with the toggle off. If the existing mocks cannot express that, assert
+        the toggle's own state after the save instead — and say so; do not drop the case.
+      - **Delete every assertion on the toolbar heading**, and every one that puts the toggle before
+        Connect.
+      - **The `JsonEditorBase` mock must change** and this is the trap in the file: it currently
+        hardcodes `aria-label="rows-json"` and does not forward `options.readOnly`, so the two mounted
+        editors are indistinguishable and the read-only case cannot be written. Accept `options`,
+        set `readOnly={options?.readOnly}`, and derive a distinct label from that discriminator while
+        keeping `rows-json` on the editable mount so existing assertions survive.
+      - Also confirm `apps/ai-dial-admin/src/components/Analytics/Tables/tests/TableProperties.spec.tsx`
+        is at HEAD: `git diff --stat` on it must print nothing. If 3.2 did not finish the revert,
+        restore it by writing back `git show HEAD:<path>`.
+      - Verify with
+        `npx vitest run src/components/Analytics/Tables/tests/TableDetailView.spec.tsx src/components/Analytics/Tables/tests/TableProperties.spec.tsx --reporter=dot`
+        from `apps/ai-dial-admin/`.
+
+## 4. Browser verification — waived by the owner on this run
+
+Design: `design.md` §D11 — why the task exists, and why only two scenarios would go into a browser.
+**The owner waived the pass on this run**: his local backend is down and he chose to ship without it.
+The task is kept rather than dropped so a later run picks it up unchanged; the waiver is recorded in
+`plan.json` under `browser_verification.waiver`. EM decides whether to dispatch it.
+
+- [ ] 4.1 Run the `spec-browser-verify` skill against the running local app
+      (`http://localhost:4200`, an `ACTIVE` analytics table's detail page) for exactly two scenarios of
+      `openspec/changes/add-active-table-json-view/specs/analytics/tables/spec.md`: **"The view cannot
+      be edited"** and **"Copying places the whole displayed document on the clipboard"**. Both cross
+      what jsdom mocks away — the real Monaco instance inside a body-height flex container, and the
+      real clipboard plus the notification container. While there, note whether the icon-only copy
+      control reads as an affordance beside a switch and a primary button; that is a judgement no unit
+      test makes. Resolve any `fail` verdict before the change is complete; a blocked verdict caused
+      by the local sign-in wall is an environment escalation, not a fix.
+
+## 5. Quality checks
+
+- [x] 5.1 From `apps/ai-dial-admin/`, in this order: `npx prettier --write` over exactly the files this
+      change touched (never a directory or a glob — a human works in this tree concurrently);
+      `npm run lint 2>&1 | tail -30`, comparing against the 111 pre-existing warnings rather than aiming
+      at zero; `npx tsc -p tsconfig.app.json --noEmit` (a red app typecheck is this change's and it
+      blocks); and `npx vitest run --reporter=dot --coverage --coverage.reporter=text-summary`. Also
+      confirm the two reverts landed and the two deletions did:
+      `git status --porcelain apps/ai-dial-admin/src/components/Analytics/Tables/` must show
+      `TableDefinitionJson.tsx` and `tests/TableDefinitionJson.spec.tsx` as deleted and neither
+      `TableProperties.tsx` nor `tests/TableProperties.spec.tsx` at all. Report the actual output.
+      Anything this turns up is a new dispatch to the owner of the file, not an edit from here.


### PR DESCRIPTION
**Description:**

Copying an analytics table's definition between environments already had a target — a `PENDING`/`FAILED`
table's JSON editor (#4492) — but no source. Once a table is `ACTIVE`, the console showed its
definition only as rendered UI (columns grid, keys panel, status badge, tag chips), so an operator who
wanted to stand the same table up elsewhere either re-typed every column by hand or left the console
for a REST client and pruned the `GET` response by hand before it would paste.

This adds a JSON-editor toggle to the end of an `ACTIVE` table's detail header, after **Connect**. Turning
it on replaces the whole body — Properties/Audit tab strip included — with the table's stored definition
rendered read-only through the shared `EntityJsonEditor` (`apps/ai-dial-admin/src/components/EntityTabs/JsonEditor/JsonEditor.tsx`,
its existing `readonly` prop). A copy control sits beside the toggle while the view is on.

The document is `buildDraftDocument(table, draft.baselineDto)`
(`apps/ai-dial-admin/src/components/Analytics/Tables/draft-document.ts`) — the same paste-ready shape the
draft screen's editor seeds, not the raw `GET` body. It carries none of `status`, `system`,
`permissions`, `column_count`, `name`, `type`, `source_table`, and no nested `grain`; a column renamed
after materialization contributes both its physical `source_name` and its exposed `name`, so the target
reproduces the rename. That is why the definition read on one environment pastes into another with
nothing removed, renamed or unpacked.

The view is offered to every caller who can open the detail page — including on a system table, which
reports `{write: false, modify: false}` to everyone, on the same reasoning that already keeps **Connect**
ungated — and with `ANALYTICS_ENABLED` off, where no tab strip renders at all. Read-only is asserted, not
merely intended: no Save, no Discard, no changed-entity header in any reachable state, and no
`updateTable`, `defineTableSchema` or `updateTableSchema` request from it.

Issues:

- Issue #4499

**Two things a reviewer should know going in:**

- **This branches from #4492 (`add-table-draft-schema-json-editor`) and depends on it landing first.**
  Two of this change's delta blocks in
  `openspec/changes/add-active-table-json-view/specs/analytics/tables/spec.md` are `## MODIFIED
  Requirements` that name requirements living only in #4492's own unmerged delta (`### Requirement: JSON
  editor for a table draft` and `### Requirement: A changed table draft's header offers Discard and
  Save`). They reach the consolidated `openspec/specs/analytics/tables/spec.md` only once **#4492 merges
  and is archived**. If this change is archived first, those two blocks fold against a target that
  doesn't exist yet, and #4492's later archive restores its original (now-false) wording with no diff to
  show for it. `openspec validate --strict` does not catch the violation — measured on this change, it
  exits 0 with a MODIFIED target absent from every consolidated spec. **#4492 must merge and be archived
  before this change is archived.** (`design.md` §D8.)
- **The consolidated spec's "primary action last" clause is superseded, not deleted, at the owner's
  explicit request.** The header order becomes Manage access, Delete table, Add columns, Add rows,
  **Connect**, copy control, JSON-editor toggle — the toggle after Connect rather than before it. Connect
  stays the header's only primary action; it just stops being the last *control*. The replacement rule,
  written into the delta: actions on the table before Connect, controls that act on the view after it.
  Named cost: this diverges from `analytics/query-builder`'s toolbar, the one sibling that puts Copy
  immediately before its primary action and the primary last — one page wide today, and it will read as
  an inconsistency in review. (`design.md` §D6a.)

**Key Changes:**

- `apps/ai-dial-admin/src/components/Analytics/Tables/TableDetailView.tsx` — renders the read-only
  `EntityJsonEditor` inline on the `isActive` branch (no `TableDefinitionJson` wrapper — see below),
  moves the JSON-editor toggle to the end of the header after Connect, and adds the copy control gated
  `isActive && isEditorEnabled`.
- `apps/ai-dial-admin/src/components/Analytics/Tables/draft-document.ts` — `formatDraftDocument`, the
  pure serializer the read-only view and the copy control both use.
- `apps/ai-dial-admin/src/components/Analytics/Tables/tests/TableDetailView.spec.tsx` — re-aimed at the
  revised header order, the copy control, and read-only behaviour (typing/pasting leaves the document
  unchanged; no `updateTable`/`defineTableSchema`/`updateTableSchema` call from this view).
- `apps/ai-dial-admin/src/components/Analytics/Tables/tests/draft-document.spec.ts` — unit coverage for
  the document and its copy text.
- `apps/ai-dial-admin/src/constants/i18n.ts` / `apps/ai-dial-admin/src/locales/en.ts` —
  `AnalyticsTablesI18nKey.JsonDefinition`, the copy control's `valueLabel` (accessible name "copy JSON
  definition"; toast "JSON definition Copied successfully").
- `openspec/changes/add-active-table-json-view/specs/analytics/tables/spec.md` — the delta: one `MODIFIED`
  block on the header-order/permission requirement, plus the two `MODIFIED` blocks against #4492's delta
  described above.
- **Deleted**: `apps/ai-dial-admin/src/components/Analytics/Tables/TableDefinitionJson.tsx` and its spec —
  an earlier revision wrapped the read-only surface in its own component with a heading; once the heading
  was dropped and the copy control moved into the header, the wrapper was one element around one element,
  so it was removed in favor of rendering `EntityJsonEditor` inline beside the draft editor it mirrors.
- **Re-aimed, not deleted, from #4492**: `TableDraftJsonEditor.spec.tsx`'s case asserting that no toggle
  appears on an `ACTIVE` table is exactly what this change supersedes. It now asserts that the toggle
  **is** offered on an `ACTIVE` table and that the authoring (writable) editor still is not.

**Breaking Changes:**

None to any shared component's props — `EntityJsonEditor`'s `readonly` prop and `Common/CopyButton`
already existed and are used as-is. The consolidated spec's header-action order for `analytics/tables`
changes as described above.

**Verification:**

- Full suite: 977 files / 11 442 tests passed, 2 files / 16 tests skipped — none of the sixteen belong to
  this change (fourteen pre-exist on `development`, two belong to #4492).
- Lint: 111 problems, 0 errors, 111 warnings — unchanged from the clean-tree baseline.
- App typecheck (`tsc -p tsconfig.app.json`): exit 0.
- Coverage: 73.27 / 64.55 / 66.73 / 73.51 against thresholds 50 / 40 / 40 / 50.
- Three rounds of code review, zero blocking findings.
- Scenario verdict: **42 pass / 0 fail / 2 unverified, out of 44 scenarios.**
- **Browser verification was waived by the owner on this run** — his local backend was unreachable.
  `The view cannot be edited` and `Copying places the whole displayed document on the clipboard` are
  recorded `unverified`, not `pass`. Both are covered by unit tests instead: the first against a mocked
  `JsonEditorBase` that now forwards `options.readOnly` through the native DOM `readOnly` property and
  drives real `userEvent.type`/`.paste` against it; the second against a `navigator.clipboard.writeText`
  spy. What neither reaches is real Monaco actually honouring `options.readOnly` inside the new
  flex-filled body container (rather than a fixed box — the classic zero-height-editor failure is
  jsdom-invisible by construction), and a real clipboard write with its live-region announcement in an
  actual browser.

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #4499)` (comma-separated list of issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
