### PR TITLE
fix: [Assets-Applications/Toolsets] Move to modal displays all folders instead of only the current storage folder and its subfolders (Issue #4418)

### DIFF
--- a/apps/ai-dial-admin/src/components/Common/FileManager/utils.ts
+++ b/apps/ai-dial-admin/src/components/Common/FileManager/utils.ts
@@ -74,6 +74,7 @@ export const getDestinationFolderPopupOptions = (
       ? t(FileManagerI18nKey.MoveItem, { item: itemName })
       : t(FileManagerI18nKey.MoveItems, { count: itemsCount }),
   processDestinationFolderPath: (path: string) => addTrailingSlash(path),
+  excludedPaths: ['platform/'],
 });
 
 export const createEmptyFile = () => {

--- a/apps/ai-dial-admin/src/components/Common/FilePath/FilePath.tsx
+++ b/apps/ai-dial-admin/src/components/Common/FilePath/FilePath.tsx
@@ -10,15 +10,15 @@ import {
 } from '@epam/ai-dial-ui-kit';
 import { IconFolderShare } from '@tabler/icons-react';
 
+import { getParentPathByFullPath } from '@/src/components/Assets/utils';
+import { ROOT_FOLDER } from '@/src/constants/file';
 import { ActionMenuOperationI18nKey } from '@/src/constants/i18n';
 import { BASE_BUTTON_ICON_PROPS, CONTROL_WITH_BUTTON_WIDTH } from '@/src/constants/main-layout';
 import { AssetsFolderContext } from '@/src/context/assets/AssetsFolderContext';
 import { useI18n } from '@/src/locales/client';
-import { ROOT_FOLDER } from '@/src/constants/file';
 import { ServerActionResponse } from '@/src/models/server-action';
-import { getParentPathByFullPath } from '@/src/components/Assets/utils';
-import { excludePlatformRoot, getFilePathGridOptions, processAssetsData } from './utils';
 import { ApplicationRoute } from '@/src/types/routes';
+import { getFilePathGridOptions, processAssetsData } from './utils';
 
 interface Props {
   label: string;
@@ -47,8 +47,7 @@ const FilePath: FC<Props> = ({
 }) => {
   const t = useI18n();
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const { files: rawFiles, fetchFiles } = context?.() || {};
-  const files = excludePlatformRoot(rawFiles, view);
+  const { files, fetchFiles } = context?.() || {};
   const [loadedPaths, setLoadedPaths] = useState(new Set(['']));
   const [path, setPath] = useState(`${ROOT_FOLDER}/`);
 
@@ -141,6 +140,7 @@ const FilePath: FC<Props> = ({
             searchable: false,
           }}
           showCreateFolderButton={shouldAbleToCreateNewFolder}
+          excludedPaths={['/platform']}
         />
       </div>
     </div>

--- a/apps/ai-dial-admin/src/components/Common/FilePath/tests/FilePath.spec.tsx
+++ b/apps/ai-dial-admin/src/components/Common/FilePath/tests/FilePath.spec.tsx
@@ -11,15 +11,34 @@ vi.mock('@epam/ai-dial-ui-kit', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@epam/ai-dial-ui-kit')>();
   return {
     ...actual,
-    DialDestinationFolderPopup: ({ open, rootItem, items }: { open: boolean; rootItem?: Asset; items: Asset[] }) =>
-      open ? (
+    // Mirrors the real component's own `excludedPaths` filtering, so the test exercises the actual
+    // contract FilePath relies on rather than assuming FilePath pre-filters `rootItem`/`items` itself.
+    DialDestinationFolderPopup: ({
+      open,
+      rootItem,
+      items,
+      excludedPaths = [],
+    }: {
+      open: boolean;
+      rootItem?: Asset;
+      items: Asset[];
+      excludedPaths?: string[];
+    }) => {
+      if (!open) return null;
+
+      const isExcluded = (path?: string) => !!path && excludedPaths.some((excluded) => `/${path}`.startsWith(excluded));
+
+      return (
         <div>
-          <span>root:{rootItem?.name}</span>
-          {items.map((item) => (
-            <span key={item.path}>item:{item.name}</span>
-          ))}
+          {!isExcluded(rootItem?.path) && <span>root:{rootItem?.name}</span>}
+          {items
+            .filter((item) => !isExcluded(item.path))
+            .map((item) => (
+              <span key={item.path}>item:{item.name}</span>
+            ))}
         </div>
-      ) : null,
+      );
+    },
   };
 });
 
@@ -49,7 +68,7 @@ describe('FilePath', () => {
 
     await user.click(screen.getByRole('button', { name: 'ActionMenuOperation.Move_to' }));
 
-    expect(screen.getByText('root:public')).toBeInTheDocument();
+    expect(screen.getByText('item:public')).toBeInTheDocument();
     expect(screen.queryByText('root:platform')).not.toBeInTheDocument();
     expect(screen.queryByText('item:platform')).not.toBeInTheDocument();
   });

--- a/apps/ai-dial-admin/src/components/Common/FilePath/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/Common/FilePath/tests/utils.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ApplicationRoute } from '@/src/types/routes';
 import { DialFileNodeType } from '@epam/ai-dial-ui-kit';
-import { processAssetsData, getFilePathGridOptions, excludePlatformRoot } from '../utils';
+import { processAssetsData, getFilePathGridOptions } from '../utils';
 import * as fileManagerUtils from '@/src/components/Common/FileManager/utils';
 import * as baseAssetListUtils from '@/src/components/Assets/BaseAssetList/utils';
 import { Asset, AssetWithVersion } from '@/src/models/dial/deployment-asset';
@@ -186,41 +186,6 @@ describe('FilePath utils', () => {
 
       expect(result).toHaveLength(1);
       expect((result[0] as AssetWithVersion).versions).toEqual(['1.0']);
-    });
-  });
-
-  describe('excludePlatformRoot', () => {
-    const platformRoot = { name: 'platform', path: 'platform/', nodeType: DialFileNodeType.FOLDER, items: [] };
-    const publicRoot = { name: 'public', path: 'public/', nodeType: DialFileNodeType.FOLDER, items: [] };
-
-    it('drops the platform root for a dual-bucket view', () => {
-      const result = excludePlatformRoot([platformRoot, publicRoot] as Asset[], ApplicationRoute.AssetsApplications);
-
-      expect(result).toEqual([publicRoot]);
-    });
-
-    it('drops the platform root for the AssetsToolsets dual-bucket view', () => {
-      const result = excludePlatformRoot([platformRoot, publicRoot] as Asset[], ApplicationRoute.AssetsToolsets);
-
-      expect(result).toEqual([publicRoot]);
-    });
-
-    it('returns files unchanged for a non-dual-bucket view', () => {
-      const result = excludePlatformRoot([platformRoot, publicRoot] as Asset[], ApplicationRoute.Prompts);
-
-      expect(result).toEqual([platformRoot, publicRoot]);
-    });
-
-    it('returns files unchanged when view is undefined', () => {
-      const result = excludePlatformRoot([platformRoot, publicRoot] as Asset[]);
-
-      expect(result).toEqual([platformRoot, publicRoot]);
-    });
-
-    it('returns an empty array when no files are given', () => {
-      const result = excludePlatformRoot(undefined, ApplicationRoute.AssetsApplications);
-
-      expect(result).toEqual([]);
     });
   });
 

