### PR TITLE
feat(analytics/Queries): format numeric and temporal result columns (Issue #4513)

### DIFF
--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Result/ResultArea.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Result/ResultArea.tsx
@@ -8,6 +8,7 @@ import type { SegmentedControlOption } from '@epam/ai-dial-ui-kit';
 
 import GridView from '@/src/components/Grid/GridView/GridView';
 import ResultChart from '@/src/components/Analytics/QueryBuilder/Result/ResultChart';
+import { getValueClassColumn } from '@/src/components/Analytics/QueryBuilder/Result/result-column-format';
 import ResultValueCell from '@/src/components/Analytics/QueryBuilder/Result/ResultValueCell';
 import StatChip from '@/src/components/Analytics/QueryBuilder/Result/StatChip';
 import { getResultColumns, getResultTotal } from '@/src/components/Analytics/QueryBuilder/utils/result';
@@ -33,8 +34,13 @@ const ResultArea: FC<Props> = ({ result, meta, isRunning, view, onChangeView, ch
 
   // Attached here rather than in the column builder, which stays a pure description of the columns.
   const columns = useMemo(
-    () => getResultColumns(result, meta?.columnLabels).map((col) => ({ ...col, cellRenderer: ResultValueCell })),
-    [result, meta?.columnLabels],
+    () =>
+      getResultColumns(result, meta?.columnLabels).map((col) => ({
+        ...col,
+        ...getValueClassColumn(meta?.columnValueClasses?.[col.field ?? '']),
+        cellRenderer: ResultValueCell,
+      })),
+    [result, meta?.columnLabels, meta?.columnValueClasses],
   );
   const rows = result?.rows ?? [];
   const total = getResultTotal(result);

--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Result/chart-options.ts
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Result/chart-options.ts
@@ -42,7 +42,7 @@ export const getNumericColumns = (rows: ResultRows, columns: string[]): string[]
 
 // Stricter than `toNumber`, which coerces anything `Number()` accepts: `true` becomes 1 and an empty
 // array becomes 0, so a boolean or an array-valued column (request_tags) would read as a measure.
-const strictNumber = (value: unknown): number | null => {
+export const strictNumber = (value: unknown): number | null => {
   if (typeof value === 'number') return Number.isFinite(value) ? value : null;
   if (typeof value !== 'string' || value === '') return null;
   const n = Number(value);

--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Result/result-column-format.ts
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Result/result-column-format.ts
@@ -1,0 +1,54 @@
+import { ColDef, ITooltipParams, ValueFormatterParams } from 'ag-grid-community';
+
+import { strictNumber } from '@/src/components/Analytics/QueryBuilder/Result/chart-options';
+import { renderCell } from '@/src/components/Analytics/QueryBuilder/utils/result';
+import { dateTimeColumn, numericColumn } from '@/src/constants/grid-columns/configs';
+import { baseNumberFilter, dateFilter } from '@/src/constants/grid-columns/filters';
+import { ResultValueClass } from '@/src/models/analytics/query-builder';
+import {
+  formatNumberByDelimiter,
+  formatNumberWithExponent,
+  formatSignificantNumber,
+} from '@/src/utils/formatting/number-formatting';
+
+const exactNumberText = (value: unknown): string => {
+  const parsed = strictNumber(value);
+  if (parsed !== null && Number.isInteger(parsed)) {
+    return formatNumberByDelimiter(value as string | number);
+  }
+  return renderCell(value);
+};
+
+const getNumericColumn = (format: (value: number) => string): Partial<ColDef> => ({
+  ...numericColumn,
+  ...baseNumberFilter,
+  valueFormatter: ({ value }: ValueFormatterParams) => {
+    const parsed = strictNumber(value);
+    // Fall back to today's rendering rather than blanking a value the run returned.
+    return parsed === null ? renderCell(value) : format(parsed);
+  },
+  tooltipValueGetter: ({ value }: ITooltipParams) => exactNumberText(value),
+});
+
+export const getValueClassColumn = (valueClass?: ResultValueClass): Partial<ColDef> => {
+  switch (valueClass) {
+    case ResultValueClass.Compact:
+      return getNumericColumn(formatNumberWithExponent);
+    case ResultValueClass.Significant:
+      return getNumericColumn(formatSignificantNumber);
+    // A duration column is left unformatted on purpose. Its header is the catalog's `display_name`, which
+    // states the unit ("Duration (ms)"), so a formatted cell would contradict its own header — and the client
+    // does not rewrite catalog display text. The recognition's whole job is to keep this column out of
+    // `Compact`, which rendered a millisecond count as `698.7 K`. Do not "fix" this back to a duration
+    // formatter without first moving the unit out of the header; see design.md §12.
+    case ResultValueClass.Duration:
+      return {};
+    // `dateFilter` travels with `dateTimeColumn` as one unit: its `filterValueGetter` returns a Date,
+    // and `agDateColumnFilter` without `dateFilter`'s `floatingFilter: false` throws on the `contains`
+    // model a text floating filter sends (see `constants/grid-columns/filters.ts`).
+    case ResultValueClass.DateTime:
+      return { ...dateTimeColumn, ...dateFilter };
+    default:
+      return {};
+  }
+};

--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Result/tests/ResultArea.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Result/tests/ResultArea.spec.tsx
@@ -1,5 +1,6 @@
 import { FC, useState } from 'react';
 
+import { ColDef, ValueFormatterParams } from 'ag-grid-community';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, test, vi } from 'vitest';
@@ -12,11 +13,22 @@ import {
   ExecutedQueryMeta,
   QueryRequestKind,
   QueryResultView,
+  ResultValueClass,
 } from '@/src/models/analytics/query-builder';
 
+// Captures the columnDefs GridView receives on each render, so a test can call a column's own
+// valueFormatter directly and prove the fragment from getValueClassColumn reached the grid.
+const { capturedColumnDefs } = vi.hoisted(() => ({ capturedColumnDefs: { current: [] as ColDef[] } }));
+
 vi.mock('@/src/components/Grid/GridView/GridView', () => ({
-  default: ({ rowData }: { rowData?: unknown[] }) => <div>grid rows: {rowData?.length ?? 0}</div>,
+  default: ({ rowData, columnDefs }: { rowData?: unknown[]; columnDefs?: ColDef[] }) => {
+    capturedColumnDefs.current = columnDefs ?? [];
+    return <div>grid rows: {rowData?.length ?? 0}</div>;
+  },
 }));
+
+const formatWith = (col: ColDef | undefined, value: unknown): string =>
+  (col?.valueFormatter as (p: ValueFormatterParams) => string)({ value } as ValueFormatterParams);
 
 const AGG_RESULT: StructuredQueryResult = {
   columns: ['deployment', 'total'],
@@ -33,6 +45,7 @@ const AGG_META: ExecutedQueryMeta = {
   dimensionColumns: ['deployment'],
   aggregateColumns: ['total'],
   columnLabels: {},
+  columnValueClasses: { total: ResultValueClass.Compact },
 };
 
 const ROW_META: ExecutedQueryMeta = {
@@ -41,6 +54,7 @@ const ROW_META: ExecutedQueryMeta = {
   dimensionColumns: [],
   aggregateColumns: [],
   columnLabels: {},
+  columnValueClasses: {},
 };
 
 const SQL_TRANSLATED_META: ExecutedQueryMeta = {
@@ -49,6 +63,7 @@ const SQL_TRANSLATED_META: ExecutedQueryMeta = {
   dimensionColumns: ['deployment'],
   aggregateColumns: ['total'],
   columnLabels: {},
+  columnValueClasses: {},
 };
 
 const SQL_FALLBACK_META: ExecutedQueryMeta = {
@@ -57,6 +72,7 @@ const SQL_FALLBACK_META: ExecutedQueryMeta = {
   dimensionColumns: ['event_id', 'project_id'],
   aggregateColumns: [],
   columnLabels: {},
+  columnValueClasses: {},
 };
 
 type AreaProps = Parameters<typeof ResultArea>[0];
@@ -177,5 +193,35 @@ describe('QueryBuilder :: ResultArea', () => {
     await user.click(screen.getByRole('tab', { name: 'QueryBuilder.ViewChart' }));
 
     expect(screen.getByText('QueryBuilder.ChartNoRows')).toBeInTheDocument();
+  });
+
+  test('formats a classified column while an unclassified column in the same result renders as today', () => {
+    renderArea({ result: AGG_RESULT, meta: AGG_META });
+
+    const totalColumn = capturedColumnDefs.current.find((col) => col.field === 'total');
+    const deploymentColumn = capturedColumnDefs.current.find((col) => col.field === 'deployment');
+
+    expect(formatWith(totalColumn, 4897666958)).toBe('4.9 B');
+    expect(formatWith(deploymentColumn, 'gpt-4o')).toBe('gpt-4o');
+  });
+
+  test('reformats a column once a re-render classifies it, proving columnValueClasses re-triggers the memo', () => {
+    const { rerender } = render(
+      <ControlledArea result={AGG_RESULT} meta={{ ...AGG_META, columnValueClasses: {} }} isRunning={false} />,
+    );
+
+    const initialTotalColumn = capturedColumnDefs.current.find((col) => col.field === 'total');
+    expect(formatWith(initialTotalColumn, 4897666958)).toBe('4897666958');
+
+    rerender(
+      <ControlledArea
+        result={AGG_RESULT}
+        meta={{ ...AGG_META, columnValueClasses: { total: ResultValueClass.Compact } }}
+        isRunning={false}
+      />,
+    );
+
+    const updatedTotalColumn = capturedColumnDefs.current.find((col) => col.field === 'total');
+    expect(formatWith(updatedTotalColumn, 4897666958)).toBe('4.9 B');
   });
 });

--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Result/tests/ResultChart.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Result/tests/ResultChart.spec.tsx
@@ -21,6 +21,7 @@ const META: ExecutedQueryMeta = {
   dimensionColumns: ['deployment'],
   aggregateColumns: ['total', 'tokens'],
   columnLabels: { deployment: 'Deployment' },
+  columnValueClasses: {},
 };
 
 const renderChart = (config: ChartConfig = DEFAULT_CHART_CONFIG, result = RESULT, meta = META) => {

--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Result/tests/result-column-format.spec.ts
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Result/tests/result-column-format.spec.ts
@@ -1,0 +1,166 @@
+import { ColDef, IRowNode, ITooltipParams, ValueFormatterParams, ValueGetterParams } from 'ag-grid-community';
+import { describe, expect, test } from 'vitest';
+
+import { getValueClassColumn } from '@/src/components/Analytics/QueryBuilder/Result/result-column-format';
+import { ResultValueClass } from '@/src/models/analytics/query-builder';
+
+const format = (col: Partial<ColDef>, value: unknown): string =>
+  (col.valueFormatter as (p: ValueFormatterParams) => string)({ value } as ValueFormatterParams);
+
+const tooltip = (col: Partial<ColDef>, value: unknown): unknown =>
+  (col.tooltipValueGetter as (p: ITooltipParams) => unknown)({ value } as ITooltipParams);
+
+const filterValue = (col: Partial<ColDef>, data: Record<string, unknown>, field: string): unknown =>
+  (col.filterValueGetter as (p: ValueGetterParams) => unknown)({
+    data,
+    colDef: { field },
+  } as unknown as ValueGetterParams);
+
+const compare = (col: Partial<ColDef>, a: unknown, b: unknown): number =>
+  (col.comparator as (a: unknown, b: unknown, nodeA: IRowNode, nodeB: IRowNode, isInverted: boolean) => number)(
+    a,
+    b,
+    {} as IRowNode,
+    {} as IRowNode,
+    false,
+  );
+
+describe('getValueClassColumn — Compact', () => {
+  const col = getValueClassColumn(ResultValueClass.Compact);
+
+  test('renders a value below one thousand without a unit and without a decimal', () => {
+    expect(format(col, 999)).toBe('999');
+  });
+
+  test('compacts one thousand to a thousands unit', () => {
+    expect(format(col, 1000)).toBe('1 K');
+  });
+
+  test('compacts a numeric string the way a backend sends a Long', () => {
+    expect(format(col, '1500000')).toBe('1.5 M');
+  });
+
+  test('falls back to the plain rendering when the value will not parse as a number', () => {
+    expect(format(col, 'n/a')).toBe('n/a');
+    expect(format(col, true)).toBe('true');
+    expect(format(col, null)).toBe('');
+  });
+
+  test('puts the exact thousand-delimited value in the tooltip, not the compacted text', () => {
+    expect(tooltip(col, 1234567)).toBe('1,234,567');
+    expect(tooltip(col, '1500000')).toBe('1,500,000');
+  });
+
+  test('sorts by numeric value, so "9" comes before "10"', () => {
+    expect(compare(col, '9', '10')).toBeLessThan(0);
+  });
+
+  test('treats a zero as a value rather than as an absent one', () => {
+    expect(compare(col, '0', '10')).toBeLessThan(0);
+  });
+
+  test('resolves a dotted column name as a literal key for the filter', () => {
+    expect(filterValue(col, { 'usage.tokens': '201' }, 'usage.tokens')).toBe(201);
+  });
+
+  test('carries no valueGetter, so the result column keeps its own', () => {
+    expect('valueGetter' in col).toBe(false);
+  });
+
+  test('filters through the number filter the compacted cell text could not serve', () => {
+    expect(col.filter).toBe('agNumberColumnFilter');
+  });
+});
+
+describe('getValueClassColumn — Significant', () => {
+  const col = getValueClassColumn(ResultValueClass.Significant);
+
+  test('keeps two significant digits of a sub-unit decimal instead of rounding it to zero', () => {
+    expect(format(col, '0.00000228123')).toBe('0.0000023');
+  });
+
+  test('renders an exact zero as zero', () => {
+    expect(format(col, 0)).toBe('0');
+  });
+
+  test('compacts a value at or above one unit', () => {
+    expect(format(col, '19.74')).toBe('19.7');
+  });
+
+  test('puts a fractional value in the tooltip verbatim, without rounding it to two decimals', () => {
+    expect(tooltip(col, '0.00000228123')).toBe('0.00000228123');
+  });
+
+  test('puts a whole value in the tooltip thousand-delimited', () => {
+    expect(tooltip(col, 2000)).toBe('2,000');
+  });
+
+  test('falls back to the plain rendering when the value will not parse as a number', () => {
+    expect(format(col, '')).toBe('');
+    expect(format(col, 'NaN')).toBe('NaN');
+  });
+});
+
+describe('getValueClassColumn — Duration', () => {
+  const col = getValueClassColumn(ResultValueClass.Duration);
+
+  test('carries no valueFormatter, so the cell stays in the unit its header declares', () => {
+    expect(col.valueFormatter).toBeUndefined();
+  });
+
+  test('carries no tooltipValueGetter', () => {
+    expect(col.tooltipValueGetter).toBeUndefined();
+  });
+
+  test('carries no comparator', () => {
+    expect(col.comparator).toBeUndefined();
+  });
+
+  test('carries no filter', () => {
+    expect(col.filter).toBeUndefined();
+  });
+
+  test('carries no cellClass', () => {
+    expect(col.cellClass).toBeUndefined();
+  });
+
+  test('is the same empty fragment an unclassified column gets', () => {
+    expect(col).toEqual(getValueClassColumn(undefined));
+  });
+});
+
+describe('getValueClassColumn — DateTime', () => {
+  const col = getValueClassColumn(ResultValueClass.DateTime);
+  const millis = 1784186472371;
+
+  test('renders millisecond epochs as a local date-time', () => {
+    expect(format(col, millis)).toBe(new Date(millis).toLocaleString());
+    expect(format(col, String(millis))).toBe(new Date(millis).toLocaleString());
+  });
+
+  test('puts the same local date-time in the tooltip', () => {
+    expect(tooltip(col, millis)).toBe(new Date(millis).toLocaleString());
+  });
+
+  test('gives the filter a Date, so agDateColumnFilter can compare it', () => {
+    const filtered = filterValue(col, { started_at: millis }, 'started_at');
+
+    expect(filtered).toBeInstanceOf(Date);
+    expect((filtered as Date).getTime()).toBe(millis);
+  });
+
+  test('pairs the date filter with a suppressed floating filter, which is what keeps the grid from throwing', () => {
+    expect(col.filter).toBe('agDateColumnFilter');
+    expect(col.floatingFilter).toBe(false);
+  });
+
+  test('carries no valueGetter, so the result column keeps its own', () => {
+    expect('valueGetter' in col).toBe(false);
+  });
+});
+
+describe('getValueClassColumn — unclassified', () => {
+  test('returns an empty fragment for an unclassified column', () => {
+    expect(getValueClassColumn(undefined)).toEqual({});
+  });
+});

--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/utils/executed-meta.ts
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/utils/executed-meta.ts
@@ -1,5 +1,6 @@
 import { getStrictNumericColumns } from '@/src/components/Analytics/QueryBuilder/Result/chart-options';
 import { getResultColumns } from '@/src/components/Analytics/QueryBuilder/utils/result';
+import { DURATION_FIELD_TAG, FIELD_TYPE_VALUE_CLASS } from '@/src/constants/analytics/query-builder';
 import { AnalyticsEntityField } from '@/src/models/analytics/entity';
 import { QueryExprType, QueryMode, StructuredQuery, StructuredQueryResult } from '@/src/models/analytics/query';
 import {
@@ -7,6 +8,7 @@ import {
   QueryRequestKind,
   QueryRunRequest,
   ResultColumnClassification,
+  ResultValueClass,
 } from '@/src/models/analytics/query-builder';
 
 type ResultRows = Array<Record<string, unknown>>;
@@ -50,6 +52,50 @@ export const buildColumnLabels = (columns: string[], fields: AnalyticsEntityFiel
   return labels;
 };
 
+// The tag narrows a class the type map already resolved as numeric; it never creates one. A
+// Timestamp/Date field keeps DateTime however it is tagged, and a String/Enum/Uuid/Boolean field
+// tagged `performance` stays unformatted — matching the tag before the type would let the tag create
+// formatting the declared type refused.
+const schemaValueClass = (field: AnalyticsEntityField): ResultValueClass | undefined => {
+  const declared = FIELD_TYPE_VALUE_CLASS[field.type];
+  const isUnitBearing = declared === ResultValueClass.Compact || declared === ResultValueClass.Significant;
+
+  return isUnitBearing && field.tag === DURATION_FIELD_TAG ? ResultValueClass.Duration : declared;
+};
+
+// A column's rendering class, resolved in two steps: a column that names a schema field takes that
+// field's declared class or nothing — a declared non-numeric type (Uuid, Enum, Boolean, String) is
+// never overridden by its values. Only a measure column with no schema field at all is classified
+// from its own values, using the same strict numeric parse `getStrictNumericColumns` used to decide
+// it counted as a measure in the first place. Everything else gets no entry.
+export const buildColumnValueClasses = (
+  columns: string[],
+  fields: AnalyticsEntityField[],
+  measureColumns: string[],
+  rows: ResultRows,
+): Record<string, ResultValueClass> => {
+  const classes: Record<string, ResultValueClass> = {};
+  const candidates: string[] = [];
+
+  for (const column of columns) {
+    const field = fields.find((f) => f.name === column);
+    if (field) {
+      const declaredClass = schemaValueClass(field);
+      if (declaredClass) classes[column] = declaredClass;
+    } else if (measureColumns.includes(column)) {
+      candidates.push(column);
+    }
+  }
+
+  const numericCandidates = getStrictNumericColumns(rows, candidates);
+  for (const column of numericCandidates) {
+    const isWhole = rows.every((row) => Number.isInteger(Number(row[column])));
+    classes[column] = isWhole ? ResultValueClass.Compact : ResultValueClass.Significant;
+  }
+
+  return classes;
+};
+
 export const buildExecutedMeta = (
   request: QueryRunRequest,
   response: StructuredQueryResult,
@@ -68,24 +114,34 @@ export const buildExecutedMeta = (
         mode: QueryMode.Row,
         ...classifyResultColumns(resultColumns, response.rows ?? []),
         columnLabels: {},
+        columnValueClasses: {},
       };
     }
     const dimensionColumns = resolveGroupByColumns(translated, resultColumns);
+    const aggregateColumns = resultColumns.filter((c) => !dimensionColumns.includes(c));
+    const isSameEntity = translated.entity === entityName;
+    const measureColumns = translated.mode === QueryMode.Aggregate ? aggregateColumns : [];
     return {
       kind: request.kind,
       mode: translated.mode,
       dimensionColumns,
-      aggregateColumns: resultColumns.filter((c) => !dimensionColumns.includes(c)),
-      columnLabels: translated.entity === entityName ? buildColumnLabels(resultColumns, fields) : {},
+      aggregateColumns,
+      columnLabels: isSameEntity ? buildColumnLabels(resultColumns, fields) : {},
+      columnValueClasses: isSameEntity
+        ? buildColumnValueClasses(resultColumns, fields, measureColumns, response.rows ?? [])
+        : {},
     };
   }
 
   const dimensionColumns = request.query.group_by ?? [];
+  const aggregateColumns = resultColumns.filter((c) => !dimensionColumns.includes(c));
+  const measureColumns = request.query.mode === QueryMode.Aggregate ? aggregateColumns : [];
   return {
     kind: request.kind,
     mode: request.query.mode,
     dimensionColumns,
-    aggregateColumns: resultColumns.filter((c) => !dimensionColumns.includes(c)),
+    aggregateColumns,
     columnLabels: buildColumnLabels(resultColumns, fields),
+    columnValueClasses: buildColumnValueClasses(resultColumns, fields, measureColumns, response.rows ?? []),
   };
 };

--- a/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/utils/tests/executed-meta.spec.ts
+++ b/apps/ai-dial-admin/src/components/Analytics/QueryBuilder/utils/tests/executed-meta.spec.ts
@@ -1,13 +1,14 @@
 import { describe, expect, test } from 'vitest';
 
 import {
+  buildColumnValueClasses,
   buildExecutedMeta,
   classifyResultColumns,
   resolveGroupByColumns,
 } from '@/src/components/Analytics/QueryBuilder/utils/executed-meta';
 import { AnalyticsEntityField, AnalyticsFieldType } from '@/src/models/analytics/entity';
 import { QueryExprType, QueryMode, StructuredQuery, StructuredQueryResult } from '@/src/models/analytics/query';
-import { QueryRequestKind, QueryRunRequest } from '@/src/models/analytics/query-builder';
+import { QueryRequestKind, QueryRunRequest, ResultValueClass } from '@/src/models/analytics/query-builder';
 
 const query = (partial: Partial<StructuredQuery>): StructuredQuery => ({
   entity: 'dial_usage_log',
@@ -137,6 +138,140 @@ describe('QueryBuilder :: executed-meta :: classifyResultColumns', () => {
   });
 });
 
+describe('QueryBuilder :: executed-meta :: buildColumnValueClasses', () => {
+  const FIELDS: AnalyticsEntityField[] = [
+    { name: 'count', type: AnalyticsFieldType.Integer, source: 'count' },
+    { name: 'total', type: AnalyticsFieldType.Long, source: 'total' },
+    { name: 'rate', type: AnalyticsFieldType.Decimal, source: 'rate' },
+    { name: 'created_at', type: AnalyticsFieldType.Timestamp, source: 'created_at' },
+    { name: 'day', type: AnalyticsFieldType.Date, source: 'day' },
+    { name: 'id', type: AnalyticsFieldType.Uuid, source: 'id' },
+  ];
+
+  test('a declared Integer, Long, Decimal, Timestamp and Date column each resolve from the schema type', () => {
+    const rows = [{ count: 1, total: 2, rate: 1.5, created_at: 123, day: 456, id: 'a' }];
+    const columns = ['count', 'total', 'rate', 'created_at', 'day', 'id'];
+
+    expect(buildColumnValueClasses(columns, FIELDS, [], rows)).toEqual({
+      count: ResultValueClass.Compact,
+      total: ResultValueClass.Compact,
+      rate: ResultValueClass.Significant,
+      created_at: ResultValueClass.DateTime,
+      day: ResultValueClass.DateTime,
+    });
+  });
+
+  test('a Uuid column gets no entry', () => {
+    expect(buildColumnValueClasses(['id'], FIELDS, [], [{ id: 'a' }])).toEqual({});
+  });
+
+  test('a measure column with no schema field is compact when every value is whole', () => {
+    const rows = [{ total_cost: 3 }, { total_cost: 7 }];
+
+    expect(buildColumnValueClasses(['total_cost'], [], ['total_cost'], rows)).toEqual({
+      total_cost: ResultValueClass.Compact,
+    });
+  });
+
+  test('a measure column with no schema field is significant-digit when one value is fractional', () => {
+    const rows = [{ avg_cost: 3 }, { avg_cost: 7.5 }];
+
+    expect(buildColumnValueClasses(['avg_cost'], [], ['avg_cost'], rows)).toEqual({
+      avg_cost: ResultValueClass.Significant,
+    });
+  });
+
+  test('an empty rows array yields no entry for a measure column', () => {
+    expect(buildColumnValueClasses(['total'], [], ['total'], [])).toEqual({});
+  });
+
+  // The declared type wins even when the column is a measure and its values happen to parse as
+  // numbers: a schema field never falls through to value-based classification.
+  test('a declared Enum measure column with numeric-looking values gets no entry', () => {
+    const enumFields: AnalyticsEntityField[] = [{ name: 'status', type: AnalyticsFieldType.Enum, source: 'status' }];
+    const rows = [{ status: '200' }, { status: '429' }];
+
+    expect(buildColumnValueClasses(['status'], enumFields, ['status'], rows)).toEqual({});
+  });
+
+  test('a Long field tagged performance resolves Duration where its type alone would resolve Compact', () => {
+    const durationFields: AnalyticsEntityField[] = [
+      { name: 'duration_ms', type: AnalyticsFieldType.Long, source: 'duration_ms', tag: 'performance' },
+    ];
+
+    expect(buildColumnValueClasses(['duration_ms'], durationFields, [], [{ duration_ms: 698700 }])).toEqual({
+      duration_ms: ResultValueClass.Duration,
+    });
+  });
+
+  test('a Decimal field tagged performance resolves Duration where its type alone would resolve Significant', () => {
+    const durationFields: AnalyticsEntityField[] = [
+      { name: 'avg_duration_ms', type: AnalyticsFieldType.Decimal, source: 'avg_duration_ms', tag: 'performance' },
+    ];
+
+    expect(buildColumnValueClasses(['avg_duration_ms'], durationFields, [], [{ avg_duration_ms: 12.5 }])).toEqual({
+      avg_duration_ms: ResultValueClass.Duration,
+    });
+  });
+
+  // A millisecond-named but untagged field falls through to Compact — a decision, not an accident —
+  // beside a tagged field in the same result that resolves Duration and, per `result-column-format.ts`
+  // (design.md §12), is left unformatted: the untagged column still reads compacted, the tagged one raw.
+  test('a millisecond-named but untagged field falls through to Compact beside a tagged field resolving Duration', () => {
+    const mixedFields: AnalyticsEntityField[] = [
+      { name: 'demo_duration_ms', type: AnalyticsFieldType.Long, source: 'demo_duration_ms' },
+      { name: 'duration_ms', type: AnalyticsFieldType.Long, source: 'duration_ms', tag: 'performance' },
+    ];
+    const rows = [{ demo_duration_ms: 5000, duration_ms: 698700 }];
+
+    expect(buildColumnValueClasses(['demo_duration_ms', 'duration_ms'], mixedFields, [], rows)).toEqual({
+      demo_duration_ms: ResultValueClass.Compact,
+      duration_ms: ResultValueClass.Duration,
+    });
+  });
+
+  // The tag only narrows a class the type map already resolved as numeric; a declared String or
+  // Timestamp field tagged performance keeps exactly what its type resolves.
+  test('a String-typed and a Timestamp-typed field tagged performance keep what their types resolve', () => {
+    const taggedNonNumericFields: AnalyticsEntityField[] = [
+      { name: 'label', type: AnalyticsFieldType.String, source: 'label', tag: 'performance' },
+      { name: 'measured_at', type: AnalyticsFieldType.Timestamp, source: 'measured_at', tag: 'performance' },
+    ];
+    const rows = [{ label: 'x', measured_at: 123 }];
+
+    expect(buildColumnValueClasses(['label', 'measured_at'], taggedNonNumericFields, [], rows)).toEqual({
+      measured_at: ResultValueClass.DateTime,
+    });
+  });
+
+  test('a bucket-tagged ordinal and an untagged status code still resolve Compact', () => {
+    const bucketFields: AnalyticsEntityField[] = [
+      { name: 'duration_bucket', type: AnalyticsFieldType.Integer, source: 'duration_bucket', tag: 'bucket' },
+      { name: 'response_status', type: AnalyticsFieldType.Integer, source: 'response_status' },
+    ];
+    const rows = [{ duration_bucket: 3, response_status: 200 }];
+
+    expect(buildColumnValueClasses(['duration_bucket', 'response_status'], bucketFields, [], rows)).toEqual({
+      duration_bucket: ResultValueClass.Compact,
+      response_status: ResultValueClass.Compact,
+    });
+  });
+
+  // An output column with no schema field carries no tag to read, so it never becomes a Duration —
+  // it keeps the value-shape class §4 step 2 already gives it, and so stays compacted rather than raw.
+  test('an aggregate alias over a tagged field resolves Compact/Significant and never Duration', () => {
+    const wholeRows = [{ total_duration_ms: 100 }, { total_duration_ms: 200 }];
+    expect(buildColumnValueClasses(['total_duration_ms'], [], ['total_duration_ms'], wholeRows)).toEqual({
+      total_duration_ms: ResultValueClass.Compact,
+    });
+
+    const fractionalRows = [{ avg_duration_ms: 100 }, { avg_duration_ms: 150.5 }];
+    expect(buildColumnValueClasses(['avg_duration_ms'], [], ['avg_duration_ms'], fractionalRows)).toEqual({
+      avg_duration_ms: ResultValueClass.Significant,
+    });
+  });
+});
+
 describe('QueryBuilder :: executed-meta :: buildExecutedMeta', () => {
   const FIELDS: AnalyticsEntityField[] = [
     {
@@ -172,6 +307,28 @@ describe('QueryBuilder :: executed-meta :: buildExecutedMeta', () => {
     expect(meta.dimensionColumns).toEqual(['deployment', 'total']);
     expect(meta.aggregateColumns).toEqual(['total']);
     expect(meta.columnLabels).toEqual({});
+  });
+
+  // No group-by semantics behind that aggregateColumns list — it is every returned column, so
+  // trusting it would compact an id or a raw epoch column.
+  test('an untranslated SQL run withholds every value class', () => {
+    const meta = buildExecutedMeta(sqlRequest, result([{ deployment: 'gpt-4o', total: 3 }]), FIELDS, '', null);
+
+    expect(meta.columnValueClasses).toEqual({});
+  });
+
+  test('a translated SQL run over another entity withholds every value class', () => {
+    const translated = query({ entity: 'conversations', group_by: ['deployment'], select: [field('deployment')] });
+
+    const meta = buildExecutedMeta(
+      sqlRequest,
+      result([{ deployment: 'gpt-4o', total: 3 }]),
+      FIELDS,
+      'dial_usage_log',
+      translated,
+    );
+
+    expect(meta.columnValueClasses).toEqual({});
   });
 
   test('schema display names apply when the translated entity is the selected one', () => {
@@ -223,5 +380,45 @@ describe('QueryBuilder :: executed-meta :: buildExecutedMeta', () => {
 
     expect(meta.dimensionColumns).toEqual([]);
     expect(meta.mode).toBe(QueryMode.Row);
+  });
+
+  // In row mode `aggregateColumns` degenerates to every returned column, so a scalar-function alias
+  // with no schema field must stay unformatted even though its every value is whole.
+  test('a row-mode alias with no schema field stays unformatted even though its values are whole', () => {
+    const request: QueryRunRequest = { kind: QueryRequestKind.Structured, query: query({ mode: QueryMode.Row }) };
+
+    const meta = buildExecutedMeta(request, result([{ bucket: 1000 }, { bucket: 2000 }]), FIELDS, 'dial_usage_log');
+
+    expect(meta.columnValueClasses).toEqual({});
+  });
+
+  test('a structured aggregate run classifies a measure alias with no schema field from its values', () => {
+    const request: QueryRunRequest = { kind: QueryRequestKind.Structured, query: query({ group_by: ['deployment'] }) };
+
+    const meta = buildExecutedMeta(request, result([{ deployment: 'gpt-4o', total: 3 }]), FIELDS, 'dial_usage_log');
+
+    expect(meta.columnValueClasses).toEqual({ total: ResultValueClass.Compact });
+  });
+
+  // A measure column that names a schema field of a non-numeric type (Enum) must stay unformatted
+  // even when its values happen to parse as numbers — the declared type decides, not the values.
+  test('a structured aggregate run withholds the class of a declared Enum measure with numeric-looking values', () => {
+    const enumFields: AnalyticsEntityField[] = [
+      ...FIELDS,
+      { name: 'status', type: AnalyticsFieldType.Enum, source: 'status' },
+    ];
+    const request: QueryRunRequest = { kind: QueryRequestKind.Structured, query: query({ group_by: ['deployment'] }) };
+
+    const meta = buildExecutedMeta(
+      request,
+      result([
+        { deployment: 'gpt-4o', status: '200' },
+        { deployment: 'gpt-4o', status: '429' },
+      ]),
+      enumFields,
+      'dial_usage_log',
+    );
+
+    expect(meta.columnValueClasses).toEqual({});
   });
 });

--- a/apps/ai-dial-admin/src/constants/analytics/query-builder.ts
+++ b/apps/ai-dial-admin/src/constants/analytics/query-builder.ts
@@ -1,5 +1,6 @@
 import { SelectOption } from '@epam/ai-dial-ui-kit';
 
+import { AnalyticsFieldType } from '@/src/models/analytics/entity';
 import {
   QueryLogicalOperator,
   QueryOperator,
@@ -15,6 +16,7 @@ import {
   ChartType,
   CompactSelectOptionDescriptor,
   QueryBuilderWarning,
+  ResultValueClass,
 } from '@/src/models/analytics/query-builder';
 import { QueryBuilderI18nKey } from '@/src/constants/i18n';
 
@@ -173,3 +175,20 @@ export const WARNING_I18N: Record<QueryBuilderWarning, QueryBuilderI18nKey> = {
 // Which section header surfaces which aggregate-validation warning.
 export const GROUP_BY_SECTION_WARNINGS = [QueryBuilderWarning.EmptyAggregate, QueryBuilderWarning.MissingGroupByField];
 export const AGGREGATE_SECTION_WARNINGS = [QueryBuilderWarning.EmptyAggregate];
+
+// The schema's own statement about a column's value class. A type absent from this map is a type the
+// result grid does not format — Uuid, Enum, Boolean, String, Object, Array.
+export const FIELD_TYPE_VALUE_CLASS: Partial<Record<AnalyticsFieldType, ResultValueClass>> = {
+  [AnalyticsFieldType.Integer]: ResultValueClass.Compact,
+  [AnalyticsFieldType.Long]: ResultValueClass.Compact,
+  [AnalyticsFieldType.Decimal]: ResultValueClass.Significant,
+  [AnalyticsFieldType.Timestamp]: ResultValueClass.DateTime,
+  [AnalyticsFieldType.Date]: ResultValueClass.DateTime,
+};
+
+// The catalog's own classification of what a column measures, and the only machine-readable unit signal a
+// field carries that is not its name: there is no unit attribute, `description` states the unit in prose
+// and `display_name` states it in parentheses on some rows only. The frontend already depends on this same
+// tag vocabulary — CONVERSATION_TAG_LABEL_KEY in constants/analytics/conversations-trace.ts maps nine tag
+// values, `performance` among them, to the conversations column picker's group labels.
+export const DURATION_FIELD_TAG = 'performance';

--- a/apps/ai-dial-admin/src/models/analytics/query-builder.ts
+++ b/apps/ai-dial-admin/src/models/analytics/query-builder.ts
@@ -266,6 +266,15 @@ export interface PieSlice {
   value: number;
 }
 
+// How a result cell renders its value. Resolved from the executed query, not from the live builder
+// state, so what the grid shows follows the run that produced the shown result.
+export enum ResultValueClass {
+  Compact = 'compact',
+  Significant = 'significant',
+  DateTime = 'date-time',
+  Duration = 'duration',
+}
+
 // Snapshot of the query a result came from. Chart availability and the X/Y option lists must follow
 // what was actually executed — the live builder state can diverge from the shown result between runs.
 // columnLabels maps result columns to their schema display names (group-by columns of the executed
@@ -276,6 +285,7 @@ export interface ExecutedQueryMeta {
   dimensionColumns: string[];
   aggregateColumns: string[];
   columnLabels: Record<string, string>;
+  columnValueClasses: Record<string, ResultValueClass>;
 }
 
 export interface ResultColumnClassification {

--- a/apps/ai-dial-admin/src/utils/formatting/number-formatting.ts
+++ b/apps/ai-dial-admin/src/utils/formatting/number-formatting.ts
@@ -78,3 +78,37 @@ const getIntegerPart = (integerPart: string): string => {
 function formatInt(value: string | number, delimiter: string): string {
   return (value + '').replace(/(\d)(?=(\d\d\d)+(?!\d))/g, '$1' + delimiter);
 }
+
+const SIGNIFICANT_DIGITS = 2;
+// At and above one unit, two significant digits would report 19.74 as 20 and switch to exponential
+// notation past two integer digits; the compact formatter reads better and keeps the leading digits.
+const SIGNIFICANT_COMPACT_THRESHOLD = 1;
+
+// Only meaningful after a decimal point: on an integer it would turn 20 into 2.
+const stripTrailingZeros = (text: string): string =>
+  text.includes('.') ? text.replace(/0+$/, '').replace(/\.$/, '') : text;
+
+export const formatSignificantNumber = (value: number | string): string => {
+  if (value === '' || value == null || isNaN(+value) || !isFinite(+value)) {
+    return '';
+  }
+
+  const amount = new Big(+value);
+  if (amount.eq(0)) {
+    return '0';
+  }
+
+  const sign = amount.lt(0) ? '-' : '';
+  const absAmount = amount.abs();
+
+  // At and above one unit, the compact formatter is currency-agnostic and already reads better.
+  if (absAmount.gte(SIGNIFICANT_COMPACT_THRESHOLD)) {
+    return `${sign}${formatNumberWithExponent(absAmount.toNumber())}`;
+  }
+
+  // Sub-unit values need significant digits, not decimal places, to stay legible across orders of
+  // magnitude. Deriving the scale from Big's own exponent keeps it from switching to exponential
+  // notation below 1e-7, which is what toPrecision would do.
+  const decimals = -absAmount.e + SIGNIFICANT_DIGITS - 1;
+  return `${sign}${stripTrailingZeros(absAmount.toFixed(decimals))}`;
+};

--- a/apps/ai-dial-admin/src/utils/formatting/tests/number-formmating.spec.ts
+++ b/apps/ai-dial-admin/src/utils/formatting/tests/number-formmating.spec.ts
@@ -1,4 +1,8 @@
-import { formatNumberWithExponent, formatNumberByDelimiter } from '@/src/utils/formatting/number-formatting';
+import {
+  formatNumberWithExponent,
+  formatNumberByDelimiter,
+  formatSignificantNumber,
+} from '@/src/utils/formatting/number-formatting';
 import { describe, expect, test, vi } from 'vitest';
 
 describe('Utils :: formatting :: formatNumber', () => {
@@ -70,5 +74,19 @@ describe('Utils ::formatting :: formatNumberByDelimiter', () => {
   test('Should return formatted string', () => {
     const result = formatNumberByDelimiter('rherger');
     expect(result).toBe('');
+  });
+});
+
+describe('Utils :: formatting :: formatSignificantNumber', () => {
+  test.each([
+    [0, '0'],
+    [0.0004792, '0.00048'],
+    [19.74, '19.7'],
+    [4897666958, '4.9 B'],
+    [-0.0004792, '-0.00048'],
+    ['abc', ''],
+    ['', ''],
+  ])('Should format %p as %p', (value, expected) => {
+    expect(formatSignificantNumber(value)).toBe(expected);
   });
 });

--- a/openspec/changes/archive/2026-09-10-analytics-numeric-column-rounding/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-10-analytics-numeric-column-rounding/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-10

--- a/openspec/changes/archive/2026-09-10-analytics-numeric-column-rounding/design.md
+++ b/openspec/changes/archive/2026-09-10-analytics-numeric-column-rounding/design.md
@@ -1,0 +1,739 @@
+# Design — numeric and temporal formatting for the Query Builder result grid
+
+Read this in slices. Every section names the files it governs on its first line, so an implementer can
+grep its own paths and read only that section. Section 1 is the only one everybody needs.
+
+## 1. The shape of the change (everybody reads this)
+
+Files, in dependency order:
+
+| # | File | What it gains |
+|---|---|---|
+| 1 | `apps/ai-dial-admin/src/utils/formatting/number-formatting.ts` | `formatSignificantNumber` — currency-agnostic significant digits |
+| 2 | `apps/ai-dial-admin/src/models/analytics/query-builder.ts` | `ResultValueClass` enum, `ExecutedQueryMeta.columnValueClasses` |
+| 3 | `apps/ai-dial-admin/src/constants/analytics/query-builder.ts` | `FIELD_TYPE_VALUE_CLASS` lookup |
+| 4 | `apps/ai-dial-admin/src/components/Analytics/QueryBuilder/utils/executed-meta.ts` | `buildColumnValueClasses`, wired into all three `buildExecutedMeta` branches |
+| 5 | `apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Result/chart-options.ts` | `strictNumber` becomes an export (one word, no logic change) |
+| 6 | `apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Result/result-column-format.ts` | **new** — value class → `Partial<ColDef>` |
+| 7 | `apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Result/ResultArea.tsx` | spreads the fragment onto each column |
+
+**`apps/ai-dial-admin/src/components/Analytics/QueryBuilder/utils/result.ts` is NOT touched.** Its
+`getResultColumns` stays a pure, dependency-light description of the columns, exactly as its own comment
+says, and it keeps being safe for `executed-meta.ts` to call. The formatting is layered on in
+`ResultArea.tsx`, next to where `cellRenderer: ResultValueCell` is already attached, and for the same
+stated reason: grid-runtime concerns are attached there, not in the column builder.
+
+The dependency chain that matters for dispatch: 4 needs 2 and 3; 6 needs 1, 2 and 5; 7 needs 4 and 6.
+
+**§12 adds a fourth value class — `Duration` — to files 2, 3, 4 and 6 and to nothing else.** It landed
+after §1-§5 shipped, on a defect in the shipped behaviour: a millisecond column read `698.7 K`. If your
+item is 7.1 or 7.2, read §12 plus §3, §4 and §6; if your item is anything else, §12 does not touch it.
+
+## 2. The significant-digit formatter
+
+File: `apps/ai-dial-admin/src/utils/formatting/number-formatting.ts`. Nothing else in section 2.
+
+Add one export and one module-private helper. Do not touch `formatNumberWithExponent` or
+`formatNumberByDelimiter`; do not touch `apps/ai-dial-admin/src/utils/analytics/conversation-formatting.ts`.
+
+```ts
+const SIGNIFICANT_DIGITS = 2;
+// At and above one unit, two significant digits would report 19.74 as 20 and switch to exponential
+// notation past two integer digits; the compact formatter reads better and keeps the leading digits.
+const SIGNIFICANT_COMPACT_THRESHOLD = 1;
+
+// Only meaningful after a decimal point: on an integer it would turn 20 into 2.
+const stripTrailingZeros = (text: string): string => ...;
+
+export const formatSignificantNumber = (value: number | string): string => ...;
+```
+
+Behaviour, and these are the boundaries the tests must name:
+
+| Input | Output | Why |
+|---|---|---|
+| `0` | `'0'` | not `''`; a returned zero is a value |
+| `0.0004792` | `'0.00048'` | two significant digits; the measured median cost, which `formatNumberWithExponent` renders as `0` and `formatNumberByDelimiter` as `0.00` |
+| `19.74` | `'19.7'` | at/above 1 → compact, so the leading digits survive |
+| `4897666958` | `'4.9 B'` | at/above 1 → compact |
+| `-0.0004792` | `'-0.00048'` | sign preserved |
+| unparseable (`'abc'`, `''`) | `''` | the call site substitutes today's rendering; see §6 |
+
+Implementation constraint: derive the decimal count from `Big`'s own exponent
+(`-amount.e + SIGNIFICANT_DIGITS - 1`) rather than calling `toPrecision`, which switches to exponential
+notation below `1e-7`. This is the same technique `formatSignificantCost` uses, and the two functions are
+deliberately separate — see §10.
+
+## 3. The contract: value class and where it travels
+
+Files: `apps/ai-dial-admin/src/models/analytics/query-builder.ts` and
+`apps/ai-dial-admin/src/constants/analytics/query-builder.ts`.
+
+An `enum`, not a string-literal union (`.claude/rules/code-standards.md`), in the models file beside
+`ExecutedQueryMeta`:
+
+```ts
+// How a result cell renders its value. Resolved from the executed query, not from the live builder
+// state, so what the grid shows follows the run that produced the shown result.
+export enum ResultValueClass {
+  Compact = 'compact',
+  Significant = 'significant',
+  DateTime = 'date-time',
+}
+```
+
+and one **required** field on `ExecutedQueryMeta`:
+
+```ts
+columnValueClasses: Record<string, ResultValueClass>;
+```
+
+Required, not optional, on purpose: `buildExecutedMeta` returns from three branches, and a required field
+makes TypeScript refuse a fourth branch that forgets it. An optional field would let a new branch silently
+lose the formatting, and a column that is merely unformatted looks plausible — which is the exact failure
+mode this change exists to fix. The cost is five fixture literals in two spec files
+(`Result/tests/ResultArea.spec.tsx`, `Result/tests/ResultChart.spec.tsx`); they are in scope for the items
+that own those files.
+
+The type→class map is a const lookup, so it belongs in `constants/`, not in `models/`
+(`.claude/rules/code-standards.md`, constants/models split). Put it in
+`apps/ai-dial-admin/src/constants/analytics/query-builder.ts`:
+
+```ts
+// The schema's own statement about a column's value class. A type absent from this map is a type the
+// result grid does not format — Uuid, Enum, Boolean, String, Object, Array.
+export const FIELD_TYPE_VALUE_CLASS: Partial<Record<AnalyticsFieldType, ResultValueClass>> = {
+  [AnalyticsFieldType.Integer]: ResultValueClass.Compact,
+  [AnalyticsFieldType.Long]: ResultValueClass.Compact,
+  [AnalyticsFieldType.Decimal]: ResultValueClass.Significant,
+  [AnalyticsFieldType.Timestamp]: ResultValueClass.DateTime,
+  [AnalyticsFieldType.Date]: ResultValueClass.DateTime,
+};
+```
+
+A `Partial<Record<...>>` rather than a full one: the absent keys *are* the "everything else unchanged"
+rule, and spelling them out as `undefined` would only invite someone to fill them in.
+
+## 4. Resolving the class
+
+File: `apps/ai-dial-admin/src/components/Analytics/QueryBuilder/utils/executed-meta.ts`.
+
+A **new sibling function**, not an extension of `buildColumnLabels`. `columnLabels` is consumed as
+`Record<string, string>` by `ChartBuildContext`, `ResultChart.tsx` and `getResultColumns`; widening its
+element type to carry a second, unrelated resolution would change every one of those consumers for no
+benefit, and it would conflate "what this column is called" with "how its values read".
+
+```ts
+export const buildColumnValueClasses = (
+  columns: string[],
+  fields: AnalyticsEntityField[],
+  measureColumns: string[],
+  rows: ResultRows,
+): Record<string, ResultValueClass> => { ... };
+```
+
+The algorithm, in this order:
+
+1. For each column, match it against `fields` by name — the **same match `buildColumnLabels` already
+   makes**. **A column that matches a field is decided by the schema and by nothing else**: it takes
+   `FIELD_TYPE_VALUE_CLASS[field.type]` when the map has an entry, and otherwise gets no class at all.
+   The gate on step 2 is therefore *the absence of a schema field*, not the absence of a resolved class
+   — `if (field) { … } else if (measureColumns.includes(column))`. `FIELD_TYPE_VALUE_CLASS` is a
+   `Partial` record, so a declared `Enum`, `Uuid`, `Boolean` or `String` yields `undefined`; gating on
+   the class would drop exactly those columns into step 2, where an `Enum` whose values are numeric
+   strings would be compacted — contradicting the scenario *A non-numeric schema column is untouched*.
+   (Settled on a QA finding during implementation; the ruling is recorded in the run's `run.json`. Do
+   not re-derive the looser version from an earlier reading of this section.)
+2. Only a column that names **no** schema field and appears in `measureColumns` goes into a candidate
+   list.
+   Classify the candidates with the existing exported `getStrictNumericColumns(rows, candidates)` — which
+   already rejects a boolean and an array, unlike a plain `Number()` coercion — and then split the
+   survivors: `rows.every((row) => Number.isInteger(Number(row[column])))` → `Compact`, otherwise
+   `Significant`. A candidate that is not strictly numeric gets no class.
+3. Everything else gets no entry. An empty `rows` yields no step-2 class at all, which is correct: there
+   is nothing to render anyway.
+
+`measureColumns` is a parameter rather than being read off the meta inside the function, because **the
+caller is where the two exclusions live** and they are the part BA asked to be checked against the real
+branches. Read `buildExecutedMeta` as it stands today: three returns.
+
+| Branch (as the code stands) | `columnValueClasses` | `measureColumns` |
+|---|---|---|
+| `request.kind === Sql` and `!translated` | `{}` | — |
+| `request.kind === Sql` and `translated` | `{}` when `translated.entity !== entityName`, else `buildColumnValueClasses(...)` | `translated.mode === QueryMode.Aggregate ? aggregateColumns : []` |
+| structured | `buildColumnValueClasses(...)` | `request.query.mode === QueryMode.Aggregate ? aggregateColumns : []` |
+
+Three decisions are encoded in that table, and each is load-bearing:
+
+- **The untranslated-SQL branch gets `{}`.** In that branch `aggregateColumns` comes from
+  `classifyResultColumns`, i.e. `getStrictNumericColumns` over *every* returned column with no group-by
+  semantics behind it — so a raw id or an unrecognised epoch column lands in it. Driving formatting from
+  that list would compact an id, which is precisely what the proposal's SQL non-goal exists to prevent.
+  Verified against the code, not inferred from the prose: `executed-meta.ts` lines 64-72.
+- **The entity gate is shared with the labels.** A translated SQL run over another entity already
+  withholds `columnLabels`; withholding the classes on the same condition gives one rule instead of two,
+  and the justification is the same one — the selected schema does not describe these columns.
+- **The value-shape source applies only in aggregate mode.** In row mode `dimensionColumns` is empty, so
+  `aggregateColumns` degenerates to *every* returned column, and a scalar-function projection such as a
+  time bucket returning epoch millis would be whole-valued and compact as `1.8 T`. Gating on
+  `QueryMode.Aggregate` removes that whole class of misclassification, and it matches the proposal's own
+  wording that the declared schema type is "the primary and only source for a row-mode projection".
+
+## 5. `strictNumber` becomes an export
+
+File: `apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Result/chart-options.ts`. One word.
+
+Add `export` to the existing `strictNumber`; change nothing else in the file. §6 needs the same
+definition of "this value really is a number" that produced the class in §4 — a column classified by
+`getStrictNumericColumns` must be formatted by a parser that agrees with it, or a `true` or an `[]` reads
+as a number in one place and not the other. A third private copy of that four-line parse would be the one
+that drifts.
+
+## 6. Value class → `Partial<ColDef>`
+
+File: `apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Result/result-column-format.ts` — **new**.
+It sits in `Result/` rather than in `utils/` for the same reason `Result/chart-options.ts` does: it
+describes grid/chart output and it may import `'use client'` modules and shared `ColDef` partials, which a
+file under `utils/` should not (`.claude/rules/utils.md`).
+
+```ts
+export const getValueClassColumn = (valueClass?: ResultValueClass): Partial<ColDef> => { ... };
+```
+
+One export, one switch on the enum (a switch, not nested ternaries — `.claude/rules/code-standards.md`),
+returning `{}` for `undefined` so an unclassified column is untouched.
+
+| Class | Fragment |
+|---|---|
+| `Compact` | `...numericColumn`, `...baseNumberFilter`, `valueFormatter` → `formatNumberWithExponent`, `tooltipValueGetter` → exact text (below) |
+| `Significant` | the same, with `valueFormatter` → `formatSignificantNumber` |
+| `DateTime` | `...dateTimeColumn`, `...dateFilter` — nothing else |
+
+Both numeric fragments share one private builder taking the `(n: number) => string` formatter, so the
+branch that differs is one argument.
+
+**Spread the shared partials; do not re-implement them.** `numericColumn`
+(`apps/ai-dial-admin/src/constants/grid-columns/configs.ts`) carries the `align-right` cell and header
+classes, `numberValueComparator`, and a `filterValueGetter` that feeds `toNumberOrNull` — see §7 for why
+all three are wanted. `dateTimeColumn` carries the triplet the proposal asks for:
+`formatDateTimeToLocalString` as both the `valueFormatter` and the `tooltipValueGetter`, and
+`toDateOrNull` as the `filterValueGetter`.
+
+**`dateFilter` is not optional — but not because the alternative throws.** Verified against
+`node_modules/ag-grid-community` and against this repository's own columns, because an earlier draft of
+this section had the reason inverted:
+
+- Spreading `dateTimeColumn` alone, under the inherited `agTextColumnFilter` +
+  `floatingFilter: true` from `AgGridWrapper`'s `defaultColDef`, does **not** throw. ag-grid's text
+  filter runs both sides through `defaultLowercaseFormatter = (from) => from == null ? null :
+  from.toString().toLowerCase()` (`node_modules/ag-grid-community/dist/package/main.cjs.js:54856`),
+  and a `Date` has a `toString()`. Columns ship that combination in production today —
+  `CREATED_AT_COLUMN` and `UPDATED_AT_COLUMN` in `constants/grid-columns/base-columns.ts:20-32`, and
+  `keyGeneratedAt`, `expiresAt` and `firstTimestamp` in `constants/grid-columns/grid-columns.tsx`
+  (lines 347, 352, 1056).
+- What actually happens is **silent incoherence**: the user types text that is matched against
+  `"mon mar 30 2026 … gmt+0300"` — the `Date`'s own `toString()` — while the cell shows
+  `toLocaleString()`. Nothing the user can see explains a miss.
+- The crash recorded at `apps/ai-dial-admin/src/constants/grid-columns/filters.ts:7-9`
+  (`date.getFullYear is not a function`) is the **other** direction: `agDateColumnFilter` receiving the
+  `contains` model a *text* floating filter sends. That is why `dateFilter` itself carries
+  `floatingFilter: false`, and it is why `filter: 'agDateColumnFilter'` and `floatingFilter: false` can
+  only be adopted together.
+
+So the pairing stays required — for filter/cell coherence, and because `dateFilter`'s
+`floatingFilter: false` clause is what makes its own `filter` safe. The real hazard is hand-assembling
+the filter (a `filter: 'agDateColumnFilter'` without the `floatingFilter` clause) rather than spreading
+`dateFilter` whole. `dateTimeColumn` + `dateFilter` is exactly the combination shipped at
+`constants/grid-columns/grid-columns.tsx:1314-1316`; take it as one unit. `baseNumberFilter` pairs with
+the numeric fragment for the same coherence reason — `toNumberOrNull` in a `filterValueGetter` under a
+text filter would have the user filtering digits the cell no longer shows — and that pairing is shipped at
+`grid-columns.tsx:558-559`.
+
+Two rules the fragment must implement itself:
+
+- **Fall back, never blank.** `valueFormatter` parses with the exported `strictNumber` (§5) and, on
+  `null`, returns `renderCell(value)` — today's rendering. A `formatSignificantNumber` that returned `''`
+  straight into a cell would hide a value the run returned.
+- **The tooltip carries the value, not the text — within double precision.** A private
+  `exactNumberText(value)`: `strictNumber` it; if it parses and `Number.isInteger` holds, return
+  `formatNumberByDelimiter(value)` passing the **raw** value rather than the formatted text; otherwise
+  return `renderCell(value)` verbatim. Passing the raw value is the right design — it is strictly
+  better than repeating the shortened text — but it buys **no exactness guarantee at the extremes**,
+  and no test asserts one. `formatNumberByDelimiter` coerces with `+value` before it ever reaches `Big`
+  (`apps/ai-dial-admin/src/utils/formatting/number-formatting.ts:27` and `:59`), so a `Long` past 2^53
+  has already lost digits whichever way it is passed; and `splitNumber` splits the `Big`'s string on
+  `'e'` and discards the exponent (`:64`), so `1e21` comes back as `"1"`. Both ranges are outside what
+  this change's measured cases cover; the limit is named in §11 rather than worked around here.
+  Never route a fractional value through
+  `formatNumberByDelimiter`, whose default precision rounds it to two decimals — that is one of the two
+  measured failures this change exists to fix. Do **not** copy the precedent at
+  `grid-columns.tsx:1487`, which repeats the compacted string in its own tooltip; `.claude/rules/a11y.md`
+  forbids shortening a value with no way to reach the full one, and that precedent is a defect this change
+  should not spread.
+
+## 7. Alignment, sorting and filtering — the risk BA left open, decided
+
+Files: the fragment in §6; the behaviour under test in
+`apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Result/tests/result-column-format.spec.ts`.
+
+**Decision: adopt `numericColumn` whole — the `align-right` classes, `numberValueComparator` and the
+numeric `filterValueGetter`.** BA flagged that this may change how a result column sorts today. It does,
+and the change is a fix rather than a regression:
+
+- Today a result column inherits `baseColumnComparator` from `AgGridWrapper`'s `defaultColDef`
+  (`apps/ai-dial-admin/src/components/Grid/AgGridWrapper.tsx:217`). That comparator lowercases strings and
+  then compares with `>`. For a `Decimal(38,12)` that arrives as a JSON string — which is how a backend
+  preserves precision — that is a lexicographic sort, so `"9"` sorts after `"10"`. It also has
+  `if (!aLower)`, so a legitimate `0` is treated as absent and pushed to the end of the result.
+- `numberValueComparator` coerces a string through `Big` and tests `=== undefined` rather than
+  falsiness, so both defects disappear.
+- Nothing depends on the current order: `getResultColumns` sets no `sort` and no `sortIndex`, and the
+  saved-query payload carries the view and the chart config, not a grid sort. The Chart view does its own
+  ordering in `sortRowsByX`, untouched here.
+
+Right-alignment comes along with it and is wanted: it is what every other numeric column in this app does,
+and a compacted figure is much easier to compare down a right-aligned column.
+
+**What the spread can and cannot clobber — settled, not a risk.** An earlier draft treated this as an
+open hazard; all four questions are now answered by reading the sources, so do not re-open them:
+
+- **No member of the fragment declares a `valueGetter`** — not `numericColumn` or `dateTimeColumn`
+  (`constants/grid-columns/configs.ts:11-23`), not `baseNumberFilter` or `dateFilter`
+  (`constants/grid-columns/filters.ts`). The result column's deliberate getter, which resolves a dotted
+  column name as a literal key instead of a nested path (`utils/result.ts:38`), therefore survives the
+  spread in §8. The constraint in §8 stands as a constraint on future edits, not as a live doubt.
+- **The result column sets no `cellClass` and no `headerClass`**, so `numericColumn`'s `align-right`
+  pair adds alignment rather than replacing anything.
+- **A dotted column name resolves in the filter too.** Both shared `filterValueGetter`s read
+  `data?.[colDef.field || '']` — a literal key lookup, not a path walk — so `usage.tokens` reaches
+  `toNumberOrNull` / `toDateOrNull` correctly even though `field` alone would not have.
+- **`ResultValueCell` keeps a populated `valueFormatted`.** Both branches of the fragment return a
+  string from `valueFormatter` — the numeric one via `format(parsed)` or `renderCell(value)`, the
+  date-time one via `formatDateTimeToLocalString`, which returns `''` rather than `undefined` for an
+  absent value (`utils/formatting/date.ts:20-27`). The cell's `valueFormatted ?? ''` never falls
+  through to the empty string by accident, and a formatted number or date is far below
+  `RESULT_TOOLTIP_MAX_CHARS`, so the preview/dialog path stays unreached for these classes.
+
+The residual hazards are named in §11.
+
+## 8. Wiring
+
+File: `apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Result/ResultArea.tsx`. One `useMemo`.
+
+```tsx
+const columns = useMemo(
+  () =>
+    getResultColumns(result, meta?.columnLabels).map((col) => ({
+      ...col,
+      ...getValueClassColumn(meta?.columnValueClasses?.[col.field ?? '']),
+      cellRenderer: ResultValueCell,
+    })),
+  [result, meta?.columnLabels, meta?.columnValueClasses],
+);
+```
+
+Spread order is the whole of the correctness here, and getting it backwards is silent
+(`.claude/rules/components.md` §3): the fragment must come **after** `...col` so its `valueFormatter` and
+`tooltipValueGetter` win, and it must never carry a `valueGetter` — `getResultColumns` sets one
+deliberately, because `field` alone makes AG Grid read a dotted column name as a nested path. Add
+`meta?.columnValueClasses` to the dependency list; forgetting it leaves a stale formatter across two runs
+whose columns happen to be named the same.
+
+`ResultValueCell` needs no change: it already renders `valueFormatted`, so the formatter drives the cell
+text, and a formatted number or date is far below `RESULT_TOOLTIP_MAX_CHARS`, so the preview/dialog path is
+never reached for these classes.
+
+## 9. Tests
+
+Files, one per implementation slice:
+
+| Spec file | What it must pin |
+|---|---|
+| `apps/ai-dial-admin/src/utils/formatting/tests/number-formmating.spec.ts` (note the existing typo in the name) | the table in §2, each boundary by value: `0`, a sub-unit decimal, `19.74`, a multi-billion integer, a negative sub-unit, an unparseable string |
+| `apps/ai-dial-admin/src/components/Analytics/QueryBuilder/utils/tests/executed-meta.spec.ts` | the branch table in §4: declared `Integer`/`Long`/`Decimal`/`Timestamp`/`Date`, a `Uuid` getting no class, an aggregate alias whole vs fractional, a row-mode alias getting nothing, untranslated SQL `{}`, translated SQL over another entity `{}`, empty rows |
+| `apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Result/tests/result-column-format.spec.ts` (new) | call the fragment's own `valueFormatter`, `tooltipValueGetter`, `filterValueGetter` and `comparator` directly — the way `constants/grid-columns/tests/configs.spec.ts` already tests `dateTimeColumn` — for `999` vs `1000`, a sub-unit decimal, an epoch-millis timestamp, a non-numeric value in a numeric column, `9` vs `10` as strings through the comparator |
+| `apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Result/tests/ResultArea.spec.tsx` | that the fragment reaches the grid: the existing `GridView` mock must also capture `columnDefs`, and one case asserts a compacted string and one an unformatted column |
+
+Two facts about this repository that change what a green run means here (both from the studio's durable
+notes, both measured): spec files are **eslint-ignored repo-wide**, and `npm run typecheck` excludes
+`*.spec.ts(x)` — so a passing test is not a type-correct test, and a final "run lint" task says nothing
+about the specs. Assert on values, not on shapes: a test that checks a `ColDef` merely *has* a
+`valueFormatter` passes against any function.
+
+**One boundary case is not independently guarded, and that is accepted.** `999 → '999'` in
+`result-column-format.spec.ts` cannot be reddened: `renderCell(999)` also yields `'999'`, so the
+assertion passes whether the value went through the compact formatter or through the fallback. What it
+does constrain is `formatNumberWithExponent`'s `.replace(/\.0$/, '')`, which lives in
+`utils/formatting/number-formatting.ts` — outside the ColDef fragment. `1000 → '1 K'` in the same
+describe is the case that actually pins the fragment's formatter, and the scenario *The compact
+threshold is exact* is verified by the pair, not by the `999` assertion alone. This is a known weakness
+of that one assertion, not a defect: nothing about the change would make it fail.
+
+Run them the cheap way, from `apps/ai-dial-admin/`:
+`npx vitest run src/components/Analytics/QueryBuilder/Result/tests/result-column-format.spec.ts --reporter=dot`.
+
+## 12. The duration class — recognising a millisecond column
+
+Files: `apps/ai-dial-admin/src/models/analytics/query-builder.ts` (the enum),
+`apps/ai-dial-admin/src/constants/analytics/query-builder.ts` (the tag constant),
+`apps/ai-dial-admin/src/components/Analytics/QueryBuilder/utils/executed-meta.ts`
+(`buildColumnValueClasses`) and
+`apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Result/result-column-format.ts`
+(`getValueClassColumn`). Rejected alternatives for this rule are in §10 and its risks in §11 — it is placed
+ahead of those two so they stay the document's closing sections, which is why the numbering runs
+1-9, 12, 10, 11. Read §1, §3,
+§4 and §6 alongside this section — it adds a fourth value class to all four files those sections govern
+and changes nothing else in them.
+
+**What went wrong.** `duration_ms` is a schema `Long`, so §3's map resolves it `Compact` and the cell reads
+`698.7 K` under a header that names milliseconds. Compacting a quantity that carries a unit is the same
+failure class as rendering a sub-unit cost as `0` — the failure this change exists to fix — so it is fixed
+here rather than deferred.
+
+**What went wrong the second time, and the decision that replaced it.** The first fix rendered the cell
+through `formatDurationMs`, so `698700` read `698.7s`. The owner rejected it, on a point nothing in this
+design had caught: **the header still says `Duration (ms)`, so a cell reading `698.7s` under it is a lie.**
+Two ways out — strip the unit from the header, or leave the value in the unit the header declares — and the
+owner chose the second: **a duration column is shown unformatted.** Stripping the unit was declined because
+the header is the catalog's `display_name` and the delta already requires that a schema column be headed by
+it ("Result grid heads schema columns by display name"); rewriting catalog display text in the client to
+accommodate a client-side formatter inverts which of the two is authoritative. So the recognition below
+survives intact and only its consequence changes — see "The consequence" further down, which is the whole of
+what §12 now asks for in `result-column-format.ts`.
+
+### The recognition rule
+
+A column that matched a schema field, and whose class §3's map resolved to `Compact` or `Significant`,
+becomes `Duration` when **`field.tag === 'performance'`**. The column's **name is not read**. Nothing else
+ever produces `Duration`.
+
+```ts
+// constants/analytics/query-builder.ts
+// The catalog's own classification of what a column measures, and the only machine-readable unit signal a
+// field carries that is not its name: there is no unit attribute, `description` states the unit in prose
+// and `display_name` states it in parentheses on some rows only. The frontend already depends on this same
+// tag vocabulary — CONVERSATION_TAG_LABEL_KEY in constants/analytics/conversations-trace.ts maps nine tag
+// values, `performance` among them, to the conversations column picker's group labels.
+export const DURATION_FIELD_TAG = 'performance';
+```
+
+```ts
+// executed-meta.ts — module-private, called from step 1 of buildColumnValueClasses
+const schemaValueClass = (field: AnalyticsEntityField): ResultValueClass | undefined => {
+  const declared = FIELD_TYPE_VALUE_CLASS[field.type];
+  const isUnitBearing = declared === ResultValueClass.Compact || declared === ResultValueClass.Significant;
+
+  return isUnitBearing && field.tag === DURATION_FIELD_TAG ? ResultValueClass.Duration : declared;
+};
+```
+
+Step 1 of `buildColumnValueClasses` changes to `const declaredClass = schemaValueClass(field);` and nothing
+else in §4's algorithm moves. Two properties of that ordering are load-bearing:
+
+- **The tag narrows, it never creates.** It is consulted only after the type map has already resolved a
+  numeric class, so a `Timestamp`/`Date` field keeps `DateTime` however it is tagged, and a `String`,
+  `Enum`, `Uuid` or `Boolean` field tagged `performance` stays unformatted. Matching the tag before the
+  type is the implementation mistake this ordering forbids, and it is what bounds the blast radius of the
+  tag being free text (below).
+- **It cannot reach the neighbours that must not move.** `duration_bucket`, `token_bucket` and
+  `turn_bucket` are ordinals tagged `bucket`, `response_status` / `max_response_status` are untagged codes,
+  and `request_body_bytes` / `response_body_bytes` are tagged `request` / `response`; all of them keep the
+  `Compact` class they have today.
+
+**Coverage, measured — including what falls through.** Read straight out of the provisioned catalog
+(`column_mapping`, the table behind the entity-schema endpoint), not inferred:
+
+| Field | Type | Tag | Class it gets |
+|---|---|---|---|
+| `conversations.avg_duration_ms` | decimal | `performance` | `Duration` |
+| `conversations.duration_ms` | long | `performance` | `Duration` |
+| `turns.duration_ms` | long | `performance` | `Duration` |
+| `turns.hop_duration_total_ms` | long | `performance` | `Duration` |
+| `dial_usage_log.operation_duration_ms` | long | `performance` | `Duration` |
+| `demo_conversations.duration_ms` | long | *(none)* | **`Compact`** — falls through |
+| `dial_usage_log.request_body_bytes` | long | `request` | `Compact` (a non-goal; see §10) |
+| `conversation_buckets.duration_bucket` | integer | `bucket` | `Compact` (correct — an ordinal) |
+
+Two facts settle the rule. First, `performance` falls on **exactly** those five columns and on nothing
+else in the whole catalog — so the tag has no false positive to defend against as provisioned, only a
+future one. Second, the **one** millisecond field it misses is `demo_conversations.duration_ms`, on a
+seeded demo table, and what it degrades to is `Compact` — the rendering that column has today. So the
+whole cost of refusing to read the name is: one demo column keeps a defect the four real duration
+fields lose.
+
+**Why the name is not read, even as a fallback.** A `_ms` suffix would have covered the demo column too,
+and it was the rule an earlier draft of this section carried. It is rejected on three counts:
+
+- The name is **the same provisioned catalog data as the tag** (`column_mapping.name`), re-versionable in
+  exactly the same way, so "the tag can change under us" is not a reason to prefer the name — it applies
+  identically to both. What differs is that the tag is the column's *classification*, maintained as a
+  vocabulary (`tag_order` on the table-management API exists so a table's tags stay curated and ordered
+  for exactly this kind of UI consumption), while the name is a spelling.
+- The earlier draft's premise — "the name is the only per-field unit statement the schema carries" — is
+  **false as written**. `description` states the unit in prose on the tagged rows ("Wall-clock duration of
+  the operation, in milliseconds", "Size of the request body, in bytes") and `display_name` states it in
+  parentheses on four of them ("Duration (ms)"). The catalog knows the unit; what it lacks is a field to
+  put it in — `column_mapping` has thirteen columns and none of them is `unit`.
+- A suffix rule commits the result grid to a naming convention it cannot enforce, and the failure it
+  admits is the worse direction: a non-duration column someone names `*_ms` renders as a time, which
+  states something false, where the tag's failure mode as provisioned is a demo column that keeps
+  rendering as it does today.
+
+**Follow-up, not designed here:** ask the analytics service for a real `unit` attribute on
+`column_mapping`, surfaced on `QuerySchemaFieldDto` beside `tag` and `display_name`. That is where this
+belongs long-term — it closes the untagged demo column, it removes the free-text risk below, and it is the
+one thing that would let the bytes non-goal in §10 be reopened cheaply. Filing it is the owner's; the
+design records the dependency so the tag gate can be replaced by one read of `field.unit` when it lands.
+
+**The residual risk this leaves is in §11:** `tag` is free text on the wire (`QuerySchemaFieldDto` calls it
+"Optional label identifying the column"), so a future numeric field tagged `performance` in some other unit
+— a rate, a ratio, a percentile — would render as a time. The class gate keeps it to numeric fields, and
+§11 names what it looks like and how it is undone.
+
+### Aggregate aliases stay as they are
+
+An output column with no schema field keeps §4 step 2's value-shape class — `Compact` when every returned
+value is whole, `Significant` otherwise — and **never** becomes a `Duration`. An alias is authored, not
+declared: `computedColumnNames`/`deriveAlias`
+(`apps/ai-dial-admin/src/components/Analytics/QueryBuilder/utils/fields.ts:118-184`) builds it from the
+argument field's *display name* and the function's label, and the user may retype it, so it carries no unit
+the client can read. Recovering the unit would mean walking the executed query's select expression to the
+argument field **and** knowing whether the function preserves the unit — `SUM`/`AVG`/`MIN`/`MAX` do,
+`COUNT` does not — which is either a hardcoded function vocabulary against a catalog that is
+runtime-supplied, or the function catalog's declared return type, which the proposal's Non-goals exclude.
+Getting it wrong is worse than not formatting: `COUNT(duration_ms)` over 1 200 conversations would read
+`1.2s`. The consequence is stated plainly in the delta and in §11: an `AVG(duration_ms)` column reads as a
+compact figure under an alias naming the field, with the exact number in its tooltip.
+
+### The consequence: no formatting at all
+
+File: `apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Result/result-column-format.ts` — one case
+and one import.
+
+```ts
+// A duration column is left unformatted on purpose. Its header is the catalog's `display_name`, which
+// states the unit ("Duration (ms)"), so a formatted cell would contradict its own header — and the client
+// does not rewrite catalog display text. The recognition's whole job is to keep this column out of
+// `Compact`, which rendered a millisecond count as `698.7 K`. Do not "fix" this back to a duration
+// formatter without first moving the unit out of the header; see design.md §12.
+case ResultValueClass.Duration:
+  return {};
+```
+
+The `formatDurationMs` import goes with it — nothing else in the file uses it, and an unused import is a
+lint error. **`formatDurationMs` itself is not deleted and not edited**: it predates this change, it belongs
+to `analytics/conversation-trace-listing`, and four trace-view call sites depend on its current shape.
+
+**Why the class still exists when it maps to `{}`.** This is the question a future reader will ask, and the
+answer is the measurement above: without the recognition, `turns.duration_ms` is a schema `Long`, §3's map
+resolves it `Compact`, and the cell reads `698.7 K` — the defect this section was opened for. The class is
+doing real work; the work is *negative*. `{}` is not "nothing happened", it is "this column is deliberately
+excluded from the numeric formatting the rest of §3 applies", and it is the only value that leaves the
+figure in the unit the header declares.
+
+**Why the member keeps the name `Duration`** rather than something like `Unformatted`. The enum names what
+the column *is*, and `executed-meta.ts` is where that is decided: `schemaValueClass` reads a `performance`
+tag and concludes "this column is a time measurement", which is a statement about the data and is true
+whatever the grid then does with it. Naming it `Unformatted` would move the confusion rather than remove
+it — the resolver would then read "a `performance` tag means unformatted", which hides the reason — and it
+would make the enum a mix of two vocabularies, three members naming a rendering and one naming its absence.
+The formatting decision belongs in the formatting module, so that is where the comment lives.
+
+**What follows from `{}`, stated as limits rather than left to be discovered:**
+
+- **A recognised duration column gets no numeric column configuration.** No `align-right`, no
+  `numberValueComparator`, no `agNumberColumnFilter` — it keeps the result grid's defaults, exactly as it
+  did before this change. That is a smaller column than a `Compact` one, and it is the price of `{}`. The
+  alternative considered was `{ ...numericColumn, ...baseNumberFilter }` with no `valueFormatter`: raw text,
+  right-aligned, numeric sort. Declined because the owner's instruction was the unclassified outcome, and
+  because adopting `numberValueComparator` on a column this change no longer formats would import that
+  comparator's `new Big('')` throw (§11) for no rendering benefit. Trigger to revisit: a report that a
+  duration column sorts wrongly — at which point that fragment is the one-line answer.
+- **A tagged millisecond column reads raw while an untagged one reads compacted.** `turns.duration_ms`
+  shows `698700`; `demo_conversations.duration_ms`, which the catalog leaves untagged, shows `698.7 K`. Two
+  columns of the same quantity, two renderings, possibly in the same result. This is the fall-through of the
+  tag rule meeting the new consequence, and it is a real inconsistency — it is written into the delta as a
+  scenario so it is visible rather than discovered. It is not closed by reading the column name (declined,
+  measured, §10) but by the catalog declaring a unit (the follow-up above).
+- **An aggregate over a duration field still compacts.** `AVG(duration_ms)` under a derived alias reads
+  `698.7 K`, because an alias carries no tag. Unchanged from the previous decision, and now the second face
+  of the same inconsistency.
+- **`formatHopDuration` and `formatDurationMs` are both moot here**, so the earlier comparison between them
+  is gone. It survives in §10 only as a rejected alternative, because "render it as a duration" is the
+  decision that was reversed and a future reader has to be able to see that it was considered twice.
+
+**What would have to change if the shape of the problem changed.** If the analytics service grows a `unit`
+attribute on `column_mapping` (the follow-up above), the tag gate becomes one read of `field.unit` and the
+question of whether to format reopens — with the header still the deciding fact. If instead a design decides
+the result grid owns its own headers and may drop a unit from a display name, then the duration formatter
+comes back and this section's `{}` becomes `getNumericColumn(formatDurationMs)` again. Both of those are
+decisions about the header, not about the cell; that is the invariant this section leaves behind.
+
+### Tests
+
+| Spec file | What it must pin |
+|---|---|
+| `apps/ai-dial-admin/src/components/Analytics/QueryBuilder/utils/tests/executed-meta.spec.ts` | a `Long` field tagged `performance` resolving `Duration` where its type alone would have resolved `Compact`; the same for a `Decimal`-typed tagged field, where the type alone resolves `Significant`; a millisecond-**named** but untagged field resolving `Compact` — the fall-through, asserted so it is a decision rather than an accident — beside a tagged field in the same result resolving `Duration`; a `String`-typed and a `Timestamp`-typed field both tagged `performance`, keeping what their types resolve (no class and `DateTime`); a `bucket`-tagged ordinal and an untagged status code resolving `Compact`; an aggregate alias over a tagged field resolving `Compact`/`Significant` and never `Duration` |
+| `apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Result/tests/result-column-format.spec.ts` | that the `Duration` fragment is empty, and empty in the ways that matter rather than by a deep-equality check alone: it carries no `valueFormatter`, no `tooltipValueGetter`, no `comparator`, no `filter` and no `cellClass`, so the column keeps the result grid's own rendering; and it equals the fragment an unclassified column gets. Pin the negative directly — a test that only asserted `toEqual({})` would pass if a future edit returned a differently-shaped no-op, and the point is which members are absent |
+
+The `Duration` fragment is now the one case whose correctness is an absence, which inverts §9's usual
+advice: for the two formatting classes, assert values and never shapes; for this one, assert the specific
+members that must not be there, because an absence has no value to assert. What the `executed-meta` spec
+pins is unchanged — the recognition still resolves the same classes — so no assertion in that file moves,
+only the comments that described what the class then rendered.
+Run them the cheap way, from `apps/ai-dial-admin/`:
+`npx vitest run src/components/Analytics/QueryBuilder/utils/tests/executed-meta.spec.ts src/components/Analytics/QueryBuilder/Result/tests/result-column-format.spec.ts --reporter=dot`.
+
+## 10. Alternatives rejected
+
+- **One formatter for every numeric column.** Rejected upstream in the proposal on measured evidence: over
+  a real usage-log distribution a compact formatter renders a median cost of `0.0004792` as `0` and a
+  delimited formatter as `0.00`, while a multi-billion token sum is only readable compacted. Recorded here
+  because it is the decision the whole design hangs off.
+- **Extract the digit logic out of `formatSignificantCost` and have it delegate.** This was the tidier
+  option and it loses on three counts. `analytics/conversations-listing` requires that cost rounding "be
+  local to this page and MUST NOT change the shared currency formatter" — moving its implementation into a
+  shared util puts a spec-owned behaviour where a later edit to the generic silently changes the money
+  column. The two functions differ where it matters: cost renders `$0` for zero, the result cell renders
+  `0`. And `formatSignificantCost` parses through `toBig` from
+  `apps/ai-dial-admin/src/utils/analytics/scalar.ts`; a cross-cutting formatter must not import an
+  analytics helper (`.claude/rules/utils.md` placement). Cost of the rejection: the six-line technique
+  exists twice. Trigger to revisit: a third caller.
+- **Move `stripTrailingZeros` into `number-formatting.ts` and import it back into
+  `conversation-formatting.ts`.** Rejected: it is a two-line private helper, the rule of three is not met
+  (`.claude/rules/components.md` §3), and it is the only thing that would have put a file the
+  conversations-listing spec owns into this change's blast radius. Duplicate the two lines with its
+  comment.
+- **Extend `buildColumnLabels` to return label *and* type.** Rejected in §4: it changes three consumers of
+  `Record<string, string>` for no benefit and conflates two resolutions.
+- **Put the formatting into `getResultColumns` in `utils/result.ts`.** Rejected in §1: it would drag
+  `configs.ts` (a `'use client'` module that imports a React header component) into a pure util that
+  `executed-meta.ts` and `chart-options.ts` both import, and `ResultArea.tsx` is already the stated place
+  for grid-runtime concerns.
+- **Infer a temporal column from epoch-looking values.** Rejected by the proposal and re-encoded here as
+  an explicit scenario: an aggregate alias whose values are all epoch millis must not become a date
+  column. There is no way to tell it from a large count.
+- **Reuse `numericColumn` for alignment but keep the inherited comparator.** Rejected in §7 — the
+  inherited comparator sorts a string decimal lexicographically and sorts a `0` to the end, so declaring a
+  column numeric and leaving it sorting as text is the worse of the two inconsistencies.
+- **Recognise a duration from the column's name** — a `_ms` suffix, alone or as a fallback behind the
+  `performance` tag. This was the rule an earlier draft of §12 carried, and it is rejected there on
+  measured catalog evidence. In summary: the name is the same provisioned catalog data as the tag, so it
+  is no more stable, while being a spelling rather than a classification; the premise that the name is the
+  schema's only unit statement is false (`description` says "in milliseconds" and `display_name` says
+  "(ms)"); and the suffix admits the worse failure direction, a non-duration column named `*_ms` rendering
+  as a time. Taken as a *fallback* behind the tag it would have covered the one field the tag misses
+  (`demo_conversations.duration_ms`, a seeded demo table) — that is the whole of what the rejection costs,
+  and what that column degrades to is the compact rendering it already has. Trigger to revisit: none. The
+  fix for the gap is the catalog unit attribute in §12's follow-up, not a second heuristic.
+- **Recognise bytes columns too** (`request_body_bytes`, `response_body_bytes`), since `formatBytes`
+  already exists. Rejected and recorded as a non-goal, and the reason is now precise: the catalog gives
+  them no unit signal at all. Their tags (`request`, `response`) name the message part they belong to, not
+  a unit, so the tag rule has nothing to key on — the unit lives only in their `description` ("in bytes")
+  and their `display_name` ("Request body size"), which are prose and display text. This is a catalog gap
+  rather than a frontend one: the frontend already has the formatter and the call site, and is missing only
+  the declaration. A byte count compacted to `4.2 M` is coarse rather than nonsense, where a duration
+  compacted to `698.7 K` states a nonsense figure, so the gap is also cheap to leave open. Trigger to
+  revisit: the catalog unit attribute in §12's follow-up, which would let bytes join in one line.
+- **Render a recognised duration column as a duration** — `formatDurationMs`, so `698700` reads `698.7s`.
+  This shipped, and the owner rejected it: the column's header is the catalog display name and states the
+  unit ("Duration (ms)"), so a converted cell contradicts its own header. Rejected in §12, and with it the
+  alternative way out, **stripping the unit from the header** — the client does not rewrite catalog display
+  text, and the delta requires a schema column to be headed by it. Cost of the rejection: a long duration
+  reads as a large millisecond count, which is at least the count its header claims. Trigger to revisit: the
+  catalog `unit` attribute of §12's follow-up, or a decision that the result grid owns its own headers.
+- **Reuse `formatHopDuration`**, which escalates to minutes and hours and would render 698 700 ms as
+  `11m 39s`. Rejected before the decision above made every duration formatter moot, and recorded because it
+  is the first thing a reader will reach for if the header question is ever reopened: it returns `''` for
+  any value `<= 0`, encoding a conversations-trace ruling that `analytics/conversation-trace-listing` owns
+  as a requirement, and the result grid must not implement another capability's spec over data from any
+  table — the same objection this list already raises against `formatSignificantCost`.
+- **Keep `numericColumn` and `baseNumberFilter` on a duration column while dropping only the
+  `valueFormatter`** — raw text, right-aligned, numeric sort and filter. Rejected in §12: the owner's
+  instruction was that a recognised duration render exactly as an unclassified column does, and adopting
+  `numberValueComparator` on a column this change no longer formats would import its `new Big('')` throw
+  (§11) for no rendering benefit. Cost of the rejection: that column loses right-alignment and numeric
+  sorting. Trigger to revisit: a report that a duration column sorts wrongly.
+- **Carry the unit through an aggregate function** to a `SUM`/`AVG` alias. Rejected in §12: it needs either
+  a hardcoded function vocabulary against a runtime-supplied catalog or the function catalog's declared
+  return type, which the proposal's Non-goals exclude — and a wrong answer (`COUNT(duration_ms)` reading
+  `1.2s`) states something false, where today's answer merely fails to shorten.
+- **A browser-verification pass over every scenario.** Narrowed rather than rejected; see
+  `plan.json`'s `browser_verification`. Two scenarios go to the browser, because the grid is mocked in
+  every unit test in this area and the date-time branch is the only one that changes filter machinery. The
+  other fifteen are a formatter's output asserted directly.
+
+## 11. Risks — what could be wrong here, and where it shows up first
+
+- **A schema `Long` that is really an id compacts to `1.2 T`.** The design takes the declared type as the
+  schema's own statement about the value class and has no way to tell a quantity from an identifier.
+  Shows up first as a nonsense figure in a row-mode projection of such a column. If it bites, the fix is a
+  denylist by field name in `FIELD_TYPE_VALUE_CLASS`'s neighbourhood, not a value heuristic.
+- **An aggregate alias that is decimal by nature but whole in every returned row classifies as
+  `Compact`.** `AVG` returning exactly `2` across a short result is the case. Shows up as a compacted
+  average; the next run with a fractional value classifies correctly, so it presents as inconsistency
+  between runs rather than as a wrong number. Accepted: the alternative is wiring the function catalog's
+  return type, which the proposal excludes.
+- **The tooltip is not digit-exact past double precision.** `formatNumberByDelimiter` coerces with
+  `+value` before constructing `Big`, and its `splitNumber` discards the exponent of a `Big` that
+  stringifies in exponential form — so a `Long` past 2^53 loses low-order digits and `1e21` renders as
+  `"1"` (§6). Shows up as a tooltip that disagrees with the backend on the last few digits of a very
+  large id-like `Long`, which is the same column §11's first bullet says should not have been compacted
+  in the first place. Not pre-empted: `formatNumberByDelimiter` is shared and this repository's rule is
+  to use rather than edit a shared helper. If it bites, the fix is a string-path delimiter in
+  `result-column-format.ts`, not a change to the shared formatter.
+- **`numberValueComparator` throws on `new Big('')`.** A declared `Decimal` column that returns an empty
+  string in a row would throw inside AG Grid's sort. `null` is safe (it takes the non-string path).
+  Shows up first as a crash on the first click of that column's header, not as a wrong order — so it is
+  loud rather than silent. Not pre-empted here, because `numberValueComparator` is shared and this
+  repository's rule is to use rather than edit a shared helper; if it bites, wrap the comparator inside
+  `result-column-format.ts`.
+- **`formatNumberWithExponent` does not compact a negative magnitude** — its first branch is
+  `num < 1000`, so `-5000` renders `-5000`. Pre-existing in the shared formatter and out of scope. Shows
+  up on a negative measure (a delta or a difference aggregate), which analytics measures here are not.
+- **`AnalyticsFieldType.Date` renders through `toLocaleString`, so a date-only value grows a
+  `00:00:00`.** The proposal mandates reusing `dateTimeColumn`, which has no date-only variant. Shows up
+  on a `Date`-typed column. If it matters, it is a new partial in `configs.ts` and a fourth value class.
+- **A long duration reads as a large millisecond count.** A recognised duration column is unformatted
+  (§12), so a five-minute conversation reads `312450` rather than `5m 12s`. It is the figure its header
+  claims and no digit is lost, so this is legibility rather than accuracy — and it is the shipped state of
+  every millisecond column in this grid before this change, minus the compaction. Shows up first on
+  `duration_ms` for a long conversation. The fix is not a formatter at this call site while the header
+  states the unit: it is the catalog `unit` attribute of §12's follow-up, or a decision about who owns the
+  header.
+- **A recognised duration column loses right-alignment and numeric sorting.** `{}` carries no
+  `numericColumn`, so the column sits with the grid's defaults and a millisecond value arriving as a string
+  sorts lexicographically — `'9'` after `'10'` — exactly as it did before this change. Shows up on the first
+  click of that column's header. If it bites, the one-line fix is the fragment §10 records as rejected:
+  `{ ...numericColumn, ...baseNumberFilter }` with no `valueFormatter`.
+- **`performance` is a classification, not a declared unit, and it is free text on the wire.**
+  `QuerySchemaFieldDto` types `tag` as an optional label with no value set (`user_email` is the example in
+  its own schema annotation), so nothing but current practice keeps `performance` meaning "a millisecond
+  measurement". Two directions, and they cost differently. A duration field that arrives **untagged** or
+  retagged loses its duration rendering and compacts — the defect returns for that one column, visibly,
+  and that is already the state of `demo_conversations.duration_ms` today (§12). A **non-duration numeric**
+  field tagged `performance` — a rate, a ratio, a percentile — loses its compact rendering and shows raw
+  digits. Both directions are now benign, which is the one thing the reversal in §12 bought: when the
+  consequence was a duration formatter, a mistagged percentile read "0.9s" and stated something false;
+  with no formatter, the worst a mistag can do is leave a large number uncompacted. Shows up as one column
+  rendered unlike its numeric neighbours. If it bites, the fix is one line in `schemaValueClass` — a
+  field-name denylist beside the tag gate, or the catalog `unit` attribute of §12's follow-up read in place
+  of the tag. Do not reach for the column name as a second signal without re-reading §12: that trade was
+  measured and declined.
+- **The rule is verified against the catalog as provisioned locally, which is not a contract.** The
+  five-column coverage table in §12 was read out of `column_mapping` on the local instance, and this
+  repository's own notes record that local and dev provisioning differ in places. A dev or production
+  catalog that tags fewer fields shows up as a duration column compacting — the same benign direction as
+  the untagged demo field, and the reason item 7.3 puts one duration cell in front of a real backend
+  rather than trusting a hand-written field fixture. Item 7.3 is now withdrawn, so nothing below the
+  browser proves the fetched entity schema delivers `tag: performance` at all, and a catalog that tags
+  fewer fields than the local one silently degrades every duration column to a compacted count.
+- **An aggregate over a duration field still compacts.** `AVG(duration_ms)` under the builder's derived
+  alias — which names the field, so its header still implies milliseconds — reads `698.7 K`. This is the
+  reported defect surviving in aggregate mode, accepted deliberately in §12 and pinned by a scenario so it
+  is visible rather than silent. Shows up on any grouped duration query. If the owner wants it, the fix is
+  select-expression resolution plus a unit-preserving function set, and it needs the proposal's Non-goal on
+  the function catalog reopened.
+- **The `Timestamp` branch changes a column's filter type**, not only its text. If `dateFilter` were
+  omitted or paired wrongly the failure is a runtime throw inside the grid, and every unit test in this
+  area mocks `GridView` away. This is the reason the browser subset is not empty.

--- a/openspec/changes/archive/2026-09-10-analytics-numeric-column-rounding/proposal.md
+++ b/openspec/changes/archive/2026-09-10-analytics-numeric-column-rounding/proposal.md
@@ -1,0 +1,172 @@
+## Why
+
+The Analytics Query Builder's result grid (`analytics/query-viewer`) renders every cell — including
+numeric and timestamp ones — through `renderCell` in `apps/ai-dial-admin/src/components/Analytics/QueryBuilder/utils/result.ts`,
+which is `String(value)` with no numeric or datetime handling at all (`getResultColumns`'s
+`valueFormatter` calls it directly). A row-mode or aggregate query that returns a large integer, a
+sub-unit decimal, a cost figure, or an epoch-millis timestamp shows every digit unrounded and every
+timestamp as a raw number, unlike the rest of the app: `grid-columns.tsx:1480-1495` already formats a
+numeric column (`parameters`) with `formatNumberWithExponent`, and `openspec/specs/analytics/conversations-listing/spec.md`
+already specifies the same discipline for two Analytics grid columns ("Token counts SHALL be
+compacted..." / "Cost SHALL be rounded to significant digits..."). The result grid is the one
+Analytics grid whose columns are derived at runtime from the query rather than declared in a
+`ColDef[]`, so it is the one place this formatting was never wired in.
+
+A single formatter for every number was measured and rejected against a real usage-log distribution:
+a compact/exponent formatter renders a typical sub-unit decimal (a per-row average cost) as `0`, and a
+thousand-delimited formatter renders the same value as a two-decimal figure indistinguishable from
+zero — both destroy the money signal a `Decimal` column carries, while compaction is the only readable
+choice for a multi-billion-value integer sum. The fix is a **formatter that branches by the result
+column's value class**, not one formatter applied uniformly.
+
+A fourth class was added to this same change after sections 1-5 shipped: the owner found a
+`duration_ms` column (schema type `Long`) rendering compacted (`698.7 K`) under a header naming
+milliseconds. Compacting a quantity that carries a unit is the same class of failure as rendering a
+sub-unit cost as `0` — the failure this change already exists to fix — so it is fixed here rather than
+as separate work.
+
+## What Changes
+
+- Add cell formatting to the Query Builder result grid (`getResultColumns` / `ResultArea.tsx`),
+  branching by the result column's resolved value class:
+  - **`Integer` / `Long`** — compact `K/M/B/T` notation, reusing `formatNumberWithExponent`
+    (`src/utils/formatting/number-formatting.ts`), the same formatter `grid-columns.tsx:1480-1495`
+    already uses for the `parameters` column.
+  - **`Decimal`** — significant-digit formatting so a sub-unit value survives rather than rounding to
+    zero. `formatSignificantCost` (`src/utils/analytics/conversation-formatting.ts`) already does
+    significant-digit rounding but always prefixes `$` and is written for cost specifically — it
+    cannot be reused as-is for a plain (non-money) decimal measurement. This change needs a
+    currency-agnostic significant-digit formatter (an extraction of `formatSignificantCost`'s digit
+    logic, or an equivalent); introducing it is in scope for this change, and its exact shape is SA's
+    to design.
+  - **`Timestamp` / `Date`** — reuse the existing `dateTimeColumn` partial `ColDef`
+    (`src/constants/grid-columns/configs.ts:11`) rather than calling `formatDateTimeToLocalString`
+    by hand, so the result column gets the same `valueFormatter` + `tooltipValueGetter` +
+    `filterValueGetter` triplet every other datetime column in the app already gets.
+  - **`Duration`** — reuse the existing `formatDurationMs`
+    (`src/utils/analytics/conversation-formatting.ts`) unmodified, so a millisecond quantity reads in
+    its own unit (`"698.7s"`, `"12ms"`) rather than as a compacted count of milliseconds. A column
+    takes this class only when both hold: the declared-schema-type source below has already resolved
+    it to a numeric class (`Integer`/`Long` → compact, `Decimal` → significant-digit), **and** the
+    catalog tags that field `performance` — the same tag vocabulary the frontend already reads for
+    the conversations column picker (`CONVERSATION_TAG_LABEL_KEY`,
+    `src/constants/analytics/conversations-trace.ts:319-329`). The tag is consulted only after the
+    type has already resolved a numeric class, so it narrows a numeric class and never creates
+    formatting the type refused: a `Timestamp`/`Date`/`String`/`Enum`/`Boolean` field tagged
+    `performance` keeps exactly what its declared type resolves, and the column's **name plays no
+    part** in recognition. Measured against the provisioned catalog, the tag falls on exactly five
+    millisecond-measurement fields and nothing else; one duration field on a seeded demo table
+    carries no tag and deliberately falls through to plain compact rendering, which the delta pins as
+    its own scenario ("An untagged millisecond column keeps its compact rendering",
+    `specs/analytics/query-viewer/spec.md`). **Rejected:** recognizing a duration by an `_ms` name
+    suffix instead of, or as a fallback behind, the tag — it would have additionally covered the
+    untagged demo field, but it keys behaviour on a column's name/spelling rather than the catalog's
+    own classification, and it risks a non-duration column named `*_ms` rendering as a time.
+    `design.md` §10 records the rejection.
+  - **Everything else** (a dimension column that is a `Uuid`/`Enum`/`Boolean`, or a computed column
+    with no resolvable value class) — unchanged, through today's `renderCell`.
+- **Where the value class comes from — two sources, in priority order:**
+  1. **The declared schema type.** `buildColumnLabels` (`executed-meta.ts`) already matches a returned
+     column against `AnalyticsEntityField[]` to resolve its display name; the same match yields the
+     field's `type` (`AnalyticsFieldType`: `Integer`, `Long`, `Decimal`, `Timestamp`, `Date`, `Uuid`,
+     `Enum`, `Boolean`, `String`). This is the primary and only source for a row-mode projection or a
+     `group_by` dimension column, and it is the sole route by which a `Timestamp`/`Date` column, or a
+     `Duration` column, is ever recognized — the mechanism does not infer either from a column's raw
+     value or its name.
+  2. **For an aggregate output column under an alias** (e.g. a `SUM`/`AVG` result with no schema
+     field of its own), `ExecutedQueryMeta.aggregateColumns` already marks it a measure by query
+     semantics (everything in the result that is not a `group_by` dimension), and `getStrictNumericColumns`
+     (`Result/chart-options.ts:52`) already confirms every returned value is a number, rejecting a
+     boolean or an array. With no declared sub-type available for an alias, whether the aggregate
+     formats as compact (`Integer`/`Long`-like) or significant-digit (`Decimal`-like) is decided from
+     the returned values themselves (whole-valued throughout vs. not) — the same shape of check
+     `getStrictNumericColumns` already performs, extended to classify rather than merely confirm.
+     This source never yields `Duration`: an aggregate alias carries no schema field to read a
+     `performance` tag from, so it keeps the compact or significant-digit class its returned values
+     resolve, whatever it is named or aliased as.
+  - **This second source applies only outside the untranslated-SQL fallback.** For an untranslated
+    SQL run, `ExecutedQueryMeta.aggregateColumns` is populated by `classifyResultColumns` calling the
+    same `getStrictNumericColumns` directly over *every* returned column, including a raw id or an
+    unrecognized epoch column — using that path to drive formatting would misclassify exactly the
+    columns the SQL non-goal below excludes. The aggregate-column formatting path therefore only
+    applies when `ExecutedQueryMeta` was built from a structured query or a successfully translated
+    SQL query, where `aggregateColumns` is derived from `group_by` semantics, not from a blind
+    value scan.
+- No wiring of the query builder's function catalog return type into aggregate columns: the two
+  sources above already answer the question that wiring would have answered, so it is not part of
+  this change and no follow-up is filed for it.
+- Keep the full, unrounded value reachable on a formatted cell — the grid's tooltip (already present in
+  `getResultColumns` and, for the precedent column, in `grid-columns.tsx:1480-1495`) SHALL carry the
+  formatted text on the same terms `formatNumberWithExponent` already establishes there, per
+  `.claude/rules/a11y.md`'s rule against truncating a value with no way to reach the full one. For the
+  `Timestamp`/`Date` branch, `dateTimeColumn`'s own `tooltipValueGetter` already satisfies this; for the
+  `Duration` branch, the tooltip carries the millisecond count, thousand-delimited, not the duration
+  text the cell shows.
+- Excluded from this change (see Non-goals): the SQL view's untyped result columns, and the small
+  integer counters elsewhere in Analytics.
+
+## Impact
+
+- **Affected capability:** `analytics/query-viewer` (the result grid) is the only sub-capability whose
+  spec changes — now covering numeric, timestamp/date and duration result-column formatting, not
+  numeric alone. `analytics/query-builder`'s `buildColumnLabels`/`ExecutedQueryMeta` plumbing (`executed-meta.ts`,
+  shared by the chart views) is touched to carry a field's declared type, so a change there is shared
+  with the chart axis/column-classification code in `Result/chart-options.ts` — that file's own
+  value-based `getStrictNumericColumns`/`getNumericColumns` heuristics are read (not modified) by the
+  aggregate-column path above, and remain otherwise unaffected: they still classify dimensions vs.
+  measures for chart axes, not cell display.
+- **Formatters reused unmodified:** `formatNumberWithExponent`
+  (`src/utils/formatting/number-formatting.ts`), `dateTimeColumn`'s existing
+  `formatDateTimeToLocalString`/`toDateOrNull` triplet (`src/constants/grid-columns/configs.ts`,
+  `src/utils/formatting/date.ts`), and `formatDurationMs`
+  (`src/utils/analytics/conversation-formatting.ts`) — the duration recognition rule adds one
+  `DURATION_FIELD_TAG = 'performance'` constant and one field-tag check to the same classification
+  path already built for the other three classes, with no new file and no change to
+  `formatDurationMs` or its siblings (`formatHopDuration`, `formatSignificantCost`). **One formatter
+  needs new or extracted code:** the `Decimal` branch's significant-digit formatting has no
+  currency-agnostic existing implementation — `formatSignificantCost` is money-specific (always
+  `$`-prefixed). This is the one place this change is not a pure reuse, and SA should treat the exact
+  extraction/naming as a design decision.
+- **`dateTimeColumn`'s `valueFormatter` calls `formatDateTimeToLocalString` (which uses
+  `toLocaleString`) directly, with no SSR-hydration guard, and this is the established, safe pattern
+  for a grid cell** — confirmed by the two existing call sites that already do this in an AG Grid
+  `valueFormatter`/`valueGetter` (`Analytics/Pipelines/PipelinesView.tsx:192`,
+  `Analytics/Evaluators/EvaluatorsView.tsx:37`), as opposed to `useLocalDateTimeString`
+  (`src/hooks/use-local-date-time-string.ts`), which exists only for text rendered directly in a
+  component's JSX during SSR (headers, detail panels) to avoid a server/client mismatch on first
+  paint. A grid cell computed by AG Grid's own imperative rendering is outside that SSR-matched React
+  tree, so reusing `dateTimeColumn` as-is carries no hydration risk.
+- **Risk, not a decision:** reusing `numericColumn`'s `align-right` cell class / `numberValueComparator`
+  (`src/constants/grid-columns/configs.ts`) on a dynamically derived result column may change how that
+  column sorts today (string sort vs. numeric sort). Flagged for SA to decide, not decided here.
+- **No backend or API contract change.** Scope stays inside
+  `apps/ai-dial-admin/src/components/Analytics/**` and the grid-column/formatting utilities it uses.
+
+## Non-goals
+
+- **Other Analytics listing grids are reviewed and left out.** The Tables catalog's `columnsCount`
+  (`TablesView.tsx`), the Pipelines listing's `generation` (`PipelinesView.tsx`), and the Evaluators
+  listing's `latest_version` (`EvaluatorsView.tsx`) are the only other currently-raw numeric cells found
+  in Analytics grids. All three are small sequence/version counters, not quantities, and stay
+  unformatted permanently — not "for now."
+- **`Uuid`/`Enum`/`Boolean` result columns stay excluded by construction**, not by a new rule: the
+  formatting branch keys on a resolved value class of `Integer`/`Long`/`Decimal`/`Timestamp`/`Date`/
+  `Duration`, so none of these ever reaches it.
+- **The SQL view's result columns stay unformatted.** A SQL-authored query's columns carry no schema
+  attribution at all (`openspec/specs/analytics/query-viewer/spec.md`: "A SQL-view run... SHALL head
+  every column by its returned name"), confirmed by `executed-meta.ts` returning `columnLabels: {}`
+  for an untranslated SQL request, so there is no declared type to format from and the aggregate-column
+  path above is deliberately scoped to exclude this case too — applying a blind value scan here would
+  risk formatting an id or a raw epoch column, which is exactly what must not happen.
+- **No wiring of the query builder's function catalog's declared return type into aggregate columns.**
+  The two existing sources this change relies on (declared schema type; `aggregateColumns` +
+  value-shape classification) already answer the question that wiring would answer.
+- **Byte-size columns (`request_body_bytes`, `response_body_bytes`) stay unformatted.** Their catalog
+  tags (`request`, `response`) name the message part they belong to, not a unit, so the duration tag
+  rule has nothing to key on for them — the unit exists only in the field's prose `description`, never
+  in a machine-readable attribute.
+- **The catalog carries no `unit` attribute.** This is the limitation behind both the byte-size gap
+  above and the one untagged duration field falling through to compact rendering: there is no
+  machine-readable place for a unit to live beyond the `performance` tag's narrow, free-text
+  vocabulary.
+- **No change to the conversations log, conversation trace, tables, pipelines or evaluators specs.**

--- a/openspec/specs/analytics/query-viewer/spec.md
+++ b/openspec/specs/analytics/query-viewer/spec.md
@@ -3,13 +3,13 @@
 ## Purpose
 
 What a run produces: execution of the current query, the result grid, the stat tiles, and the table and chart views over the returned rows. How the query was authored is `analytics/query-builder`.
-
 ## Requirements
-
 ### Requirement: Run query and result
 
 The toolbar Run action SHALL execute the current query and render the result in the main results area. In the Builder view the query is the serialized `StructuredQuery` from the builder state; in the JSON view it is the query as written in the editor — both executed via a server action delegating to `analyticsDataApi.executeAction` (`/v1/queries/execute`). The result SHALL be shown as a grid whose columns are derived from the returned result (the result's declared columns when present, otherwise the union of keys across the returned rows), with object/array cell values stringified. A cell SHALL make its value readable whatever its size: up to a
-bounded length the value SHALL be reachable as a tooltip carrying that rendered text — including for an
+bounded length the value SHALL be reachable as a tooltip — carrying that rendered text, or, where that
+rendered text is a rounded or compacted rendering of a numeric value, the value as returned in full (see
+"Numeric and temporal result-cell formatting") — including for an
 object, which the grid's shared tooltip otherwise drops for not being a string — and beyond that length the
 cell SHALL instead show a bounded preview and a named control that opens the value in a dialog. The dialog
 SHALL present the value in a read-only editor that scrolls, folds and searches, SHALL indent a value that is
@@ -192,3 +192,175 @@ Each reason the Chart view has nothing to render SHALL have its own hint text na
 
 - **WHEN** a result row includes a column whose name contains a literal `.` (e.g. an enrichment projection) and the backend response carries a value for it
 - **THEN** the Table view shows that value in the corresponding cell rather than leaving it blank
+
+### Requirement: Numeric and temporal result-cell formatting
+
+The result grid SHALL render a numeric or temporal result cell through the formatter its column's resolved **value class** selects, and SHALL leave every other column rendering exactly as it does today. There are four resolved classes — compact, significant-digit, duration and date-time — and "no class", which means no change. Three of the four select a formatter. The **duration** class deliberately selects none: it is a recognition whose whole consequence is to withhold the compact formatter, so a duration column renders exactly as an unclassified one does.
+
+The value class SHALL be resolved when the executed-query metadata is built, and carried on that metadata beside the column labels, so that what the grid renders follows the query that produced the shown result rather than the live builder state. Two sources resolve it, in this order:
+
+1. **The declared schema type.** A returned column that names a field of the executed entity's schema takes its class from that field's `AnalyticsFieldType`: `Integer` and `Long` are compact, `Decimal` is significant-digit, `Timestamp` and `Date` are date-time, and every other type — `Uuid`, `Enum`, `Boolean`, `String`, `Object`, `Array` — resolves to no class and so to no formatting. This is the only source that can ever yield the date-time class: a temporal column SHALL NOT be inferred from a value that merely looks like epoch millis.
+
+   A field this source resolves to a **numeric** class — compact or significant-digit — **which the catalog tags `performance`** SHALL take the **duration** class instead of that numeric class, and a duration column SHALL be left unformatted: its cells render the value exactly as returned, in the unit the column is measured in. The field's `tag` is the catalog's own classification of what a column measures, and it is the only machine-readable signal of a unit the schema carries that does not read the column's name: a field carries no unit attribute, its `description` states the unit only in prose ("in milliseconds", "in bytes"), and its `display_name` states it only sometimes and only as display text. The column's **name SHALL NOT be consulted**: a name is a naming convention rather than a declaration, and the same catalog that supplies the tag supplies the name, so keying on the name buys no stability while committing the grid to a spelling. The tag SHALL only ever narrow a class this source already resolved as numeric — a declared temporal, string, enum or boolean field keeps what its declared type resolves however it is tagged, so the tag can never create formatting where the declared type asked for none. A numeric column the catalog tags anything else — a `*_bucket` ordinal, a status code, a counter, a byte size — is therefore never a duration, whatever it is named.
+
+   **Why a recognised duration is left unformatted rather than rendered as a duration.** The column's header is the catalog's `display_name`, and on a duration field that display name states the unit — "Duration (ms)". The grid heads a schema column by that display name (see "Result grid heads schema columns by display name"), and the frontend SHALL NOT rewrite a catalog-supplied display name to strip a unit from it. A cell reading "698.7s" under a header reading "Duration (ms)" contradicts its own header, which is a worse defect than the one it fixes. So the duration class SHALL leave the value in the unit the header declares: it withholds the compact formatter — the thing that stated the nonsense figure, "698.7 K" for a count of milliseconds — and adds nothing. A duration column SHALL adopt no formatter, no tooltip override and no numeric column configuration, and SHALL therefore render, align, sort, filter and tooltip exactly as a column of no class does.
+
+   **The coverage this buys, and what it misses, are both known.** Measured against the provisioned catalog, the `performance` tag falls on exactly the millisecond measurements — the per-hop mean and the summed hop durations of a conversation, a turn's wall-clock and summed hop durations, and a usage-log operation's duration — and on nothing else, so the rule withholds compaction from exactly the millisecond measurements the builder can project and from nothing else. A numeric millisecond field the catalog leaves **untagged** SHALL keep the class its declared type resolves — a compact count — rather than being recovered from its name. The catalog has one such field, on a seeded demo table, and the trade is deliberate: a name-derived rule would state a unit the catalog never declared.
+
+   **This leaves one inconsistency, which SHALL be stated rather than hidden:** a millisecond column the catalog tags reads as a raw millisecond count, while a millisecond column it leaves untagged reads as a compacted one ("698.7 K"), so two columns measuring the same quantity can read differently in the same result. The inconsistency is accepted on the same terms as the fall-through itself — the untagged column keeps the rendering it has today, and the tagged one is the only one the catalog lets the client recognise. It is closed by the catalog declaring a unit per column, not by a second heuristic in the client.
+2. **The returned values of an aggregate output column.** A column the executed query marks as a measure — returned but not grouped by — and that names no schema field SHALL take its class from its own values across the whole result: compact when every value is a number and whole, significant-digit when every value is a number and at least one is fractional, and no class when any value is not a number. This source SHALL apply only to an **aggregate-mode** run. In row mode every returned column is a projection rather than a measure, so an alias with no schema field — a scalar-function projection such as a time bucket — SHALL stay unformatted rather than be guessed at from its digits.
+
+   This source SHALL NOT yield the duration class. An output column names no schema field, so there is no tag to read: what it carries is an alias, derived from a field's display name and its function or typed by the user. Recovering the unit would mean resolving the alias back to the argument field **and** knowing whether the function preserves the unit, which takes the function catalog's own semantics — excluded by this change's Non-goals. An aggregate over a millisecond field therefore keeps a compact or significant-digit rendering, under an alias that names the field it aggregated. This is the second face of the inconsistency above: `AVG(duration_ms)` compacts while `duration_ms` itself is left raw, under headers that both imply milliseconds.
+
+The value class SHALL be withheld for every column of a run, leaving the grid rendering as it does today, in exactly the two cases where the column labels are withheld: a SQL run the backend could not translate, whose measure list comes from a blind scan of every returned column rather than from group-by semantics and so cannot be trusted to exclude an id or a raw epoch column; and a translated SQL run whose entity is not the entity selected in the builder, whose schema cannot describe the returned columns.
+
+A **compact** cell SHALL render through the app's shared compact formatter, the same one the platform models grid's Parameters column uses, so a multi-billion count reads as a unit-suffixed figure. A **significant-digit** cell SHALL render at two significant digits below one and compact at one and above, so a sub-unit value survives instead of rounding to zero while a value of a few units is not rounded to its leading digit. That formatter SHALL be currency-agnostic and SHALL live beside the app's other number formatters; the conversations log's cost formatter SHALL NOT be reused for it, re-parameterised, or stripped of its currency symbol at a call site — its rounding stays local to that page, as `analytics/conversations-listing` requires. A **duration** cell SHALL NOT be formatted: it SHALL render the value as returned, which is the rendering an unclassified cell gets, so the figure stays in the unit its header declares. In particular a returned zero SHALL render as `0` rather than as an empty cell — in a result grid a zero is a value the query returned — and no duration formatter SHALL be introduced at this call site while the header states the unit. A **date-time** cell SHALL render through the app's shared date-time column configuration rather than by calling the date formatter by hand, so the column carries the same formatted value, tooltip and typed filter every other date-time column in the app carries.
+
+A value a resolved numeric class cannot read as a number SHALL fall back to today's rendering rather than to an empty cell, so no value a run returned is ever hidden by a formatter.
+
+On a cell whose text is a rounded or compacted rendering the tooltip SHALL carry the value as returned: every digit the app's shared number formatting can represent, which is double precision, thousand-delimited where the value is whole and unmodified where it is fractional. It SHALL NOT repeat the shortened text: a shortened value with no way to reach the full one is unreadable, per `.claude/rules/a11y.md`. A date-time cell keeps the shared date-time configuration's own tooltip. A duration cell shortens nothing, so it needs no such tooltip and SHALL keep the result grid's own.
+
+A formatted numeric column SHALL right-align its cells and its header and SHALL sort by numeric value rather than as text, by adopting the app's shared numeric column configuration. The result grid's default comparator compares raw values with `>`, which orders a decimal that arrives as a JSON string lexicographically and sorts a zero to the end of the result, so a column this change has just declared numeric has to sort as a number. Formatting SHALL NOT change which rows a filter matches: the filter SHALL keep reading the column's numeric value, never its formatted text.
+
+#### Scenario: A large integer column is compacted
+
+- **WHEN** a run returns a column whose schema type is `Long` and a row whose value is 4897666958
+- **THEN** the cell shows a unit-suffixed compact figure ("4.9 B") rather than every digit
+
+#### Scenario: A sub-unit decimal survives instead of rounding to zero
+
+- **WHEN** a run returns a column whose schema type is `Decimal` and a row whose value is 0.0004792
+- **THEN** the cell shows it at two significant digits ("0.00048")
+- **AND** it is not shown as "0" or as "0.00"
+
+#### Scenario: A decimal of a few units keeps its leading digits
+
+- **WHEN** a `Decimal` column returns 19.74
+- **THEN** the cell shows "19.7" rather than "20"
+
+#### Scenario: The compact threshold is exact
+
+- **WHEN** an `Integer` column returns 999 in one row and 1000 in another
+- **THEN** the 999 cell shows "999" and the 1000 cell shows "1 K"
+
+#### Scenario: A timestamp column shows a local date-time
+
+- **WHEN** a row-mode run projects a column whose schema type is `Timestamp` and whose value is epoch millis
+- **THEN** the cell shows the local date-time rendering rather than the raw number
+
+#### Scenario: A temporal column is never inferred from its values
+
+- **WHEN** an aggregate run returns a measure alias that names no schema field and whose every value is epoch millis
+- **THEN** that column is not rendered as a date-time
+
+#### Scenario: An aggregate alias over whole values is compacted
+
+- **WHEN** an aggregate run sums a column under an alias and every returned value is whole
+- **THEN** the alias column is compacted
+
+#### Scenario: An aggregate alias over fractional values gets significant digits
+
+- **WHEN** an aggregate run averages a column under an alias and at least one returned value is fractional
+- **THEN** the alias column shows significant digits
+
+#### Scenario: A row-mode alias with no schema field stays unformatted
+
+- **WHEN** a row-mode run projects a scalar-function expression under an alias and every returned value is a whole number
+- **THEN** that column renders as it does today
+
+#### Scenario: A non-numeric schema column is untouched
+
+- **WHEN** a run returns a `Uuid`, `Enum` or `Boolean` column
+- **THEN** its cells render as they do today
+
+#### Scenario: An untranslated SQL run stays unformatted
+
+- **WHEN** the user runs SQL the backend cannot translate and the result carries an all-numeric id column
+- **THEN** no result column is formatted
+
+#### Scenario: A translated SQL run over another entity stays unformatted
+
+- **WHEN** a translated SQL run's entity is not the entity selected in the builder
+- **THEN** no result column is formatted, on the same terms its headers keep their returned names
+
+#### Scenario: The exact value stays reachable on a compacted cell
+
+- **WHEN** the user hovers a compacted integer cell
+- **THEN** the tooltip shows the value in full, thousand-delimited
+- **AND** it does not repeat the compacted text
+
+#### Scenario: A fractional value's tooltip is unrounded
+
+- **WHEN** the user hovers a significant-digit decimal cell
+- **THEN** the tooltip shows every digit the run returned
+
+#### Scenario: A formatted numeric column sorts numerically
+
+- **WHEN** the user sorts a formatted numeric column whose values arrive as numeric strings
+- **THEN** the rows order by numeric value, putting 9 before 10 ascending rather than after it
+
+#### Scenario: A filter still matches on the numeric value
+
+- **WHEN** a filter is applied to a formatted numeric column
+- **THEN** it matches on the column's numeric value rather than on the formatted text
+
+#### Scenario: An unreadable value in a numeric column is still shown
+
+- **WHEN** a column resolved as numeric returns a value in one row that cannot be read as a number
+- **THEN** that cell shows the value as it does today rather than an empty cell
+
+#### Scenario: A duration column is recognised by its catalog tag
+
+- **WHEN** a run returns a column whose declared type is numeric and which the catalog tags `performance`, and a row whose value is 698700
+- **THEN** the cell shows the value as returned, unformatted ("698700")
+- **AND** it is not shown as a unit-suffixed count of milliseconds ("698.7 K")
+- **AND** it is not shown as a duration in another unit ("698.7s")
+- **AND** the column's name plays no part in the recognition
+
+#### Scenario: A duration column's cells stay in the unit its header declares
+
+- **WHEN** a run returns a column the catalog tags `performance` whose display name states its unit, such as "Duration (ms)"
+- **THEN** the grid heads the column by that display name, unchanged
+- **AND** the cells under it are in the unit that header names, because no formatter converts them
+
+#### Scenario: A zero duration is still a value
+
+- **WHEN** a duration column returns 0
+- **THEN** the cell shows "0" rather than an empty cell
+
+#### Scenario: An untagged millisecond column keeps its compact rendering
+
+- **WHEN** a run returns two numeric millisecond columns, one the catalog tags `performance` and one it leaves untagged
+- **THEN** the untagged column is compacted ("698.7 K") while the tagged one is left raw
+- **AND** the untagged one is not recovered as a duration from its name
+- **AND** the two therefore read differently in the same result, which is the accepted inconsistency the requirement states
+
+#### Scenario: The performance tag on a non-numeric column changes nothing
+
+- **WHEN** a run returns a column the catalog tags `performance` whose declared type is not numeric
+- **THEN** it renders as its declared type resolves, which for a string or an enum is no formatting at all
+
+#### Scenario: A bucket ordinal and a status code are not mistaken for durations
+
+- **WHEN** a run returns a `*_bucket` ordinal column and a response-status column, both declared numeric and neither tagged `performance`
+- **THEN** neither is recognised as a time measurement
+- **AND** both keep the compact rendering their declared type resolves
+
+#### Scenario: The exact millisecond value stays reachable on a duration cell
+
+- **WHEN** the user reads a duration cell
+- **THEN** the millisecond count is shown in the cell in full, so no tooltip is needed to reach it
+- **AND** the cell text is not a shortened rendering of the value
+
+#### Scenario: A duration column keeps the grid's default sort and filter
+
+- **WHEN** a duration column is sorted, or a filter is applied to it
+- **THEN** it behaves exactly as an unclassified column does, because it adopts no numeric column configuration
+- **AND** the change adds neither numeric sorting nor a numeric filter to it
+
+#### Scenario: An aggregate over a duration field is not rendered as a duration
+
+- **WHEN** an aggregate run returns an output-column alias over a millisecond field
+- **THEN** that column keeps the class its returned values resolve — compact when they are all whole, significant-digit otherwise
+- **AND** it is not recognised as a duration, so it is compacted where the underlying column would have been left raw
+


### PR DESCRIPTION
**Description:**

The Query Builder's result grid rendered every cell — including numeric and timestamp ones —
through `String(value)` (`Analytics/QueryBuilder/utils/result.ts`'s `renderCell`), unlike the
rest of the app, so a large integer, a sub-unit decimal, or an epoch-millis timestamp showed
every raw digit. This adds cell formatting branched by the result column's resolved value
class: `Integer`/`Long` compact to `K/M/B/T` (reusing the same `formatNumberWithExponent` the
platform models grid's Parameters column already uses), `Decimal` renders at significant
digits through a new currency-agnostic formatter, and `Timestamp`/`Date` render through the
app's existing shared `dateTimeColumn` config. Everything else — dimension columns, an
untranslated SQL run's columns, a translated SQL run over another entity — is left exactly as
it renders today. A single uniform formatter was measured and rejected: over a real usage-log
distribution, a compact formatter renders a typical sub-unit cost as `0` and a
thousand-delimited one renders it as `0.00` — both destroy the money signal a `Decimal` column
carries.

A defect found after the sections above shipped is fixed in this same change: a `duration_ms`
column rendered as a compacted count (`698.7 K`) under a header the catalog names
`Duration (ms)` — compacting a quantity that carries a unit is the same failure class as the
`Decimal`-as-`0` defect this change already exists to fix. The fix leaves such a column
unformatted, so its cells stay in the unit the header declares; `formatDurationMs`
(`utils/analytics/conversation-formatting.ts`) is not used by this change at all and stays
untouched, owned by another capability. Recognition is by the catalog's `performance` tag on
the field, consulted only after the declared schema type has already resolved a numeric class
— the column's name plays no part in it, and without that tag a `Long`-typed duration falls
into the compact class and reads `698.7 K` again. One millisecond field on a seeded demo table
carries no tag and is a known, accepted limit: it keeps rendering as a compacted count. The
alternative — stripping the unit from the header instead — was rejected because the header
comes from the catalog's `display_name`, and the spec requires the grid to head schema columns
by it.

The exact value stays reachable on every formatted cell's tooltip (thousand-delimited when
whole, verbatim when fractional), and the filter keeps reading the column's numeric/date value
rather than its formatted text.

Issues:

- Issue #4513

**Key Changes:**

- `apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Result/result-column-format.ts` —
  new `getValueClassColumn(valueClass)`, mapping a resolved value class to a `ColDef` fragment
  (spreads the shared `numericColumn`/`dateTimeColumn` partials; falls back to `renderCell` for
  a value that won't parse)
- `apps/ai-dial-admin/src/components/Analytics/QueryBuilder/Result/ResultArea.tsx` — spreads
  that fragment into each result column, after `...col` and before `cellRenderer`
- `apps/ai-dial-admin/src/components/Analytics/QueryBuilder/utils/executed-meta.ts` — adds
  `buildColumnValueClasses`, resolving a column's value class from its declared schema type,
  or — for an aggregate-mode measure column with no schema field — from the shape of its own
  returned values (reusing the existing `getStrictNumericColumns`, exported from
  `Result/chart-options.ts` for this)
- `apps/ai-dial-admin/src/models/analytics/query-builder.ts` — adds the `ResultValueClass` enum
  and the required `columnValueClasses` field on `ExecutedQueryMeta`
- `apps/ai-dial-admin/src/constants/analytics/query-builder.ts` — `FIELD_TYPE_VALUE_CLASS`
  lookup from `AnalyticsFieldType` to value class
- `apps/ai-dial-admin/src/utils/formatting/number-formatting.ts` — new
  `formatSignificantNumber`, a currency-agnostic significant-digit formatter (two significant
  digits below one unit, compact at one unit and above); `formatSignificantCost` in
  `utils/analytics/conversation-formatting.ts` is left untouched, its rounding stays local to
  the conversations log page

**New Components:**

- `getValueClassColumn` (`Result/result-column-format.ts`) — a reusable module resolving a
  result column's value class into an AG Grid `ColDef` fragment; no new React component.

**Breaking Changes:**

None — `ExecutedQueryMeta.columnValueClasses` is a new required field on an internal model, not
a public prop or API contract; no backend or API change.

**Verification:**

- Unit tests: 22 assertions on the new `result-column-format.ts` fragment (formatter, tooltip,
  filter, comparator, fallback), 12 on `ResultArea.tsx`'s wiring of that fragment into the
  grid's columns, 33 on `buildColumnValueClasses`/`buildExecutedMeta`'s value-class resolution,
  plus `formatSignificantNumber`'s own cases in `number-formmating.spec.ts`. Every formatting
  branch has a test proven to fail before its corresponding fix.
- Browser-verified against the running local app (`spec-browser-verify`) for two of the
  browser-observable scenarios: a `Timestamp` column renders a local date-time rather than
  epoch millis, and a large `Long` column renders compacted (`K`/`M`/`B`/`T`-suffixed) rather
  than every digit. Both passed. The duration behaviour was not browser-verified as part of
  this change — an earlier attempt was blocked by a real login wall, and the owner elected to
  check it himself. The remaining scenarios are formatter output over a value and are covered
  by the unit tests above.

**Known limits (out of scope, called out for the reviewer):**

- The tooltip's exactness is bounded by the app's shared number formatting, i.e. double
  precision.
- A SQL view's untyped result columns are deliberately left unformatted — there is no declared
  schema type to format from, and a blind value scan risks formatting a raw id or epoch column.
- Other Analytics grids' remaining raw numeric cells (Tables' `columnsCount`, Pipelines'
  `generation`, Evaluators' `latest_version`) were reviewed and are small sequence/version
  counters, not quantities — left unformatted permanently, not deferred.

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #4513)`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
