### PR TITLE
fix(Eval/TestSuits): Try out Columns tab missing turn breakdown for multi-turn single-request suites (Issue #4518)

### DIFF
--- a/apps/ai-dial-admin/src/components/TestSuites/RequestTemplate/components/TryOutColumns.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/RequestTemplate/components/TryOutColumns.tsx
@@ -163,7 +163,7 @@ const TryOutColumns: FC<Props> = ({
     );
   };
 
-  const showGrouped = results.shape === 'requests' || results.shape === 'combined';
+  const showGrouped = results.shape === 'requests' || results.shape === 'combined' || results.shape === 'turns';
 
   return (
     <div className="flex-1 flex flex-col gap-y-8 pb-2 min-h-0 overflow-auto">

--- a/apps/ai-dial-admin/src/components/TestSuites/RequestTemplate/tests/TryOutColumns.spec.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/RequestTemplate/tests/TryOutColumns.spec.tsx
@@ -246,6 +246,54 @@ describe('TryOutColumns', () => {
     expect(screen.queryByText('JsonEditor:{"out":"c"}')).not.toBeInTheDocument();
   });
 
+  test('shows Turn labels for single-request multi-turn suites', async () => {
+    vi.mocked(evaluateTryOutColumnSections).mockResolvedValueOnce({
+      shape: 'turns',
+      groups: [
+        {
+          requestIndex: 0,
+          showTurnLabels: true,
+          turns: [
+            {
+              turnIndex: 0,
+              columns: [makeEvaluatedColumn({ name: 'answer', result: 'a' })],
+              responseBody: { out: 'a' },
+            },
+            {
+              turnIndex: 1,
+              columns: [makeEvaluatedColumn({ name: 'answer', result: 'b' })],
+              responseBody: { out: 'b' },
+            },
+          ],
+        },
+      ],
+    } satisfies TryOutColumnResults);
+
+    render(
+      <TryOutColumns
+        testSuite={{
+          suiteType: SuiteType.Deployment,
+          inputBindings: [{ templateVariable: 'prompt', dataField: 'prompt' }],
+        }}
+        history={[entry({ r: 0, t: 0 }, { out: 'a' }), entry({ r: 0, t: 1 }, { out: 'b' })]}
+        schema={[]}
+        multiTurnData={[{ prompt: 'a' }, { prompt: 'b' }]}
+        response={{}}
+        responseBody={<div>FlatResponseBody</div>}
+        selectedRequestIndex={0}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByText(TestSuitesI18nKey.TurnLabel)).toHaveLength(2);
+    });
+
+    expect(screen.getByText('JsonEditor:{"out":"a"}')).toBeInTheDocument();
+    expect(screen.getByText('JsonEditor:{"out":"b"}')).toBeInTheDocument();
+    expect(screen.queryByText(TestSuitesI18nKey.Results)).not.toBeInTheDocument();
+    expect(screen.queryByText('FlatResponseBody')).not.toBeInTheDocument();
+  });
+
   test('renders no column rows when evaluation returns empty flat results', async () => {
     vi.mocked(evaluateTryOutColumnSections).mockResolvedValueOnce({
       shape: 'single',

--- a/apps/ai-dial-admin/src/components/TestSuites/TestCases/tests/TestCasesList.spec.tsx
+++ b/apps/ai-dial-admin/src/components/TestSuites/TestCases/tests/TestCasesList.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { createRef } from 'react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -534,9 +534,14 @@ describe('TestCasesList — multi-turn grouping', () => {
 
     render(<TestCasesList selectedTestSuite={suite} onChange={mockOnChange} dataset={perTurnSchemaDataset} />);
 
-    await waitFor(() => expect(capturedTurnActionHandlers).not.toBeNull());
+    await waitFor(() => {
+      expect(capturedTurnActionHandlers).not.toBeNull();
+      expect(capturedRowData).toEqual([expect.objectContaining({ id: 'case-2', rowType: GridRowType.SINGLE })]);
+    });
 
-    capturedTurnActionHandlers!.onAddTurn('case-2');
+    act(() => {
+      capturedTurnActionHandlers!.onAddTurn('case-2');
+    });
 
     await waitFor(() => expect(capturedRowData!.length).toBe(3));
     expect(capturedRowData!.map((row) => row.rowType)).toEqual([GridRowType.GROUP, GridRowType.TURN, GridRowType.TURN]);

--- a/apps/ai-dial-admin/src/components/TestSuites/utils/evaluate-columns.ts
+++ b/apps/ai-dial-admin/src/components/TestSuites/utils/evaluate-columns.ts
@@ -148,8 +148,7 @@ export const evaluateTryOutColumnSections = async ({
   const turnCounts = getRequestTurnCounts(testSuite, schema, multiTurnLength);
   const shape = getTryOutSectionShape(turnCounts);
 
-  const useGroupedHistory =
-    !!history?.length && (shape === 'requests' || shape === 'combined') && turnCounts.length > 1;
+  const useGroupedHistory = !!history?.length && (shape === 'requests' || shape === 'combined' || shape === 'turns');
 
   if (!useGroupedHistory) {
     if (!hasContent(fallbackResponse) && !hasContent(fallbackRequest)) {

--- a/apps/ai-dial-admin/src/components/TestSuites/utils/tests/evaluate-columns.spec.ts
+++ b/apps/ai-dial-admin/src/components/TestSuites/utils/tests/evaluate-columns.spec.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from 'vitest';
 
-import { ResponseColumn, TestSuite, TryOutHistoryEntry } from '@/src/models/evaluation/test-suite';
+import {
+  ResponseColumn,
+  SuiteType,
+  TestCaseSchema,
+  TestSuite,
+  TryOutHistoryEntry,
+} from '@/src/models/evaluation/test-suite';
+import { TestCaseItemType } from '@/src/types/evaluation';
 import { evaluateColumns, evaluateTryOutColumnSections, EvaluatedColumn } from '../evaluate-columns';
 
 const makeColumn = (overrides: Partial<ResponseColumn> = {}): ResponseColumn => ({
@@ -333,5 +340,42 @@ describe('evaluateTryOutColumnSections', () => {
 
     expect(results.shape).toBe('single');
     expect(results.flatColumns?.[0].result).toBe('Paris');
+  });
+
+  test('returns grouped per-turn results for a single-request multi-turn history', async () => {
+    const suite: TestSuite = {
+      suiteType: SuiteType.Deployment,
+      inputBindings: [{ templateVariable: 'prompt', dataField: 'prompt' }],
+      responseColumns: [makeColumn({ name: 'answer', expression: 'choices[0].message.content' })],
+    };
+    const schema: TestCaseSchema[] = [
+      { name: 'prompt', type: TestCaseItemType.STRING, required: false, description: '', perTurn: true },
+    ];
+    const history: TryOutHistoryEntry[] = [
+      {
+        turnIndex: 0,
+        resolvedRequest: { body: { contentType: 'application/json', content: { q: 1 } } },
+        response: { body: { choices: [{ message: { content: 'Paris' } }] } },
+      },
+      {
+        turnIndex: 1,
+        resolvedRequest: { body: { contentType: 'application/json', content: { q: 2 } } },
+        response: { body: { choices: [{ message: { content: 'London' } }] } },
+      },
+    ];
+
+    const results = await evaluateTryOutColumnSections({
+      testSuite: suite,
+      history,
+      schema,
+      multiTurnLength: 2,
+    });
+
+    expect(results.shape).toBe('turns');
+    expect(results.groups).toHaveLength(1);
+    expect(results.groups?.[0].showTurnLabels).toBe(true);
+    expect(results.groups?.[0].turns).toHaveLength(2);
+    expect(results.groups?.[0].turns[0].columns[0].result).toBe('Paris');
+    expect(results.groups?.[0].turns[1].columns[0].result).toBe('London');
   });
 });


### PR DESCRIPTION
**Description:**

<SHORT_DESCRIPTION>

Issues:

- Issue #4518 

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