--- a/apps/ai-dial-admin/src/components/Common/FilePath/utils.ts
+++ b/apps/ai-dial-admin/src/components/Common/FilePath/utils.ts
@@ -3,23 +3,6 @@ import { ApplicationRoute } from '@/src/types/routes';
 import { DialFileNodeType } from '@epam/ai-dial-ui-kit';
 import { getGridOptions } from '@/src/components/Common/FileManager/utils';
 import { getGridColumns } from '@/src/components/Assets/BaseAssetList/utils';
-import { DUAL_BUCKET_VIEWS, isPlatformBucketPath } from '@/src/utils/files/root-folder';
-
-/**
- * The Move-to popup only ever offers `public` destinations (the `platform` bucket is flat, see
- * `platform-applications`/`platform-toolsets`), so its source tree drops the `platform` root that
- * `AssetsFolderContext.files` otherwise carries for `DUAL_BUCKET_VIEWS`. Views outside that set never
- * have a `platform` root in `files` to begin with, so this is a no-op for them.
- */
-export const excludePlatformRoot = (
-  files: (Asset | AssetWithVersion)[] = [],
-  view?: ApplicationRoute,
-): (Asset | AssetWithVersion)[] => {
-  if (!view || !DUAL_BUCKET_VIEWS.includes(view)) {
-    return files;
-  }
-  return files.filter((file) => !isPlatformBucketPath(file.path));
-};
 
 export const processAssetsData = (
   assets: (Asset | AssetWithVersion)[] = [],

--- a/openspec/changes/archive/2026-09-07-fix-platform-bucket-folder-storage/tasks.md
+++ b/openspec/changes/archive/2026-09-07-fix-platform-bucket-folder-storage/tasks.md
@@ -65,26 +65,16 @@
 - [x] 4.1 In `apps/ai-dial-admin/src/components/Common/FilePath/utils.ts`, add a pure helper that,
       given the shared `AssetsFolderContext` `files` array and the current `view`, drops the `platform`
       root node when `view` is in `DUAL_BUCKET_VIEWS` and returns the array unchanged otherwise.
-      Added `excludePlatformRoot`: for `DUAL_BUCKET_VIEWS`, filters out any root whose `path` satisfies
-      `isPlatformBucketPath` (confirmed via `AssetsFolderContext`'s `fetchRoots` that dual-bucket root
-      nodes carry a trailing-slash path, e.g. `'platform/'`/`'public/'` — `FileManager.tsx` appends the
-      slash before calling `fetchFiles`); returns `files` unchanged for every other view.
+      
 - [x] 4.2 In `apps/ai-dial-admin/src/components/Common/FilePath/FilePath.tsx`, apply that helper to
       `files` before computing `items={processAssetsData(...)}` and `rootItem`, so `rootItem` resolves
       to the `public` root for dual-bucket views instead of `files?.[0]`.
-      Wired in: context's raw `files` is renamed `rawFiles` and passed through `excludePlatformRoot`
-      before use, so both `rootItem={files?.[0]}` and `items={processAssetsData(files, view)}` already
-      exclude `platform` with no further change to those two lines.
+     
 - [x] 4.3 Add/update unit tests for the new filtering helper (drops `platform` for a dual-bucket view's
       `files`, passes non-dual-bucket `files` through unchanged) and a `FilePath`/`DialDestinationFolderPopup`
       component test confirming `platform` is not offered as a Move-to destination for a public-bucket
       application/toolset.
-      Extended `Common/FilePath/tests/utils.spec.ts` with an `excludePlatformRoot` describe block (5
-      cases: dual-bucket Applications/Toolsets drop `platform`, non-dual-bucket view and undefined view
-      pass through unchanged, no-files input). Added `Common/FilePath/tests/FilePath.spec.tsx` (no prior
-      test file existed), mocking `DialDestinationFolderPopup` to render `rootItem`/`items` and asserting
-      `platform` is absent from both for a dual-bucket view, present for a non-dual-bucket view. 23/23
-      passing across both files.
+     
 
 ## 5. Final quality checks
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@epam/ai-dial-shared": "^0.44.8",
-        "@epam/ai-dial-ui-kit": "0.14.0-dev.4",
+        "@epam/ai-dial-ui-kit": "0.14.0-dev.49",
         "@epam/ai-dial-visualizer-connector": "^0.44.8",
         "@floating-ui/react": "^0.27.19",
         "@modelcontextprotocol/sdk": "^1.30.0",
@@ -2237,9 +2237,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@epam/ai-dial-ui-kit": {
-      "version": "0.14.0-dev.4",
-      "resolved": "https://registry.npmjs.org/@epam/ai-dial-ui-kit/-/ai-dial-ui-kit-0.14.0-dev.4.tgz",
-      "integrity": "sha512-WZurAnayFLwpeUBd9sQ99jDGNvEZQvua/IaTJLhm3bi7ivNWyhu35xaNSke3XyOK9wOeaFUlyPxzPeJIlizGpQ==",
+      "version": "0.14.0-dev.49",
+      "resolved": "https://registry.npmjs.org/@epam/ai-dial-ui-kit/-/ai-dial-ui-kit-0.14.0-dev.49.tgz",
+      "integrity": "sha512-GT3iy2sHBslsyisKxp866OsUM2IOXA+YSeZHn44u8iWYCy7KxVt3P6laAO4jIIuNJPcTDBXxzQ/t825luZFafA==",
       "license": "Apache-2.0",
       "dependencies": {
         "ag-grid-community": "^35.2.1",
@@ -2862,9 +2862,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2880,9 +2877,6 @@
       "integrity": "sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2900,9 +2894,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2918,9 +2909,6 @@
       "integrity": "sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2938,9 +2926,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2956,9 +2941,6 @@
       "integrity": "sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2976,9 +2958,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2995,9 +2974,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3013,9 +2989,6 @@
       "integrity": "sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3039,9 +3012,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3063,9 +3033,6 @@
       "integrity": "sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3089,9 +3056,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3113,9 +3077,6 @@
       "integrity": "sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3139,9 +3100,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3164,9 +3122,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3188,9 +3143,6 @@
       "integrity": "sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -4045,9 +3997,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4063,9 +4012,6 @@
       "integrity": "sha512-TlNAnpsjxSF3aAUtqnfmtXXf8m9sIDBlmF3c7bTAlnshUYu2U0OxN2uf5d0gcFwqHVEdivJNBcCaqNOwPGNimw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4083,9 +4029,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4101,9 +4044,6 @@
       "integrity": "sha512-kGZxM+WhkYs0276lFrMkj7PRtXT3Btp6cwvfSO/cCVLxJJttB5Ccnl2niaCgUja8HgSbEVnMHpg3FJWoOJ9e/g==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6813,6 +6753,7 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
       "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6852,6 +6793,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6872,6 +6814,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6892,6 +6835,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6912,6 +6856,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6932,6 +6877,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6952,6 +6898,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6972,6 +6919,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6992,6 +6940,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7012,6 +6961,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7032,6 +6982,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7052,6 +7003,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7072,6 +7024,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7092,6 +7045,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10212,7 +10166,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -11564,6 +11518,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "bin": {
@@ -13176,7 +13131,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -14947,7 +14902,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -15008,7 +14963,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -15074,7 +15029,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -17581,7 +17536,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -17595,7 +17550,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -18138,6 +18093,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -23681,7 +23637,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@epam/ai-dial-shared": "^0.44.8",
-    "@epam/ai-dial-ui-kit": "0.14.0-dev.4",
+    "@epam/ai-dial-ui-kit": "0.14.0-dev.49",
     "@epam/ai-dial-visualizer-connector": "^0.44.8",
     "@floating-ui/react": "^0.27.19",
     "@modelcontextprotocol/sdk": "^1.30.0",


### PR DESCRIPTION
**Description:**

correct move popup folders

Issues:

- Issue #4418

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
