### PR TITLE
feat(Catalog/PlatformTranslators): add duplicate action to translator row context menu (Issue #4527)

### DIFF
--- a/apps/ai-dial-admin/src/components/Assets/tests/utils.spec.ts
+++ b/apps/ai-dial-admin/src/components/Assets/tests/utils.spec.ts
@@ -138,11 +138,10 @@ describe('getGridActionLabels', () => {
     expect(getGridActionLabels(ApplicationRoute.PlatformKeys, true)).toEqual([]);
   });
 
-  test('PlatformTranslators offers delete and openInNewTab but no duplicate', () => {
+  test('PlatformTranslators exposes duplicate, delete, and openInNewTab for a non-read-only admin', () => {
     const keys = getGridActionLabels(ApplicationRoute.PlatformTranslators, false).map((item) => item.key);
 
-    expect(keys).toEqual(expect.arrayContaining(['delete', 'openInNewTab']));
-    expect(keys).not.toContain('duplicate');
+    expect(keys).toEqual(expect.arrayContaining(['duplicate', 'delete', 'openInNewTab']));
   });
 
   test('PlatformTranslators returns no options for a read-only admin', () => {

--- a/apps/ai-dial-admin/src/components/Assets/utils.ts
+++ b/apps/ai-dial-admin/src/components/Assets/utils.ts
@@ -115,19 +115,12 @@ export const getGridActionLabels = (view: ApplicationRoute, isReadOnlyAdmin: boo
     case ApplicationRoute.PlatformRoutes:
     case ApplicationRoute.PlatformRoles:
     case ApplicationRoute.PlatformKeys:
+    case ApplicationRoute.PlatformTranslators:
       return isReadOnlyAdmin
         ? []
         : allActionLabels.filter(
             (item) => item.key === 'duplicate' || item.key === 'delete' || item.key === 'openInNewTab',
           );
-    // Deliberately scoped out of this change (design.md D6) — the shared `DuplicatePlatformAsset`
-    // modal already supports a name-only entity (`hasDisplayName` is false for Routes/Roles/Keys), so
-    // nothing technical blocks it, but duplicate was not requested for Translators and can follow as
-    // its own change later, the way `catalog-keys-duplicate-action` did for Keys.
-    case ApplicationRoute.PlatformTranslators:
-      return isReadOnlyAdmin
-        ? []
-        : allActionLabels.filter((item) => item.key === 'delete' || item.key === 'openInNewTab');
     case ApplicationRoute.AssetsApplications:
     case ApplicationRoute.AssetsToolsets:
       if (isPlatformDualBucketView(view, currentPath)) {

--- a/apps/ai-dial-admin/src/constants/i18n.ts
+++ b/apps/ai-dial-admin/src/constants/i18n.ts
@@ -362,6 +362,7 @@ export enum DuplicateI18nKey {
   Toolset = 'DuplicateEntity.Entities.Toolset',
   Route = 'DuplicateEntity.Entities.Route',
   Interceptor = 'DuplicateEntity.Entities.Interceptor',
+  Translator = 'DuplicateEntity.Entities.Translator',
   Role = 'DuplicateEntity.Entities.Role',
   Key = 'DuplicateEntity.Entities.Key',
   Prompt = 'DuplicateEntity.Entities.Prompt',

--- a/apps/ai-dial-admin/src/locales/en.ts
+++ b/apps/ai-dial-admin/src/locales/en.ts
@@ -383,6 +383,7 @@ export default {
       Toolset: 'Toolset',
       Interceptor: 'Interceptor',
       Route: 'Route',
+      Translator: 'Translator',
       Role: 'Role',
       Key: 'Key',
       Prompt: 'Prompt',

--- a/apps/ai-dial-admin/src/utils/entities/duplicate-entity.ts
+++ b/apps/ai-dial-admin/src/utils/entities/duplicate-entity.ts
@@ -7,6 +7,7 @@ export const duplicateEntityMap: Record<string, DuplicateI18nKey> = {
   [ApplicationRoute.PlatformAppRunners]: DuplicateI18nKey.ApplicationRunner,
   [ApplicationRoute.PlatformInterceptors]: DuplicateI18nKey.Interceptor,
   [ApplicationRoute.PlatformRoutes]: DuplicateI18nKey.Route,
+  [ApplicationRoute.PlatformTranslators]: DuplicateI18nKey.Translator,
   [ApplicationRoute.Applications]: DuplicateI18nKey.Application,
   [ApplicationRoute.AssetsApplications]: DuplicateI18nKey.Application,
   [ApplicationRoute.AssetsToolsets]: DuplicateI18nKey.Toolset,


### PR DESCRIPTION
**Description:**

The Duplicate action was missing from the translator row context menu in Catalog → Translators. Other catalog entities (Interceptors, Routes, Keys) already expose duplicate — translators were explicitly scoped out of an earlier change, but the underlying `DuplicatePlatformAsset` modal already supports name-only entities, so nothing technical blocked it. This change adds duplicate parity for translators.

Issues:

- Issue #4527

**Key Changes:**

- [apps/ai-dial-admin/src/components/Assets/utils.ts](https://github.com/epam/ai-dial-admin-frontend/blob/feat/add-duplicate-action-for-translators/apps/ai-dial-admin/src/components/Assets/utils.ts) — merged `PlatformTranslators` into the shared case that exposes duplicate/delete/openInNewTab, removing the separate branch that omitted duplicate
- [apps/ai-dial-admin/src/utils/entities/duplicate-entity.ts](https://github.com/epam/ai-dial-admin-frontend/blob/feat/add-duplicate-action-for-translators/apps/ai-dial-admin/src/utils/entities/duplicate-entity.ts) — added `PlatformTranslators` to the duplicate entity map
- [apps/ai-dial-admin/src/constants/i18n.ts](https://github.com/epam/ai-dial-admin-frontend/blob/feat/add-duplicate-action-for-translators/apps/ai-dial-admin/src/constants/i18n.ts) — added `Translator` i18n key to `DuplicateI18nKey`
- [apps/ai-dial-admin/src/locales/en.ts](https://github.com/epam/ai-dial-admin-frontend/blob/feat/add-duplicate-action-for-translators/apps/ai-dial-admin/src/locales/en.ts) — added English translation string for Translator
- [apps/ai-dial-admin/src/components/Assets/tests/utils.spec.ts](https://github.com/epam/ai-dial-admin-frontend/blob/feat/add-duplicate-action-for-translators/apps/ai-dial-admin/src/components/Assets/tests/utils.spec.ts) — updated test to assert duplicate is now present for translators

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #4527)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)