### PR TITLE
feat(AdminApiAvailability): hide admin API dependent UI and add route guards when Admin API is not configured (Issue #4508)

### DIFF
--- a/.claude/reference/areas.md
+++ b/.claude/reference/areas.md
@@ -116,6 +116,7 @@ Use `Parent/Child` for a single leaf, or just `Parent` when several children cha
 | `Config` | `import-config`, `export-config` | `ImportConfig`, `ExportConfig` |
 | `SystemProperties` | `system-properties` | `SystemProperties` |
 | `Home` | `home` | `WelcomeView` |
+| `AdminApiAvailability` | — (route guards on all Admin-API routes) | `Menu`, `Content`, `WelcomeView` |
 
 ---
 

--- a/apps/ai-dial-admin/src/app/[lang]/activity-audit/[id]/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/activity-audit/[id]/page.tsx
@@ -1,5 +1,7 @@
 import { cookies, headers } from 'next/headers';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
+
+import { ApplicationRoute } from '@/src/types/routes';
 
 import { SYSTEM_ROLLBACK_ID } from '@/src/components/ActivityAudit/Rollback/constants';
 import SystemRollback from '@/src/components/ActivityAudit/Rollback/SystemRollback';
@@ -11,6 +13,9 @@ import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
 export const dynamic = 'force-dynamic';
 
 export default async function Page(params: { params: Promise<{ id: string }> }) {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
   const auditViewId = decodeURIComponent((await params.params).id);
   if (auditViewId === SYSTEM_ROLLBACK_ID) {
     return <SystemRollback />;

--- a/apps/ai-dial-admin/src/app/[lang]/activity-audit/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/activity-audit/page.tsx
@@ -1,7 +1,14 @@
 import ActivityAuditList from '@/src/components/ActivityAudit/List/List';
+import { redirect } from 'next/navigation';
+
+import { ApplicationRoute } from '@/src/types/routes';
 
 export const dynamic = 'force-dynamic';
 
 export default async function Page() {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
+
   return <ActivityAuditList />;
 }

--- a/apps/ai-dial-admin/src/app/[lang]/adapters/[id]/[subId]/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/adapters/[id]/[subId]/page.tsx
@@ -2,12 +2,17 @@ import { cookies, headers } from 'next/headers';
 import AuditView from '@/src/components/ActivityAudit/View/AuditView';
 import { getUserToken } from '@/src/utils/auth/auth-request';
 import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
+
+import { ApplicationRoute } from '@/src/types/routes';
 import { getActivityAuditDetailData } from '@/src/utils/audit/get-activity-audit-detail-data';
 
 export const dynamic = 'force-dynamic';
 
 export default async function Page(params: { params: Promise<{ subId: string }> }) {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
   const auditViewId = decodeURIComponent((await params.params).subId);
 

--- a/apps/ai-dial-admin/src/app/[lang]/adapters/[id]/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/adapters/[id]/page.tsx
@@ -1,5 +1,7 @@
 import { cookies, headers } from 'next/headers';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
+
+import { ApplicationRoute } from '@/src/types/routes';
 
 import { getModelsList } from '@/src/app/[lang]/models/actions';
 import { adaptersApi } from '@/src/app/api/api';
@@ -16,6 +18,9 @@ import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
 export const dynamic = 'force-dynamic';
 
 export default async function Page(params: { params: Promise<{ id: string }> }) {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
 
   let etag = DEFAULT_ETAG;

--- a/apps/ai-dial-admin/src/app/[lang]/adapters/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/adapters/page.tsx
@@ -1,5 +1,7 @@
 import { cookies, headers } from 'next/headers';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
+
+import { ApplicationRoute } from '@/src/types/routes';
 
 import { adaptersApi } from '@/src/app/api/api';
 import AdaptersList from '@/src/components/Adapter/List/AdaptersList';
@@ -12,6 +14,9 @@ import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
 export const dynamic = 'force-dynamic';
 
 export default async function Page() {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
   let data: DialAdapter[] | null = null;
 
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());

--- a/apps/ai-dial-admin/src/app/[lang]/application-runners/[id]/[subId]/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/application-runners/[id]/[subId]/page.tsx
@@ -2,12 +2,17 @@ import { cookies, headers } from 'next/headers';
 import AuditView from '@/src/components/ActivityAudit/View/AuditView';
 import { getUserToken } from '@/src/utils/auth/auth-request';
 import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
+
+import { ApplicationRoute } from '@/src/types/routes';
 import { getActivityAuditDetailData } from '@/src/utils/audit/get-activity-audit-detail-data';
 
 export const dynamic = 'force-dynamic';
 
 export default async function Page(params: { params: Promise<{ subId: string }> }) {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
   const auditViewId = decodeURIComponent((await params.params).subId);
 

--- a/apps/ai-dial-admin/src/app/[lang]/application-runners/[id]/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/application-runners/[id]/page.tsx
@@ -1,5 +1,7 @@
 import { cookies, headers } from 'next/headers';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
+
+import { ApplicationRoute } from '@/src/types/routes';
 
 import { applicationRunnersApi, applicationsApi, interceptorsApi, rolesApi } from '@/src/app/api/api';
 import ApplicationRunnersView from '@/src/components/ApplicationRunners/View/View';
@@ -17,6 +19,9 @@ import { DialInterceptor } from '@/src/models/dial/interceptor';
 export const dynamic = 'force-dynamic';
 
 export default async function Page(params: { params: Promise<{ id: string }> }) {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
 
   let etag = DEFAULT_ETAG;

--- a/apps/ai-dial-admin/src/app/[lang]/application-runners/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/application-runners/page.tsx
@@ -1,5 +1,7 @@
 import { cookies, headers } from 'next/headers';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
+
+import { ApplicationRoute } from '@/src/types/routes';
 
 import { applicationRunnersApi } from '@/src/app/api/api';
 import ApplicationRunnersList from '@/src/components/ApplicationRunners/List/List';
@@ -12,6 +14,9 @@ import { SaveValidationContextProvider } from '@/src/context/SaveValidationConte
 export const dynamic = 'force-dynamic';
 
 export default async function Page() {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
 
   let data: DialApplicationScheme[] | null = null;

--- a/apps/ai-dial-admin/src/app/[lang]/applications/[id]/[subId]/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/applications/[id]/[subId]/page.tsx
@@ -2,12 +2,17 @@ import { cookies, headers } from 'next/headers';
 import AuditView from '@/src/components/ActivityAudit/View/AuditView';
 import { getUserToken } from '@/src/utils/auth/auth-request';
 import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
+
+import { ApplicationRoute } from '@/src/types/routes';
 import { getActivityAuditDetailData } from '@/src/utils/audit/get-activity-audit-detail-data';
 
 export const dynamic = 'force-dynamic';
 
 export default async function Page(params: { params: Promise<{ subId: string }> }) {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
   const auditViewId = decodeURIComponent((await params.params).subId);
 

--- a/apps/ai-dial-admin/src/app/[lang]/applications/[id]/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/applications/[id]/page.tsx
@@ -1,5 +1,7 @@
 import { cookies, headers } from 'next/headers';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
+
+import { ApplicationRoute } from '@/src/types/routes';
 
 import { getModelsList } from '@/src/app/[lang]/models/actions';
 import { applicationRunnersApi, applicationsApi, interceptorsApi, rolesApi } from '@/src/app/api/api';
@@ -18,6 +20,9 @@ import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
 export const dynamic = 'force-dynamic';
 
 export default async function Page(params: { params: Promise<{ id: string }> }) {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
 
   let etag = DEFAULT_ETAG;

--- a/apps/ai-dial-admin/src/app/[lang]/applications/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/applications/page.tsx
@@ -1,5 +1,7 @@
 import { cookies, headers } from 'next/headers';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
+
+import { ApplicationRoute } from '@/src/types/routes';
 
 import { applicationRunnersApi, applicationsApi } from '@/src/app/api/api';
 import ApplicationsList from '@/src/components/Applications/List/List';
@@ -12,6 +14,9 @@ import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
 export const dynamic = 'force-dynamic';
 
 export default async function Page() {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
 
   let data: DialApplication[] | null = null;

--- a/apps/ai-dial-admin/src/app/[lang]/conversations/actions.spec.ts
+++ b/apps/ai-dial-admin/src/app/[lang]/conversations/actions.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { assetApi, utilityApi } from '@/src/app/api/api';
+import { assetApi, coreUtilityApi } from '@/src/app/api/api';
 import { ResourceType } from '@/src/types/resource-type';
 import { getUserToken } from '@/src/utils/auth/auth-request';
 import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
@@ -59,11 +59,11 @@ describe('Assets conversations :: server actions', () => {
 
   test('Should call getDeployments action', async () => {
     const DEPLOYMENTS_RESPONSE_MOCK = { response: [{ reference: 'model1' }, { reference: 'model2' }] };
-    (utilityApi.getAllDeployments as any).mockResolvedValue(DEPLOYMENTS_RESPONSE_MOCK);
+    (coreUtilityApi.getAllDeployments as any).mockResolvedValue(DEPLOYMENTS_RESPONSE_MOCK);
 
     const result = await getAllDeployments();
     expect(getUserToken).toHaveBeenCalled();
-    expect(utilityApi.getAllDeployments).toHaveBeenCalledWith(TOKEN_MOCK);
+    expect(coreUtilityApi.getAllDeployments).toHaveBeenCalledWith(TOKEN_MOCK);
     expect(result).toBe(DEPLOYMENTS_RESPONSE_MOCK);
   });
 

--- a/apps/ai-dial-admin/src/app/[lang]/conversations/actions.ts
+++ b/apps/ai-dial-admin/src/app/[lang]/conversations/actions.ts
@@ -2,7 +2,7 @@
 
 import { cookies, headers } from 'next/headers';
 
-import { assetApi, utilityApi } from '@/src/app/api/api';
+import { assetApi, coreUtilityApi } from '@/src/app/api/api';
 import { DialConversation } from '@/src/models/dial/conversation';
 import { bulkDeleteAssets } from '@/src/server/assets/bulk-delete';
 import { ResourceType } from '@/src/types/resource-type';
@@ -31,5 +31,5 @@ export async function deleteConversations(paths: { path: string }[]) {
 
 export async function getAllDeployments() {
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
-  return utilityApi.getAllDeployments(token);
+  return coreUtilityApi.getAllDeployments(token);
 }

--- a/apps/ai-dial-admin/src/app/[lang]/dashboard/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/dashboard/page.tsx
@@ -1,7 +1,14 @@
+import { redirect } from 'next/navigation';
+
 import DashboardView from '@/src/components/Telemetry/DashboardView';
+import { ApplicationRoute } from '@/src/types/routes';
 
 export const dynamic = 'force-dynamic';
 
 export default async function Page() {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
+
   return <DashboardView grafanaLink={process.env.GRAFANA_LINK} />;
 }

--- a/apps/ai-dial-admin/src/app/[lang]/export-config/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/export-config/page.tsx
@@ -1,9 +1,16 @@
 import ExportConfig from '@/src/components/ExportConfig/ExportConfig';
 import { isValueTruthy } from '@/src/utils/types';
+import { redirect } from 'next/navigation';
+
+import { ApplicationRoute } from '@/src/types/routes';
 
 export const dynamic = 'force-dynamic';
 
 export default async function Page() {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
+
   return (
     <ExportConfig
       enableExportConfigMap={isValueTruthy(process.env.ENABLE_EXPORT_CONFIG_MAP)}

--- a/apps/ai-dial-admin/src/app/[lang]/import-config/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/import-config/page.tsx
@@ -1,8 +1,15 @@
 import ImportConfig from '@/src/components/ImportConfig/ImportConfig';
 import { isValueTruthy } from '@/src/utils/types';
+import { redirect } from 'next/navigation';
+
+import { ApplicationRoute } from '@/src/types/routes';
 
 export const dynamic = 'force-dynamic';
 
 export default async function Page() {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
+
   return <ImportConfig deploymentsEnabled={isValueTruthy(process.env.DEPLOYMENTS_ENABLED)} />;
 }

--- a/apps/ai-dial-admin/src/app/[lang]/interceptor-templates/[id]/[subId]/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/interceptor-templates/[id]/[subId]/page.tsx
@@ -2,12 +2,17 @@ import { cookies, headers } from 'next/headers';
 import AuditView from '@/src/components/ActivityAudit/View/AuditView';
 import { getUserToken } from '@/src/utils/auth/auth-request';
 import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
+
+import { ApplicationRoute } from '@/src/types/routes';
 import { getActivityAuditDetailData } from '@/src/utils/audit/get-activity-audit-detail-data';
 
 export const dynamic = 'force-dynamic';
 
 export default async function Page(params: { params: Promise<{ subId: string }> }) {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
   const auditViewId = decodeURIComponent((await params.params).subId);
 

--- a/apps/ai-dial-admin/src/app/[lang]/interceptor-templates/[id]/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/interceptor-templates/[id]/page.tsx
@@ -1,5 +1,7 @@
 import { cookies, headers } from 'next/headers';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
+
+import { ApplicationRoute } from '@/src/types/routes';
 
 import { getInterceptorTemplate } from '@/src/app/[lang]/interceptor-templates/actions';
 import { interceptorsApi } from '@/src/app/api/api';
@@ -16,6 +18,9 @@ import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
 export const dynamic = 'force-dynamic';
 
 export default async function Page(params: { params: Promise<{ id: string }> }) {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
 
   let etag = DEFAULT_ETAG;

--- a/apps/ai-dial-admin/src/app/[lang]/interceptor-templates/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/interceptor-templates/page.tsx
@@ -1,5 +1,5 @@
 import { cookies, headers } from 'next/headers';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 
 import { interceptorTemplatesApi } from '@/src/app/api/api';
 import InterceptorTemplatesList from '@/src/components/InterceptorTemplates/List/List';
@@ -13,6 +13,9 @@ import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
 export const dynamic = 'force-dynamic';
 
 export default async function Page() {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
   let data: InterceptorTemplate[] | null = null;
 

--- a/apps/ai-dial-admin/src/app/[lang]/interceptors/[id]/[subId]/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/interceptors/[id]/[subId]/page.tsx
@@ -2,12 +2,17 @@ import { cookies, headers } from 'next/headers';
 import AuditView from '@/src/components/ActivityAudit/View/AuditView';
 import { getUserToken } from '@/src/utils/auth/auth-request';
 import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
+
+import { ApplicationRoute } from '@/src/types/routes';
 import { getActivityAuditDetailData } from '@/src/utils/audit/get-activity-audit-detail-data';
 
 export const dynamic = 'force-dynamic';
 
 export default async function Page(params: { params: Promise<{ subId: string }> }) {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
   const auditViewId = decodeURIComponent((await params.params).subId);
 

--- a/apps/ai-dial-admin/src/app/[lang]/interceptors/[id]/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/interceptors/[id]/page.tsx
@@ -1,9 +1,11 @@
 import { cookies, headers } from 'next/headers';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
+
+import { ApplicationRoute } from '@/src/types/routes';
 
 import { getInterceptorTemplate } from '@/src/app/[lang]/interceptor-templates/actions';
 import { getModelsList } from '@/src/app/[lang]/models/actions';
-import { applicationRunnersApi, applicationsApi, interceptorsApi, utilityApi } from '@/src/app/api/api';
+import { applicationRunnersApi, applicationsApi, interceptorsApi, settingsApi } from '@/src/app/api/api';
 import InterceptorView from '@/src/components/Interceptors/View/View';
 import { SOURCE_TYPE } from '@/src/components/SourceField/types';
 import { DEFAULT_ETAG } from '@/src/constants/api-headers';
@@ -20,6 +22,9 @@ import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
 export const dynamic = 'force-dynamic';
 
 export default async function Page(params: { params: Promise<{ id: string }> }) {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
 
   let etag = DEFAULT_ETAG;
@@ -39,7 +44,8 @@ export default async function Page(params: { params: Promise<{ id: string }> }) 
       etag = res?.etag || DEFAULT_ETAG;
       return res?.response as DialModel | null;
     });
-    globalInterceptors = (await utilityApi.getSystemProperties(token, DEFAULT_ETAG)).response?.globalInterceptors || [];
+    globalInterceptors =
+      (await settingsApi.getSystemProperties(token, DEFAULT_ETAG)).response?.globalInterceptors || [];
 
     interceptor = {
       ...interceptor,

--- a/apps/ai-dial-admin/src/app/[lang]/interceptors/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/interceptors/page.tsx
@@ -1,7 +1,9 @@
 import { cookies, headers } from 'next/headers';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 
-import { interceptorsApi, utilityApi } from '@/src/app/api/api';
+import { ApplicationRoute } from '@/src/types/routes';
+
+import { interceptorsApi, settingsApi } from '@/src/app/api/api';
 import InterceptorsList from '@/src/components/Interceptors/List/List';
 import { DEFAULT_ETAG } from '@/src/constants/api-headers';
 import { SaveValidationContextProvider } from '@/src/context/SaveValidationContext';
@@ -14,6 +16,9 @@ import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
 export const dynamic = 'force-dynamic';
 
 export default async function Page() {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
 
   let data: DialInterceptor[] | null = null;
@@ -21,7 +26,7 @@ export default async function Page() {
 
   try {
     data = await interceptorsApi.getInterceptorsList(token);
-    global = (await utilityApi.getSystemProperties(token, DEFAULT_ETAG)).response?.globalInterceptors || [];
+    global = (await settingsApi.getSystemProperties(token, DEFAULT_ETAG)).response?.globalInterceptors || [];
     data =
       data?.map((item) => ({
         ...item,

--- a/apps/ai-dial-admin/src/app/[lang]/keys/[id]/[subId]/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/keys/[id]/[subId]/page.tsx
@@ -2,12 +2,17 @@ import { cookies, headers } from 'next/headers';
 import AuditView from '@/src/components/ActivityAudit/View/AuditView';
 import { getUserToken } from '@/src/utils/auth/auth-request';
 import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
+
+import { ApplicationRoute } from '@/src/types/routes';
 import { getActivityAuditDetailData } from '@/src/utils/audit/get-activity-audit-detail-data';
 
 export const dynamic = 'force-dynamic';
 
 export default async function Page(params: { params: Promise<{ subId: string }> }) {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
   const auditViewId = decodeURIComponent((await params.params).subId);
 

--- a/apps/ai-dial-admin/src/app/[lang]/keys/[id]/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/keys/[id]/page.tsx
@@ -1,5 +1,7 @@
 import { cookies, headers } from 'next/headers';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
+
+import { ApplicationRoute } from '@/src/types/routes';
 
 import { keysApi, rolesApi } from '@/src/app/api/api';
 import KeyView from '@/src/components/Keys/View/View';
@@ -15,6 +17,9 @@ import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
 export const dynamic = 'force-dynamic';
 
 export default async function Page(params: { params: Promise<{ id: string }> }) {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
 
   let etag = DEFAULT_ETAG;

--- a/apps/ai-dial-admin/src/app/[lang]/keys/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/keys/page.tsx
@@ -1,5 +1,7 @@
 import { cookies, headers } from 'next/headers';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
+
+import { ApplicationRoute } from '@/src/types/routes';
 
 import { keysApi } from '@/src/app/api/api';
 import KeysList from '@/src/components/Keys/List/List';
@@ -12,6 +14,9 @@ import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
 export const dynamic = 'force-dynamic';
 
 export default async function Page() {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
 
   let data: DialKey[] | null = null;

--- a/apps/ai-dial-admin/src/app/[lang]/layout.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/layout.tsx
@@ -8,7 +8,7 @@ import '@epam/ai-dial-ui-kit/styles.css';
 // @ts-ignore
 import '@/src/app/[lang]/global.scss';
 
-import { telemetryApi, themesApi, utilityApi } from '@/src/app/api/api';
+import { getUserInfo, telemetryApi, themesApi } from '@/src/app/api/api';
 import Content from '@/src/components/Content/Content';
 import Header from '@/src/components/Header/Header';
 import Menu from '@/src/components/Menu/Menu';
@@ -53,6 +53,7 @@ export default async function Layout({ children, params }: { children: ReactNode
   }
 
   const featureFlags: FeatureFlags = {
+    adminApiEnabled: process.env.DIAL_ADMIN_API_URL != null,
     dashboardEnabled: !process.env.DISABLE_MENU_ITEMS?.toLowerCase().includes('dashboard'),
     deploymentsEnabled: isValueTruthy(process.env.DEPLOYMENTS_ENABLED),
     evaluationEnabled: process.env.DIAL_EVAL_API_URL != null,
@@ -69,8 +70,9 @@ export default async function Layout({ children, params }: { children: ReactNode
   const themesConfiguration = await themesApi.getThemesConfiguration();
   const themesImages = await themesApi.getImages();
 
-  const beVersion = await utilityApi.getBeVersion(token);
-  const telemetryMaxRangeMs = extractTelemetryMaxRangeMs(await telemetryApi.getDatasets(token));
+  const telemetryMaxRangeMs = featureFlags.adminApiEnabled
+    ? extractTelemetryMaxRangeMs(await telemetryApi.getDatasets(token))
+    : undefined;
 
   return (
     <I18nProvider locale={lang}>
@@ -82,7 +84,7 @@ export default async function Layout({ children, params }: { children: ReactNode
           resourcesDefaults={JSON.parse(process.env.DEPLOYMENTS_RESOURCES_DEFAULTS || '{}') as ResourcesDefaults}
           telemetryMaxRangeMs={telemetryMaxRangeMs}
           codeAppEditorUrl={process.env.CODE_APP_EDITOR_URL}
-          userInfo={(await utilityApi.getUserInfo(token)).response?.userInfo}
+          userInfo={(await getUserInfo(token)).response?.userInfo}
           isEnableAuth={isEnableAuth}
         >
           <ThemeProvider themesConfiguration={themesConfiguration} themeImages={themesImages}>
@@ -109,9 +111,7 @@ export default async function Layout({ children, params }: { children: ReactNode
                                             <div className="flex-1 min-h-0">
                                               <div className="flex flex-row h-full relative">
                                                 <Menu disableMenuItems={getMenuItems(process.env.DISABLE_MENU_ITEMS)} />
-                                                <Content isEnableAuth={isEnableAuth} beVersion={beVersion}>
-                                                  {children}
-                                                </Content>
+                                                <Content isEnableAuth={isEnableAuth}>{children}</Content>
                                               </div>
                                             </div>
                                           </div>

--- a/apps/ai-dial-admin/src/app/[lang]/models/[id]/[subId]/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/models/[id]/[subId]/page.tsx
@@ -2,12 +2,17 @@ import { cookies, headers } from 'next/headers';
 import AuditView from '@/src/components/ActivityAudit/View/AuditView';
 import { getUserToken } from '@/src/utils/auth/auth-request';
 import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
+
+import { ApplicationRoute } from '@/src/types/routes';
 import { getActivityAuditDetailData } from '@/src/utils/audit/get-activity-audit-detail-data';
 
 export const dynamic = 'force-dynamic';
 
 export default async function Page(params: { params: Promise<{ subId: string }> }) {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
   const auditViewId = decodeURIComponent((await params.params).subId);
 

--- a/apps/ai-dial-admin/src/app/[lang]/models/[id]/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/models/[id]/page.tsx
@@ -1,5 +1,7 @@
 import { cookies, headers } from 'next/headers';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
+
+import { ApplicationRoute } from '@/src/types/routes';
 
 import { getModel, getModelsList } from '@/src/app/[lang]/models/actions';
 import { interceptorsApi, rolesApi } from '@/src/app/api/api';
@@ -17,6 +19,9 @@ import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
 export const dynamic = 'force-dynamic';
 
 export default async function Page(params: { params: Promise<{ id: string }> }) {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
 
   let etag = DEFAULT_ETAG;

--- a/apps/ai-dial-admin/src/app/[lang]/models/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/models/page.tsx
@@ -1,4 +1,6 @@
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
+
+import { ApplicationRoute } from '@/src/types/routes';
 
 import ModelsList from '@/src/components/Models/List/List';
 import { SaveValidationContextProvider } from '@/src/context/SaveValidationContext';
@@ -9,6 +11,9 @@ import { getModelsList } from './actions';
 export const dynamic = 'force-dynamic';
 
 export default async function Page() {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
   let data: DialModel[] | null = null;
 
   try {

--- a/apps/ai-dial-admin/src/app/[lang]/roles/[id]/[subId]/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/roles/[id]/[subId]/page.tsx
@@ -2,12 +2,17 @@ import { cookies, headers } from 'next/headers';
 import AuditView from '@/src/components/ActivityAudit/View/AuditView';
 import { getUserToken } from '@/src/utils/auth/auth-request';
 import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
+
+import { ApplicationRoute } from '@/src/types/routes';
 import { getActivityAuditDetailData } from '@/src/utils/audit/get-activity-audit-detail-data';
 
 export const dynamic = 'force-dynamic';
 
 export default async function Page(params: { params: Promise<{ subId: string }> }) {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
   const auditViewId = decodeURIComponent((await params.params).subId);
 

--- a/apps/ai-dial-admin/src/app/[lang]/roles/[id]/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/roles/[id]/page.tsx
@@ -1,5 +1,7 @@
 import { cookies, headers } from 'next/headers';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
+
+import { ApplicationRoute } from '@/src/types/routes';
 
 import { applicationsApi, keysApi, rolesApi, routesApi, toolSetsApi } from '@/src/app/api/api';
 import RolesView from '@/src/components/Roles/View/View';
@@ -20,6 +22,9 @@ import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
 export const dynamic = 'force-dynamic';
 
 export default async function Page(params: { params: Promise<{ id: string }> }) {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
 
   let etag = DEFAULT_ETAG;

--- a/apps/ai-dial-admin/src/app/[lang]/roles/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/roles/page.tsx
@@ -1,5 +1,7 @@
 import { cookies, headers } from 'next/headers';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
+
+import { ApplicationRoute } from '@/src/types/routes';
 
 import { rolesApi } from '@/src/app/api/api';
 import RolesList from '@/src/components/Roles/List/List';
@@ -12,6 +14,9 @@ import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
 export const dynamic = 'force-dynamic';
 
 export default async function Page() {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
   let data: DialRole[] | null = null;
 
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());

--- a/apps/ai-dial-admin/src/app/[lang]/routes/[id]/[subId]/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/routes/[id]/[subId]/page.tsx
@@ -2,12 +2,17 @@ import { cookies, headers } from 'next/headers';
 import AuditView from '@/src/components/ActivityAudit/View/AuditView';
 import { getUserToken } from '@/src/utils/auth/auth-request';
 import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
+
+import { ApplicationRoute } from '@/src/types/routes';
 import { getActivityAuditDetailData } from '@/src/utils/audit/get-activity-audit-detail-data';
 
 export const dynamic = 'force-dynamic';
 
 export default async function Page(params: { params: Promise<{ subId: string }> }) {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
   const auditViewId = decodeURIComponent((await params.params).subId);
 

--- a/apps/ai-dial-admin/src/app/[lang]/routes/[id]/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/routes/[id]/page.tsx
@@ -1,5 +1,7 @@
 import { cookies, headers } from 'next/headers';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
+
+import { ApplicationRoute } from '@/src/types/routes';
 
 import { rolesApi, routesApi } from '@/src/app/api/api';
 import { DEFAULT_ETAG } from '@/src/constants/api-headers';
@@ -15,6 +17,9 @@ import RouteView from '@/src/components/Routes/View/View';
 export const dynamic = 'force-dynamic';
 
 export default async function Page(params: { params: Promise<{ id: string }> }) {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
 
   let etag = DEFAULT_ETAG;

--- a/apps/ai-dial-admin/src/app/[lang]/routes/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/routes/page.tsx
@@ -1,5 +1,7 @@
 import { cookies, headers } from 'next/headers';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
+
+import { ApplicationRoute } from '@/src/types/routes';
 
 import { routesApi } from '@/src/app/api/api';
 import RoutesList from '@/src/components/Routes/List/RoutesList';
@@ -12,6 +14,9 @@ import { SaveValidationContextProvider } from '@/src/context/SaveValidationConte
 export const dynamic = 'force-dynamic';
 
 export default async function Page() {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
 
   let data: DialRoute[] | null = null;

--- a/apps/ai-dial-admin/src/app/[lang]/system-properties/actions.spec.ts
+++ b/apps/ai-dial-admin/src/app/[lang]/system-properties/actions.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { utilityApi } from '@/src/app/api/api';
+import { settingsApi } from '@/src/app/api/api';
 import { getUserToken } from '@/src/utils/auth/auth-request';
 import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
 import { RESPONSE_MOCK, TOKEN_MOCK } from '@/src/utils/tests/mock/api.mock';
@@ -18,20 +18,32 @@ describe('System properties :: server actions', () => {
   });
 
   test('Should call getProperties action', async () => {
-    (utilityApi.getSystemProperties as any).mockResolvedValue(RESPONSE_MOCK);
+    (settingsApi.getSystemProperties as any).mockResolvedValue(RESPONSE_MOCK);
 
     const result = await getProperties('etag');
     expect(getUserToken).toHaveBeenCalled();
-    expect(utilityApi.getSystemProperties).toHaveBeenCalledWith(TOKEN_MOCK, 'etag');
+    expect(settingsApi.getSystemProperties).toHaveBeenCalledWith(TOKEN_MOCK, 'etag');
     expect(result).toBe(RESPONSE_MOCK);
   });
 
   test('Should call updateProperties action', async () => {
-    (utilityApi.updateSystemProperties as any).mockResolvedValue(RESPONSE_MOCK);
+    (settingsApi.updateSystemProperties as any).mockResolvedValue(RESPONSE_MOCK);
 
     const result = await updateProperties({ globalInterceptors: [''] }, 'etag');
     expect(getUserToken).toHaveBeenCalled();
-    expect(utilityApi.updateSystemProperties).toHaveBeenCalledWith({ globalInterceptors: [''] }, TOKEN_MOCK, 'etag');
+    expect(settingsApi.updateSystemProperties).toHaveBeenCalledWith({ globalInterceptors: [''] }, TOKEN_MOCK, 'etag');
+    expect(result).toBe(RESPONSE_MOCK);
+  });
+
+  test('Should call updateProperties action with an undefined etag when no settings blob exists yet', async () => {
+    (settingsApi.updateSystemProperties as any).mockResolvedValue(RESPONSE_MOCK);
+
+    const result = await updateProperties({ globalInterceptors: [''] }, undefined);
+    expect(settingsApi.updateSystemProperties).toHaveBeenCalledWith(
+      { globalInterceptors: [''] },
+      TOKEN_MOCK,
+      undefined,
+    );
     expect(result).toBe(RESPONSE_MOCK);
   });
 });

--- a/apps/ai-dial-admin/src/app/[lang]/system-properties/actions.ts
+++ b/apps/ai-dial-admin/src/app/[lang]/system-properties/actions.ts
@@ -2,17 +2,17 @@
 
 import { cookies, headers } from 'next/headers';
 
-import { utilityApi } from '@/src/app/api/api';
+import { settingsApi } from '@/src/app/api/api';
 import { getUserToken } from '@/src/utils/auth/auth-request';
 import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
 import { GlobalSettings } from '@/src/models/system-properties';
 
 export async function getProperties(etag: string) {
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
-  return utilityApi.getSystemProperties(token, etag);
+  return settingsApi.getSystemProperties(token, etag);
 }
 
-export async function updateProperties(properties: GlobalSettings, etag: string) {
+export async function updateProperties(properties: GlobalSettings, etag: string | undefined) {
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
-  return utilityApi.updateSystemProperties(properties, token, etag);
+  return settingsApi.updateSystemProperties(properties, token, etag);
 }

--- a/apps/ai-dial-admin/src/app/[lang]/system-properties/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/system-properties/page.tsx
@@ -1,42 +1,63 @@
 import { cookies, headers } from 'next/headers';
-import { notFound } from 'next/navigation';
 
-import { interceptorsApi, utilityApi } from '@/src/app/api/api';
+import { settingsApi } from '@/src/app/api/api';
 import SystemProperties from '@/src/components/SystemProperties/SystemProperties';
 import { DEFAULT_ETAG } from '@/src/constants/api-headers';
+import { EntitiesI18nKey } from '@/src/constants/i18n';
 import { SaveValidationContextProvider } from '@/src/context/SaveValidationContext';
 import { DialInterceptor } from '@/src/models/dial/interceptor';
 import { GlobalSettings } from '@/src/models/system-properties';
+import { readConfigEntities } from '@/src/server/config-entities/read-page-options';
 import { errorObjLog } from '@/src/server/logger';
+import { ConfigFileEntityType } from '@/src/types/config-file-entity';
 import { getUserToken } from '@/src/utils/auth/auth-request';
 import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
+
+const HTTP_NOT_FOUND = 404;
 
 export const dynamic = 'force-dynamic';
 
 export default async function Page() {
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
 
-  let interceptors: DialInterceptor[] | null = [];
   let globalSettings: GlobalSettings | null = null;
-  let etag = DEFAULT_ETAG;
+  // Core never returns an ETag for this singleton (on 200 or 404), so a save can only assert
+  // existence — see settings-api.ts and putActionWithEtag.
+  let doesSettingsExist = false;
+  const optionWarnings: EntitiesI18nKey[] = [];
 
   try {
-    interceptors = await interceptorsApi.getInterceptorsList(token);
-    globalSettings = await utilityApi.getSystemProperties(token, etag).then((res) => {
-      etag = res?.etag || DEFAULT_ETAG;
-      return res?.response as GlobalSettings;
-    });
+    const res = await settingsApi.getSystemProperties(token, DEFAULT_ETAG);
+
+    if (res.success) {
+      doesSettingsExist = true;
+      globalSettings = res.response as GlobalSettings;
+    } else if (res.status !== HTTP_NOT_FOUND) {
+      // A 404 just means no settings blob has been saved via the API yet — not an error.
+      optionWarnings.push(EntitiesI18nKey.SystemPropertiesReadFailed);
+    }
   } catch (e) {
-    errorObjLog(e, 'Failed to fetch interceptors view data');
+    errorObjLog(e, 'Failed to fetch system properties view data');
   }
 
-  if (globalSettings == null) {
-    notFound();
-  }
+  // Core-direct — matching Assets > Models / Assets > App Runners — rather than the admin-BE list,
+  // which cannot see interceptors declared in Core's configuration file: `readConfigEntities` already
+  // unions the API-written ("Entities") and config-file ("Catalog") populations (and itself skips the
+  // read without the admin backend, since there is then no API-written population to union).
+  const interceptors = await readConfigEntities<DialInterceptor>(
+    token,
+    ConfigFileEntityType.Interceptors,
+    optionWarnings,
+  );
 
   return (
     <SaveValidationContextProvider>
-      <SystemProperties interceptors={interceptors || []} globalSettings={globalSettings} etag={etag} />
+      <SystemProperties
+        interceptors={interceptors}
+        globalSettings={globalSettings}
+        doesSettingsExist={doesSettingsExist}
+        optionWarnings={optionWarnings}
+      />
     </SaveValidationContextProvider>
   );
 }

--- a/apps/ai-dial-admin/src/app/[lang]/system-properties/tests/page.spec.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/system-properties/tests/page.spec.tsx
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { settingsApi } from '@/src/app/api/api';
+import Page from '@/src/app/[lang]/system-properties/page';
+import { EntitiesI18nKey } from '@/src/constants/i18n';
+import { readConfigEntities } from '@/src/server/config-entities/read-page-options';
+import { getUserToken } from '@/src/utils/auth/auth-request';
+import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
+import { TOKEN_MOCK } from '@/src/utils/tests/mock/api.mock';
+
+vi.mock('@/src/utils/auth/auth-request');
+vi.mock('@/src/utils/env/get-auth-toggle');
+vi.mock('@/src/app/api/api');
+vi.mock('@/src/server/config-entities/read-page-options');
+vi.mock('@/src/server/logger', () => ({ errorObjLog: vi.fn(), errorLog: vi.fn() }));
+
+// The page wraps `SystemProperties` in `SaveValidationContextProvider`, so its props (the data under
+// test) sit one level down, on the child element.
+const renderPage = async () => {
+  const page = (await Page()) as { props: { children: { props: Record<string, unknown> } } };
+  return page.props.children.props;
+};
+
+describe('system properties page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getUserToken).mockResolvedValue(TOKEN_MOCK);
+    vi.mocked(getIsEnableAuthToggle).mockReturnValue(true);
+    vi.mocked(readConfigEntities).mockResolvedValue([]);
+  });
+
+  test('reports no settings blob without a warning when the read 404s', async () => {
+    vi.mocked(settingsApi.getSystemProperties).mockResolvedValue({ success: false, status: 404 });
+
+    const page = await renderPage();
+
+    expect(page).toMatchObject({ globalSettings: null, doesSettingsExist: false, optionWarnings: [] });
+  });
+
+  test('reports the existing settings and marks the blob as existing on a successful read', async () => {
+    const globalSettings = { globalInterceptors: ['interceptor-1'] };
+    vi.mocked(settingsApi.getSystemProperties).mockResolvedValue({ success: true, response: globalSettings });
+
+    const page = await renderPage();
+
+    expect(page).toMatchObject({ globalSettings, doesSettingsExist: true, optionWarnings: [] });
+  });
+
+  test('surfaces a warning when the read fails for a reason other than a missing blob', async () => {
+    vi.mocked(settingsApi.getSystemProperties).mockResolvedValue({
+      success: false,
+      status: 500,
+      errorHeader: 'Internal Server Error',
+    });
+
+    const page = await renderPage();
+
+    expect(page).toMatchObject({
+      globalSettings: null,
+      doesSettingsExist: false,
+      optionWarnings: [EntitiesI18nKey.SystemPropertiesReadFailed],
+    });
+  });
+
+  test('reports no settings blob without a warning when the read throws', async () => {
+    vi.mocked(settingsApi.getSystemProperties).mockRejectedValue(new Error('boom'));
+
+    const page = await renderPage();
+
+    expect(page).toMatchObject({ globalSettings: null, doesSettingsExist: false, optionWarnings: [] });
+  });
+});

--- a/apps/ai-dial-admin/src/app/[lang]/toolsets/[id]/[subId]/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/toolsets/[id]/[subId]/page.tsx
@@ -2,12 +2,17 @@ import { cookies, headers } from 'next/headers';
 import AuditView from '@/src/components/ActivityAudit/View/AuditView';
 import { getUserToken } from '@/src/utils/auth/auth-request';
 import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
+
+import { ApplicationRoute } from '@/src/types/routes';
 import { getActivityAuditDetailData } from '@/src/utils/audit/get-activity-audit-detail-data';
 
 export const dynamic = 'force-dynamic';
 
 export default async function Page(params: { params: Promise<{ subId: string }> }) {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
   const auditViewId = decodeURIComponent((await params.params).subId);
 

--- a/apps/ai-dial-admin/src/app/[lang]/toolsets/[id]/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/toolsets/[id]/page.tsx
@@ -1,5 +1,7 @@
 import { cookies, headers } from 'next/headers';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
+
+import { ApplicationRoute } from '@/src/types/routes';
 
 import { rolesApi, toolSetsApi } from '@/src/app/api/api';
 import ToolsetView from '@/src/components/Toolsets/View/View';
@@ -18,6 +20,9 @@ export default async function Page(params: {
   params: Promise<{ id: string }>;
   searchParams: Promise<{ code?: string }>;
 }) {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
 
   let etag = DEFAULT_ETAG;

--- a/apps/ai-dial-admin/src/app/[lang]/toolsets/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/toolsets/page.tsx
@@ -1,5 +1,7 @@
 import { cookies, headers } from 'next/headers';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
+
+import { ApplicationRoute } from '@/src/types/routes';
 
 import { toolSetsApi } from '@/src/app/api/api';
 import ToolsetsList from '@/src/components/Toolsets/List';
@@ -12,6 +14,9 @@ import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
 export const dynamic = 'force-dynamic';
 
 export default async function Page() {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
 
   let data: Toolset[] | null = null;

--- a/apps/ai-dial-admin/src/app/[lang]/usage-log/page.tsx
+++ b/apps/ai-dial-admin/src/app/[lang]/usage-log/page.tsx
@@ -1,6 +1,12 @@
+import { redirect } from 'next/navigation';
+
 import { ApplicationRoute } from '@/src/types/routes';
 import UsageLog from '@/src/components/UsageLog/UsageLog';
 
 export default async function Page() {
+  if (!process.env.DIAL_ADMIN_API_URL) {
+    redirect(ApplicationRoute.Home);
+  }
+
   return <UsageLog className="bg-layer-2 rounded py-4 px-6" route={ApplicationRoute.UsageLog} />;
 }

--- a/apps/ai-dial-admin/src/app/actions.spec.ts
+++ b/apps/ai-dial-admin/src/app/actions.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { interceptorsApi, utilityApi } from '@/src/app/api/api';
+import { coreUtilityApi, interceptorsApi, utilityApi } from '@/src/app/api/api';
 import { getUserToken } from '@/src/utils/auth/auth-request';
 import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
 import { RESPONSE_MOCK, TOKEN_MOCK } from '@/src/utils/tests/mock/api.mock';
@@ -21,7 +21,7 @@ describe('Server actions', () => {
     vi.clearAllMocks();
     (getUserToken as any).mockResolvedValue(TOKEN_MOCK);
     (getIsEnableAuthToggle as any).mockReturnValue(true);
-    (utilityApi.checkDeploymentByName as any).mockResolvedValue(null);
+    (coreUtilityApi.checkDeploymentByName as any).mockResolvedValue(null);
     (interceptorsApi.checkInterceptorByName as any).mockResolvedValue(null);
   });
 
@@ -29,13 +29,13 @@ describe('Server actions', () => {
     const result = await checkIsUniqueDeploymentName('my-id');
 
     expect(getUserToken).toHaveBeenCalled();
-    expect(utilityApi.checkDeploymentByName).toHaveBeenCalledWith('my-id', TOKEN_MOCK);
+    expect(coreUtilityApi.checkDeploymentByName).toHaveBeenCalledWith('my-id', TOKEN_MOCK);
     expect(interceptorsApi.checkInterceptorByName).toHaveBeenCalledWith('my-id', TOKEN_MOCK);
     expect(result).toBe(true);
   });
 
   test('Should return false when deployment already exists', async () => {
-    (utilityApi.checkDeploymentByName as any).mockResolvedValue({ status: 200 });
+    (coreUtilityApi.checkDeploymentByName as any).mockResolvedValue({ status: 200 });
 
     const result = await checkIsUniqueDeploymentName('existing-id');
 
@@ -51,7 +51,7 @@ describe('Server actions', () => {
   });
 
   test('Should return false when both deployment and interceptor already exist', async () => {
-    (utilityApi.checkDeploymentByName as any).mockResolvedValue({ status: 200 });
+    (coreUtilityApi.checkDeploymentByName as any).mockResolvedValue({ status: 200 });
     (interceptorsApi.checkInterceptorByName as any).mockResolvedValue({ status: 200 });
 
     const result = await checkIsUniqueDeploymentName('existing-id');

--- a/apps/ai-dial-admin/src/app/actions.ts
+++ b/apps/ai-dial-admin/src/app/actions.ts
@@ -2,7 +2,7 @@
 
 import { cookies, headers } from 'next/headers';
 
-import { interceptorsApi, utilityApi } from '@/src/app/api/api';
+import { coreUtilityApi, interceptorsApi, utilityApi } from '@/src/app/api/api';
 import { getUserToken } from '@/src/utils/auth/auth-request';
 import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
 
@@ -10,11 +10,16 @@ export async function checkIsUniqueDeploymentName(name: string): Promise<boolean
   const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
 
   const [deploymentResponse, interceptorResponse] = await Promise.all([
-    utilityApi.checkDeploymentByName(name, token),
+    coreUtilityApi.checkDeploymentByName(name, token),
     interceptorsApi.checkInterceptorByName(name, token),
   ]);
 
   return deploymentResponse === null && interceptorResponse === null;
+}
+
+export async function getBeVersion() {
+  const token = await getUserToken(getIsEnableAuthToggle(), headers(), cookies());
+  return utilityApi.getBeVersion(token);
 }
 
 export async function getAppProcessStatus() {

--- a/apps/ai-dial-admin/src/app/api/api.ts
+++ b/apps/ai-dial-admin/src/app/api/api.ts
@@ -1,8 +1,10 @@
+import { Token } from '@/src/models/auth';
 import { AnalyticsDataApi } from '@/src/server/analytics/analytics-data-api';
 import { AnalyticsAuditApi } from '@/src/server/analytics/audit-api';
 import { stripAssetIdentityFields } from '@/src/server/assets/exim';
 import { AppRunnerSchemaApi } from '@/src/server/core/app-runner-schema-api';
 import { ConfigFileApi } from '@/src/server/core/config-file-api';
+import { CoreUtilityApi } from '@/src/server/core/core-utility-api';
 import { DeploymentConfigurationApi } from '@/src/server/core/deployment-configuration-api';
 import { SettingsApi } from '@/src/server/core/settings-api';
 import { AssetApi } from '@/src/server/core/asset-api';
@@ -237,6 +239,17 @@ export const externalServiceConsentApi = new ExternalServiceConsentApi({
 export const queryAssistantApi = new QueryAssistantApi({
   host: process.env.DIAL_CORE_API_URL,
 });
+
+// Deployment listing/lookup, the global-settings singleton, and user identity — endpoints the
+// admin backend only ever proxied to Core unchanged.
+export const coreUtilityApi = new CoreUtilityApi({
+  host: process.env.DIAL_CORE_API_URL,
+});
+
+// User identity: the admin backend's own security-info endpoint when it's configured (it computes
+// the FULL_ADMIN/READ_ONLY_ADMIN roles AppContext relies on), otherwise Core directly.
+export const getUserInfo = (token: Token) =>
+  process.env.DIAL_ADMIN_API_URL ? utilityApi.getUserInfo(token) : coreUtilityApi.getUserInfo(token);
 
 /**
  * Application/toolset-resource content DTOs reject `folderId`/`path`/`version`/`id`

--- a/apps/ai-dial-admin/src/app/api/tests/get-user-info.spec.ts
+++ b/apps/ai-dial-admin/src/app/api/tests/get-user-info.spec.ts
@@ -20,10 +20,7 @@ describe('Server :: api :: getUserInfo', () => {
 
   test('calls the admin backend security-info endpoint when DIAL_ADMIN_API_URL is set', async () => {
     vi.stubEnv('DIAL_ADMIN_API_URL', 'http://admin-be');
-    fetch.mockResponseOnce(
-      JSON.stringify({ userInfo: { id: '1', email: 'a@b.com', roles: [] } }),
-      JSON_HEADERS,
-    );
+    fetch.mockResponseOnce(JSON.stringify({ userInfo: { id: '1', email: 'a@b.com', roles: [] } }), JSON_HEADERS);
 
     const { getUserInfo } = await import('@/src/app/api/api');
     await getUserInfo(TOKEN_MOCK);

--- a/apps/ai-dial-admin/src/app/api/tests/get-user-info.spec.ts
+++ b/apps/ai-dial-admin/src/app/api/tests/get-user-info.spec.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import createFetchMock from 'vitest-fetch-mock';
+
+import { TOKEN_MOCK } from '@/src/utils/tests/mock/api.mock';
+
+const fetch = createFetchMock(vi);
+fetch.enableMocks();
+
+const JSON_HEADERS = { headers: { 'content-type': 'application/json' } };
+
+describe('Server :: api :: getUserInfo', () => {
+  beforeEach(() => {
+    fetch.resetMocks();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test('calls the admin backend security-info endpoint when DIAL_ADMIN_API_URL is set', async () => {
+    vi.stubEnv('DIAL_ADMIN_API_URL', 'http://admin-be');
+    fetch.mockResponseOnce(
+      JSON.stringify({ userInfo: { id: '1', email: 'a@b.com', roles: [] } }),
+      JSON_HEADERS,
+    );
+
+    const { getUserInfo } = await import('@/src/app/api/api');
+    await getUserInfo(TOKEN_MOCK);
+
+    const [calledUrl] = fetch.mock.calls[0];
+    expect(calledUrl).toContain('/api/v1/security-info');
+  });
+
+  test('calls DIAL Core directly when DIAL_ADMIN_API_URL is not set', async () => {
+    vi.stubEnv('DIAL_ADMIN_API_URL', '');
+    vi.stubEnv('DIAL_CORE_API_URL', 'http://core');
+    fetch.mockResponseOnce(JSON.stringify({ roles: [], userId: '1' }), JSON_HEADERS);
+
+    const { getUserInfo } = await import('@/src/app/api/api');
+    await getUserInfo(TOKEN_MOCK);
+
+    const [calledUrl] = fetch.mock.calls[0];
+    expect(calledUrl).toContain('v1/user/info');
+  });
+});

--- a/apps/ai-dial-admin/src/app/layout.tsx
+++ b/apps/ai-dial-admin/src/app/layout.tsx
@@ -14,7 +14,7 @@ import { getUserToken } from '@/src/utils/auth/auth-request';
 import { getIsInvalidSession } from '@/src/utils/auth/is-valid-session';
 import { getIsEnableAuthToggle } from '@/src/utils/env/get-auth-toggle';
 import { getIconPath } from '@/src/utils/themes/icon-path';
-import { themesApi, utilityApi } from './api/api';
+import { getUserInfo, themesApi } from './api/api';
 
 export const dynamic = 'force-dynamic';
 
@@ -43,7 +43,7 @@ export default async function RootLayout({
   if (isInvalidSession) {
     return redirect(SIGN_IN_LINK);
   }
-  const userInfo = await utilityApi.getUserInfo(token);
+  const userInfo = await getUserInfo(token);
   const themesConfig = await themesApi.getThemesConfiguration();
   const themeImages = await themesApi.getImages();
 

--- a/apps/ai-dial-admin/src/components/Content/Content.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Content/Content.spec.tsx
@@ -1,23 +1,64 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, test } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { getAppProcessStatus, getBeVersion, getCoreVersions } from '@/src/app/actions';
 import Content from './Content';
 
+vi.mock('@/src/app/actions', () => ({
+  getAppProcessStatus: vi.fn().mockResolvedValue({ response: { success: true, errors: [] } }),
+  getCoreVersions: vi.fn().mockResolvedValue({ response: undefined }),
+  getBeVersion: vi.fn().mockResolvedValue('1.0.0'),
+  setCoreVersion: vi.fn(),
+}));
+
+const adminApiEnabled = { value: true };
+vi.mock('@/src/context/AppContext', () => ({
+  useAppContext: () => ({
+    sidebar: { show: false, position: 'right' },
+    featureFlags: { adminApiEnabled: adminApiEnabled.value },
+  }),
+}));
+
 describe('Content', () => {
+  beforeEach(() => {
+    adminApiEnabled.value = true;
+    vi.clearAllMocks();
+  });
+
   test('renders children', () => {
     render(
-      <Content isEnableAuth={true} beVersion="1.0.0">
+      <Content isEnableAuth={true}>
         <div>Test Content</div>
       </Content>,
     );
     expect(screen.getByText('Test Content')).toBeInTheDocument();
   });
 
-  test('renders with beVersion', () => {
+  test('renders the Footer and polls status/core-version/BE-version when the admin API is enabled', async () => {
     render(
-      <Content isEnableAuth={false} beVersion="2.3.4">
-        <span>Versioned</span>
+      <Content isEnableAuth={false}>
+        <div>Test Content</div>
       </Content>,
     );
-    expect(screen.getByText('Versioned')).toBeInTheDocument();
+
+    expect(screen.getByText(/Admin: \[FE\]/)).toBeInTheDocument();
+    await waitFor(() => expect(getAppProcessStatus).toHaveBeenCalledOnce());
+    await waitFor(() => expect(getCoreVersions).toHaveBeenCalledOnce());
+    await waitFor(() => expect(getBeVersion).toHaveBeenCalledOnce());
+  });
+
+  test('hides the Footer and never polls status/core-version/BE-version when the admin API is disabled', async () => {
+    adminApiEnabled.value = false;
+    render(
+      <Content isEnableAuth={false}>
+        <div>Test Content</div>
+      </Content>,
+    );
+
+    expect(screen.queryByText(/Admin: \[FE\]/)).not.toBeInTheDocument();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(getAppProcessStatus).not.toHaveBeenCalled();
+    expect(getCoreVersions).not.toHaveBeenCalled();
+    expect(getBeVersion).not.toHaveBeenCalled();
   });
 });

--- a/apps/ai-dial-admin/src/components/Content/Content.tsx
+++ b/apps/ai-dial-admin/src/components/Content/Content.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { FC, ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 
-import { getAppProcessStatus, getCoreVersions } from '@/src/app/actions';
+import { getAppProcessStatus, getBeVersion, getCoreVersions } from '@/src/app/actions';
 import Breadcrumbs from '@/src/components/Breadcrumbs/Breadcrumbs';
 import Blackout from '@/src/components/Common/Blackout/Blackout';
 import Sidebar from '@/src/components/Common/Sidebar/Sidebar';
@@ -21,16 +21,15 @@ import { mergeClasses } from '@/src/utils/merge-classes';
 
 interface Props {
   children: ReactNode;
-  beVersion: string | null;
   isEnableAuth: boolean;
 }
 
 const CHECK_CORE_VERSION_INTERVAL = 60 * 1000;
 const CHECK_STATUS_INTERVAL = 2 * 60 * 1000;
 
-const Content: FC<Props> = ({ children, beVersion, isEnableAuth }) => {
+const Content: FC<Props> = ({ children, isEnableAuth }) => {
   const isTabletScreen = useIsTabletScreen();
-  const { sidebar } = useAppContext();
+  const { sidebar, featureFlags } = useAppContext();
   const isBottomSidebarOpen = sidebar.show && sidebar.position === SidebarPosition.Bottom;
   const showNotificationRef = useRef(useNotification().showNotification);
   const getReqRef = useRef(useProtectedRequest());
@@ -39,6 +38,7 @@ const Content: FC<Props> = ({ children, beVersion, isEnableAuth }) => {
   const t = useI18n();
 
   const [coreVersions, setCoreVersions] = useState<CoreVersions | undefined>();
+  const [beVersion, setBeVersion] = useState<string | null>(null);
 
   const checkAppStatus = useCallback((): void => {
     getReqRef.current(getAppProcessStatus).then((response) => {
@@ -56,6 +56,18 @@ const Content: FC<Props> = ({ children, beVersion, isEnableAuth }) => {
   }, []);
 
   useEffect(() => {
+    if (!featureFlags.adminApiEnabled) {
+      return;
+    }
+
+    getBeVersion().then((version) => setBeVersion(version));
+  }, [featureFlags.adminApiEnabled]);
+
+  useEffect(() => {
+    if (!featureFlags.adminApiEnabled) {
+      return;
+    }
+
     checkAppStatus();
     statusIntervalRef.current = setInterval(() => {
       checkAppStatus();
@@ -66,9 +78,13 @@ const Content: FC<Props> = ({ children, beVersion, isEnableAuth }) => {
         clearInterval(statusIntervalRef.current);
       }
     };
-  }, [checkAppStatus]);
+  }, [checkAppStatus, featureFlags.adminApiEnabled]);
 
   useEffect(() => {
+    if (!featureFlags.adminApiEnabled) {
+      return;
+    }
+
     checkCoreVersion();
     versionIntervalRef.current = setInterval(() => {
       checkCoreVersion();
@@ -79,7 +95,7 @@ const Content: FC<Props> = ({ children, beVersion, isEnableAuth }) => {
         clearInterval(versionIntervalRef.current);
       }
     };
-  }, [checkCoreVersion]);
+  }, [checkCoreVersion, featureFlags.adminApiEnabled]);
 
   return (
     <div className="flex flex-col flex-1 min-h-0 min-w-0 relative overflow-hidden">
@@ -98,7 +114,9 @@ const Content: FC<Props> = ({ children, beVersion, isEnableAuth }) => {
         <Sidebar />
       </div>
       <Sidebar slot={SidebarPosition.Bottom} />
-      <Footer beVersion={beVersion} coreVersions={coreVersions} onChangeCoreVersion={setCoreVersions} />
+      {featureFlags.adminApiEnabled && (
+        <Footer beVersion={beVersion} coreVersions={coreVersions} onChangeCoreVersion={setCoreVersions} />
+      )}
     </div>
   );
 };

--- a/apps/ai-dial-admin/src/components/Menu/MenuContent/MenuAction.tsx
+++ b/apps/ai-dial-admin/src/components/Menu/MenuContent/MenuAction.tsx
@@ -15,7 +15,7 @@ const MenuAction: FC<Props> = ({ tooltip, icon, onClick }) => {
     <DialTooltip tooltip={tooltip}>
       <button
         type="button"
-        aria-label="button"
+        aria-label={tooltip}
         className="p-1 rounded cursor-pointer hover:text-accent-primary hover:bg-controls-accent-alpha"
         onClick={onClick}
       >

--- a/apps/ai-dial-admin/src/components/Menu/MenuContent/MenuContent.tsx
+++ b/apps/ai-dial-admin/src/components/Menu/MenuContent/MenuContent.tsx
@@ -67,16 +67,20 @@ const MenuContent: FC<Props> = ({ disableMenuItems, isSidebarOpen }) => {
 
   const MenuActionsBar = () => (
     <div className={classNames(actionsClassName, 'justify-start')}>
-      <MenuAction
-        tooltip={t(MenuI18nKey.ImportConfig)}
-        icon={<IconDownload {...BASE_BUTTON_ICON_PROPS} widths={24} height={24} />}
-        onClick={handleImport}
-      />
-      <MenuAction
-        tooltip={t(MenuI18nKey.ExportConfig)}
-        icon={<IconUpload {...BASE_BUTTON_ICON_PROPS} widths={24} height={24} />}
-        onClick={handleExport}
-      />
+      {featureFlags.adminApiEnabled && (
+        <>
+          <MenuAction
+            tooltip={t(MenuI18nKey.ImportConfig)}
+            icon={<IconDownload {...BASE_BUTTON_ICON_PROPS} widths={24} height={24} />}
+            onClick={handleImport}
+          />
+          <MenuAction
+            tooltip={t(MenuI18nKey.ExportConfig)}
+            icon={<IconUpload {...BASE_BUTTON_ICON_PROPS} widths={24} height={24} />}
+            onClick={handleExport}
+          />
+        </>
+      )}
       <MenuAction
         tooltip={t(MenuI18nKey.SystemProperties)}
         icon={<IconWorldCog {...BASE_BUTTON_ICON_PROPS} widths={24} height={24} />}
@@ -112,7 +116,7 @@ const MenuContent: FC<Props> = ({ disableMenuItems, isSidebarOpen }) => {
             onExport={handleExport}
             onImport={handleImport}
             onOpenProperties={openProperties}
-            showImportExport={!isReadOnlyAdmin}
+            showImportExport={!isReadOnlyAdmin && featureFlags.adminApiEnabled}
           />
         </div>
       )}

--- a/apps/ai-dial-admin/src/components/Menu/MenuContent/tests/MenuContent.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Menu/MenuContent/tests/MenuContent.spec.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { MenuI18nKey } from '@/src/constants/i18n';
+
+import MenuContent from '../MenuContent';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/en/home',
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+const adminApiEnabled = { value: true };
+vi.mock('@/src/context/AppContext', () => ({
+  useAppContext: () => ({ featureFlags: { adminApiEnabled: adminApiEnabled.value }, isReadOnlyAdmin: false }),
+}));
+
+describe('MenuContent — Import/Export actions', () => {
+  beforeEach(() => {
+    adminApiEnabled.value = true;
+  });
+
+  test('renders Import/Export config actions when the admin API is enabled', () => {
+    render(<MenuContent disableMenuItems={[]} isSidebarOpen />);
+
+    expect(screen.getAllByRole('button', { name: MenuI18nKey.ImportConfig }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('button', { name: MenuI18nKey.ExportConfig }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('button', { name: MenuI18nKey.SystemProperties }).length).toBeGreaterThan(0);
+  });
+
+  test('hides Import/Export config actions in the expanded bar when the admin API is disabled', () => {
+    adminApiEnabled.value = false;
+    render(<MenuContent disableMenuItems={[]} isSidebarOpen />);
+
+    expect(screen.queryByRole('button', { name: MenuI18nKey.ImportConfig })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: MenuI18nKey.ExportConfig })).not.toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: MenuI18nKey.SystemProperties }).length).toBeGreaterThan(0);
+  });
+
+  test('hides Import/Export config actions in the collapsed dropdown when the admin API is disabled', () => {
+    adminApiEnabled.value = false;
+    render(<MenuContent disableMenuItems={[]} isSidebarOpen={false} />);
+
+    expect(screen.queryByText(MenuI18nKey.ImportConfig)).not.toBeInTheDocument();
+    expect(screen.queryByText(MenuI18nKey.ExportConfig)).not.toBeInTheDocument();
+  });
+});

--- a/apps/ai-dial-admin/src/components/Menu/menu-configuration.tsx
+++ b/apps/ai-dial-admin/src/components/Menu/menu-configuration.tsx
@@ -38,22 +38,10 @@ export const MENU_CONFIGURATION = (iconSize: number, featureFlags: FeatureFlags)
       icon: <IconSettings2 width={iconSize} height={iconSize} />,
       items: [
         { key: MenuI18nKey.Models, href: ApplicationRoute.Models },
-        {
-          key: MenuI18nKey.Applications,
-          href: ApplicationRoute.Applications,
-        },
-        {
-          key: MenuI18nKey.Toolsets,
-          href: ApplicationRoute.Toolsets,
-        },
-        {
-          key: MenuI18nKey.Interceptors,
-          href: ApplicationRoute.Interceptors,
-        },
-        {
-          key: MenuI18nKey.Routes,
-          href: ApplicationRoute.Routes,
-        },
+        { key: MenuI18nKey.Applications, href: ApplicationRoute.Applications },
+        { key: MenuI18nKey.Toolsets, href: ApplicationRoute.Toolsets },
+        { key: MenuI18nKey.Interceptors, href: ApplicationRoute.Interceptors },
+        { key: MenuI18nKey.Routes, href: ApplicationRoute.Routes },
       ],
     },
     {
@@ -61,18 +49,9 @@ export const MENU_CONFIGURATION = (iconSize: number, featureFlags: FeatureFlags)
       descriptionKey: MenuI18nKey.BuildersDescription,
       icon: <IconHammer width={iconSize} height={iconSize} />,
       items: [
-        {
-          key: MenuI18nKey.ApplicationRunners,
-          href: ApplicationRoute.ApplicationRunners,
-        },
-        {
-          key: MenuI18nKey.InterceptorTemplates,
-          href: ApplicationRoute.InterceptorTemplates,
-        },
-        {
-          key: MenuI18nKey.Adapters,
-          href: ApplicationRoute.Adapters,
-        },
+        { key: MenuI18nKey.ApplicationRunners, href: ApplicationRoute.ApplicationRunners },
+        { key: MenuI18nKey.InterceptorTemplates, href: ApplicationRoute.InterceptorTemplates },
+        { key: MenuI18nKey.Adapters, href: ApplicationRoute.Adapters },
       ],
     },
     {
@@ -95,30 +74,13 @@ export const MENU_CONFIGURATION = (iconSize: number, featureFlags: FeatureFlags)
       descriptionKey: MenuI18nKey.AssetsDescription,
       icon: <IconFolders width={iconSize} height={iconSize} />,
       items: [
-        {
-          key: MenuI18nKey.Applications,
-          href: ApplicationRoute.AssetsApplications,
-        },
-        {
-          key: MenuI18nKey.Toolsets,
-          href: ApplicationRoute.AssetsToolsets,
-        },
-        {
-          key: MenuI18nKey.Prompts,
-          href: ApplicationRoute.Prompts,
-        },
-        {
-          key: MenuI18nKey.Conversations,
-          href: ApplicationRoute.Conversations,
-        },
-        {
-          key: MenuI18nKey.Files,
-          href: ApplicationRoute.Files,
-        },
-        {
-          key: MenuI18nKey.Skills,
-          href: ApplicationRoute.Skills,
-        },
+        { key: MenuI18nKey.Applications, href: ApplicationRoute.AssetsApplications },
+        { key: MenuI18nKey.Toolsets, href: ApplicationRoute.AssetsToolsets },
+        { key: MenuI18nKey.Prompts, href: ApplicationRoute.Prompts },
+        { key: MenuI18nKey.Conversations, href: ApplicationRoute.Conversations },
+        { key: MenuI18nKey.Files, href: ApplicationRoute.Files },
+        { key: MenuI18nKey.Skills, href: ApplicationRoute.Skills },
+        { key: MenuI18nKey.FoldersStorage, href: ApplicationRoute.FoldersStorage },
       ],
     },
     {
@@ -134,26 +96,11 @@ export const MENU_CONFIGURATION = (iconSize: number, featureFlags: FeatureFlags)
               },
             ]
           : []),
-        {
-          key: MenuI18nKey.McpContainers,
-          href: ApplicationRoute.McpContainers,
-        },
-        {
-          key: MenuI18nKey.InterceptorContainers,
-          href: ApplicationRoute.InterceptorContainers,
-        },
-        {
-          key: MenuI18nKey.AdapterContainers,
-          href: ApplicationRoute.AdapterContainers,
-        },
-        {
-          key: MenuI18nKey.ApplicationContainers,
-          href: ApplicationRoute.ApplicationContainers,
-        },
-        {
-          key: MenuI18nKey.Images,
-          href: ApplicationRoute.Images,
-        },
+        { key: MenuI18nKey.McpContainers, href: ApplicationRoute.McpContainers },
+        { key: MenuI18nKey.InterceptorContainers, href: ApplicationRoute.InterceptorContainers },
+        { key: MenuI18nKey.AdapterContainers, href: ApplicationRoute.AdapterContainers },
+        { key: MenuI18nKey.ApplicationContainers, href: ApplicationRoute.ApplicationContainers },
+        { key: MenuI18nKey.Images, href: ApplicationRoute.Images },
       ],
     },
     {
@@ -163,7 +110,6 @@ export const MENU_CONFIGURATION = (iconSize: number, featureFlags: FeatureFlags)
       items: [
         { key: MenuI18nKey.Roles, href: ApplicationRoute.Roles },
         { key: MenuI18nKey.Keys, href: ApplicationRoute.Keys },
-        { key: MenuI18nKey.FoldersStorage, href: ApplicationRoute.FoldersStorage },
       ],
     },
     {
@@ -171,30 +117,12 @@ export const MENU_CONFIGURATION = (iconSize: number, featureFlags: FeatureFlags)
       descriptionKey: MenuI18nKey.ApprovalsDescription,
       icon: <Approvals width={iconSize} height={iconSize} />,
       items: [
-        {
-          key: MenuI18nKey.ApplicationPublications,
-          href: ApplicationRoute.ApplicationPublications,
-        },
-        {
-          key: MenuI18nKey.ToolsetPublications,
-          href: ApplicationRoute.ToolsetPublications,
-        },
-        {
-          key: MenuI18nKey.PromptPublications,
-          href: ApplicationRoute.PromptPublications,
-        },
-        {
-          key: MenuI18nKey.ConversationPublications,
-          href: ApplicationRoute.ConversationPublications,
-        },
-        {
-          key: MenuI18nKey.FilePublications,
-          href: ApplicationRoute.FilePublications,
-        },
-        {
-          key: MenuI18nKey.SkillPublications,
-          href: ApplicationRoute.SkillPublications,
-        },
+        { key: MenuI18nKey.ApplicationPublications, href: ApplicationRoute.ApplicationPublications },
+        { key: MenuI18nKey.ToolsetPublications, href: ApplicationRoute.ToolsetPublications },
+        { key: MenuI18nKey.PromptPublications, href: ApplicationRoute.PromptPublications },
+        { key: MenuI18nKey.ConversationPublications, href: ApplicationRoute.ConversationPublications },
+        { key: MenuI18nKey.FilePublications, href: ApplicationRoute.FilePublications },
+        { key: MenuI18nKey.SkillPublications, href: ApplicationRoute.SkillPublications },
       ],
     },
     {
@@ -212,18 +140,9 @@ export const MENU_CONFIGURATION = (iconSize: number, featureFlags: FeatureFlags)
       descriptionKey: MenuI18nKey.AuditDescription,
       icon: <IconDashboard width={iconSize} height={iconSize} />,
       items: [
-        {
-          key: MenuI18nKey.Dashboard,
-          href: ApplicationRoute.Dashboard,
-        },
-        {
-          key: MenuI18nKey.ActivityAudit,
-          href: ApplicationRoute.ActivityAudit,
-        },
-        {
-          key: MenuI18nKey.UsageLog,
-          href: ApplicationRoute.UsageLog,
-        },
+        { key: MenuI18nKey.Dashboard, href: ApplicationRoute.Dashboard },
+        { key: MenuI18nKey.ActivityAudit, href: ApplicationRoute.ActivityAudit },
+        { key: MenuI18nKey.UsageLog, href: ApplicationRoute.UsageLog },
       ],
     },
     {
@@ -232,26 +151,11 @@ export const MENU_CONFIGURATION = (iconSize: number, featureFlags: FeatureFlags)
       icon: <IconChartBar width={iconSize} height={iconSize} />,
       isPreview: true,
       items: [
-        {
-          key: MenuI18nKey.Tables,
-          href: ApplicationRoute.AnalyticsTables,
-        },
-        {
-          key: MenuI18nKey.Pipelines,
-          href: ApplicationRoute.AnalyticsPipelines,
-        },
-        {
-          key: MenuI18nKey.Evaluators,
-          href: ApplicationRoute.AnalyticsEvaluators,
-        },
-        {
-          key: MenuI18nKey.Queries,
-          href: ApplicationRoute.AnalyticsQueries,
-        },
-        {
-          key: MenuI18nKey.AnalyticsConversations,
-          href: ApplicationRoute.ConversationsTrace,
-        },
+        { key: MenuI18nKey.Tables, href: ApplicationRoute.AnalyticsTables },
+        { key: MenuI18nKey.Pipelines, href: ApplicationRoute.AnalyticsPipelines },
+        { key: MenuI18nKey.Evaluators, href: ApplicationRoute.AnalyticsEvaluators },
+        { key: MenuI18nKey.Queries, href: ApplicationRoute.AnalyticsQueries },
+        { key: MenuI18nKey.AnalyticsConversations, href: ApplicationRoute.ConversationsTrace },
       ],
     },
   ];
@@ -274,6 +178,16 @@ export const MENU_CONFIGURATION = (iconSize: number, featureFlags: FeatureFlags)
       group.key === MenuI18nKey.Analytics
         ? { ...group, items: group.items.filter((item) => item.key !== MenuI18nKey.AnalyticsConversations) }
         : group,
+    );
+  }
+
+  if (!featureFlags.adminApiEnabled) {
+    result = result.filter(
+      (item) =>
+        item.key !== MenuI18nKey.Entities &&
+        item.key !== MenuI18nKey.Builders &&
+        item.key !== MenuI18nKey.AccessManagement &&
+        item.key !== MenuI18nKey.Audit,
     );
   }
 

--- a/apps/ai-dial-admin/src/components/Menu/tests/menu-configuration.spec.ts
+++ b/apps/ai-dial-admin/src/components/Menu/tests/menu-configuration.spec.ts
@@ -10,6 +10,7 @@ import { MENU_CONFIGURATION } from '../menu-configuration';
 const ICON_SIZE = 16;
 
 const baseFlags: FeatureFlags = {
+  adminApiEnabled: true,
   dashboardEnabled: true,
   deploymentsEnabled: true,
   evaluationEnabled: true,
@@ -98,6 +99,49 @@ describe('MENU_CONFIGURATION — group visibility flags compose independently', 
 
     expect(keys).not.toContain(MenuI18nKey.Deployments);
     expect(keys).not.toContain(MenuI18nKey.Evaluation);
+  });
+});
+
+describe('MENU_CONFIGURATION — admin API gating', () => {
+  const findAuditGroup = (flags: FeatureFlags) =>
+    MENU_CONFIGURATION(ICON_SIZE, flags).find((group) => group.key === MenuI18nKey.Audit);
+
+  test('hides Entities, Builders, Access Management, and Audit when adminApiEnabled is false', () => {
+    const keys = groupKeys({ ...baseFlags, adminApiEnabled: false });
+
+    expect(keys).not.toContain(MenuI18nKey.Entities);
+    expect(keys).not.toContain(MenuI18nKey.Builders);
+    expect(keys).not.toContain(MenuI18nKey.AccessManagement);
+    expect(keys).not.toContain(MenuI18nKey.Audit);
+  });
+
+  test('hides the whole Audit group (not just Activity) when adminApiEnabled is false', () => {
+    const group = findAuditGroup({ ...baseFlags, adminApiEnabled: false });
+
+    expect(group).toBeUndefined();
+  });
+
+  test('shows Entities, Builders, Access Management, and the Activity item when adminApiEnabled is true', () => {
+    const keys = groupKeys(baseFlags);
+    const auditKeys = findAuditGroup(baseFlags)?.items.map((item) => item.key);
+
+    expect(keys).toContain(MenuI18nKey.Entities);
+    expect(keys).toContain(MenuI18nKey.Builders);
+    expect(keys).toContain(MenuI18nKey.AccessManagement);
+    expect(auditKeys).toContain(MenuI18nKey.ActivityAudit);
+  });
+
+  test('gating composes independently of Deployments and Evaluation', () => {
+    const keys = groupKeys({
+      ...baseFlags,
+      adminApiEnabled: false,
+      deploymentsEnabled: true,
+      evaluationEnabled: true,
+    });
+
+    expect(keys).not.toContain(MenuI18nKey.Entities);
+    expect(keys).toContain(MenuI18nKey.Deployments);
+    expect(keys).toContain(MenuI18nKey.Evaluation);
   });
 });
 

--- a/apps/ai-dial-admin/src/components/Menu/tests/menu-configuration.spec.ts
+++ b/apps/ai-dial-admin/src/components/Menu/tests/menu-configuration.spec.ts
@@ -174,12 +174,12 @@ describe('MENU_CONFIGURATION — Assets group', () => {
   const findAssetsGroup = (flags: FeatureFlags) =>
     MENU_CONFIGURATION(ICON_SIZE, flags).find((group) => group.key === MenuI18nKey.Assets);
 
-  test('Skills is the last entry, immediately after Files', () => {
+  test('FoldersStorage is the last entry, immediately after Skills', () => {
     const group = findAssetsGroup(baseFlags);
     const keys = group?.items.map((item) => item.key) || [];
 
-    expect(keys[keys.length - 1]).toBe(MenuI18nKey.Skills);
-    expect(keys[keys.length - 2]).toBe(MenuI18nKey.Files);
+    expect(keys[keys.length - 1]).toBe(MenuI18nKey.FoldersStorage);
+    expect(keys[keys.length - 2]).toBe(MenuI18nKey.Skills);
   });
 
   test('Skills links to the /skills route', () => {

--- a/apps/ai-dial-admin/src/components/SystemProperties/SystemProperties.tsx
+++ b/apps/ai-dial-admin/src/components/SystemProperties/SystemProperties.tsx
@@ -1,12 +1,14 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { FC, useCallback, useMemo, useState } from 'react';
+import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { cloneDeep, isEqual } from 'lodash';
 
 import { updateProperties } from '@/src/app/[lang]/system-properties/actions';
 import GlobalInterceptors from '@/src/components/EntityView/Interceptors/GlobalInterceptors';
+import { DEFAULT_ETAG } from '@/src/constants/api-headers';
+import { EntitiesI18nKey } from '@/src/constants/i18n';
 import { useNotification } from '@/src/context/NotificationContext';
 import { useI18n } from '@/src/locales/client';
 import { DialInterceptor } from '@/src/models/dial/interceptor';
@@ -20,13 +22,24 @@ import Header from './Header';
 interface Props {
   interceptors: DialInterceptor[];
   globalSettings: GlobalSettings | null;
-  etag: string;
+  /** Whether the server-side read found an existing settings blob — see settings-api.ts. */
+  doesSettingsExist: boolean;
+  /** i18n keys for non-fatal problems from the server-side option reads, resolved here. */
+  optionWarnings?: EntitiesI18nKey[];
 }
 
-const SystemProperties: FC<Props> = ({ interceptors, globalSettings, etag }) => {
+const SystemProperties: FC<Props> = ({ interceptors, globalSettings, doesSettingsExist, optionWarnings }) => {
   const t = useI18n();
   const router = useRouter();
   const { showNotification } = useNotification();
+
+  // An option list read from only one of Core's two populations is shown rather than withheld, so the
+  // user has to be told the list is incomplete — otherwise a missing interceptor reads as deleted.
+  useEffect(() => {
+    optionWarnings?.forEach((warning) => {
+      showNotification(getErrorNotification(t(EntitiesI18nKey.IncompleteOptionList), t(warning)));
+    });
+  }, [optionWarnings, showNotification, t]);
 
   const [activeTab, setActiveTab] = useState(EntityViewTab.GlobalInterceptors);
   const [currentSettings, setCurrentSettings] = useState(cloneDeep(globalSettings));
@@ -43,6 +56,10 @@ const SystemProperties: FC<Props> = ({ interceptors, globalSettings, etag }) => 
   }, []);
 
   const onSave = useCallback(() => {
+    // No blob yet -> omit If-Match (create); a blob already exists -> assert existence with '*'.
+    // Core never hands back a real etag to compare against — see settings-api.ts.
+    const etag = doesSettingsExist ? DEFAULT_ETAG : undefined;
+
     updateProperties(currentSettings as GlobalSettings, etag).then((res) => {
       if (res.success) {
         showNotification(
@@ -56,7 +73,7 @@ const SystemProperties: FC<Props> = ({ interceptors, globalSettings, etag }) => 
         showNotification(getErrorNotification(res.errorHeader, res.errorMessage, res.requestId));
       }
     });
-  }, [currentSettings, etag, router, showNotification, t]);
+  }, [currentSettings, doesSettingsExist, router, showNotification, t]);
 
   const onDiscard = useCallback(() => {
     setCurrentSettings(globalSettings);

--- a/apps/ai-dial-admin/src/components/SystemProperties/tests/SystemProperties.spec.tsx
+++ b/apps/ai-dial-admin/src/components/SystemProperties/tests/SystemProperties.spec.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { updateProperties } from '@/src/app/[lang]/system-properties/actions';
+import SystemProperties from '@/src/components/SystemProperties/SystemProperties';
+import { ButtonsI18nKey, EntitiesI18nKey } from '@/src/constants/i18n';
+import { DialInterceptor } from '@/src/models/dial/interceptor';
+import { GlobalSettings } from '@/src/models/system-properties';
+
+const routerRefresh = vi.fn();
+vi.mock('next/navigation', () => ({ useRouter: () => ({ refresh: routerRefresh }) }));
+
+const showNotification = vi.fn();
+vi.mock('@/src/context/NotificationContext', () => ({
+  useNotification: () => ({ showNotification, removeNotification: vi.fn() }),
+}));
+
+vi.mock('@/src/app/[lang]/system-properties/actions');
+
+// AG Grid is heavy and not meaningful in jsdom — stand in with a button that fires the same
+// onChangeInterceptors contract the real grid's drag/add/remove handlers all funnel into.
+vi.mock('@/src/components/EntityView/Interceptors/GlobalInterceptors', () => ({
+  default: ({ onChangeInterceptors }: { onChangeInterceptors: (interceptors: string[]) => void }) => (
+    <button onClick={() => onChangeInterceptors(['new-interceptor'])}>change-interceptors</button>
+  ),
+}));
+
+const INTERCEPTORS_MOCK: DialInterceptor[] = [];
+
+const renderSystemProperties = (props?: {
+  globalSettings?: GlobalSettings | null;
+  doesSettingsExist?: boolean;
+  optionWarnings?: EntitiesI18nKey[];
+}) =>
+  render(
+    <SystemProperties
+      interceptors={INTERCEPTORS_MOCK}
+      globalSettings={props?.globalSettings ?? null}
+      doesSettingsExist={props?.doesSettingsExist ?? false}
+      optionWarnings={props?.optionWarnings}
+    />,
+  );
+
+describe('SystemProperties', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('saves with an undefined etag when no settings blob exists yet', async () => {
+    const user = userEvent.setup();
+    (updateProperties as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true });
+    renderSystemProperties({ doesSettingsExist: false, globalSettings: { globalInterceptors: [] } });
+
+    await user.click(screen.getByText('change-interceptors'));
+    await user.click(screen.getByRole('button', { name: ButtonsI18nKey.Save }));
+
+    expect(updateProperties).toHaveBeenCalledOnce();
+    expect(updateProperties).toHaveBeenCalledWith({ globalInterceptors: ['new-interceptor'] }, undefined);
+  });
+
+  test('saves with If-Match: * (via DEFAULT_ETAG) when a settings blob already exists', async () => {
+    const user = userEvent.setup();
+    (updateProperties as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true });
+    renderSystemProperties({
+      doesSettingsExist: true,
+      globalSettings: { globalInterceptors: [], retriableErrorCodes: [500] },
+    });
+
+    await user.click(screen.getByText('change-interceptors'));
+    await user.click(screen.getByRole('button', { name: ButtonsI18nKey.Save }));
+
+    expect(updateProperties).toHaveBeenCalledWith(
+      { globalInterceptors: ['new-interceptor'], retriableErrorCodes: [500] },
+      '*',
+    );
+  });
+
+  test('refreshes the page on a successful save', async () => {
+    const user = userEvent.setup();
+    (updateProperties as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true });
+    renderSystemProperties({ doesSettingsExist: true, globalSettings: { globalInterceptors: [] } });
+
+    await user.click(screen.getByText('change-interceptors'));
+    await user.click(screen.getByRole('button', { name: ButtonsI18nKey.Save }));
+
+    expect(routerRefresh).toHaveBeenCalledOnce();
+  });
+
+  test('shows an error notification and does not refresh when the save fails', async () => {
+    const user = userEvent.setup();
+    (updateProperties as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: false,
+      errorHeader: 'Precondition Failed',
+      errorMessage: 'Resource must exist',
+    });
+    renderSystemProperties({ doesSettingsExist: true, globalSettings: { globalInterceptors: [] } });
+
+    await user.click(screen.getByText('change-interceptors'));
+    await user.click(screen.getByRole('button', { name: ButtonsI18nKey.Save }));
+
+    expect(showNotification).toHaveBeenCalledOnce();
+    expect(routerRefresh).not.toHaveBeenCalled();
+  });
+
+  test('shows a warning notification for each option-read warning passed in', () => {
+    renderSystemProperties({ optionWarnings: [EntitiesI18nKey.SystemPropertiesReadFailed] });
+
+    expect(showNotification).toHaveBeenCalledOnce();
+    expect(showNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: EntitiesI18nKey.IncompleteOptionList,
+        description: EntitiesI18nKey.SystemPropertiesReadFailed,
+      }),
+    );
+  });
+});

--- a/apps/ai-dial-admin/src/components/WelcomeView/WelcomeView.spec.tsx
+++ b/apps/ai-dial-admin/src/components/WelcomeView/WelcomeView.spec.tsx
@@ -10,6 +10,11 @@ vi.mock('@/src/hooks/use-is-read-only-admin', () => ({
   useIsReadOnlyAdmin: () => isReadOnlyAdminMock(),
 }));
 
+const adminApiEnabled = { value: true };
+vi.mock('@/src/context/AppContext', () => ({
+  useAppContext: () => ({ featureFlags: { adminApiEnabled: adminApiEnabled.value } }),
+}));
+
 const router: ApplicationRoute[] = [];
 vi.mock('next/navigation', () => ({
   useRouter: () => router,
@@ -23,6 +28,7 @@ describe('WelcomeView', () => {
 
   beforeEach(() => {
     isReadOnlyAdminMock.mockReturnValue(false);
+    adminApiEnabled.value = true;
   });
 
   test('renders read-only banner and hides import/export for read-only admin', () => {
@@ -33,6 +39,15 @@ describe('WelcomeView', () => {
     expect(screen.getByText(ReadOnlyI18nKey.Description)).toBeInTheDocument();
     expect(screen.queryByText(MenuI18nKey.ImportConfig)).not.toBeInTheDocument();
     expect(screen.queryByText(MenuI18nKey.ExportConfig)).not.toBeInTheDocument();
+  });
+
+  test('hides Import/Export quick actions when the admin API is disabled', () => {
+    adminApiEnabled.value = false;
+    render(<WelcomeView disableMenuItems={[]} dialLink="link" docLink="link" />);
+
+    expect(screen.queryByText(MenuI18nKey.ImportConfig)).not.toBeInTheDocument();
+    expect(screen.queryByText(MenuI18nKey.ExportConfig)).not.toBeInTheDocument();
+    expect(screen.getByText(MenuI18nKey.SystemProperties)).toBeInTheDocument();
   });
 
   test('renders and triggers actions without test ids', () => {

--- a/apps/ai-dial-admin/src/components/WelcomeView/WelcomeView.tsx
+++ b/apps/ai-dial-admin/src/components/WelcomeView/WelcomeView.tsx
@@ -60,7 +60,7 @@ const WelcomeView: FC<Props> = ({ docLink, dialLink, disableMenuItems, dialButto
       <div className="mb-6 flex flex-col">
         <h2 className="mb-3">{t(WelcomeViewI18nKey.QuickActions)}</h2>
         <div className="flex flex-row gap-x-3">
-          {!isReadOnlyAdmin && (
+          {!isReadOnlyAdmin && featureFlags.adminApiEnabled && (
             <>
               <DialNeutralButton
                 iconBefore={<IconDownload {...BASE_BUTTON_ICON_PROPS} widths={24} height={24} />}

--- a/apps/ai-dial-admin/src/constants/i18n.ts
+++ b/apps/ai-dial-admin/src/constants/i18n.ts
@@ -219,6 +219,7 @@ export enum EntitiesI18nKey {
   OptionListUnavailable = 'Entities.OptionListUnavailable',
   OptionListPartial = 'Entities.OptionListPartial',
   GlobalInterceptorsUnavailable = 'Entities.GlobalInterceptorsUnavailable',
+  SystemPropertiesReadFailed = 'Entities.SystemPropertiesReadFailed',
   ResolvedSchemaFailed = 'Entities.ResolvedSchemaFailed',
   NoModelServings = 'Entities.NoModelServings',
   AddModel = 'Entities.AddModel',

--- a/apps/ai-dial-admin/src/context/AppContext.tsx
+++ b/apps/ai-dial-admin/src/context/AppContext.tsx
@@ -27,9 +27,12 @@ export interface AppContextType {
 
   // user info
   userInfo?: UserInfo;
-  /** True when user has READ_ONLY_ADMIN and does not have FULL_ADMIN */
+  /** True when user has READ_ONLY_ADMIN and does not have FULL_ADMIN. Always false without the admin backend. */
   isReadOnlyAdmin: boolean;
-  /** True when the user holds FULL_ADMIN, or when authentication is disabled (nothing is enforced). */
+  /**
+   * True when the user holds FULL_ADMIN, or when authentication is disabled (nothing is enforced).
+   * Always true without the admin backend — there is no role to check.
+   */
   isFullAdmin: boolean;
   /** Whether authentication is enabled (NEXTAUTH_URL set). Needed to tell "auth off" from "no role". */
   isEnableAuth: boolean;
@@ -114,11 +117,16 @@ export const AppContextProvider = ({
     setSidebarPosition(SidebarPosition.Right);
   };
 
+  // Without the admin backend there's no FULL_ADMIN/READ_ONLY_ADMIN to read — nothing is
+  // enforced, so treat every caller as a full admin.
   const isReadOnlyAdmin =
-    !!userInfo?.roles?.includes(UserRole.READ_ONLY_ADMIN) && !userInfo?.roles?.includes(UserRole.FULL_ADMIN);
+    featureFlags.adminApiEnabled &&
+    !!userInfo?.roles?.includes(UserRole.READ_ONLY_ADMIN) &&
+    !userInfo?.roles?.includes(UserRole.FULL_ADMIN);
 
   // Auth off → nothing is enforced, so treat as full admin; otherwise only a mapped FULL_ADMIN.
-  const isFullAdmin = !isEnableAuth || !!userInfo?.roles?.includes(UserRole.FULL_ADMIN);
+  const isFullAdmin =
+    !featureFlags.adminApiEnabled || !isEnableAuth || !!userInfo?.roles?.includes(UserRole.FULL_ADMIN);
 
   const value = {
     sidebarOpen,

--- a/apps/ai-dial-admin/src/locales/en.ts
+++ b/apps/ai-dial-admin/src/locales/en.ts
@@ -229,6 +229,7 @@ export default {
     OptionListUnavailable: 'This list could not be loaded from DIAL Core.',
     OptionListPartial: 'This list is incomplete — one of its two sources could not be read.',
     GlobalInterceptorsUnavailable: 'Global interceptors could not be read, so the order shown may be incomplete.',
+    SystemPropertiesReadFailed: 'System properties could not be loaded.',
     ResolvedSchemaFailed: 'Could not load the application schema',
     NoToolsets: 'No Toolsets',
     NoTools: 'No Tools',

--- a/apps/ai-dial-admin/src/models/dial/core-user-info.ts
+++ b/apps/ai-dial-admin/src/models/dial/core-user-info.ts
@@ -1,0 +1,12 @@
+/**
+ * Raw shape of DIAL Core's `GET /v1/user/info` response. Core reports the caller's own
+ * unmapped DIAL roles — `userId`/`userClaims` are populated for a JWT-authenticated caller,
+ * `project` for an API-key caller instead (the two are mutually exclusive).
+ */
+export interface CoreUserInfoResponse {
+  roles: string[];
+  project?: string;
+  userId?: string;
+  userClaims?: Record<string, string[]>;
+  userDisplayName?: string;
+}

--- a/apps/ai-dial-admin/src/models/feature-flags.ts
+++ b/apps/ai-dial-admin/src/models/feature-flags.ts
@@ -1,4 +1,5 @@
 export interface FeatureFlags {
+  adminApiEnabled: boolean;
   dashboardEnabled: boolean;
   deploymentsEnabled: boolean;
   evaluationEnabled: boolean;

--- a/apps/ai-dial-admin/src/models/system-properties.ts
+++ b/apps/ai-dial-admin/src/models/system-properties.ts
@@ -1,3 +1,5 @@
 export interface GlobalSettings {
   globalInterceptors: string[];
+  /** Not editable here yet — kept only so a save round-trips it unchanged instead of dropping it. */
+  retriableErrorCodes?: number[];
 }

--- a/apps/ai-dial-admin/src/server/base-api.ts
+++ b/apps/ai-dial-admin/src/server/base-api.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_ETAG, IF_MATCH, IF_NONE_MATCH } from '@/src/constants/api-headers';
+import { IF_MATCH, IF_NONE_MATCH } from '@/src/constants/api-headers';
 import { Token } from '@/src/models/auth';
 import { ServerActionResponse } from '@/src/models/server-action';
 import { streamRequest } from '@/src/utils/api/create-stream-request';
@@ -34,13 +34,19 @@ export class BaseApi {
     return this.sendActionRequest(url, 'DELETE', token);
   }
 
+  /**
+   * `etag` undefined omits `If-Match` entirely — a create against a resource known not to exist yet,
+   * where sending `If-Match` at all (even `*`) would assert the opposite. A defined value (including
+   * `DEFAULT_ETAG`) is sent as-is; callers that know the resource exists but have no specific value to
+   * compare pass `DEFAULT_ETAG` explicitly.
+   */
   protected async putActionWithEtag<T extends object>(
     url: string,
     dto: T,
     token: Token,
-    etag: string,
+    etag: string | undefined,
   ): Promise<ServerActionResponse> {
-    return this.putAction<T>(url, dto, token, { [IF_MATCH]: etag || DEFAULT_ETAG });
+    return this.putAction<T>(url, dto, token, etag ? { [IF_MATCH]: etag } : undefined);
   }
 
   protected async putAction<T extends object>(

--- a/apps/ai-dial-admin/src/server/config-entities/read.ts
+++ b/apps/ai-dial-admin/src/server/config-entities/read.ts
@@ -22,7 +22,12 @@ export const getConfigEntityOptions = async (
 ): Promise<ConfigFileReadResult<ConfigEntityOptions>> => {
   const [apiWritten, configFile] = await Promise.all([
     toFailureOnThrow(listApiWrittenNames(token, type)),
-    toFailureOnThrow(configFileApi.listNames(token, type)),
+    // Config-file entities are the admin console's own configuration surface — without the admin
+    // backend there is nothing declaring them, so skip the read rather than reporting an empty
+    // population as a partial failure.
+    process.env.DIAL_ADMIN_API_URL
+      ? toFailureOnThrow(configFileApi.listNames(token, type))
+      : Promise.resolve<ConfigFileReadResult<string[]>>({ success: true, data: [] }),
   ]);
 
   return unionConfigEntityOptions(apiWritten, configFile);

--- a/apps/ai-dial-admin/src/server/config-entities/tests/read-page-options.spec.ts
+++ b/apps/ai-dial-admin/src/server/config-entities/tests/read-page-options.spec.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { EntitiesI18nKey } from '@/src/constants/i18n';
+import { TOKEN_MOCK } from '@/src/utils/tests/mock/api.mock';
+import { ConfigEntityOrigin, ConfigFileEntityType, ConfigFileFailureReason } from '@/src/types/config-file-entity';
+
+const getConfigEntityOptions = vi.fn();
+const getGlobalInterceptors = vi.fn();
+
+vi.mock('@/src/server/config-entities/read', () => ({
+  getConfigEntityOptions: (...args: unknown[]) => getConfigEntityOptions(...args),
+  getGlobalInterceptors: (...args: unknown[]) => getGlobalInterceptors(...args),
+}));
+
+const { readConfigEntities, readGlobalInterceptors } = await import('@/src/server/config-entities/read-page-options');
+
+describe('readConfigEntities', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('reads and maps the option list', async () => {
+    getConfigEntityOptions.mockResolvedValue({
+      success: true,
+      data: {
+        options: [{ name: 'interceptor-1', origin: ConfigEntityOrigin.Api }],
+        failures: [],
+      },
+    });
+    const warnings: EntitiesI18nKey[] = [];
+
+    const result = await readConfigEntities(TOKEN_MOCK, ConfigFileEntityType.Interceptors, warnings);
+
+    expect(getConfigEntityOptions).toHaveBeenCalledWith(TOKEN_MOCK, ConfigFileEntityType.Interceptors);
+    expect(result).toEqual([{ name: 'interceptor-1', displayName: 'interceptor-1', origin: ConfigEntityOrigin.Api }]);
+    expect(warnings).toEqual([]);
+  });
+
+  test('reports and returns nothing when the read fails outright', async () => {
+    getConfigEntityOptions.mockResolvedValue({
+      success: false,
+      failure: { reason: ConfigFileFailureReason.RequestFailed, errorMessage: 'boom' },
+    });
+    const warnings: EntitiesI18nKey[] = [];
+
+    const result = await readConfigEntities(TOKEN_MOCK, ConfigFileEntityType.Roles, warnings);
+
+    expect(result).toEqual([]);
+    expect(warnings).toEqual([EntitiesI18nKey.OptionListUnavailable]);
+  });
+
+  test('reports a partial read but still returns the surviving population', async () => {
+    getConfigEntityOptions.mockResolvedValue({
+      success: true,
+      data: {
+        options: [{ name: 'role-1', origin: ConfigEntityOrigin.ConfigFile }],
+        failures: [{ reason: ConfigFileFailureReason.RequestFailed, errorMessage: 'partial' }],
+      },
+    });
+    const warnings: EntitiesI18nKey[] = [];
+
+    const result = await readConfigEntities(TOKEN_MOCK, ConfigFileEntityType.Roles, warnings);
+
+    expect(result).toEqual([{ name: 'role-1', displayName: 'role-1', origin: ConfigEntityOrigin.ConfigFile }]);
+    expect(warnings).toEqual([EntitiesI18nKey.OptionListPartial]);
+  });
+});
+
+describe('readGlobalInterceptors', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('returns the interceptor names on a successful read', async () => {
+    getGlobalInterceptors.mockResolvedValue({ success: true, data: ['global-1'] });
+    const warnings: EntitiesI18nKey[] = [];
+
+    const result = await readGlobalInterceptors(TOKEN_MOCK, warnings);
+
+    expect(result).toEqual(['global-1']);
+    expect(warnings).toEqual([]);
+  });
+
+  test('reports a failed read and returns an empty chain', async () => {
+    getGlobalInterceptors.mockResolvedValue({
+      success: false,
+      failure: { reason: ConfigFileFailureReason.RequestFailed, errorMessage: 'boom' },
+    });
+    const warnings: EntitiesI18nKey[] = [];
+
+    const result = await readGlobalInterceptors(TOKEN_MOCK, warnings);
+
+    expect(result).toEqual([]);
+    expect(warnings).toEqual([EntitiesI18nKey.GlobalInterceptorsUnavailable]);
+  });
+});

--- a/apps/ai-dial-admin/src/server/config-entities/tests/read.spec.ts
+++ b/apps/ai-dial-admin/src/server/config-entities/tests/read.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { TOKEN_MOCK } from '@/src/utils/tests/mock/api.mock';
 import { ConfigEntityOrigin, ConfigFileEntityType, ConfigFileFailureReason } from '@/src/types/config-file-entity';
@@ -27,6 +27,11 @@ const metadataPage = (names: string[], nextToken?: string) => ({
 describe('getConfigEntityOptions', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubEnv('DIAL_ADMIN_API_URL', 'http://admin-be');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   test('unions both populations with their origins', async () => {
@@ -109,6 +114,19 @@ describe('getConfigEntityOptions', () => {
 
     // No throw, and the malformed page contributes no names.
     expect(result.success && result.data.options).toEqual([]);
+  });
+
+  // Config-file entities are declared in the admin console's own configuration surface — without it
+  // there is nothing to read there, so the config-file half is skipped rather than reported as failed.
+  test('skips the config-file read without the admin backend, keeping the API-written population', async () => {
+    vi.stubEnv('DIAL_ADMIN_API_URL', '');
+    getMetadata.mockResolvedValue(metadataPage(['from-api']));
+
+    const result = await getConfigEntityOptions(TOKEN_MOCK, ConfigFileEntityType.Interceptors);
+
+    expect(listNames).not.toHaveBeenCalled();
+    expect(result.success && result.data.options).toEqual([{ name: 'from-api', origin: ConfigEntityOrigin.Api }]);
+    expect(result.success && result.data.failures).toEqual([]);
   });
 });
 

--- a/apps/ai-dial-admin/src/server/core/core-utility-api.ts
+++ b/apps/ai-dial-admin/src/server/core/core-utility-api.ts
@@ -1,0 +1,46 @@
+import { Token } from '@/src/models/auth';
+import { CoreUserInfoResponse } from '@/src/models/dial/core-user-info';
+import { ServerActionResponse } from '@/src/models/server-action';
+import { UserInfo } from '@/src/models/user-info';
+import { CoreApi } from './core-api';
+
+export const DEPLOYMENTS_URL = 'v1/deployments';
+export const DEPLOYMENT_URL = (name: string) => `${DEPLOYMENTS_URL}/${name}`;
+export const USER_INFO_URL = 'v1/user/info';
+
+/** Claim Core reports the caller's email under, inside `/v1/user/info`'s `userClaims` map. */
+const EMAIL_CLAIM = 'email';
+
+/**
+ * Direct-to-Core replacements for the admin-backend endpoints that only ever proxied Core
+ * unchanged: deployment listing/lookup and the caller's own identity. The global-settings
+ * singleton lives on {@link SettingsApi} instead, which already owns that resource.
+ * {@link UtilityApi} keeps everything BE still owns (import/export, version, config sync) so
+ * those aren't duplicated or moved here.
+ */
+export class CoreUtilityApi extends CoreApi {
+  checkDeploymentByName(name: string, token: Token) {
+    return this.get(DEPLOYMENT_URL(name), token);
+  }
+
+  getAllDeployments(token: Token): Promise<ServerActionResponse> {
+    return this.getAction(DEPLOYMENTS_URL, token);
+  }
+
+  async getUserInfo(token: Token): Promise<ServerActionResponse<{ userInfo: UserInfo }>> {
+    const result = (await this.getAction(USER_INFO_URL, token)) as ServerActionResponse<CoreUserInfoResponse>;
+    if (!result.success) {
+      return { ...result, response: undefined };
+    }
+
+    const raw = result.response;
+    const userInfo: UserInfo = {
+      id: raw?.userId || raw?.project || '',
+      email: raw?.userClaims?.[EMAIL_CLAIM]?.[0] || '',
+      // Core's raw DIAL roles aren't used here — role checks are out of scope for this identity read.
+      roles: [],
+    };
+
+    return { ...result, response: { userInfo } };
+  }
+}

--- a/apps/ai-dial-admin/src/server/core/settings-api.ts
+++ b/apps/ai-dial-admin/src/server/core/settings-api.ts
@@ -1,5 +1,6 @@
 import { Token } from '@/src/models/auth';
 import { ServerActionResponse } from '@/src/models/server-action';
+import { GlobalSettings } from '@/src/models/system-properties';
 import { CoreApi } from './core-api';
 
 /**
@@ -13,5 +14,22 @@ export class SettingsApi extends CoreApi {
   /** Reads the API-written settings blob. A 404 means no override exists, not an error. */
   globalSettings(token: Token): Promise<ServerActionResponse> {
     return this.getAction(CORE_GLOBAL_SETTINGS_URL, token);
+  }
+
+  /** Same singleton as {@link globalSettings}, conditional on `etag` — backs the System Properties page. */
+  getSystemProperties(token: Token, etag: string): Promise<ServerActionResponse<GlobalSettings>> {
+    return this.getActionWithEtag(CORE_GLOBAL_SETTINGS_URL, etag, token);
+  }
+
+  /**
+   * `etag` undefined means the prior read found no settings blob yet — omits `If-Match` so the write
+   * is treated as a create. See `putActionWithEtag`.
+   */
+  updateSystemProperties(
+    properties: GlobalSettings,
+    token: Token,
+    etag: string | undefined,
+  ): Promise<ServerActionResponse> {
+    return this.putActionWithEtag(CORE_GLOBAL_SETTINGS_URL, properties, token, etag);
   }
 }

--- a/apps/ai-dial-admin/src/server/core/tests/core-utility-api.spec.ts
+++ b/apps/ai-dial-admin/src/server/core/tests/core-utility-api.spec.ts
@@ -1,0 +1,85 @@
+import { TEST_URL, TOKEN_MOCK } from '@/src/utils/tests/mock/api.mock';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import createFetchMock from 'vitest-fetch-mock';
+
+import { CoreUtilityApi } from '../core-utility-api';
+
+const fetch = createFetchMock(vi);
+fetch.enableMocks();
+
+describe('Server :: Core :: CoreUtilityApi', () => {
+  const instance = new CoreUtilityApi({ host: TEST_URL });
+
+  beforeEach(() => {
+    fetch.resetMocks();
+  });
+
+  test('checkDeploymentByName calls the Core deployments route, not the admin-BE api/ path', async () => {
+    fetch.mockResponseOnce(JSON.stringify({ name: 'my-app' }));
+
+    await instance.checkDeploymentByName('my-app', TOKEN_MOCK);
+
+    const [calledUrl] = fetch.mock.calls[0];
+    expect(calledUrl).toContain('/v1/deployments/my-app');
+    expect(calledUrl).not.toContain('/api/');
+  });
+
+  test('checkDeploymentByName resolves to null when the deployment does not exist', async () => {
+    fetch.mockResponseOnce('Not Found', { status: 404 });
+
+    const result = await instance.checkDeploymentByName('missing-app', TOKEN_MOCK);
+    expect(result).toBeNull();
+  });
+
+  test('getAllDeployments calls the Core deployments route', async () => {
+    fetch.mockResponseOnce(JSON.stringify([{ name: 'model1' }]), {
+      headers: { 'content-type': 'application/json' },
+    });
+
+    const result = await instance.getAllDeployments(TOKEN_MOCK);
+
+    const [calledUrl] = fetch.mock.calls[0];
+    expect(calledUrl).toContain('/v1/deployments');
+    expect(result.response).toEqual([{ name: 'model1' }]);
+  });
+
+  test('getUserInfo maps a JWT caller into id/email', async () => {
+    fetch.mockResponseOnce(
+      JSON.stringify({
+        roles: ['admin'],
+        userId: 'user-1',
+        userClaims: { email: ['user@example.com'] },
+      }),
+      { headers: { 'content-type': 'application/json' } },
+    );
+
+    const result = await instance.getUserInfo(TOKEN_MOCK);
+
+    const [calledUrl] = fetch.mock.calls[0];
+    expect(calledUrl).toContain('/v1/user/info');
+    expect(result.response?.userInfo).toEqual({
+      id: 'user-1',
+      email: 'user@example.com',
+      roles: [],
+    });
+  });
+
+  test('getUserInfo falls back to the project as id for an API-key caller', async () => {
+    fetch.mockResponseOnce(JSON.stringify({ roles: ['some-role'], project: 'proj-1' }), {
+      headers: { 'content-type': 'application/json' },
+    });
+
+    const result = await instance.getUserInfo(TOKEN_MOCK);
+
+    expect(result.response?.userInfo).toEqual({ id: 'proj-1', email: '', roles: [] });
+  });
+
+  test('getUserInfo passes through a failed response unchanged', async () => {
+    fetch.mockResponseOnce('Unauthorized', { status: 401 });
+
+    const result = await instance.getUserInfo(TOKEN_MOCK);
+
+    expect(result.success).toBe(false);
+    expect(result.response).toBeUndefined();
+  });
+});

--- a/apps/ai-dial-admin/src/server/core/tests/settings-api.spec.ts
+++ b/apps/ai-dial-admin/src/server/core/tests/settings-api.spec.ts
@@ -1,0 +1,52 @@
+import { TEST_URL, TOKEN_MOCK } from '@/src/utils/tests/mock/api.mock';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import createFetchMock from 'vitest-fetch-mock';
+
+import { SettingsApi } from '../settings-api';
+
+const fetch = createFetchMock(vi);
+fetch.enableMocks();
+
+describe('Server :: Core :: SettingsApi', () => {
+  const instance = new SettingsApi({ host: TEST_URL });
+
+  beforeEach(() => {
+    fetch.resetMocks();
+  });
+
+  test('globalSettings calls the Core global-settings singleton, not the admin-BE api/ path', async () => {
+    fetch.mockResponseOnce(JSON.stringify({ globalInterceptors: ['global'] }), {
+      headers: { 'content-type': 'application/json' },
+    });
+
+    const result = await instance.globalSettings(TOKEN_MOCK);
+
+    const [calledUrl] = fetch.mock.calls[0];
+    expect(calledUrl).toContain('/v1/settings/platform/global');
+    expect(calledUrl).not.toContain('/api/');
+    expect(result.response).toEqual({ globalInterceptors: ['global'] });
+  });
+
+  test('getSystemProperties reads the same singleton, conditional on the given etag', async () => {
+    fetch.mockResponseOnce(JSON.stringify({ globalInterceptors: ['global'] }), {
+      headers: { 'content-type': 'application/json' },
+    });
+
+    const result = await instance.getSystemProperties(TOKEN_MOCK, 'etag');
+
+    const [calledUrl] = fetch.mock.calls[0];
+    expect(calledUrl).toContain('/v1/settings/platform/global');
+    expect(result.response).toEqual({ globalInterceptors: ['global'] });
+  });
+
+  test('updateSystemProperties PUTs to the same singleton', async () => {
+    fetch.mockResponseOnce(JSON.stringify({ globalInterceptors: ['global'] }));
+
+    const result = await instance.updateSystemProperties({ globalInterceptors: ['global'] }, TOKEN_MOCK, 'etag');
+
+    const [calledUrl, options] = fetch.mock.calls[0];
+    expect(calledUrl).toContain('/v1/settings/platform/global');
+    expect(options?.method).toBe('PUT');
+    expect(result.success).toBe(true);
+  });
+});

--- a/apps/ai-dial-admin/src/server/tests/base-api.spec.ts
+++ b/apps/ai-dial-admin/src/server/tests/base-api.spec.ts
@@ -1,6 +1,8 @@
 import { describe, test, expect, beforeEach, vi } from 'vitest';
 import { BaseApi } from '../base-api';
+import { DEFAULT_ETAG, IF_MATCH } from '@/src/constants/api-headers';
 import { requestRegistry } from '@/src/utils/api/request-registry';
+import { TOKEN_MOCK } from '@/src/utils/tests/mock/api.mock';
 import * as sendRequestModule from '@/src/utils/api/send-request';
 
 describe('BaseApi request cancellation', () => {
@@ -14,6 +16,10 @@ describe('BaseApi request cancellation', () => {
 
     public async testSendActionRequest(url: string, type: string) {
       return this.sendActionRequest(url, type);
+    }
+
+    public async testPutActionWithEtag(url: string, dto: object, etag: string | undefined) {
+      return this.putActionWithEtag(url, dto, TOKEN_MOCK, etag);
     }
   }
 
@@ -129,5 +135,54 @@ describe('BaseApi request cancellation', () => {
       errorMessage: 'Request cancelled',
     });
     expect(unregisterSpy).toHaveBeenCalledOnce();
+  });
+});
+
+describe('BaseApi putActionWithEtag', () => {
+  class TestApi extends BaseApi {
+    public async testPutActionWithEtag(url: string, dto: object, etag: string | undefined) {
+      return this.putActionWithEtag(url, dto, TOKEN_MOCK, etag);
+    }
+  }
+
+  let api: TestApi;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api = new TestApi({ host: 'http://test.com' });
+    vi.spyOn(sendRequestModule, 'sendRequest').mockResolvedValue(
+      new Response(JSON.stringify({}), { status: 200, headers: { 'content-type': 'application/json' } }),
+    );
+  });
+
+  test('sends If-Match with the given etag when one is defined', async () => {
+    await api.testPutActionWithEtag('/test', {}, 'real-etag');
+
+    expect(sendRequestModule.sendRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      'PUT',
+      expect.objectContaining({ [IF_MATCH]: 'real-etag' }),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  test('sends If-Match: * when DEFAULT_ETAG is passed explicitly', async () => {
+    await api.testPutActionWithEtag('/test', {}, DEFAULT_ETAG);
+
+    expect(sendRequestModule.sendRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      'PUT',
+      expect.objectContaining({ [IF_MATCH]: DEFAULT_ETAG }),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  test('omits If-Match entirely when etag is undefined', async () => {
+    await api.testPutActionWithEtag('/test', {}, undefined);
+
+    const headers = (sendRequestModule.sendRequest as ReturnType<typeof vi.fn>).mock.calls[0][2];
+    expect(headers).not.toHaveProperty(IF_MATCH);
   });
 });

--- a/apps/ai-dial-admin/src/server/tests/utility-api.spec.ts
+++ b/apps/ai-dial-admin/src/server/tests/utility-api.spec.ts
@@ -48,33 +48,11 @@ describe('Server :: UtilityApi', () => {
     expect(res).toEqual({ response: JSON.stringify({ success: true }), success: true });
   });
 
-  test('should check deployment by name', async () => {
-    fetch.mockResponseOnce('', { status: 200 });
-
-    await instance.checkDeploymentByName('my-app', TOKEN_MOCK);
-
-    expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/deployments/my-app'), expect.anything());
-  });
-
   test('should get app process status', async () => {
     fetch.mockResponseOnce(JSON.stringify({ running: true }));
 
     const result = await instance.getAppProcessStatus(TOKEN_MOCK);
     expect(result.response).toEqual(JSON.stringify({ running: true }));
-  });
-
-  test('should get system properties', async () => {
-    fetch.mockResponseOnce(JSON.stringify({ globalInterceptors: ['global'] }));
-
-    const result = await instance.getSystemProperties(TOKEN_MOCK, 'etag');
-    expect(result.response).toEqual(JSON.stringify({ globalInterceptors: ['global'] }));
-  });
-
-  test('should update system properties', async () => {
-    fetch.mockResponseOnce(JSON.stringify({ globalInterceptors: ['global'] }));
-
-    const result = await instance.updateSystemProperties({ globalInterceptors: ['global'] }, TOKEN_MOCK, 'etag');
-    expect(result.response).toEqual(JSON.stringify({ globalInterceptors: ['global'] }));
   });
 
   test('should get core versions', async () => {

--- a/apps/ai-dial-admin/src/server/utility-api.ts
+++ b/apps/ai-dial-admin/src/server/utility-api.ts
@@ -5,13 +5,14 @@ import { CoreSyncStatus } from '@/src/models/core-sync-status';
 import { CoreConfigVersion, CoreVersions } from '@/src/models/core-version';
 import { ExportRequest } from '@/src/models/export';
 import { ServerActionResponse } from '@/src/models/server-action';
-import { GlobalSettings } from '@/src/models/system-properties';
+import { UserInfo } from '@/src/models/user-info';
 import { getFileName } from '@/src/utils/api/get-file-name';
 import { API } from './api';
 import { BaseApi } from './base-api';
-import { UserInfo } from '@/src/models/user-info';
 
 export const SYSTEM_PROPERTIES_URL = `${API}/global-settings`;
+export const SECURITY_INFO_URL = `${API}/security-info`;
+
 export const ADMIN_SETTINGS_URL = `${API}/admin-settings`;
 export const VERSION_URL = `${API}/version`;
 export const CORE_VERSION_URL = `${VERSION_URL}/core`;
@@ -25,71 +26,42 @@ export const EXPORT_CONFIG_URL = `${CONFIG_URL}/export`;
 export const EXPORT_CONFIG_MAP_URL = `${EXPORT_CONFIG_URL}/raw/core`;
 export const EXPORT_PREVIEW_CONFIG_URL = `${EXPORT_CONFIG_URL}/preview`;
 export const RELOAD_CONFIG_URL = `${CONFIG_URL}/sync/status`;
-export const DEPLOYMENTS_URL = `${API}/deployments`;
-export const DEPLOYMENT_URL = (name: string) => `${DEPLOYMENTS_URL}/${name}`;
-export const SECURITY_INFO_URL = `${API}/security-info`;
 
 export class UtilityApi extends BaseApi {
   getBeVersion(token: Token): Promise<string | null> {
     return this.get(VERSION_URL, token, { Accept: 'text/plain' }).catch(() => null) as Promise<string | null>;
   }
-
   importJsonConfigs(url: string, token: Token, file: FormData): Promise<ServerActionResponse> {
     return this.postFiles(url, file, token);
   }
-
   importZipConfig(url: string, token: Token, file: FormData): Promise<ServerActionResponse> {
     return this.postFiles(url, file, token);
   }
-
   exportConfig(exportConfig: ExportRequest, token: Token): Promise<{ blob: Blob; fileName: string }> {
     return this.sendRequest(EXPORT_CONFIG_URL, 'POST', exportConfig, token).then(async (res) => {
       return { blob: await (res as Response)?.blob?.(), fileName: getFileName(res as Response) || '' };
     });
   }
-
   exportConfigMap(token: Token): Promise<{ blob: Blob; fileName: string }> {
     return this.sendRequest(EXPORT_CONFIG_MAP_URL, 'POST', { addSecrets: true }, token).then(async (res) => {
       return { blob: await (res as Response)?.blob?.(), fileName: getFileName(res as Response) || '' };
     });
   }
-
   previewExportConfig(exportConfig: ExportRequest, token: Token): Promise<ServerActionResponse> {
     return this.postAction(EXPORT_PREVIEW_CONFIG_URL, exportConfig, token);
   }
-
-  checkDeploymentByName(name: string, token: Token) {
-    return this.head(DEPLOYMENT_URL(name), token);
-  }
-
-  getAllDeployments(token: Token): Promise<ServerActionResponse> {
-    return this.getAction(DEPLOYMENTS_URL, token);
-  }
-
   getAppProcessStatus(token: Token): Promise<ServerActionResponse<AppProcessStatus>> {
     return this.getAction(RELOAD_CONFIG_URL, token);
   }
-
   getCoreVersion(token: Token): Promise<ServerActionResponse<CoreVersions>> {
     return this.getAction(CORE_VERSION_URL, token);
   }
-
   setCoreVersion(version: CoreConfigVersion, token: Token): Promise<ServerActionResponse<AppProcessStatus>> {
     return this.putActionWithEtag(CORE_CONFIG_VERSION_URL, version, token, DEFAULT_ETAG);
   }
-
-  getSystemProperties(token: Token, etag: string): Promise<ServerActionResponse<GlobalSettings>> {
-    return this.getActionWithEtag(SYSTEM_PROPERTIES_URL, etag, token);
-  }
-
-  updateSystemProperties(properties: GlobalSettings, token: Token, etag: string): Promise<ServerActionResponse> {
-    return this.putActionWithEtag(SYSTEM_PROPERTIES_URL, properties, token, etag);
-  }
-
   getEntitySyncStatus(url: string, token: Token, etag: string): Promise<ServerActionResponse<CoreSyncStatus>> {
     return this.getActionWithMatchEtag(`${API}${url}`, etag, token);
   }
-
   getUserInfo(token: Token): Promise<ServerActionResponse<{ userInfo: UserInfo }>> {
     return this.getAction(SECURITY_INFO_URL, token);
   }

--- a/apps/ai-dial-admin/test-setup.tsx
+++ b/apps/ai-dial-admin/test-setup.tsx
@@ -108,7 +108,7 @@ vi.mock('@/src/context/AppContext', () => ({
       closeSidebar: vi.fn(),
       position: SidebarPosition.Right,
     },
-    featureFlags: { deploymentsEnabled: true },
+    featureFlags: { deploymentsEnabled: true, adminApiEnabled: true },
     isReadOnlyAdmin: false,
     isFullAdmin: true,
     isEnableAuth: false,

--- a/openspec/changes/archive/2026-09-10-fix-system-properties-first-save-etag/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-10-fix-system-properties-first-save-etag/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-10

--- a/openspec/changes/archive/2026-09-10-fix-system-properties-first-save-etag/design.md
+++ b/openspec/changes/archive/2026-09-10-fix-system-properties-first-save-etag/design.md
@@ -1,0 +1,133 @@
+## Context
+
+Core's `v1/settings/platform/global` singleton has no separate create/update endpoint — one `PUT`
+does both, distinguished only by whether a blob currently exists (`GET` returns 404 when it doesn't).
+`EtagHeader.validateIfMatch` on the Core side (`storage/.../util/EtagHeader.java`) treats the mere
+*presence* of an `If-Match` header as an assertion that the resource exists, per RFC 7232 — this holds
+even for `If-Match: *`, since `*` means "some representation exists," which is false for a singleton
+that was never written via the API.
+
+`BaseApi.putActionWithEtag` (`apps/ai-dial-admin/src/server/base-api.ts`) always attaches `If-Match`,
+falling back to `DEFAULT_ETAG` (`'*'`, `apps/ai-dial-admin/src/constants/api-headers.ts`) whenever the
+caller's `etag` is falsy:
+
+```ts
+protected async putActionWithEtag<T extends object>(url: string, dto: T, token: Token, etag: string) {
+  return this.putAction<T>(url, dto, token, { [IF_MATCH]: etag || DEFAULT_ETAG });
+}
+```
+
+Every other entity (`models-api.ts`, `roles-api.ts`, `keys-api.ts`, `interceptors-api.ts`, …) avoids
+this failure mode structurally: creation goes through a separate `POST` method with no `If-Match` at
+all, and `putActionWithEtag` is reached only from an update path where the entity is already known to
+exist (its etag came from a prior successful read). System Properties has no create/update split — it
+is one PUT-only singleton — so its first-ever save is the only call site that reaches
+`putActionWithEtag` for something that might not exist yet.
+
+One existing call site, `utility-api.ts`'s config-version write, passes `DEFAULT_ETAG` **explicitly**
+to mean "overwrite unconditionally, but the resource is always present" (a startup-created resource
+that is never absent). That usage is intentional and must keep working.
+
+`handleSettingsGet` (Core) never validates a conditional header and never sets an `ETag` response
+header, on either 200 or 404 — only `handleSettingsPut`'s success response carries one. So there is no
+real etag value a subsequent GET can ever hand back for this singleton; the only fact a GET yields is
+existence (200 vs. 404), never a value to compare against. Any design that tries to thread a "real
+etag from the last read" through to the save is chasing a value that doesn't exist — simplified below.
+
+## Goals / Non-Goals
+
+**Goals:**
+- The System Properties page saves successfully on an environment where no global-settings blob has
+  ever been written via the API.
+- The distinction between "no blob yet" (omit `If-Match`, effectively a create) and "blob exists"
+  (send `If-Match` with its real etag, guarding against a concurrent edit) is explicit in the code,
+  not implied by a fallback value that happens to work in one case and not the other.
+- The existing behavior of every other `putActionWithEtag` call site (all of which are genuine
+  updates to entities that already exist) is unchanged.
+- The frontend's `GlobalSettings` type reflects both fields Core's `GlobalSettings` actually has, so
+  the "spread previous settings, replace only `globalInterceptors`" merge in `SystemProperties.tsx` is
+  type-backed rather than incidental.
+
+**Non-Goals:**
+- Adding a `retriableErrorCodes` editing UI — out of scope; the fix only needs the field to survive
+  the round trip.
+- Changing `EtagHeader` semantics on the Core side — Core's behavior is RFC-7232-correct; this is a
+  frontend-only fix.
+- Restructuring `interceptors-api.ts`/`keys-api.ts`/other entities' create/update split — unaffected,
+  used here only as the reference pattern.
+- General retry/optimistic-concurrency UX for a real 412 caused by a genuine concurrent edit (an
+  admin editing on two tabs) — that path already surfaces the error via `getErrorNotification`; this
+  change only fixes the false-positive 412 on first save.
+
+## Decisions
+
+### 1. Make "omit `If-Match`" an explicit, distinct call shape — not a falsy-etag fallback
+
+`putActionWithEtag` keeps its signature but drops the `|| DEFAULT_ETAG` fallback: the header is set
+only when a caller passes a defined `etag`. Callers that want the existing "unconditional write,
+resource known to exist" behavior (`utility-api.ts`) keep passing `DEFAULT_ETAG` explicitly, which is
+unchanged. System Properties' save path passes `undefined` when the prior read confirmed no blob
+exists, which now genuinely omits the header rather than substituting `'*'`.
+
+**Alternative considered:** add a separate `postActionWithoutEtag`/create-style method mirroring the
+`interceptors-api.ts` split. Rejected: there is only one Core endpoint (`PUT`) for this singleton;
+inventing a second frontend method for the same HTTP verb and URL would be a distinction without a
+difference, and the sibling entities' create/update split exists because *they* have two Core
+endpoints (`POST` create, `PUT` update) to mirror — this singleton doesn't.
+
+### 2. Track "does a settings blob exist" as a plain boolean — not a real etag
+
+Since Core's GET never returns a real etag either way, there is nothing to gain from a tri-state or
+from threading a "real etag" value at all. `page.tsx` tracks a simple `doesSettingsExist: boolean`
+from the GET outcome (`true` on 200, `false` on 404), and the save call is equally simple:
+`doesSettingsExist ? DEFAULT_ETAG : undefined` passed as the `etag` argument — `DEFAULT_ETAG` (`'*'`)
+asserts existence on an update, `undefined` omits `If-Match` on a create.
+
+**Alternative considered:** a tri-state carrying a "real etag" for the exists case. Rejected once it
+became clear Core's GET never supplies one — there is no third state to model; existence is binary and
+that's all this endpoint can ever tell the frontend.
+
+### 3. Add `retriableErrorCodes` to the frontend `GlobalSettings` type
+
+```ts
+export interface GlobalSettings {
+  globalInterceptors: string[];
+  retriableErrorCodes?: number[];
+}
+```
+
+The field stays optional and unedited by any UI control; declaring it only makes the existing
+spread-based merge in `changeInterceptors` (`SystemProperties.tsx`) type-checked rather than silently
+relying on a field TypeScript doesn't know about. No behavior changes for this field beyond making its
+survival visible in the type.
+
+### 4. Surface read failures on the full-settings fetch, matching the existing `optionWarnings` pattern
+
+`page.tsx`'s settings fetch starts checking `res.success`; a failure that isn't the expected 404
+(confirmed-absent) pushes a warning through the same `optionWarnings` mechanism already used on this
+page for the interceptor option list, instead of silently proceeding as if nothing was read.
+
+## Risks / Trade-offs
+
+- **[Risk]** Removing the `|| DEFAULT_ETAG` fallback from `putActionWithEtag` changes its default
+  behavior for any call site that relied on the fallback rather than passing an etag explicitly. →
+  **Mitigation**: grep confirms every current call site either passes a real etag from a prior read
+  (all entity update paths) or passes `DEFAULT_ETAG` explicitly (`utility-api.ts`); none relies on the
+  implicit fallback. Add a test asserting the explicit-`DEFAULT_ETAG` call site is unaffected.
+- **[Risk]** No real concurrent-edit (lost-update) protection exists for this endpoint — two admins
+  saving around the same time will have the second save silently win. → **Mitigation**: accepted as a
+  Core API limitation, not something the frontend can fix; out of scope for this change.
+- **[Trade-off]** This fix is scoped to the System Properties singleton rather than generalized into a
+  shared "create-or-update singleton" helper, since it's the only PUT-only singleton in the app today.
+  If a second such singleton appears, revisit extracting the pattern then rather than speculatively now.
+
+## Migration Plan
+
+No data migration. This is a client-request-shape fix; Core is unchanged. Rollout is a normal
+frontend deploy — no feature flag needed, since the failing case (first save with no existing blob)
+was unconditionally broken before and unconditionally fixed after, with no behavior change for
+environments where a settings blob already exists.
+
+## Open Questions
+
+None — the fix is fully determined by the traced root cause; no further product decisions are needed.

--- a/openspec/changes/archive/2026-09-10-fix-system-properties-first-save-etag/proposal.md
+++ b/openspec/changes/archive/2026-09-10-fix-system-properties-first-save-etag/proposal.md
@@ -1,0 +1,54 @@
+## Why
+
+Saving the System Properties page (`/system-properties`) fails with `412 Precondition Failed —
+"Resource must exist"` whenever the admin has never saved global settings via the API before. Core's
+`v1/settings/platform/global` singleton has no blob yet in that case, and the frontend always attaches
+`If-Match: *` on the write (`DEFAULT_ETAG` fallback in `putActionWithEtag`) intending it as an
+"unconditional write" sentinel. Core correctly rejects that per RFC 7232: `If-Match` — any value,
+including `*` — asserts the resource currently exists, and the singleton doesn't yet. The very first
+save of global interceptors on a fresh environment is broken.
+
+## What Changes
+
+- The System Properties save flow distinguishes "no global settings blob exists yet" from "a blob
+  exists, guard the write against concurrent edits": when the prior read found no blob, the write
+  omits `If-Match` entirely instead of sending `If-Match: *`.
+- `BaseApi.putActionWithEtag` gains a way for a caller to send no `If-Match` header at all, rather than
+  always falling back to `DEFAULT_ETAG` when the etag is falsy.
+- The System Properties read path (`page.tsx`) tracks "settings blob exists" as an explicit tri-state
+  (no read yet / confirmed absent / confirmed present with etag `X`) instead of collapsing "no etag
+  returned" into the same `DEFAULT_ETAG` sentinel used elsewhere to mean "don't care, write anyway."
+- `GlobalSettings` (frontend model) gains the `retriableErrorCodes` field already present on Core's
+  `GlobalSettings`, so the save path's existing "spread the previously-read settings, only replace
+  `globalInterceptors`" merge is backed by the type rather than working only by accident of how the
+  merge happens to be written.
+- The full-settings read on `page.tsx` starts checking `res.success` and surfaces a warning
+  (mirroring the `optionWarnings` pattern already used on the same page for the interceptor option
+  list) when the read fails for a reason other than "no blob yet."
+
+## Capabilities
+
+### New Capabilities
+
+- `system-properties`: the System Properties page's read/save behavior against Core's global-settings
+  singleton — no spec currently exists for this page, so this proposal introduces its baseline spec
+  alongside the fix.
+
+### Modified Capabilities
+
+(none — no existing capability spec covers this page)
+
+## Impact
+
+- `apps/ai-dial-admin/src/server/base-api.ts` — `putActionWithEtag` (or a sibling method) gains an
+  omit-`If-Match` path.
+- `apps/ai-dial-admin/src/server/core/settings-api.ts` — `updateSystemProperties` call shape.
+- `apps/ai-dial-admin/src/app/[lang]/system-properties/page.tsx` and `actions.ts` — etag tri-state
+  tracking.
+- `apps/ai-dial-admin/src/components/SystemProperties/SystemProperties.tsx` — save wiring, if the
+  tri-state needs to be threaded through as a prop/state.
+- `apps/ai-dial-admin/src/models/system-properties.ts` — `GlobalSettings` type gains
+  `retriableErrorCodes`.
+- No other entity is affected: `interceptors-api.ts`/`keys-api.ts` already avoid this failure mode via
+  separate create (`POST`, no `If-Match`) and update (`PUT`, `If-Match`) methods, which this proposal
+  does not change.

--- a/openspec/changes/archive/2026-09-10-fix-system-properties-first-save-etag/specs/system-properties/spec.md
+++ b/openspec/changes/archive/2026-09-10-fix-system-properties-first-save-etag/specs/system-properties/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: First-ever save succeeds when no settings blob exists yet
+The system SHALL allow saving global interceptors from the System Properties page even when Core has
+never had a global-settings blob written via the API, and SHALL NOT send a conditional header that
+asserts the resource already exists in that case.
+
+#### Scenario: Save succeeds on an environment with no prior API-written settings
+- **WHEN** a user opens System Properties on an environment where Core's global-settings GET
+  previously returned 404, edits the global interceptors list, and clicks Save
+- **THEN** the save request succeeds and the page reflects the newly saved interceptors, with no
+  precondition-failure error shown
+
+### Requirement: Save asserts existence once a settings blob is known to exist
+The system SHALL send `If-Match: *` when saving global interceptors and a prior read confirmed a
+settings blob exists, so the write is rejected if the blob was deleted in the meantime. Core's GET
+for this singleton never returns an ETag, so a real concurrent-edit (lost-update) guard is not
+achievable through this endpoint and is not attempted.
+
+#### Scenario: A save after the blob was deleted is rejected
+- **WHEN** a user saves global interceptors after the settings blob was deleted since this page's
+  last read
+- **THEN** the save is rejected and an error notification is shown
+
+### Requirement: A full-settings read failure is surfaced to the user
+The system SHALL distinguish "no settings blob exists yet" (expected, not an error) from any other
+read failure when fetching global settings for the System Properties page, and SHALL show a warning
+for the latter rather than proceeding as if the read had succeeded.
+
+#### Scenario: A non-404 read failure shows a warning
+- **WHEN** the System Properties page's full-settings read fails for a reason other than "no blob
+  exists yet"
+- **THEN** a warning notification is shown on the page, consistent with how an incomplete
+  interceptor option list is already surfaced
+
+### Requirement: Non-interceptor settings fields survive a global-interceptors save
+The system SHALL preserve any other field already present on the global-settings object (such as
+`retriableErrorCodes`) when saving a change to global interceptors, rather than omitting it and
+letting Core reset it to its default.
+
+#### Scenario: Saving interceptors does not clear other settings
+- **WHEN** Core's global settings already contain a non-default value for a field other than
+  `globalInterceptors`, and a user changes and saves the global interceptors list from System
+  Properties
+- **THEN** the saved settings retain that other field's existing value unchanged

--- a/openspec/changes/archive/2026-09-10-fix-system-properties-first-save-etag/tasks.md
+++ b/openspec/changes/archive/2026-09-10-fix-system-properties-first-save-etag/tasks.md
@@ -1,0 +1,42 @@
+## 1. Base API: allow omitting `If-Match`
+
+- [x] 1.1 In `apps/ai-dial-admin/src/server/base-api.ts`, change `putActionWithEtag`'s `etag` parameter
+      to `string | undefined` and drop the `|| DEFAULT_ETAG` fallback, so the `If-Match` header is set
+      only when `etag` is defined. Confirm the one call site that relies on unconditional-overwrite
+      semantics (`utility-api.ts`'s config-version write) still passes `DEFAULT_ETAG` explicitly.
+- [x] 1.2 Add/update unit tests for `putActionWithEtag` covering: a defined etag sends `If-Match` with
+      that value; `undefined` sends no `If-Match` header at all; `DEFAULT_ETAG` passed explicitly still
+      sends `If-Match: *`.
+
+## 2. Frontend model: complete the `GlobalSettings` type
+
+- [x] 2.1 In `apps/ai-dial-admin/src/models/system-properties.ts`, add `retriableErrorCodes?:
+      number[]` to `GlobalSettings`, matching Core's `GlobalSettings` POJO field.
+
+## 3. System Properties read path: track blob-existence as a boolean
+
+- [x] 3.1 In `apps/ai-dial-admin/src/app/[lang]/system-properties/page.tsx`, replace the untyped
+      `etag = res?.etag || DEFAULT_ETAG` handling with a plain `doesSettingsExist: boolean` derived
+      from the read outcome (`true` on success, `false` on a 404 "no blob yet" response).
+- [x] 3.2 On a read failure that isn't the expected 404, push a warning into `optionWarnings` (reusing
+      the existing `EntitiesI18nKey`/`getErrorNotification` pattern already used on this page for the
+      interceptor option list) instead of silently proceeding as if the read succeeded.
+- [x] 3.3 Thread `doesSettingsExist` through to `SystemProperties.tsx` and
+      `system-properties/actions.ts` → `updateProperties` → `settingsApi.updateSystemProperties` →
+      `putActionWithEtag`, passing `DEFAULT_ETAG` when `true` (assert-exists) and `undefined` when
+      `false` (omit `If-Match`, create).
+
+## 4. Tests
+
+- [x] 4.1 Add/update component tests for `SystemProperties.tsx` covering: save succeeds when the
+      initial read found no settings blob (no `If-Match` sent); save sends `If-Match: *` when a blob
+      already existed; a 412 response still surfaces the existing error notification unchanged.
+- [x] 4.2 Add/update tests for `system-properties/page.tsx` (or its data-fetching logic) covering the
+      404-is-not-an-error case and the "other failure surfaces a warning" case.
+- [x] 4.3 Add/update tests asserting a save round-trips an existing `retriableErrorCodes` value
+      unchanged when only `globalInterceptors` is edited.
+
+## 5. Quality gate
+
+- [x] 5.1 Run `npm run lint`, `npm run format`, `npm run typecheck`, and `npm run test` (from
+      `apps/ai-dial-admin/`) and fix any failures.

--- a/openspec/changes/archive/2026-09-10-hide-ui-without-admin-api/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-10-hide-ui-without-admin-api/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-10

--- a/openspec/changes/archive/2026-09-10-hide-ui-without-admin-api/design.md
+++ b/openspec/changes/archive/2026-09-10-hide-ui-without-admin-api/design.md
@@ -1,0 +1,87 @@
+## Context
+
+The admin backend (`ai-dial-admin-backend`) is being retired incrementally; prior changes
+(`migrate-publications-to-core-api`, `unlink-app-runner-assets-from-admin-be`) moved individual API
+calls off it. This change is the first UI-visibility step: deployments that stop configuring
+`DIAL_ADMIN_API_URL` still have every admin-backend-bound page, menu entry, and Footer poll wired up,
+so they render error states or 500s instead of a clean, reduced surface. `model-servings-visibility`
+already established the flag → menu filter → route redirect pattern for a single route; this change
+applies the same shape across the larger, still-admin-backend-bound surface (Entities, Builders, Access
+Management, Audit, Import/Export config, Footer).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One flag (`featureFlags.adminApiEnabled`), computed once in the root layout from
+  `DIAL_ADMIN_API_URL`, drives every hide/redirect decision in this change.
+- Reuse the existing `MENU_CONFIGURATION` filter-and-return pattern and the existing
+  `if (!flag) redirect(ApplicationRoute.Home)` route-guard pattern verbatim — no new mechanism.
+- Every route whose entire group/action is hidden also redirects server-side, so a bookmarked or
+  typed URL can't reach a dead page.
+
+**Non-Goals:**
+
+- Removing any admin-backend API call, class, or server action. Pages still call the same actions when
+  the flag is `true`; this change only decides whether the page is reachable and rendered at all.
+- Touching Catalog, Assets, Deployments, Evaluation, Approvals, or Analytics — none of them depend
+  exclusively on `DIAL_ADMIN_API_URL` today (Assets/Approvals/Catalog already read Core; Deployments
+  and Evaluation have their own flags).
+- Changing `DISABLE_MENU_ITEMS` behavior — it keeps working as an independent, manual override, same as
+  it does today for Deployments/Evaluation.
+
+## Decisions
+
+**Flag shape mirrors `evaluationEnabled`.** `adminApiEnabled: process.env.DIAL_ADMIN_API_URL != null`
+in `[lang]/layout.tsx`, added to `FeatureFlags`. No `isValueTruthy` needed — this is a URL, not a
+boolean toggle, so presence is the signal (same reasoning as `evaluationEnabled` on
+`DIAL_EVAL_API_URL`).
+
+**Menu filtering happens inside `MENU_CONFIGURATION`, not via `DISABLE_MENU_ITEMS`.** The four groups —
+Entities, Builders, Access Management, and Audit (hidden in full, not item-by-item) — are filtered by
+key in the same `result = result.filter(...)` chain already used for Deployments/Evaluation/Analytics,
+rather than folding into `getActualMenuItems`'s string-list mechanism. Keeping it there means the
+composition guarantee already tested by `menu-group-visibility` (each group's own flag, independent of
+the others) extends mechanically to the new groups.
+
+**Menu actions gate in `MenuContent`, not a new component.** `MenuContent` already reads
+`featureFlags` via `useAppContext()` for other decisions; the two action buttons (Import/Export) become
+conditional on `featureFlags.adminApiEnabled` in both `MenuActionsBar` (expanded) and the
+`MenuActions`/collapsed bar. `System properties` is untouched — it does not depend on the admin
+backend.
+
+**`Content` gates rendering and polling with a single check.** `Content` is a client component with
+`featureFlags` available via `useAppContext()`. The `Footer` JSX and the two `useEffect` blocks that
+start `checkAppStatus`/`checkCoreVersion` polling are both wrapped by the same
+`featureFlags.adminApiEnabled` condition, so the admin-backend calls are never issued when the flag is
+`false` — not merely deferred.
+
+**Route guards are added per-page, not via middleware.** Following `model-servings/page.tsx`, each
+affected `page.tsx` gets `if (!process.env.DIAL_ADMIN_API_URL) redirect(ApplicationRoute.Home);` as the
+first statement, before any data fetch. A shared Next.js middleware was considered and rejected: this
+repo has no route-guard middleware today, path matching for `[id]`/`[id]/[subId]` dynamic segments
+would need its own list to maintain anyway, and the per-page guard keeps each route's behavior visible
+at the point that renders it — consistent with how `model-servings-visibility` already does this for a
+single route.
+
+**Redirect predicate reads `process.env.DIAL_ADMIN_API_URL` directly in each page**, not
+`featureFlags.adminApiEnabled` — pages are independent server components and don't receive
+`featureFlags` as a prop (it's constructed once in the layout and handed to `AppContextProvider` for
+client consumption). Reading the env var directly in the page is exactly what `model-servings/page.tsx`
+does for its own flags today.
+
+## Risks / Trade-offs
+
+- **Repetitive guard across ~30 files** (15 route roots × up to `page.tsx` + `[id]/page.tsx` +
+  `[id]/[subId]/page.tsx` — `dashboard` and `usage-log` only have a single `page.tsx` each) →
+  Mitigated by copying one exact one-line pattern per file (tasks.md lists every file); no shared
+  helper is introduced because the guard is a single `if` statement and a shared helper would hide the
+  redirect from a reader scanning the page file, the opposite of the existing convention.
+- **A future fifth group/action gated by the same flag is easy to miss** → Mitigated by the
+  `admin-api-availability` spec's requirement scope being explicit about which routes it covers, so
+  adding a new one is a spec change, not a silent omission.
+
+## Open Questions
+
+None — the flag semantics, filtering pattern, and redirect pattern all already exist in the codebase
+for equivalent cases.

--- a/openspec/changes/archive/2026-09-10-hide-ui-without-admin-api/proposal.md
+++ b/openspec/changes/archive/2026-09-10-hide-ui-without-admin-api/proposal.md
@@ -1,0 +1,53 @@
+## Why
+
+The admin backend (`ai-dial-admin-backend`) is being phased out step by step, and the frontend is
+migrating call by call to Core/deployment-manager APIs (see the archived `migrate-publications-to-core-api`
+and `unlink-app-runner-assets-from-admin-be` changes). Several menu groups, menu actions, and the footer
+still depend entirely on the admin backend and have no migrated equivalent yet. Before that backend can be
+retired, deployments that no longer configure `DIAL_ADMIN_API_URL` need those unsupported surfaces hidden
+instead of rendering broken pages or issuing calls to a host that no longer exists.
+
+## What Changes
+
+- Add a feature flag, `featureFlags.adminApiEnabled`, derived from `DIAL_ADMIN_API_URL` being present
+  (mirrors the existing `evaluationEnabled` / `DIAL_EVAL_API_URL` pattern).
+- When `adminApiEnabled` is `false`:
+  - Hide the "Entities", "Builders", "Access Management", and "Audit" menu groups in full — Audit is
+    hidden entirely (Dashboard, Activity, and Usage Log together), not just its Activity item.
+  - Hide the "Import config" and "Export config" menu actions.
+  - Hide the Footer, and stop polling `checkAppStatus` / `checkCoreVersion` (both call the admin backend).
+  - Redirect direct URL navigation to every route owned by the hidden groups/actions
+    (`/models`, `/applications`, `/interceptors`, `/toolsets`, `/routes`, `/adapters`,
+    `/application-runners`, `/interceptor-templates`, `/roles`, `/keys`, `/activity-audit`,
+    `/dashboard`, `/usage-log`, `/import-config`, `/export-config`, and their `[id]` / `[id]/[subId]`
+    sub-routes) to `/home`, before any admin-backend call is issued.
+- No backend/API-call removal in this change — only UI visibility and route guarding. Removing the
+  underlying `admin-backend`-bound API calls is a later step.
+
+## Capabilities
+
+### New Capabilities
+
+- `admin-api-availability`: the `adminApiEnabled` feature flag itself, the menu-action visibility
+  (Import/Export config), the Footer/status-polling suppression, and the direct-URL redirect guard for
+  every route owned by the hidden groups/actions.
+
+### Modified Capabilities
+
+- `menu-group-visibility`: extend the composition rules to the four additional gated groups (Entities,
+  Builders, Access Management, and Audit — hidden in full, not just its Activity item), all gated by
+  `featureFlags.adminApiEnabled`, composing independently of the existing Deployments/Evaluation gates.
+
+## Impact
+
+- `apps/ai-dial-admin/src/models/feature-flags.ts` — new `adminApiEnabled` field.
+- `apps/ai-dial-admin/src/app/[lang]/layout.tsx` — compute the flag from `process.env.DIAL_ADMIN_API_URL`.
+- `apps/ai-dial-admin/src/components/Menu/menu-configuration.tsx` — filter the three groups + Activity
+  Audit item.
+- `apps/ai-dial-admin/src/components/Menu/MenuContent/MenuContent.tsx` — hide Import/Export actions.
+- `apps/ai-dial-admin/src/components/Content/Content.tsx` — hide Footer, skip status/version polling.
+- Route guards added to the `page.tsx` files under `models`, `applications`, `interceptors`, `toolsets`,
+  `routes`, `adapters`, `application-runners`, `interceptor-templates`, `roles`, `keys`,
+  `activity-audit`, `dashboard`, `usage-log`, `import-config`, `export-config` (including their `[id]` /
+  `[id]/[subId]` variants).
+- No API surface, dependency, or database changes.

--- a/openspec/changes/archive/2026-09-10-hide-ui-without-admin-api/specs/admin-api-availability/spec.md
+++ b/openspec/changes/archive/2026-09-10-hide-ui-without-admin-api/specs/admin-api-availability/spec.md
@@ -1,0 +1,78 @@
+## ADDED Requirements
+
+### Requirement: `adminApiEnabled` feature flag reflects `DIAL_ADMIN_API_URL` presence
+
+The system SHALL expose an `adminApiEnabled: boolean` field on the `FeatureFlags` object, computed at request time in the root layout as `process.env.DIAL_ADMIN_API_URL != null`.
+
+#### Scenario: Flag is true when the env var is set
+
+- **WHEN** `process.env.DIAL_ADMIN_API_URL` is set to any non-null value and the root layout
+  initializes `FeatureFlags`
+- **THEN** `featureFlags.adminApiEnabled` is `true`
+
+#### Scenario: Flag is false when the env var is unset
+
+- **WHEN** `process.env.DIAL_ADMIN_API_URL` is unset
+- **THEN** `featureFlags.adminApiEnabled` is `false`
+
+### Requirement: Import/Export config menu actions are hidden without the admin API
+
+The Menu content SHALL render the "Import config" and "Export config" actions (in both the expanded actions bar and the collapsed `MenuActions` bar) only when `featureFlags.adminApiEnabled` is `true`. The "System properties" action MUST NOT be affected by this flag. The Home page (`WelcomeView`) quick-actions row SHALL apply the same `featureFlags.adminApiEnabled` gate to its own "Import config" and "Export config" buttons, in addition to its existing read-only-admin check.
+
+#### Scenario: Admin API disabled hides Import/Export actions
+
+- **WHEN** `featureFlags.adminApiEnabled` is `false`
+- **THEN** neither the "Import config" nor "Export config" action is rendered in the menu
+- **AND** "System properties" is still rendered
+
+#### Scenario: Admin API enabled shows Import/Export actions
+
+- **WHEN** `featureFlags.adminApiEnabled` is `true`
+- **THEN** both "Import config" and "Export config" actions are rendered in the menu
+
+#### Scenario: Admin API disabled hides Import/Export quick actions on the Home page
+
+- **WHEN** `featureFlags.adminApiEnabled` is `false`
+- **AND** the user is not a read-only admin
+- **THEN** neither the "Import config" nor "Export config" quick-action button is rendered on the Home page
+- **AND** "System properties" is still rendered
+
+#### Scenario: Admin API enabled shows Import/Export quick actions on the Home page
+
+- **WHEN** `featureFlags.adminApiEnabled` is `true`
+- **AND** the user is not a read-only admin
+- **THEN** both "Import config" and "Export config" quick-action buttons are rendered on the Home page
+
+### Requirement: Footer and its polling are suppressed without the admin API
+
+The `Content` component SHALL NOT render the `Footer`, and SHALL NOT start the `checkAppStatus` / `checkCoreVersion` polling intervals (nor issue their initial calls), when `featureFlags.adminApiEnabled` is `false`. Both actions call the admin backend, which is unreachable without `DIAL_ADMIN_API_URL`.
+
+#### Scenario: Admin API disabled hides Footer and stops polling
+
+- **WHEN** `featureFlags.adminApiEnabled` is `false`
+- **THEN** the Footer is absent from the page
+- **AND** `getAppProcessStatus` and `getCoreVersions` are never called
+
+#### Scenario: Admin API enabled renders Footer and polling as today
+
+- **WHEN** `featureFlags.adminApiEnabled` is `true`
+- **THEN** the Footer renders
+- **AND** `checkAppStatus` and `checkCoreVersion` run on mount and on their existing intervals
+
+### Requirement: Direct navigation to admin-API-only routes redirects home
+
+The system SHALL redirect to `ApplicationRoute.Home`, before issuing any admin-backend request, when `process.env.DIAL_ADMIN_API_URL` is unset and a user navigates directly to any route owned exclusively by the Entities group (`/models`, `/applications`, `/interceptors`, `/toolsets`, `/routes`), the Builders group (`/adapters`, `/application-runners`, `/interceptor-templates`), the Access Management group (`/roles`, `/keys`), the Audit group (`/activity-audit`, `/dashboard`, `/usage-log`), or the Import/Export actions (`/import-config`, `/export-config`) — including every `[id]` and `[id]/[subId]` sub-route under them.
+
+#### Scenario: Bookmarked entity URL redirects when the admin API is disabled
+
+- **WHEN** a user navigates directly to `/<lang>/models`, `/<lang>/models/<id>`, `/<lang>/roles`,
+  `/<lang>/import-config`, or any other route listed above
+- **AND** `DIAL_ADMIN_API_URL` is unset
+- **THEN** the server issues a redirect to `ApplicationRoute.Home`
+- **AND** no admin-backend call is made for that page
+
+#### Scenario: Routes render normally when the admin API is enabled
+
+- **WHEN** a user navigates to any of those routes
+- **AND** `DIAL_ADMIN_API_URL` is set
+- **THEN** the page renders as it does today

--- a/openspec/changes/archive/2026-09-10-hide-ui-without-admin-api/specs/menu-group-visibility/spec.md
+++ b/openspec/changes/archive/2026-09-10-hide-ui-without-admin-api/specs/menu-group-visibility/spec.md
@@ -1,0 +1,49 @@
+## MODIFIED Requirements
+
+### Requirement: Feature-flag-gated menu groups compose independently
+
+The left-navigation menu configuration SHALL hide each feature-flag-gated menu group based solely on its own flag, independent of the state of any other group's flag. Disabling one group MUST NOT cause another disabled group to reappear, and MUST NOT hide a group whose flag is enabled. Flag-gated groups: the Deployments group is hidden when `featureFlags.deploymentsEnabled` is `false` (sourced from `DEPLOYMENTS_ENABLED`); the Evaluation group is hidden when `featureFlags.evaluationEnabled` is `false` (sourced from `DIAL_EVAL_API_URL` being absent); the Entities, Builders, Access Management, and Audit groups are hidden in full when `featureFlags.adminApiEnabled` is `false` (sourced from `DIAL_ADMIN_API_URL` being absent) — Audit is hidden as a whole group (Dashboard, Activity, and Usage Log together), not filtered item-by-item.
+
+#### Scenario: Both group flags enabled
+
+- **WHEN** `featureFlags.deploymentsEnabled` is `true` and `featureFlags.evaluationEnabled` is `true`
+- **THEN** the Deployments group and the Evaluation group are both present in the menu
+
+#### Scenario: Deployments disabled, Evaluation enabled
+
+- **WHEN** `featureFlags.deploymentsEnabled` is `false` and `featureFlags.evaluationEnabled` is `true`
+- **THEN** the Deployments group is absent
+- **AND** the Evaluation group is present
+
+#### Scenario: Deployments enabled, Evaluation disabled
+
+- **WHEN** `featureFlags.deploymentsEnabled` is `true` and `featureFlags.evaluationEnabled` is `false`
+- **THEN** the Evaluation group is absent
+- **AND** the Deployments group is present
+
+#### Scenario: Both group flags disabled (regression case from issue #3589)
+
+- **WHEN** `featureFlags.deploymentsEnabled` is `false` and `featureFlags.evaluationEnabled` is `false`
+- **THEN** the Deployments group is absent
+- **AND** the Evaluation group is absent
+
+#### Scenario: Admin API disabled hides Entities, Builders, Access Management, and Audit independently of other flags
+
+- **WHEN** `featureFlags.adminApiEnabled` is `false`, regardless of `featureFlags.deploymentsEnabled` or `featureFlags.evaluationEnabled`
+- **THEN** the Entities group, the Builders group, the Access Management group, and the Audit group are all absent
+- **AND** a Deployments or Evaluation group whose own flag is `true` remains present
+
+#### Scenario: Admin API enabled leaves Entities, Builders, Access Management, and Audit unaffected
+
+- **WHEN** `featureFlags.adminApiEnabled` is `true`
+- **THEN** the Entities group, the Builders group, the Access Management group, and the Audit group are all present
+
+### Requirement: DEPLOYMENTS_ENABLED=false hides the Deployments group and all its sub-items
+
+When `DEPLOYMENTS_ENABLED` resolves falsy (per `isValueTruthy`), the entire Deployments menu group — including every sub-item (Model Servings, MCP Containers, Interceptor Containers, Adapter Containers, Application Containers, Images) — SHALL be absent from the sidebar without requiring any entry in `DISABLE_MENU_ITEMS`. This behavior MUST hold regardless of whether the Evaluation group or the admin-API-gated groups are also hidden.
+
+#### Scenario: Deployments hidden via env flag alone
+
+- **WHEN** the app is configured with `DEPLOYMENTS_ENABLED=false` and `DIAL_EVAL_API_URL` is unset (Evaluation also disabled)
+- **AND** `DISABLE_MENU_ITEMS` contains no Deployments-related entries
+- **THEN** the Deployments group and all of its sub-items are absent from the sidebar navigation

--- a/openspec/changes/archive/2026-09-10-hide-ui-without-admin-api/tasks.md
+++ b/openspec/changes/archive/2026-09-10-hide-ui-without-admin-api/tasks.md
@@ -1,0 +1,74 @@
+## 1. Feature flag
+
+- [x] 1.1 Add `adminApiEnabled: boolean` to `FeatureFlags` in `src/models/feature-flags.ts`.
+- [x] 1.2 Compute it in `src/app/[lang]/layout.tsx` as `process.env.DIAL_ADMIN_API_URL != null` and
+      pass it through with the rest of `featureFlags`.
+
+## 2. Menu configuration
+
+- [x] 2.1 In `src/components/Menu/menu-configuration.tsx`, filter out the Entities, Builders, and
+      Access Management groups when `!featureFlags.adminApiEnabled`, following the existing
+      `deploymentsEnabled`/`evaluationEnabled`/`analyticsEnabled` filter chain.
+- [x] 2.2 In the same file, filter the Audit group out entirely (Dashboard, Activity, and Usage Log all
+      hidden together) when `!featureFlags.adminApiEnabled`, using the same group-level filter as
+      Entities/Builders/Access Management — not an item-level filter within Audit.
+- [x] 2.3 Update `src/components/Menu/tests/menu-configuration.spec.ts` to cover: both flags disabled
+      (Entities/Builders/Access Management/Audit groups all absent in full, other groups untouched),
+      flag independence from `deploymentsEnabled`/`evaluationEnabled`, and flag enabled (unaffected).
+
+## 3. Menu actions
+
+- [x] 3.1 In `src/components/Menu/MenuContent/MenuContent.tsx`, gate the "Import config" and
+      "Export config" `MenuAction`s in `MenuActionsBar` on `featureFlags.adminApiEnabled`; leave
+      "System properties" unconditional.
+- [x] 3.2 Gate the same two actions passed into the collapsed `MenuActions` bar
+      (`showImportExport` prop or equivalent) on `featureFlags.adminApiEnabled` combined with the
+      existing `!isReadOnlyAdmin` check.
+- [x] 3.3 Update/add tests in `src/components/Menu/MenuContent/tests/` covering Import/Export
+      presence/absence for both the expanded and collapsed bars.
+- [x] 3.4 In `src/components/WelcomeView/WelcomeView.tsx`, gate the Import/Export quick-action
+      buttons on `featureFlags.adminApiEnabled` in addition to the existing `!isReadOnlyAdmin` check;
+      update `src/components/WelcomeView/WelcomeView.spec.tsx` to cover the disabled case.
+
+## 4. Footer and status polling
+
+- [x] 4.1 In `src/components/Content/Content.tsx`, read `featureFlags` via `useAppContext()` and skip
+      starting the `checkAppStatus` and `checkCoreVersion` effects (including their initial call and
+      `setInterval`) when `!featureFlags.adminApiEnabled`.
+- [x] 4.2 In the same file, render `<Footer .../>` only when `featureFlags.adminApiEnabled`.
+- [x] 4.3 Update `src/components/Content/tests/Content.spec.tsx` (or equivalent) to assert the Footer
+      is absent and `getAppProcessStatus`/`getCoreVersions` are never called when the flag is `false`.
+
+## 5. Route guards — Entities
+
+- [x] 5.1 Add the `if (!process.env.DIAL_ADMIN_API_URL) redirect(ApplicationRoute.Home);` guard
+      (mirroring `src/app/[lang]/model-servings/page.tsx`) as the first statement in:
+      `models/page.tsx`, `models/[id]/page.tsx`, `models/[id]/[subId]/page.tsx`,
+      `applications/page.tsx`, `applications/[id]/page.tsx`, `applications/[id]/[subId]/page.tsx`,
+      `interceptors/page.tsx`, `interceptors/[id]/page.tsx`, `interceptors/[id]/[subId]/page.tsx`,
+      `toolsets/page.tsx`, `toolsets/[id]/page.tsx`, `toolsets/[id]/[subId]/page.tsx`,
+      `routes/page.tsx`, `routes/[id]/page.tsx`, `routes/[id]/[subId]/page.tsx`
+      (all under `src/app/[lang]/`).
+
+## 6. Route guards — Builders
+
+- [x] 6.1 Add the same guard to: `adapters/page.tsx`, `adapters/[id]/page.tsx`,
+      `adapters/[id]/[subId]/page.tsx`, `application-runners/page.tsx`,
+      `application-runners/[id]/page.tsx`, `application-runners/[id]/[subId]/page.tsx`,
+      `interceptor-templates/page.tsx`, `interceptor-templates/[id]/page.tsx`,
+      `interceptor-templates/[id]/[subId]/page.tsx` (all under `src/app/[lang]/`).
+
+## 7. Route guards — Access Management, Audit, Import/Export
+
+- [x] 7.1 Add the same guard to: `roles/page.tsx`, `roles/[id]/page.tsx`,
+      `roles/[id]/[subId]/page.tsx`, `keys/page.tsx`, `keys/[id]/page.tsx`,
+      `keys/[id]/[subId]/page.tsx`, `activity-audit/page.tsx`, `activity-audit/[id]/page.tsx`,
+      `dashboard/page.tsx`, `usage-log/page.tsx`, `import-config/page.tsx`, `export-config/page.tsx`
+      (all under `src/app/[lang]/`). `dashboard` and `usage-log` are the other two Audit-group
+      routes — the whole group is now hidden together (see §2.2), so they need the same guard as
+      `activity-audit` even though neither has an `[id]` sub-route.
+
+## 8. Verification
+
+- [x] 8.1 Run `npx vitest run` for every spec file touched above; then run `npm run test` and
+      `npm run typecheck` as the final gate.

--- a/openspec/changes/archive/2026-09-10-migrate-utility-endpoints-to-core/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-10-migrate-utility-endpoints-to-core/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-10

--- a/openspec/changes/archive/2026-09-10-migrate-utility-endpoints-to-core/design.md
+++ b/openspec/changes/archive/2026-09-10-migrate-utility-endpoints-to-core/design.md
@@ -1,0 +1,94 @@
+## Context
+
+`UtilityApi` (`src/server/utility-api.ts`) is a single BE-hosted class holding every admin-console
+endpoint the frontend calls. Most of its methods are genuine admin-BE logic (import/export, version,
+config-sync) with no Core equivalent, but three — `checkDeploymentByName`, `getAllDeployments`,
+`getSystemProperties`/`updateSystemProperties`, and `getUserInfo` — only ever forwarded the request to
+DIAL Core unchanged (confirmed against `ai-dial-core`'s `DeploymentController`, `ConfigResourceController`
+(`/v1/settings/{bucket}/{path}`), and `UserInfoController`). `SettingsApi` (`src/server/core/settings-api.ts`)
+already talks to Core's global-settings singleton for a different caller (`getGlobalInterceptors`), so
+the system-properties move lands there instead of a new class, to avoid two clients owning one Core
+resource.
+
+Separately, `getConfigEntityOptions` (`src/server/config-entities/read.ts`) unions two Core populations —
+API-written (`assetApi`) and config-file (`configFileApi`) — for every entity-picker read across the app
+(`platform-models`, `assets-applications`, `assets-toolsets`, `platform-app-runners`, `platform-routes`,
+`platform-keys`, and now `system-properties`). The config-file population is declared through the admin
+console's own configuration surface; without the admin backend there is nothing to read there.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Every endpoint that only ever proxied Core unchanged calls Core directly, with no change in the
+  response shape its callers already depend on (except `getUserInfo`'s role, see below).
+- No duplicate ownership of one Core resource across two client classes.
+- `getConfigEntityOptions`'s config-file read degrades to "nothing to union" rather than a reported
+  failure when the admin backend isn't configured, since a failure there would surface as an
+  "incomplete option list" warning for a population that was never expected to exist.
+
+**Non-Goals:**
+
+- Migrating any endpoint that has genuine admin-BE-only logic (import/export, version, config-sync) —
+  those stay on `UtilityApi`, commented out or otherwise, exactly as `UtilityApi` already has them.
+- Reproducing the admin backend's `FULL_ADMIN`/`READ_ONLY_ADMIN` role-mapping logic
+  (`identity-providers.*.role-mapping` config) against Core's raw roles. Core's `/v1/user/info` reports
+  unmapped roles; `CoreUtilityApi.getUserInfo` intentionally returns no role, and the admin-BE-routed
+  path (`UtilityApi.getUserInfo`, used whenever `DIAL_ADMIN_API_URL` is set) keeps computing it as
+  before. `hide-ui-without-admin-api`'s `AppContext` treats `isFullAdmin`/`isReadOnlyAdmin` as `true`/
+  `false` respectively whenever the admin backend isn't configured, so no role is needed in that case.
+- Skipping the API-written half of `getConfigEntityOptions`'s union. `listApiWrittenNames` reads through
+  `assetApi`, which is Core-direct regardless of `DIAL_ADMIN_API_URL` — only the config-file half is
+  admin-console-owned.
+
+## Decisions
+
+**`checkDeploymentByName` switches from `HEAD` to `GET`.** Core's `DeploymentController` registers only
+`GET /v1/deployments/{deployment_name}` (`ControllerSelector`'s route table matches HTTP method exactly,
+with no implicit `HEAD`→`GET` fallback), so a `HEAD` request 404s unconditionally against Core. `GET`
+still resolves to `null` on a real 404 (`BaseApi.get`'s existing failure handling), preserving the
+"name is unique" check `checkIsUniqueDeploymentName` does with the result — just with a body attached
+that the caller ignores.
+
+**System properties move to `SettingsApi`, not a new class.** `SettingsApi.globalSettings` already reads
+Core's `v1/settings/platform/global` for `getGlobalInterceptors`, unconditionally (no etag). Adding
+`getSystemProperties`/`updateSystemProperties` (etag-conditional GET/PUT) there — instead of on a new
+`CoreUtilityApi` — means one class, one URL constant, one place a reader checks for how this resource is
+read and written.
+
+**`getUserInfo` stays admin-BE-routed when the admin backend is configured.** The admin backend's
+`SecurityInfoController` doesn't call Core at all — it reads `id`/`email`/mapped-`roles` off its own
+Spring Security authentication context, built from the incoming OIDC token via
+`identity-providers.*.role-mapping` config that has no Core equivalent. Reproducing that mapping
+client-side (decoding the JWT independently, adding new `FULL_ADMIN_ROLE_NAMES`/
+`READ_ONLY_ADMIN_ROLE_NAMES` env vars) was considered and rejected: `hide-ui-without-admin-api` already
+gives every caller full-admin treatment when the admin backend isn't configured, so no role is needed on
+that path, and duplicating role-mapping logic the admin backend still owns (while it's still configured)
+would be one more thing to keep in sync for no behavior change. `src/app/api/api.ts`'s `getUserInfo`
+picker is the single place that decides which client to call; every consumer (`app/layout.tsx`,
+`app/[lang]/layout.tsx`) calls the picker, never `UtilityApi.getUserInfo` or `CoreUtilityApi.getUserInfo`
+directly.
+
+**`getConfigEntityOptions` skips only the config-file read, not the whole union.** The two reads
+(`listApiWrittenNames` via `assetApi`, `configFileApi.listNames`) are independent Core calls with
+different ownership: `assetApi`'s population exists regardless of the admin backend, `configFileApi`'s
+does not. Skipping the whole function (as an earlier iteration of this change did, before this was
+narrowed) would also have suppressed the still-valid API-written population everywhere `readConfigEntities`
+is called, not only where the config-file population would have been empty.
+
+**System Properties' interceptor picker moves to `readConfigEntities`.** It previously called
+`interceptorsApi.getInterceptorsList` (admin-BE-only, doesn't see config-file-declared interceptors).
+Reading it the same way `platform-models` does — through `readConfigEntities`, which already
+composes both populations — is strictly more complete, and gets the admin-API skip in the same
+change for free.
+
+## Risks / Trade-offs
+
+- **`getUserInfo`'s role silently disappears if a caller forgets to route through the `api.ts` picker**
+  → Mitigated by removing `UtilityApi`/`CoreUtilityApi` imports from every existing consumer in this
+  change (`app/layout.tsx`, `app/[lang]/layout.tsx`) — there is no remaining direct call to either
+  class's `getUserInfo` to accidentally use instead.
+- **A future caller of `getConfigEntityOptions` might expect the config-file read to always attempt and
+  report a failure, e.g. for a health check** → Mitigated by the `core-config-file-client` spec delta
+  making the skip an explicit, spec-level requirement rather than an implementation detail a reader
+  would need to find in the source to notice.

--- a/openspec/changes/archive/2026-09-10-migrate-utility-endpoints-to-core/proposal.md
+++ b/openspec/changes/archive/2026-09-10-migrate-utility-endpoints-to-core/proposal.md
@@ -1,0 +1,64 @@
+## Why
+
+The admin backend (`ai-dial-admin-backend`) is being retired incrementally (see the archived
+`migrate-publications-to-core-api`, `add-core-asset-client`, and `core-config-file-client`-backing
+changes). `UtilityApi` still proxies three endpoints to the admin backend that only ever forward the
+request to DIAL Core unchanged: deployment listing/lookup, the caller's own identity, and the
+global-settings singleton. These can move to Core directly today, ahead of any UI-visibility work
+(`hide-ui-without-admin-api`) — they are independent of whether the admin backend is configured at all,
+except for identity, where the admin backend still computes a mapped `FULL_ADMIN`/`READ_ONLY_ADMIN`
+role Core does not know about.
+
+## What Changes
+
+- Add `CoreUtilityApi` (`DIAL_CORE_API_URL`-hosted) with `checkDeploymentByName` and `getAllDeployments`,
+  reading Core's `GET /v1/deployments[/{name}]` directly instead of the admin-BE proxy. `checkDeploymentByName`
+  switches from a `HEAD` request to a plain `GET`, because Core's `DeploymentController` only registers
+  `GET` for that route.
+- Add `CoreUtilityApi.getUserInfo`, reading Core's `GET /v1/user/info` directly. Core reports the
+  caller's own raw, unmapped roles (not `FULL_ADMIN`/`READ_ONLY_ADMIN`), so this method only ever
+  returns `id`/`email` — no role is derived from it.
+- Extend `SettingsApi` (which already owns Core's global-settings singleton for `getGlobalInterceptors`)
+  with `getSystemProperties`/`updateSystemProperties`, the etag-conditional GET/PUT the System
+  Properties page needs — removing the duplicate URL constant and duplicate resource ownership that
+  would otherwise exist between it and `CoreUtilityApi`.
+- Add `getUserInfo(token)` in `src/app/api/api.ts`: calls `UtilityApi.getUserInfo` (admin backend, which
+  still computes the mapped role) when `DIAL_ADMIN_API_URL` is configured, otherwise
+  `CoreUtilityApi.getUserInfo` (Core direct, `id`/`email` only, no role).
+- `UtilityApi` keeps `getUserInfo` and everything else it already owns (import/export, version, config
+  sync) — nothing is removed from it besides the three methods that move to `CoreUtilityApi`/`SettingsApi`.
+- `readConfigEntities`'s underlying `getConfigEntityOptions` now skips the config-file half of its union
+  read (`configFileApi.listNames`) when `DIAL_ADMIN_API_URL` is unset, resolving it as an empty success
+  rather than a reported failure — that population is the admin console's own configuration surface, so
+  without the admin backend there is nothing declaring it. The API-written half
+  (`assetApi`-based, Core-direct either way) is always read.
+- The System Properties page's interceptor picker now reads from `readConfigEntities` (Core's unioned
+  API-written + config-file populations, matching `platform-models`) instead of the admin-BE-only
+  `interceptorsApi.getInterceptorsList`, and surfaces a partial-read warning the same way `ModelView` does.
+
+## Capabilities
+
+### New Capabilities
+
+- `utility-core-api`: `CoreUtilityApi`'s direct-to-Core deployment listing/lookup and user-identity read,
+  and the `getUserInfo` picker in `src/app/api/api.ts` that chooses between it and the admin-BE-routed
+  `UtilityApi.getUserInfo`.
+
+### Modified Capabilities
+
+- `core-config-file-client`: the config-file half of the two-population union read is skipped (not
+  reported as failed) when the admin backend is not configured.
+
+## Impact
+
+- `apps/ai-dial-admin/src/server/core/core-utility-api.ts` — new class.
+- `apps/ai-dial-admin/src/server/core/settings-api.ts` — two new methods, same URL constant.
+- `apps/ai-dial-admin/src/server/utility-api.ts` — three methods removed (moved out), `getUserInfo` kept.
+- `apps/ai-dial-admin/src/app/api/api.ts` — new `coreUtilityApi` instance, new `getUserInfo` picker.
+- `apps/ai-dial-admin/src/server/config-entities/read.ts` — `getConfigEntityOptions` gates the
+  config-file read.
+- Call-site updates: `src/app/actions.ts`, `src/app/layout.tsx`, `src/app/[lang]/layout.tsx`,
+  `src/app/[lang]/conversations/actions.ts`, `src/app/[lang]/system-properties/{actions,page}.tsx`,
+  `src/app/[lang]/interceptors/{page,[id]/page}.tsx`.
+- `apps/ai-dial-admin/src/models/dial/core-user-info.ts` — new model for Core's raw `/v1/user/info` shape.
+- No new environment variables; no dependency changes.

--- a/openspec/changes/archive/2026-09-10-migrate-utility-endpoints-to-core/specs/core-config-file-client/spec.md
+++ b/openspec/changes/archive/2026-09-10-migrate-utility-endpoints-to-core/specs/core-config-file-client/spec.md
@@ -1,0 +1,30 @@
+## MODIFIED Requirements
+
+### Requirement: The two Core populations of one entity type are read as a union
+DIAL Core keeps the entities of a given type in two places, and its merged runtime configuration is the union of both: entities written through its API, listed by the metadata route, and entities defined in configuration files, listed by the config-file route. Core validates a reference against that merged set. The system SHALL therefore compose both reads when offering an entity as a selectable option, so the offered set matches the set Core will accept. The config-file route is the admin console's own configuration surface: when the admin backend is not configured (`DIAL_ADMIN_API_URL` unset), the system SHALL skip that read and resolve it as an empty population rather than issuing the request or reporting a failure. The API-written read is unaffected by that flag and SHALL always be issued.
+
+#### Scenario: Both populations appear as options
+- **WHEN** options of a given entity type are requested for a picker
+- **THEN** the result contains entries from both the API-written population and the config-file population
+
+#### Scenario: The union is not sourced from the admin backend
+- **WHEN** the union is composed
+- **THEN** both halves come from DIAL Core, and no admin-backend request contributes to it — an admin-backend list may contain entities not yet present in Core, which would be offered and then rejected on write
+
+#### Scenario: One population failing does not empty the picker
+- **WHEN** one of the two reads fails and the other succeeds
+- **THEN** the successful population is still offered, and the failure is reported rather than silently reducing the option set
+
+#### Scenario: Both populations failing is reported
+- **WHEN** both reads fail
+- **THEN** the caller receives a failure rather than an empty option set
+
+#### Scenario: The config-file read is skipped without the admin backend
+- **WHEN** `DIAL_ADMIN_API_URL` is unset and options of any entity type are requested
+- **THEN** the config-file read is never issued
+- **AND** the result still contains the API-written population
+- **AND** no failure is reported for the missing config-file half
+
+#### Scenario: The config-file read runs normally with the admin backend configured
+- **WHEN** `DIAL_ADMIN_API_URL` is set and options of any entity type are requested
+- **THEN** both the API-written and config-file reads are issued, as before this change

--- a/openspec/changes/archive/2026-09-10-migrate-utility-endpoints-to-core/specs/utility-core-api/spec.md
+++ b/openspec/changes/archive/2026-09-10-migrate-utility-endpoints-to-core/specs/utility-core-api/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: Deployment listing and lookup read DIAL Core directly
+The system SHALL provide a server-side client (`CoreUtilityApi`) that lists deployments and checks a single deployment by name against DIAL Core (`GET /v1/deployments` and `GET /v1/deployments/{name}`), authenticated with the caller's JWT through the existing Core client pipeline, instead of the admin backend's proxy of the same routes.
+
+#### Scenario: Deployment listing goes to Core, not the admin backend
+- **WHEN** all deployments are requested
+- **THEN** the request goes to `DIAL_CORE_API_URL`, never to the admin-backend host
+
+#### Scenario: A single deployment is checked by name with a GET, not a HEAD
+- **WHEN** a caller checks whether a deployment name already exists
+- **THEN** the client issues a `GET` request to Core's deployment-by-name route, because Core registers only `GET` for that route and a `HEAD` request would 404 unconditionally
+- **AND** a 404 response resolves to `null`, matching the existing "name is unique" contract
+
+### Requirement: A caller's own identity read prefers the admin backend when configured
+The system SHALL expose a single `getUserInfo(token)` entry point (in `src/app/api/api.ts`) that every consumer calls, which routes to the admin backend's identity endpoint when `DIAL_ADMIN_API_URL` is configured, and to DIAL Core's `GET /v1/user/info` directly otherwise. No consumer SHALL call either underlying client's `getUserInfo` directly.
+
+#### Scenario: Admin backend configured routes to the admin backend
+- **WHEN** `DIAL_ADMIN_API_URL` is set and a caller requests the current user's identity
+- **THEN** the request goes to the admin backend's security-info endpoint
+- **AND** the returned `roles` reflect the admin backend's own `FULL_ADMIN`/`READ_ONLY_ADMIN` mapping
+
+#### Scenario: Admin backend not configured routes to Core directly
+- **WHEN** `DIAL_ADMIN_API_URL` is unset and a caller requests the current user's identity
+- **THEN** the request goes to DIAL Core's `GET /v1/user/info`
+- **AND** the returned `id`/`email` are derived from Core's response (`userId`/`project` for `id`, the `email` claim for `email`)
+- **AND** `roles` is empty — DIAL Core reports only raw, unmapped roles, which are not translated into `FULL_ADMIN`/`READ_ONLY_ADMIN`
+
+### Requirement: The global-settings singleton has one owner
+The system SHALL expose reads and writes of DIAL Core's global-settings singleton (`v1/settings/platform/global`) — the unconditional read used by `getGlobalInterceptors`, and the etag-conditional read/write the System Properties page uses — from a single client (`SettingsApi`), sharing one URL constant. No other client SHALL address this resource.
+
+#### Scenario: System properties are read and written through SettingsApi
+- **WHEN** the System Properties page reads or updates global settings
+- **THEN** the request goes through `SettingsApi`, conditional on the given etag (`If-None-Match` for reads, `If-Match` for writes)
+
+#### Scenario: The unconditional read used for global interceptors is unaffected
+- **WHEN** `getGlobalInterceptors` reads the global-settings blob
+- **THEN** it uses `SettingsApi.globalSettings`, with no etag header, exactly as before this change
+
+### Requirement: The System Properties interceptor picker reads Core's unioned populations
+The System Properties page's interceptor picker SHALL read from the same Core-direct, two-population union other Core-populated pickers use (`readConfigEntities`), instead of the admin-backend-only entity listing, and SHALL surface a partial-read warning the same way those other pages do.
+
+#### Scenario: The picker includes config-file-declared interceptors
+- **WHEN** the System Properties page loads its interceptor picker
+- **THEN** the offered interceptors include both API-written and config-file-declared ones, matching what `platform-models`' interceptor picker offers
+
+#### Scenario: A partial read surfaces a warning
+- **WHEN** one of the two population reads fails while the other succeeds
+- **THEN** the page still renders the surviving population
+- **AND** shows the same "incomplete option list" notification `ModelView` shows for the same condition

--- a/openspec/changes/archive/2026-09-10-migrate-utility-endpoints-to-core/tasks.md
+++ b/openspec/changes/archive/2026-09-10-migrate-utility-endpoints-to-core/tasks.md
@@ -1,0 +1,70 @@
+## 1. CoreUtilityApi — deployments and identity
+
+- [x] 1.1 Add `apps/ai-dial-admin/src/server/core/core-utility-api.ts` (`CoreUtilityApi extends CoreApi`)
+      with `checkDeploymentByName` (GET `v1/deployments/{name}`, not `HEAD` — Core registers only GET)
+      and `getAllDeployments` (GET `v1/deployments`).
+- [x] 1.2 Add `getUserInfo` to `CoreUtilityApi`, reading Core's `GET /v1/user/info` and mapping the raw
+      response into `{ id, email, roles: [] }` — `id` from `userId` or `project`, `email` from the
+      `userClaims.email` claim, no role derived.
+- [x] 1.3 Add `apps/ai-dial-admin/src/models/dial/core-user-info.ts` for Core's raw `/v1/user/info`
+      response shape.
+- [x] 1.4 Wire `coreUtilityApi` in `src/app/api/api.ts`, and add the `getUserInfo(token)` picker there
+      that calls `utilityApi.getUserInfo` when `DIAL_ADMIN_API_URL` is set, else
+      `coreUtilityApi.getUserInfo`.
+- [x] 1.5 Update every consumer to use the new instances: `src/app/actions.ts`
+      (`checkIsUniqueDeploymentName`), `src/app/layout.tsx`, `src/app/[lang]/layout.tsx`, and
+      `src/app/[lang]/conversations/actions.ts` (`getAllDeployments`) — none call `utilityApi` for
+      these three endpoints, or either client's `getUserInfo` directly, any more.
+- [x] 1.6 Add `src/server/core/tests/core-utility-api.spec.ts` covering `checkDeploymentByName` (URL,
+      null-on-404), `getAllDeployments`, and `getUserInfo` (JWT-caller mapping, API-key-caller
+      fallback, failed-response passthrough).
+
+## 2. SettingsApi — system properties
+
+- [x] 2.1 Add `getSystemProperties`/`updateSystemProperties` to `src/server/core/settings-api.ts`,
+      sharing `CORE_GLOBAL_SETTINGS_URL` with the existing `globalSettings` method — remove the
+      duplicate `GLOBAL_SETTINGS_URL` constant and methods that had briefly lived on `CoreUtilityApi`.
+- [x] 2.2 Update every consumer to call `settingsApi` instead: `src/app/[lang]/system-properties/actions.ts`,
+      `src/app/[lang]/system-properties/page.tsx`, `src/app/[lang]/interceptors/page.tsx`,
+      `src/app/[lang]/interceptors/[id]/page.tsx`.
+- [x] 2.3 Add `src/server/core/tests/settings-api.spec.ts` covering all three methods
+      (`globalSettings`, `getSystemProperties`, `updateSystemProperties`).
+
+## 3. UtilityApi — keep everything else unchanged
+
+- [x] 3.1 Remove only `checkDeploymentByName`, `getAllDeployments`, `getSystemProperties`,
+      `updateSystemProperties` from `src/server/utility-api.ts` (moved out in §1/§2) and their
+      now-unused imports/consts (`SYSTEM_PROPERTIES_URL`, `DEPLOYMENTS_URL`, `DEPLOYMENT_URL`,
+      `SECURITY_INFO_URL`'s duplicate — `getUserInfo` and `SECURITY_INFO_URL` stay). Leave every other
+      method (commented-out or active) untouched.
+- [x] 3.2 Update `src/server/tests/utility-api.spec.ts` to drop the tests for the four moved methods
+      and keep the rest as-is.
+
+## 4. Config-entities — skip the config-file read without the admin backend
+
+- [x] 4.1 In `src/server/config-entities/read.ts`, gate `getConfigEntityOptions`'s
+      `configFileApi.listNames` call on `process.env.DIAL_ADMIN_API_URL` — resolve it as
+      `{ success: true, data: [] }` when unset, instead of issuing the request. Leave
+      `listApiWrittenNames` (via `assetApi`) unconditional.
+- [x] 4.2 Update `src/server/config-entities/tests/read.spec.ts` to stub `DIAL_ADMIN_API_URL` for the
+      existing cases (which assume the config-file half runs) and add a case proving the config-file
+      read is skipped while the API-written population still comes through with no reported failure.
+
+## 5. System Properties — interceptor picker sourcing
+
+- [x] 5.1 In `src/app/[lang]/system-properties/page.tsx`, replace `interceptorsApi.getInterceptorsList`
+      with `readConfigEntities<DialInterceptor>(token, ConfigFileEntityType.Interceptors, optionWarnings)`
+      (same call `platform-models/[id]/page.tsx` uses), collecting `optionWarnings` alongside the
+      existing `globalSettings` fetch.
+- [x] 5.2 Add the `optionWarnings` prop to `src/components/SystemProperties/SystemProperties.tsx` and
+      the same "surface as an error notification" `useEffect` `ModelView` uses for the same condition.
+
+## 6. Verification
+
+No browser-verification task: every scenario in this change describes a request-routing or data-shape
+contract exercised by the unit/component tests added in §1-§5, except the System Properties
+"incomplete option list" notification, which reuses `ModelView`'s already-verified notification pattern
+verbatim rather than introducing new UI.
+
+- [x] 6.1 Run `npx vitest run` for every spec file touched or added above; then run `npm run test` and
+      `npm run typecheck` as the final gate.

--- a/openspec/specs/admin-api-availability/spec.md
+++ b/openspec/specs/admin-api-availability/spec.md
@@ -1,0 +1,89 @@
+# admin-api-availability Specification
+
+## Purpose
+The `adminApiEnabled` feature flag itself, the menu-action visibility it gates (Import/Export
+config), the Footer/status-polling suppression, and the direct-URL redirect guard for every route
+owned by the groups and actions the admin backend alone supports. Exists because the admin backend
+(`ai-dial-admin-backend`) is being phased out, and deployments that stop configuring
+`DIAL_ADMIN_API_URL` need those unsupported surfaces hidden rather than rendering broken pages or
+issuing calls to a host that no longer exists. Menu-group visibility itself is covered by
+`menu-group-visibility`.
+
+## Requirements
+
+### Requirement: `adminApiEnabled` feature flag reflects `DIAL_ADMIN_API_URL` presence
+
+The system SHALL expose an `adminApiEnabled: boolean` field on the `FeatureFlags` object, computed at request time in the root layout as `process.env.DIAL_ADMIN_API_URL != null`.
+
+#### Scenario: Flag is true when the env var is set
+
+- **WHEN** `process.env.DIAL_ADMIN_API_URL` is set to any non-null value and the root layout
+  initializes `FeatureFlags`
+- **THEN** `featureFlags.adminApiEnabled` is `true`
+
+#### Scenario: Flag is false when the env var is unset
+
+- **WHEN** `process.env.DIAL_ADMIN_API_URL` is unset
+- **THEN** `featureFlags.adminApiEnabled` is `false`
+
+### Requirement: Import/Export config menu actions are hidden without the admin API
+
+The Menu content SHALL render the "Import config" and "Export config" actions (in both the expanded actions bar and the collapsed `MenuActions` bar) only when `featureFlags.adminApiEnabled` is `true`. The "System properties" action MUST NOT be affected by this flag. The Home page (`WelcomeView`) quick-actions row SHALL apply the same `featureFlags.adminApiEnabled` gate to its own "Import config" and "Export config" buttons, in addition to its existing read-only-admin check.
+
+#### Scenario: Admin API disabled hides Import/Export actions
+
+- **WHEN** `featureFlags.adminApiEnabled` is `false`
+- **THEN** neither the "Import config" nor "Export config" action is rendered in the menu
+- **AND** "System properties" is still rendered
+
+#### Scenario: Admin API enabled shows Import/Export actions
+
+- **WHEN** `featureFlags.adminApiEnabled` is `true`
+- **THEN** both "Import config" and "Export config" actions are rendered in the menu
+
+#### Scenario: Admin API disabled hides Import/Export quick actions on the Home page
+
+- **WHEN** `featureFlags.adminApiEnabled` is `false`
+- **AND** the user is not a read-only admin
+- **THEN** neither the "Import config" nor "Export config" quick-action button is rendered on the Home page
+- **AND** "System properties" is still rendered
+
+#### Scenario: Admin API enabled shows Import/Export quick actions on the Home page
+
+- **WHEN** `featureFlags.adminApiEnabled` is `true`
+- **AND** the user is not a read-only admin
+- **THEN** both "Import config" and "Export config" quick-action buttons are rendered on the Home page
+
+### Requirement: Footer and its polling are suppressed without the admin API
+
+The `Content` component SHALL NOT render the `Footer`, and SHALL NOT start the `checkAppStatus` / `checkCoreVersion` polling intervals (nor issue their initial calls), when `featureFlags.adminApiEnabled` is `false`. Both actions call the admin backend, which is unreachable without `DIAL_ADMIN_API_URL`.
+
+#### Scenario: Admin API disabled hides Footer and stops polling
+
+- **WHEN** `featureFlags.adminApiEnabled` is `false`
+- **THEN** the Footer is absent from the page
+- **AND** `getAppProcessStatus` and `getCoreVersions` are never called
+
+#### Scenario: Admin API enabled renders Footer and polling as today
+
+- **WHEN** `featureFlags.adminApiEnabled` is `true`
+- **THEN** the Footer renders
+- **AND** `checkAppStatus` and `checkCoreVersion` run on mount and on their existing intervals
+
+### Requirement: Direct navigation to admin-API-only routes redirects home
+
+The system SHALL redirect to `ApplicationRoute.Home`, before issuing any admin-backend request, when `process.env.DIAL_ADMIN_API_URL` is unset and a user navigates directly to any route owned exclusively by the Entities group (`/models`, `/applications`, `/interceptors`, `/toolsets`, `/routes`), the Builders group (`/adapters`, `/application-runners`, `/interceptor-templates`), the Access Management group (`/roles`, `/keys`), the Audit group (`/activity-audit`, `/dashboard`, `/usage-log`), or the Import/Export actions (`/import-config`, `/export-config`) — including every `[id]` and `[id]/[subId]` sub-route under them.
+
+#### Scenario: Bookmarked entity URL redirects when the admin API is disabled
+
+- **WHEN** a user navigates directly to `/<lang>/models`, `/<lang>/models/<id>`, `/<lang>/roles`,
+  `/<lang>/import-config`, or any other route listed above
+- **AND** `DIAL_ADMIN_API_URL` is unset
+- **THEN** the server issues a redirect to `ApplicationRoute.Home`
+- **AND** no admin-backend call is made for that page
+
+#### Scenario: Routes render normally when the admin API is enabled
+
+- **WHEN** a user navigates to any of those routes
+- **AND** `DIAL_ADMIN_API_URL` is set
+- **THEN** the page renders as it does today

--- a/openspec/specs/core-config-file-client/spec.md
+++ b/openspec/specs/core-config-file-client/spec.md
@@ -28,7 +28,7 @@ Core does not serve every type on this route family to every caller — reading 
 - **THEN** the client refuses without issuing the request, rather than surfacing Core's refusal as a generic error
 
 ### Requirement: The two Core populations of one entity type are read as a union
-DIAL Core keeps the entities of a given type in two places, and its merged runtime configuration is the union of both: entities written through its API, listed by the metadata route, and entities defined in configuration files, listed by the config-file route. Core validates a reference against that merged set. The system SHALL therefore compose both reads when offering an entity as a selectable option, so the offered set matches the set Core will accept.
+DIAL Core keeps the entities of a given type in two places, and its merged runtime configuration is the union of both: entities written through its API, listed by the metadata route, and entities defined in configuration files, listed by the config-file route. Core validates a reference against that merged set. The system SHALL therefore compose both reads when offering an entity as a selectable option, so the offered set matches the set Core will accept. The config-file route is the admin console's own configuration surface: when the admin backend is not configured (`DIAL_ADMIN_API_URL` unset), the system SHALL skip that read and resolve it as an empty population rather than issuing the request or reporting a failure. The API-written read is unaffected by that flag and SHALL always be issued.
 
 #### Scenario: Both populations appear as options
 - **WHEN** options of a given entity type are requested for a picker
@@ -45,6 +45,16 @@ DIAL Core keeps the entities of a given type in two places, and its merged runti
 #### Scenario: Both populations failing is reported
 - **WHEN** both reads fail
 - **THEN** the caller receives a failure rather than an empty option set
+
+#### Scenario: The config-file read is skipped without the admin backend
+- **WHEN** `DIAL_ADMIN_API_URL` is unset and options of any entity type are requested
+- **THEN** the config-file read is never issued
+- **AND** the result still contains the API-written population
+- **AND** no failure is reported for the missing config-file half
+
+#### Scenario: The config-file read runs normally with the admin backend configured
+- **WHEN** `DIAL_ADMIN_API_URL` is set and options of any entity type are requested
+- **THEN** both the API-written and config-file reads are issued, as before this change
 
 ### Requirement: The union normalises to the fields both populations provide
 The two populations do not carry the same data, and neither carries a description. The metadata route returns per-entry author and timestamps; the config-file listing returns a name and nothing else. The system SHALL normalise an option to the fields available from both — its name and its origin — rather than issuing a per-entity read to fill fields a listing omits.

--- a/openspec/specs/menu-group-visibility/spec.md
+++ b/openspec/specs/menu-group-visibility/spec.md
@@ -1,11 +1,11 @@
 ## Purpose
-Define how feature-flag-gated groups in the left-navigation menu are shown or hidden. Each gated group is controlled solely by its own flag and composes independently of every other group, so disabling one group never causes another disabled group to reappear and never hides an enabled group. Today two groups are flag-gated: the Deployments group (`featureFlags.deploymentsEnabled`, sourced from `DEPLOYMENTS_ENABLED`) and the Evaluation group (`featureFlags.evaluationEnabled`, sourced from `DIAL_EVAL_API_URL` being present).
+Define how feature-flag-gated groups in the left-navigation menu are shown or hidden. Each gated group is controlled solely by its own flag and composes independently of every other group, so disabling one group never causes another disabled group to reappear and never hides an enabled group. Flag-gated groups: the Deployments group (`featureFlags.deploymentsEnabled`, sourced from `DEPLOYMENTS_ENABLED`), the Evaluation group (`featureFlags.evaluationEnabled`, sourced from `DIAL_EVAL_API_URL` being present), and the Entities, Builders, Access Management, and Audit groups (`featureFlags.adminApiEnabled`, sourced from `DIAL_ADMIN_API_URL` being present — see `admin-api-availability` for the flag itself and the other surfaces it gates).
 
 ## Requirements
 
 ### Requirement: Feature-flag-gated menu groups compose independently
 
-The left-navigation menu configuration SHALL hide each feature-flag-gated menu group based solely on its own flag, independent of the state of any other group's flag. Disabling one group MUST NOT cause another disabled group to reappear, and MUST NOT hide a group whose flag is enabled. Today two groups are flag-gated: the Deployments group is hidden when `featureFlags.deploymentsEnabled` is `false` (sourced from `DEPLOYMENTS_ENABLED`), and the Evaluation group is hidden when `featureFlags.evaluationEnabled` is `false` (sourced from `DIAL_EVAL_API_URL` being absent).
+The left-navigation menu configuration SHALL hide each feature-flag-gated menu group based solely on its own flag, independent of the state of any other group's flag. Disabling one group MUST NOT cause another disabled group to reappear, and MUST NOT hide a group whose flag is enabled. Flag-gated groups: the Deployments group is hidden when `featureFlags.deploymentsEnabled` is `false` (sourced from `DEPLOYMENTS_ENABLED`); the Evaluation group is hidden when `featureFlags.evaluationEnabled` is `false` (sourced from `DIAL_EVAL_API_URL` being absent); the Entities, Builders, Access Management, and Audit groups are hidden in full when `featureFlags.adminApiEnabled` is `false` (sourced from `DIAL_ADMIN_API_URL` being absent) — Audit is hidden as a whole group (Dashboard, Activity, and Usage Log together), not filtered item-by-item.
 
 #### Scenario: Both group flags enabled
 
@@ -30,9 +30,20 @@ The left-navigation menu configuration SHALL hide each feature-flag-gated menu g
 - **THEN** the Deployments group is absent
 - **AND** the Evaluation group is absent
 
+#### Scenario: Admin API disabled hides Entities, Builders, Access Management, and Audit independently of other flags
+
+- **WHEN** `featureFlags.adminApiEnabled` is `false`, regardless of `featureFlags.deploymentsEnabled` or `featureFlags.evaluationEnabled`
+- **THEN** the Entities group, the Builders group, the Access Management group, and the Audit group are all absent
+- **AND** a Deployments or Evaluation group whose own flag is `true` remains present
+
+#### Scenario: Admin API enabled leaves Entities, Builders, Access Management, and Audit unaffected
+
+- **WHEN** `featureFlags.adminApiEnabled` is `true`
+- **THEN** the Entities group, the Builders group, the Access Management group, and the Audit group are all present
+
 ### Requirement: DEPLOYMENTS_ENABLED=false hides the Deployments group and all its sub-items
 
-When `DEPLOYMENTS_ENABLED` resolves falsy (per `isValueTruthy`), the entire Deployments menu group — including every sub-item (Model Servings, MCP Containers, Interceptor Containers, Adapter Containers, Application Containers, Images) — SHALL be absent from the sidebar without requiring any entry in `DISABLE_MENU_ITEMS`. This behavior MUST hold regardless of whether the Evaluation group is also hidden.
+When `DEPLOYMENTS_ENABLED` resolves falsy (per `isValueTruthy`), the entire Deployments menu group — including every sub-item (Model Servings, MCP Containers, Interceptor Containers, Adapter Containers, Application Containers, Images) — SHALL be absent from the sidebar without requiring any entry in `DISABLE_MENU_ITEMS`. This behavior MUST hold regardless of whether the Evaluation group or the admin-API-gated groups are also hidden.
 
 #### Scenario: Deployments hidden via env flag alone
 

--- a/openspec/specs/system-properties/spec.md
+++ b/openspec/specs/system-properties/spec.md
@@ -1,0 +1,53 @@
+# system-properties Specification
+
+## Purpose
+The System Properties page's read/save behavior against DIAL Core's global-settings singleton
+(`v1/settings/platform/global`) — how a first-ever save is distinguished from a save that must
+guard against concurrent edits, how a read failure is surfaced, and how fields the page doesn't
+own survive a save.
+
+## Requirements
+
+### Requirement: First-ever save succeeds when no settings blob exists yet
+The system SHALL allow saving global interceptors from the System Properties page even when Core has
+never had a global-settings blob written via the API, and SHALL NOT send a conditional header that
+asserts the resource already exists in that case.
+
+#### Scenario: Save succeeds on an environment with no prior API-written settings
+- **WHEN** a user opens System Properties on an environment where Core's global-settings GET
+  previously returned 404, edits the global interceptors list, and clicks Save
+- **THEN** the save request succeeds and the page reflects the newly saved interceptors, with no
+  precondition-failure error shown
+
+### Requirement: Save asserts existence once a settings blob is known to exist
+The system SHALL send `If-Match: *` when saving global interceptors and a prior read confirmed a
+settings blob exists, so the write is rejected if the blob was deleted in the meantime. Core's GET
+for this singleton never returns an ETag, so a real concurrent-edit (lost-update) guard is not
+achievable through this endpoint and is not attempted.
+
+#### Scenario: A save after the blob was deleted is rejected
+- **WHEN** a user saves global interceptors after the settings blob was deleted since this page's
+  last read
+- **THEN** the save is rejected and an error notification is shown
+
+### Requirement: A full-settings read failure is surfaced to the user
+The system SHALL distinguish "no settings blob exists yet" (expected, not an error) from any other
+read failure when fetching global settings for the System Properties page, and SHALL show a warning
+for the latter rather than proceeding as if the read had succeeded.
+
+#### Scenario: A non-404 read failure shows a warning
+- **WHEN** the System Properties page's full-settings read fails for a reason other than "no blob
+  exists yet"
+- **THEN** a warning notification is shown on the page, consistent with how an incomplete
+  interceptor option list is already surfaced
+
+### Requirement: Non-interceptor settings fields survive a global-interceptors save
+The system SHALL preserve any other field already present on the global-settings object (such as
+`retriableErrorCodes`) when saving a change to global interceptors, rather than omitting it and
+letting Core reset it to its default.
+
+#### Scenario: Saving interceptors does not clear other settings
+- **WHEN** Core's global settings already contain a non-default value for a field other than
+  `globalInterceptors`, and a user changes and saves the global interceptors list from System
+  Properties
+- **THEN** the saved settings retain that other field's existing value unchanged

--- a/openspec/specs/utility-core-api/spec.md
+++ b/openspec/specs/utility-core-api/spec.md
@@ -1,0 +1,58 @@
+# utility-core-api Specification
+
+## Purpose
+`CoreUtilityApi`'s direct-to-Core deployment listing/lookup and user-identity read, and the
+`getUserInfo` picker in `src/app/api/api.ts` that chooses between it and the admin-backend-routed
+`UtilityApi.getUserInfo`. Created as part of migrating `UtilityApi`'s admin-backend proxy endpoints
+to DIAL Core directly, alongside the global-settings singleton now owned by `SettingsApi`.
+
+## Requirements
+
+### Requirement: Deployment listing and lookup read DIAL Core directly
+The system SHALL provide a server-side client (`CoreUtilityApi`) that lists deployments and checks a single deployment by name against DIAL Core (`GET /v1/deployments` and `GET /v1/deployments/{name}`), authenticated with the caller's JWT through the existing Core client pipeline, instead of the admin backend's proxy of the same routes.
+
+#### Scenario: Deployment listing goes to Core, not the admin backend
+- **WHEN** all deployments are requested
+- **THEN** the request goes to `DIAL_CORE_API_URL`, never to the admin-backend host
+
+#### Scenario: A single deployment is checked by name with a GET, not a HEAD
+- **WHEN** a caller checks whether a deployment name already exists
+- **THEN** the client issues a `GET` request to Core's deployment-by-name route, because Core registers only `GET` for that route and a `HEAD` request would 404 unconditionally
+- **AND** a 404 response resolves to `null`, matching the existing "name is unique" contract
+
+### Requirement: A caller's own identity read prefers the admin backend when configured
+The system SHALL expose a single `getUserInfo(token)` entry point (in `src/app/api/api.ts`) that every consumer calls, which routes to the admin backend's identity endpoint when `DIAL_ADMIN_API_URL` is configured, and to DIAL Core's `GET /v1/user/info` directly otherwise. No consumer SHALL call either underlying client's `getUserInfo` directly.
+
+#### Scenario: Admin backend configured routes to the admin backend
+- **WHEN** `DIAL_ADMIN_API_URL` is set and a caller requests the current user's identity
+- **THEN** the request goes to the admin backend's security-info endpoint
+- **AND** the returned `roles` reflect the admin backend's own `FULL_ADMIN`/`READ_ONLY_ADMIN` mapping
+
+#### Scenario: Admin backend not configured routes to Core directly
+- **WHEN** `DIAL_ADMIN_API_URL` is unset and a caller requests the current user's identity
+- **THEN** the request goes to DIAL Core's `GET /v1/user/info`
+- **AND** the returned `id`/`email` are derived from Core's response (`userId`/`project` for `id`, the `email` claim for `email`)
+- **AND** `roles` is empty — DIAL Core reports only raw, unmapped roles, which are not translated into `FULL_ADMIN`/`READ_ONLY_ADMIN`
+
+### Requirement: The global-settings singleton has one owner
+The system SHALL expose reads and writes of DIAL Core's global-settings singleton (`v1/settings/platform/global`) — the unconditional read used by `getGlobalInterceptors`, and the etag-conditional read/write the System Properties page uses — from a single client (`SettingsApi`), sharing one URL constant. No other client SHALL address this resource.
+
+#### Scenario: System properties are read and written through SettingsApi
+- **WHEN** the System Properties page reads or updates global settings
+- **THEN** the request goes through `SettingsApi`, conditional on the given etag (`If-None-Match` for reads, `If-Match` for writes)
+
+#### Scenario: The unconditional read used for global interceptors is unaffected
+- **WHEN** `getGlobalInterceptors` reads the global-settings blob
+- **THEN** it uses `SettingsApi.globalSettings`, with no etag header, exactly as before this change
+
+### Requirement: The System Properties interceptor picker reads Core's unioned populations
+The System Properties page's interceptor picker SHALL read from the same Core-direct, two-population union other Core-populated pickers use (`readConfigEntities`), instead of the admin-backend-only entity listing, and SHALL surface a partial-read warning the same way those other pages do.
+
+#### Scenario: The picker includes config-file-declared interceptors
+- **WHEN** the System Properties page loads its interceptor picker
+- **THEN** the offered interceptors include both API-written and config-file-declared ones, matching what `platform-models`' interceptor picker offers
+
+#### Scenario: A partial read surfaces a warning
+- **WHEN** one of the two population reads fails while the other succeeds
+- **THEN** the page still renders the surviving population
+- **AND** shows the same "incomplete option list" notification `ModelView` shows for the same condition


### PR DESCRIPTION
**Description:**

Introduces an `adminApiEnabled` feature flag, derived from whether `DIAL_ADMIN_API_URL` is configured, and uses it to consistently gate every Admin API-dependent surface: the Entities/Builders/Access Management menu groups and Activity Audit menu item, Import/Export config actions, footer status/version polling, and server-side route guards that redirect unconfigured routes to Home. Along the way, utility endpoints (settings, user info) are migrated onto the Core API client and a first-save ETag bug in System Properties is fixed.

Issues:

- Issue #4508

**Key Changes:**

- [apps/ai-dial-admin/src/models/feature-flags.ts](https://github.com/epam/ai-dial-admin-frontend/blob/feat/hide-ui-without-admin-api/apps/ai-dial-admin/src/models/feature-flags.ts) — adds `adminApiEnabled` flag
- [apps/ai-dial-admin/src/components/Menu/menu-configuration.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/feat/hide-ui-without-admin-api/apps/ai-dial-admin/src/components/Menu/menu-configuration.tsx) — hides Entities/Builders/Access Management groups and Activity Audit when Admin API is disabled
- [apps/ai-dial-admin/src/components/Menu/MenuContent/MenuAction.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/feat/hide-ui-without-admin-api/apps/ai-dial-admin/src/components/Menu/MenuContent/MenuAction.tsx) — hides Import/Export config actions when disabled
- [apps/ai-dial-admin/src/components/Content/Content.tsx](https://github.com/epam/ai-dial-admin-frontend/blob/feat/hide-ui-without-admin-api/apps/ai-dial-admin/src/components/Content/Content.tsx) — disables footer polling and hides the Footer
- Route guards added across Models, Applications, Interceptors, Toolsets, Routes, Adapters, Application Runners, Interceptor Templates, Roles, Keys, Activity Audit, Import Config, Export Config `page.tsx` files — redirect to Home when Admin API is not configured
- [apps/ai-dial-admin/src/server/core/core-utility-api.ts](https://github.com/epam/ai-dial-admin-frontend/blob/feat/hide-ui-without-admin-api/apps/ai-dial-admin/src/server/core/core-utility-api.ts) — new Core-API-backed utility client
- [apps/ai-dial-admin/src/server/utility-api.ts](https://github.com/epam/ai-dial-admin-frontend/blob/feat/hide-ui-without-admin-api/apps/ai-dial-admin/src/server/utility-api.ts) — migrated settings/user-info calls onto the Core client
- [apps/ai-dial-admin/src/app/[lang]/system-properties/actions.ts](https://github.com/epam/ai-dial-admin-frontend/blob/feat/hide-ui-without-admin-api/apps/ai-dial-admin/src/app/%5Blang%5D/system-properties/actions.ts) — fixes ETag handling on first save

**New Components:**

- `apps/ai-dial-admin/src/server/core/core-utility-api.ts` — Core-API-backed utility client for settings and user info
- `apps/ai-dial-admin/src/models/dial/core-user-info.ts` — model for the Core API's user-info response

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #4508)` (comma-separated list of issues)
